### PR TITLE
temporary set target codecov coverage to 0%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,5 +4,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        # target: auto
+        # disable for now, we have only e2e tests
+        target: 0%
         base: auto 


### PR DESCRIPTION
Currently, we are not writing unit tests. 
Codecov check is failing for most PR, and it makes it hard to quickly see for what PR is Travis failing.


This will make sure that codecov check will be always green. We will enable this check again once we start requiring unit tests for every PR.