### PR TITLE
Description of component using `describe` subcommand

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/project"
+	"github.com/spf13/cobra"
+)
+
+var describeCmd = &cobra.Command{
+	Use:   "describe [component_name]",
+	Short: "Describe the given component",
+	Long:  `Describe the given component.`,
+	Example: `  # Describe nodejs component,
+  odo describe nodejs
+	`,
+	Args: cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+		// Application
+		currentApplication, err := application.GetCurrent(client)
+		checkError(err, "")
+		// Project
+		currentProject := project.GetCurrent(client)
+		var cmpnt string
+		if len(args) == 0 {
+			var err error
+			cmpnt, err = component.GetCurrent(client, currentApplication, currentProject)
+			checkError(err, "")
+		} else {
+			cmpnt = args[0]
+			//Check whether component exist or not
+			exists, err := component.Exists(client, cmpnt, currentApplication, currentProject)
+			checkError(err, "")
+			if !exists {
+				fmt.Printf("component with the name %s does not exist\n", cmpnt)
+				os.Exit(1)
+			}
+		}
+
+		componentType, path, componentURL, appStore, err := component.GetComponentDesc(client, cmpnt, currentApplication, currentProject)
+		checkError(err, "")
+		// Source
+		if path != "" {
+			fmt.Println("Component", cmpnt, "of type", componentType, "with source in", path)
+		}
+		// URL
+		if componentURL != "" {
+			fmt.Println("This Component is externally exposed via", componentURL)
+		}
+		// Storage
+		for _, store := range appStore {
+			fmt.Println("This Component uses storage", store.Name, "of size", store.Size)
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(describeCmd)
+
+}


### PR DESCRIPTION
Resolves #196

As of now, it looks like,

```
$ ocdev component describe nodejs
Component nodejs with source in file:///tmp/nodejs-ex
This Component is externally exposed via nodejs-myproject.192.168.42.231.nip.io
```