### PR TITLE
Unify application create logic

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+
+	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/project"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +32,11 @@ var componentGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debugf("component get called")
 		client := getOcClient()
-		component, err := component.GetCurrent(client)
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
+
+		component, err := component.GetCurrent(client, applicationName, projectName)
 		checkError(err, "unable to get current component")
 		if componentShortFlag {
 			fmt.Print(component)
@@ -53,7 +60,11 @@ var componentSetCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		err := component.SetCurrent(client, args[0])
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
+
+		err = component.SetCurrent(client, args[0], applicationName, projectName)
 		checkError(err, "")
 		fmt.Printf("Switched to component: %v\n", args[0])
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+
+	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
 )
 
@@ -13,8 +16,11 @@ var componentListCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
 
-		components, err := component.List(client)
+		components, err := component.List(client, applicationName, projectName)
 		checkError(err, "")
 
 		if len(components) == 0 {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -29,15 +29,15 @@ var pushCmd = &cobra.Command{
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		projectName := project.GetCurrent(client)
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "unable to get current application")
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
 
 		var componentName string
 		if len(args) == 0 {
 			var err error
 			log.Debug("No component name passed, assuming current component")
-			componentName, err = component.GetCurrent(client)
+			componentName, err = component.GetCurrent(client, applicationName, projectName)
 			checkError(err, "unable to get current component")
 			if componentName == "" {
 				fmt.Println("No component is set as active.")

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/redhat-developer/odo/pkg/storage"
 	"github.com/spf13/cobra"
 )
@@ -16,9 +17,9 @@ var (
 	storagePath      string
 )
 
-func getComponent(client *occlient.Client) string {
+func getComponent(client *occlient.Client, applicationName, projectName string) string {
 	if len(storageComponent) == 0 {
-		c, err := component.GetCurrent(client)
+		c, err := component.GetCurrent(client, applicationName, projectName)
 		checkError(err, "Could not get current component")
 		return c
 	}
@@ -37,10 +38,11 @@ var storageCreateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		cmpnt := getComponent(client)
-		app, err := application.GetCurrent(client)
+		applicationName, err := application.GetCurrent(client)
 		checkError(err, "")
-		_, err = storage.Create(client, args[0], storageSize, storagePath, cmpnt, app)
+		projectName := project.GetCurrent(client)
+		cmpnt := getComponent(client, applicationName, projectName)
+		_, err = storage.Create(client, args[0], storageSize, storagePath, cmpnt, applicationName)
 		checkError(err, "")
 		fmt.Printf("Added storage %v to %v\n", args[0], cmpnt)
 	},
@@ -57,12 +59,13 @@ var storageRemoveCmd = &cobra.Command{
 		if len(args) != 0 {
 			storageName = args[0]
 		}
-
-		cmpnt := getComponent(client)
-		app, err := application.GetCurrent(client)
+		applicationName, err := application.GetCurrent(client)
 		checkError(err, "")
+		projectName := project.GetCurrent(client)
 
-		err = storage.Remove(client, storageName, app, cmpnt)
+		cmpnt := getComponent(client, applicationName, projectName)
+
+		err = storage.Remove(client, storageName, applicationName, cmpnt)
 		checkError(err, "failed to remove storage")
 
 		switch storageName {
@@ -80,11 +83,12 @@ var storageListCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		cmpnt := getComponent(client)
-		app, err := application.GetCurrent(client)
+		applicationName, err := application.GetCurrent(client)
 		checkError(err, "")
+		projectName := project.GetCurrent(client)
 
-		storageList, err := storage.List(client, app, cmpnt)
+		cmpnt := getComponent(client, applicationName, projectName)
+		storageList, err := storage.List(client, applicationName, cmpnt)
 		checkError(err, "failed to list storage")
 
 		if len(storageList) == 0 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
+
+	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/project"
+	"github.com/spf13/cobra"
 )
 
 var updateCmd = &cobra.Command{
@@ -26,6 +29,9 @@ var updateCmd = &cobra.Command{
 	Short: "Change the source of a component",
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
 
 		checkFlag := 0
 
@@ -51,10 +57,9 @@ var updateCmd = &cobra.Command{
 
 		var (
 			componentName string
-			err           error
 		)
 		if len(args) == 0 {
-			componentName, err = component.GetCurrent(client)
+			componentName, err = component.GetCurrent(client, applicationName, projectName)
 			checkError(err, "unable to get current component")
 		} else {
 			componentName = args[0]

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/redhat-developer/odo/pkg/url"
 	"github.com/spf13/cobra"
 )
@@ -40,12 +41,15 @@ odo url create <component name>
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
 
 		var cmp string
 		switch len(args) {
 		case 0:
 			var err error
-			cmp, err = component.GetCurrent(client)
+			cmp, err = component.GetCurrent(client, applicationName, projectName)
 			checkError(err, "")
 		case 1:
 			cmp = args[0]
@@ -55,7 +59,7 @@ odo url create <component name>
 		}
 
 		fmt.Printf("Adding URL to component: %v\n", cmp)
-		u, err := url.Create(client, cmp)
+		u, err := url.Create(client, cmp, applicationName)
 		checkError(err, "")
 		fmt.Printf("URL created for component: %v\n\n"+
 			"%v - %v\n", cmp, u.Name, url.GetUrlString(*u))

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -5,7 +5,6 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/application"
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
@@ -25,16 +24,10 @@ func Delete(client *occlient.Client, name string) error {
 }
 
 // Create creates a URL
-func Create(client *occlient.Client, cmp string) (*URL, error) {
+func Create(client *occlient.Client, componentName, applicationName string) (*URL, error) {
+	labels := componentlabels.GetLabels(componentName, applicationName, false)
 
-	app, err := application.GetCurrentOrGetAndSetDefault(client)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get current application")
-	}
-
-	labels := componentlabels.GetLabels(cmp, app, false)
-
-	route, err := client.CreateRoute(cmp, labels)
+	route, err := client.CreateRoute(componentName, labels)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create route")
 	}


### PR DESCRIPTION
This commit removes the application create logic from component
and url packages. Application is now only created at 2 places -
- when `ocdev application create` is called
- when `ocdev create` is called without creating a new application

This commit also refactors GetCurrentOrGetAndSetDefault() function
to GetCurrentOrGetCreateSetDefault() which now also creates the
default application if there is no current application set

Fix #350