### PR TITLE
Check if component type exists before deploying

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/project"
 	log "github.com/sirupsen/logrus"
@@ -61,6 +62,13 @@ A full list of component types that can be deployed is available using: 'odo com
 		//We don't have to check it anymore, Args check made sure that args has at least one item
 		// and no more than two
 		componentType := args[0]
+		exists, err := catalog.Exists(client, componentType)
+		checkError(err, "")
+		if !exists {
+			fmt.Printf("Invalid component type: %v\nRun 'ocdev catalog list' to see a list of supported components\n", componentType)
+			os.Exit(1)
+		}
+
 		componentName := args[0]
 		if len(args) == 2 {
 			componentName = args[1]
@@ -71,7 +79,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			os.Exit(1)
 		}
 
-		exists, err := component.Exists(client, componentName, applicationName, projectName)
+		exists, err = component.Exists(client, componentName, applicationName, projectName)
 		if err != nil {
 			checkError(err, "")
 		}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -45,6 +45,21 @@ func Search(client *occlient.Client, name string) ([]string, error) {
 	return result, nil
 }
 
+// Exists returns true if the given component type is valid, false if not
+func Exists(client *occlient.Client, componentType string) (bool, error) {
+	catalogList, err := List(client)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to list catalog")
+	}
+
+	for _, supported := range catalogList {
+		if componentType == supported {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // getDefaultBuilderImages returns the default builder images available in the
 // openshift namespace
 func getDefaultBuilderImages(client *occlient.Client) ([]string, error) {


### PR DESCRIPTION
This component first queries the catalog if the given component
type is supported or not. If the component type does not match
any name in catalog list, an error is thrown.