### PR TITLE
Don't automatically start build when component is created

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -83,22 +83,31 @@ A full list of component types that can be deployed is available using: 'odo com
 		if len(componentGit) != 0 {
 			err := component.CreateFromGit(client, componentName, componentType, componentGit, applicationName)
 			checkError(err, "")
+			fmt.Printf("Component '%s' was created.\n", componentName)
+			fmt.Printf("Triggering build from %s.\n\n", componentGit)
+			err = component.RebuildGit(client, componentName)
+			checkError(err, "")
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs(componentLocal)
 			checkError(err, "")
 			err = component.CreateFromDir(client, componentName, componentType, dir, applicationName)
 			checkError(err, "")
+			fmt.Printf("Component '%s' was created.\n", componentName)
+			fmt.Printf("To push source code to the component run 'odo push'\n")
 		} else {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs("./")
 			checkError(err, "")
 			err = component.CreateFromDir(client, componentName, componentType, dir, applicationName)
+			fmt.Printf("Component '%s' was created.\n", componentName)
+			fmt.Printf("To push source code to the component run 'odo push'\n")
 			checkError(err, "")
 		}
 		// after component is successfully created, set is as active
 		err = component.SetCurrent(client, componentName, applicationName, projectName)
 		checkError(err, "")
+		fmt.Printf("\nComponent '%s' is now set as active component.\n", componentName)
 	},
 }
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -36,19 +36,6 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 	if err != nil {
 		return errors.Wrapf(err, "unable to create git component %s", name)
 	}
-
-	fmt.Println("please wait, building component...")
-
-	//get the latest build name for following
-	buildName, err := client.GetLatestBuildName(name)
-	if err != nil {
-		return errors.Wrap(err, "unable to follow build logs")
-	}
-	err = client.FollowBuildLog(buildName)
-	if err != nil {
-		return errors.Wrap(err, "unable to follow build logs")
-	}
-
 	return nil
 }
 
@@ -67,12 +54,6 @@ func CreateFromDir(client *occlient.Client, name string, ctype string, dir strin
 		return err
 	}
 
-	fmt.Println("please wait, building component...")
-
-	err = client.StartBinaryBuild(name, dir)
-	if err != nil {
-		return err
-	}
 	return nil
 
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -545,15 +545,6 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 					},
 				},
 			},
-			Triggers: []buildv1.BuildTriggerPolicy{
-				{
-					Type: "ConfigChange",
-				},
-				{
-					Type:        "ImageChange",
-					ImageChange: &buildv1.ImageChangeTrigger{},
-				},
-			},
 		},
 	}
 	_, err = c.buildClient.BuildConfigs(c.namespace).Create(&bc)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -142,6 +142,7 @@ var _ = Describe("odo", func() {
 
 				// TODO: add tests for --git
 				runCmd("odo create nodejs --local " + tmpDir + "/nodejs-ex")
+				runCmd("odo push")
 			})
 
 			It("should be the get the component created as active component", func() {


### PR DESCRIPTION
fixes #327 

BuildConfig is created without any Triggers.
Build is started explicitly after component from git repo is created.
Build is NOT started if the component is created from a local directory.

Messages informing user what is happening was added.


How output looks like
local component:
```
▶ odo create wildfly
Component 'wildfly' was created.
To push source code to the component run 'odo push'

Component 'wildfly' is now set as active component.
```
git component:
```
▶ odo create nodejs --git https://github.com/openshift/nodejs-ex.git
Component 'nodejs' was created.
Triggering build from https://github.com/openshift/nodejs-ex.git.

Cloning "https://github.com/openshift/nodejs-ex.git" ...
	Commit:	93fc25fd35068aa311f4722e4d7e5187b06edd7b (Merge pull request #170 from dharmit/add-minishift-to-readme)
	Author:	Ben Parees <bparees@users.noreply.github.com>
	Date:	Tue Mar 6 13:34:31 2018 -0500
---> Installing application source ...
---> Installing all dependencies
....
....
....
Pushed 10/10 layers, 100% complete
Push successful

Component 'nodejs' is now set as active component.
```