### PR TITLE
Adds logrus to existing logging output (fmt.Println)

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/spf13/cobra"
 )

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/component"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ A full list of component types that can be deployed is available using: 'odo com
 
 		client := getOcClient()
 		if len(componentBinary) != 0 {
-			fmt.Printf("--binary is not implemented yet\n\n")
+			log.Error("--binary is not implemented yet\n\n")
 			cmd.Help()
 			os.Exit(1)
 		}
@@ -61,7 +60,7 @@ A full list of component types that can be deployed is available using: 'odo com
 		}
 
 		if len(componentBinary) != 0 {
-			fmt.Printf("--binary is not implemented yet\n\n")
+			log.Error("--binary is not implemented yet\n\n")
 			os.Exit(1)
 		}
 
@@ -70,7 +69,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			checkError(err, "")
 		}
 		if exists {
-			fmt.Printf("component with the name %s already exists in the current application\n", componentName)
+			log.Errorf("Component with the name %s already exists in the current application\n", componentName)
 			os.Exit(1)
 		}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (
@@ -35,7 +35,7 @@ var componentDeleteCmd = &cobra.Command{
 		checkError(err, "")
 
 		if !exists {
-			fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
+			log.Errorf("Component with the name %s does not exist in the current application\n", componentName)
 			os.Exit(1)
 		}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/component"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +20,7 @@ var componentListCmd = &cobra.Command{
 		checkError(err, "")
 
 		if len(components) == 0 {
-			fmt.Println("There are no components deployed.")
+			log.Error("There are no components deployed.")
 			return
 		}
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -40,8 +40,8 @@ var pushCmd = &cobra.Command{
 			componentName, err = component.GetCurrent(client)
 			checkError(err, "unable to get current component")
 			if componentName == "" {
-				fmt.Println("No component is set as active.")
-				fmt.Println("Use 'odo component set <component name> to set and existing component as active or call this command with component name as and argument.")
+				log.Error("No component is set as active.")
+				log.Error("Use 'odo component set <component name> to set and existing component as active or call this command with component name as and argument.")
 				os.Exit(1)
 			}
 		} else {
@@ -62,7 +62,7 @@ var pushCmd = &cobra.Command{
 			checkError(err, fmt.Sprintf("unable to parse source %s from component %s", sourcePath, componentName))
 
 			if u.Scheme != "" && u.Scheme != "file" {
-				fmt.Printf("Component %s has invalid source path %s", componentName, u.Scheme)
+				log.Errorf("Component %s has invalid source path %s", componentName, u.Scheme)
 				os.Exit(1)
 			}
 
@@ -72,7 +72,7 @@ var pushCmd = &cobra.Command{
 			// currently we don't support changing build type
 			// it doesn't make sense to use --dir with git build
 			if len(componentLocal) != 0 {
-				fmt.Println("unable to push local directory to component that uses git repository as source")
+				log.Error("unable to push local directory to component that uses git repository as source")
 				os.Exit(1)
 			}
 			err := component.RebuildGit(client, componentName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,9 +89,9 @@ func checkError(err error, context string) {
 	if err != nil {
 		log.Debugf("Error:\n%v", err)
 		if context == "" {
-			fmt.Println(errors.Cause(err))
+			log.Error(errors.Cause(err))
 		} else {
-			fmt.Println(context)
+			log.Error(context)
 		}
 
 		os.Exit(1)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
+
+	"github.com/redhat-developer/odo/pkg/component"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var updateCmd = &cobra.Command{
@@ -40,12 +42,12 @@ var updateCmd = &cobra.Command{
 		}
 
 		if checkFlag > 1 {
-			fmt.Println("The source can be either --binary or --local or --git")
+			log.Error("The source can be either --binary or --local or --git")
 			os.Exit(1)
 		}
 
 		if len(componentBinary) != 0 {
-			fmt.Printf("--binary is not implemented yet\n\n")
+			log.Error("--binary is not implemented yet\n\n")
 			os.Exit(1)
 		}
 

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -7,6 +7,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/url"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +51,7 @@ odo url create <component name>
 		case 1:
 			cmp = args[0]
 		default:
-			fmt.Println("unable to get component")
+			log.Error("unable to get component")
 			os.Exit(1)
 		}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,7 @@ var versionCmd = &cobra.Command{
 		if GlobalVerbose {
 			for _, v := range os.Environ() {
 				if strings.HasPrefix(v, "KUBECTL_") {
-					fmt.Println(v)
+					log.Debug(v)
 				}
 			}
 		}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -73,7 +73,7 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 		return errors.Wrapf(err, "unable to create git component %s", name)
 	}
 
-	fmt.Println("please wait, building component...")
+	log.Info("Please wait, building component...")
 
 	//get the latest build name for following
 	buildName, err := client.GetLatestBuildName(name)
@@ -119,7 +119,7 @@ func CreateFromDir(client *occlient.Client, name string, ctype string, dir strin
 		return err
 	}
 
-	fmt.Println("please wait, building component...")
+	log.Info("Please wait, building component...")
 
 	err = client.StartBinaryBuild(name, dir)
 	if err != nil {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -267,7 +267,7 @@ func (c *Client) runOcComamnd(command *OcCommand) ([]byte, error) {
 			defer stdin.Close()
 			_, err := io.WriteString(stdin, *command.data)
 			if err != nil {
-				fmt.Printf("can't write to stdin %v\n", err)
+				log.Errorf("Cannot write to stdin %v\n", err)
 			}
 		}()
 	}


### PR DESCRIPTION
Changes the fmt.Println output to either Info or Error in each
corresponding file, using logrus as the consistent logger outputter
throughout odo.

Closes https://github.com/redhat-developer/odo/issues/364<Paste>