### PR TITLE
Add `ocdev storage umount` command

### DIFF
--- a/pkg/storage/labels/labels.go
+++ b/pkg/storage/labels/labels.go
@@ -4,6 +4,8 @@ import (
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 )
 
+// StorageLabel is the label key that is applied to all storage resources
+// that are created
 const StorageLabel = "app.kubernetes.io/storage-name"
 
 // GetLabels gets the labels to be applied to the given storage besides the


### PR DESCRIPTION
This commit adds `ocdev storage unmount` command, which will
unmount the given storage from a component. For implementing this,
an Unmount() function has been introduced in the storage package.

Other parts of code have also been refactored to use the Unmount()
function for much clearer logic.

storage.Remove() has been refactored to first use Unmount(), and
then delete the PVC. The logic looks much cleaner now. Also, to
remove all the components, List() is being used.

Also, introducing the unmount command led to a refactor in
storage.List(), because before this commit all the PVCs with the
relevant labels for storage were being printed, but this commit
decouples this logic from PVCs to the Deployment Config associated
with the component. So, the unmounted storage is no longer being
reflected in List() output.

In one of the further commits, we will need to add something like
`ocdev storage list --all` to list the unmount storage as well,
but I guess that will be go together with `ocdev storage mount`
command.