### PR TITLE
Separate pkg for labels

### DIFF
--- a/pkg/application/labels/labels.go
+++ b/pkg/application/labels/labels.go
@@ -1,0 +1,30 @@
+package labels
+
+// ApplicationLabel is label key that is used to group all object that belong to one application
+// It should be save to use just this label to filter application
+const ApplicationLabel = "app.kubernetes.io/name"
+
+// AdditionalApplicationLabels additional labels that are applied to all objects belonging to one application
+// Those labels are not used for filtering or grouping, they are used just when creating and they are mend to be used by other tools
+var AdditionalApplicationLabels = []string{
+	// OpenShift Web console uses this label for grouping
+	"app",
+}
+
+// GetLabels return labels that identifies given application
+// additional labels are used only when creating object
+// if you are creating something use additional=true
+// if you need labels to filter component than use additional=false
+func GetLabels(application string, additional bool) map[string]string {
+	labels := map[string]string{
+		ApplicationLabel: application,
+	}
+
+	if additional {
+		for _, additionalLabel := range AdditionalApplicationLabels {
+			labels[additionalLabel] = application
+		}
+	}
+
+	return labels
+}

--- a/pkg/application/labels/labels_test.go
+++ b/pkg/application/labels/labels_test.go
@@ -1,0 +1,48 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetLabels(t *testing.T) {
+	type args struct {
+		applicationName string
+		additional      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "everything",
+			args: args{
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				ApplicationLabel: "applicationame",
+			},
+		},
+		{
+			name: "everything with additional",
+			args: args{
+
+				applicationName: "applicationame",
+				additional:      true,
+			},
+			want: map[string]string{
+				ApplicationLabel:               "applicationame",
+				AdditionalApplicationLabels[0]: "applicationame",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLabels(tt.args.applicationName, tt.args.additional); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -4,23 +4,17 @@ import (
 	"fmt"
 	"net/url"
 
-	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/redhat-developer/odo/pkg/application"
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/project"
-	"github.com/redhat-developer/odo/pkg/util"
 )
-
-// ComponentLabel is a label key used to identify component
-const ComponentLabel = "app.kubernetes.io/component-name"
-
-// componentTypeLabel is kubernetes that identifies type of a component
-const componentTypeLabel = "app.kubernetes.io/component-type"
 
 // componentSourceURLAnnotation is an source url from which component was build
 // it can be also file://
@@ -30,16 +24,6 @@ const componentSourceURLAnnotation = "app.kubernetes.io/url"
 type ComponentInfo struct {
 	Name string
 	Type string
-}
-
-// GetLabels return labels that should be applied to every object for given component in active application
-// additional labels are used only for creating object
-// if you are creating something use additional=true
-// if you need labels to filter component that use additional=false
-func GetLabels(componentName string, applicationName string, additional bool) map[string]string {
-	labels := application.GetLabels(applicationName, additional)
-	labels[ComponentLabel] = componentName
-	return labels
 }
 
 func CreateFromGit(client *occlient.Client, name string, ctype string, url string) error {
@@ -61,9 +45,9 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 		}
 	}
 
-	labels := GetLabels(name, currentApplication, true)
+	labels := componentlabels.GetLabels(name, currentApplication, true)
 	// save component type as label
-	labels[componentTypeLabel] = ctype
+	labels[componentlabels.ComponentTypeLabel] = ctype
 
 	// save source path as annotation
 	annotations := map[string]string{componentSourceURLAnnotation: url}
@@ -106,9 +90,9 @@ func CreateFromDir(client *occlient.Client, name string, ctype string, dir strin
 		}
 	}
 
-	labels := GetLabels(name, currentApplication, true)
+	labels := componentlabels.GetLabels(name, currentApplication, true)
 	// save component type as label
-	labels[componentTypeLabel] = ctype
+	labels[componentlabels.ComponentTypeLabel] = ctype
 
 	// save source path as annotation
 	sourceURL := url.URL{Scheme: "file", Path: dir}
@@ -143,7 +127,7 @@ func Delete(client *occlient.Client, name string) (string, error) {
 		return "", errors.Wrapf(err, "unable to delete component %s", name)
 	}
 
-	labels := GetLabels(name, currentApplication, false)
+	labels := componentlabels.GetLabels(name, currentApplication, false)
 
 	output, err := client.Delete("all", "", labels)
 	if err != nil {
@@ -218,8 +202,8 @@ func RebuildGit(client *occlient.Client, componentName string) error {
 // GetComponentType returns type of component in given application and project
 func GetComponentType(client *occlient.Client, componentName string, applicationName string, projectName string) (string, error) {
 	// filter according to component and application name
-	selector := fmt.Sprintf("%s=%s,%s=%s", ComponentLabel, componentName, application.ApplicationLabel, applicationName)
-	ctypes, err := client.GetLabelValues(projectName, componentTypeLabel, selector)
+	selector := fmt.Sprintf("%s=%s,%s=%s", componentlabels.ComponentLabel, componentName, applabels.ApplicationLabel, applicationName)
+	ctypes, err := client.GetLabelValues(projectName, componentlabels.ComponentTypeLabel, selector)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get type of %s component")
 	}
@@ -249,8 +233,8 @@ func List(client *occlient.Client) ([]ComponentInfo, error) {
 		return nil, errors.Wrap(err, "unable to list components")
 	}
 
-	applicationSelector := fmt.Sprintf("%s=%s", application.ApplicationLabel, currentApplication)
-	componentNames, err := client.GetLabelValues(currentProject, ComponentLabel, applicationSelector)
+	applicationSelector := fmt.Sprintf("%s=%s", applabels.ApplicationLabel, currentApplication)
+	componentNames, err := client.GetLabelValues(currentProject, componentlabels.ComponentLabel, applicationSelector)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to list components")
 	}
@@ -319,29 +303,6 @@ func Update(client *occlient.Client, componentName string, to string, source str
 		return errors.Wrap(err, "unable to update the component")
 	}
 	return nil
-}
-
-// GetComponentDeploymentConfig returns the Deployment Config object associated
-// with the given component.
-// An error is thrown when exactly one Deployment Config is not found for the
-// component.
-func GetComponentDeploymentConfig(client *occlient.Client, componentName string, applicationName string) (*appsv1.DeploymentConfig, error) {
-	labels := GetLabels(componentName, applicationName, false)
-	selector := util.ConvertLabelsToSelector(labels)
-
-	deploymentConfigs, err := client.GetDeploymentConfigsFromSelector(selector)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get DeploymentConfigs for the selector: %v", selector)
-	}
-
-	numDC := len(deploymentConfigs)
-	if numDC == 0 {
-		return nil, fmt.Errorf("no Deployment Config was found for the selector: %v", selector)
-	} else if numDC > 1 {
-		return nil, fmt.Errorf("multiple Deployment Configs exist for the selector: %v. Only one must be present", selector)
-	}
-
-	return &deploymentConfigs[0], nil
 }
 
 // Checks whether a component with the given name exists in the current application or not

--- a/pkg/component/labels/labels.go
+++ b/pkg/component/labels/labels.go
@@ -1,0 +1,21 @@
+package labels
+
+import (
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+)
+
+// ComponentLabel is a label key used to identify component
+const ComponentLabel = "app.kubernetes.io/component-name"
+
+// ComponentTypeLabel is kubernetes that identifies type of a component
+const ComponentTypeLabel = "app.kubernetes.io/component-type"
+
+// GetLabels return labels that should be applied to every object for given component in active application
+// additional labels are used only for creating object
+// if you are creating something use additional=true
+// if you need labels to filter component that use additional=false
+func GetLabels(componentName string, applicationName string, additional bool) map[string]string {
+	labels := applabels.GetLabels(applicationName, additional)
+	labels[ComponentLabel] = componentName
+	return labels
+}

--- a/pkg/component/labels/labels_test.go
+++ b/pkg/component/labels/labels_test.go
@@ -1,0 +1,53 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+)
+
+func TestGetLabels(t *testing.T) {
+	type args struct {
+		componentName   string
+		applicationName string
+		additional      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "everything filled",
+			args: args{
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel: "applicationame",
+				ComponentLabel:             "componentname",
+			},
+		}, {
+			name: "everything with additional",
+			args: args{
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      true,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:               "applicationame",
+				applabels.AdditionalApplicationLabels[0]: "applicationame",
+				ComponentLabel:                           "componentname",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLabels(tt.args.componentName, tt.args.applicationName, tt.args.additional); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1182,3 +1182,24 @@ func (c *Client) GetPVCNamesFromSelector(selector string) ([]string, error) {
 
 	return names, nil
 }
+
+// GetOneDeploymentConfigFromSelector returns the Deployment Config object associated
+// with the given selector.
+// An error is thrown when exactly one Deployment Config is not found for the
+// component.
+func (c *Client) GetOneDeploymentConfigFromSelector(selector string) (*appsv1.DeploymentConfig, error) {
+
+	deploymentConfigs, err := c.GetDeploymentConfigsFromSelector(selector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get DeploymentConfigs for the selector: %v", selector)
+	}
+
+	numDC := len(deploymentConfigs)
+	if numDC == 0 {
+		return nil, fmt.Errorf("no Deployment Config was found for the selector: %v", selector)
+	} else if numDC > 1 {
+		return nil, fmt.Errorf("multiple Deployment Configs exist for the selector: %v. Only one must be present", selector)
+	}
+
+	return &deploymentConfigs[0], nil
+}

--- a/pkg/storage/labels/labels.go
+++ b/pkg/storage/labels/labels.go
@@ -1,0 +1,15 @@
+package labels
+
+import (
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+)
+
+const StorageLabel = "app.kubernetes.io/storage-name"
+
+// GetLabels gets the labels to be applied to the given storage besides the
+// component labels and application labels.
+func GetLabels(storageName string, componentName string, applicationName string, additional bool) map[string]string {
+	labels := componentlabels.GetLabels(componentName, applicationName, additional)
+	labels[StorageLabel] = storageName
+	return labels
+}

--- a/pkg/storage/labels/labels_test.go
+++ b/pkg/storage/labels/labels_test.go
@@ -1,0 +1,72 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+)
+
+func TestGetLabels(t *testing.T) {
+	type args struct {
+		storageName     string
+		componentName   string
+		applicationName string
+		additional      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "everything filled",
+			args: args{
+				storageName:     "storagename",
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:     "applicationame",
+				componentlabels.ComponentLabel: "componentname",
+				StorageLabel:                   "storagename",
+			},
+		}, {
+			name: "no storage name",
+			args: args{
+				storageName:     "",
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:     "applicationame",
+				componentlabels.ComponentLabel: "componentname",
+				StorageLabel:                   "",
+			},
+		}, {
+			name: "everything with additional",
+			args: args{
+				storageName:     "storagename",
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      true,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:               "applicationame",
+				applabels.AdditionalApplicationLabels[0]: "applicationame",
+				componentlabels.ComponentLabel:           "componentname",
+				StorageLabel:                             "storagename",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLabels(tt.args.storageName, tt.args.componentName, tt.args.applicationName, tt.args.additional); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -34,7 +34,9 @@ func Create(client *occlient.Client, name string, size string, path string, comp
 	}
 
 	// Get DeploymentConfig for the given component
-	dc, err := component.GetComponentDeploymentConfig(client, componentName, applicationName)
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+	dc, err := client.GetOneDeploymentConfigFromSelector(componentSelector)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to get Deployment Config for component: %v in application: %v", componentName, applicationName)
 	}
@@ -53,7 +55,9 @@ func Create(client *occlient.Client, name string, size string, path string, comp
 func Remove(client *occlient.Client, name string, applicationName string, componentName string) error {
 
 	// Get DeploymentConfig for the given component
-	dc, err := component.GetComponentDeploymentConfig(client, componentName, applicationName)
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+	dc, err := client.GetOneDeploymentConfigFromSelector(componentSelector)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get Deployment Config for component: %v in application: %v", componentName, applicationName)
 	}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -3,10 +3,12 @@ package url
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/application"
-	"github.com/redhat-developer/odo/pkg/component"
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
+
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,7 +30,7 @@ func Create(client *occlient.Client, cmp string) (*URL, error) {
 		return nil, errors.Wrap(err, "unable to get current application")
 	}
 
-	labels := component.GetLabels(cmp, app, false)
+	labels := componentlabels.GetLabels(cmp, app, false)
 
 	route, err := client.CreateRoute(cmp, labels)
 	if err != nil {
@@ -46,10 +48,10 @@ func Create(client *occlient.Client, cmp string) (*URL, error) {
 // given component
 func List(client *occlient.Client, componentName string, applicationName string) ([]URL, error) {
 
-	labelSelector := fmt.Sprintf("%v=%v", application.ApplicationLabel, applicationName)
+	labelSelector := fmt.Sprintf("%v=%v", applabels.ApplicationLabel, applicationName)
 
 	if componentName != "" {
-		labelSelector = labelSelector + fmt.Sprintf(",%v=%v", component.ComponentLabel, componentName)
+		labelSelector = labelSelector + fmt.Sprintf(",%v=%v", componentlabels.ComponentLabel, componentName)
 	}
 
 	log.Debugf("Listing routes with label selector: %v", labelSelector)


### PR DESCRIPTION
 - move label handling to separate packages to avoid cyclic imports
 - refactor `component.GetComponentDeploymentConfig` to `occlient.GetOneDeploymentConfigFromSelector`

This avoids importing component in storage pkg, so there is no risk of cyclic imports.

ping @containscafeine and @surajnarwade 