### PR TITLE
rename ocdev to odo on comments and warning messages

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -65,7 +65,7 @@ A full list of component types that can be deployed is available using: 'odo com
 		exists, err := catalog.Exists(client, componentType)
 		checkError(err, "")
 		if !exists {
-			fmt.Printf("Invalid component type: %v\nRun 'ocdev catalog list' to see a list of supported components\n", componentType)
+			fmt.Printf("Invalid component type: %v\nRun 'odo catalog list' to see a list of supported components\n", componentType)
 			os.Exit(1)
 		}
 

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -25,10 +25,10 @@ printed to STDOUT.
 `,
 	Example: `
   # Link current component to a component 'mariadb'
-  ocdev link mariadb
+  odo link mariadb
 
   # Link 'mariadb' component to 'nodejs' component
-  ocdev link mariadb --component nodejs`,
+  odo link mariadb --component nodejs`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -41,7 +41,7 @@ var watchCmd = &cobra.Command{
 			checkError(err, "")
 			if componentName == "" {
 				fmt.Println("No component is set as active.")
-				fmt.Println("Use 'ocdev component set <component name> to set and existing component as active or call this command with component name as and argument.")
+				fmt.Println("Use 'odo component set <component name> to set and existing component as active or call this command with component name as and argument.")
 				os.Exit(1)
 			}
 		} else {


### PR DESCRIPTION
this will rename `ocdev`  to `odo` on comments and messages