### PR TITLE
Decrease sync delay in watch to 1s.

### DIFF
--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -164,7 +164,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 		return fmt.Errorf("error watching source path %s: %v", dir, err)
 	}
 
-	delay := 5 * time.Second
+	delay := 1 * time.Second
 	ticker := time.NewTicker(delay)
 	showWaitingMessage := true
 	defer ticker.Stop()


### PR DESCRIPTION
This decreases the delay between detecting file change and sync to 1 second.

There has to be at least some small delay between file change and triggering a sync.
One file edit actually triggers multiple fs events (WRITE, and multiple CHMODs), with no delay this triggers rsync multiple times. So there has to be at least some small delay 1 second is bearly noticeable by the user.
