### PR TITLE
Namespace each component

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -98,7 +98,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			checkError(err, "")
 			fmt.Printf("Component '%s' was created.\n", componentName)
 			fmt.Printf("Triggering build from %s.\n\n", componentGit)
-			err = component.RebuildGit(client, componentName)
+			err = component.RebuildGit(client, componentName, applicationName)
 			checkError(err, "")
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
@@ -123,7 +123,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			err = component.CreateFromPath(client, componentName, componentType, path, applicationName, "binary")
 			checkError(err, "")
 
-			err = component.PushLocal(client, componentName, path, true)
+			err = component.PushLocal(client, componentName, applicationName, path, true)
 			checkError(err, fmt.Sprintf("failed to push component: %v", componentName))
 
 			fmt.Printf("Component '%s' was created.\n", componentName)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -59,7 +59,7 @@ var pushCmd = &cobra.Command{
 				fmt.Println("unable to push local directory to component that uses git repository as source")
 				os.Exit(1)
 			}
-			err := component.RebuildGit(client, componentName)
+			err := component.RebuildGit(client, componentName, applicationName)
 			checkError(err, fmt.Sprintf("failed to push component: %v", componentName))
 		} else if sourceType == "binary" || sourceType == "local" {
 			// use value of '--dir' as source if it was used
@@ -79,10 +79,10 @@ var pushCmd = &cobra.Command{
 			}
 
 			if sourceType == "local" {
-				err = component.PushLocal(client, componentName, u.Path, false)
+				err = component.PushLocal(client, componentName, applicationName, u.Path, false)
 				checkError(err, fmt.Sprintf("failed to push component: %v", componentName))
 			} else if sourceType == "binary" {
-				err = component.PushLocal(client, componentName, u.Path, true)
+				err = component.PushLocal(client, componentName, applicationName, u.Path, true)
 				checkError(err, fmt.Sprintf("failed to push component: %v", componentName))
 			}
 		}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -54,7 +54,7 @@ var storageDeleteCmd = &cobra.Command{
 		projectName := project.GetCurrent(client)
 		componentName := getComponent(client, storageComponent, applicationName, projectName)
 
-		err = storage.Remove(client, storageName, applicationName, componentName)
+		err = storage.Remove(client, storageName, componentName, applicationName)
 		checkError(err, "failed to delete storage")
 
 		switch storageName {
@@ -77,7 +77,7 @@ var storageListCmd = &cobra.Command{
 		projectName := project.GetCurrent(client)
 		componentName := getComponent(client, storageComponent, applicationName, projectName)
 
-		storageList, err := storage.List(client, applicationName, componentName)
+		storageList, err := storage.List(client, componentName, applicationName)
 		checkError(err, "Failed to list storage")
 
 		if len(storageList) == 0 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -83,20 +83,20 @@ var updateCmd = &cobra.Command{
 		}
 
 		if len(componentGit) != 0 {
-			err := component.Update(client, componentName, "git", componentGit)
+			err := component.Update(client, componentName, applicationName, "git", componentGit)
 			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs(componentLocal)
 			checkError(err, "")
-			err = component.Update(client, componentName, "local", dir)
+			err = component.Update(client, componentName, applicationName, "local", dir)
 			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else if len(componentBinary) != 0 {
 			path, err := filepath.Abs(componentBinary)
 			checkError(err, "")
-			err = component.Update(client, componentName, "binary", path)
+			err = component.Update(client, componentName, applicationName, "binary", path)
 			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -29,7 +29,7 @@ func printDeleteAppInfo(client *occlient.Client, appName string, currentProject 
 		}
 
 		for _, store := range appStore {
-			fmt.Println("  This Component uses storage", store.Name, "of size", store.Size, "will be removed")
+			fmt.Println("  This component uses storage", store.Name, "of size", store.Size, "will be removed")
 		}
 
 	}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	"github.com/redhat-developer/odo/pkg/application/labels"
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/project"
@@ -64,7 +64,7 @@ func List(client *occlient.Client) ([]config.ApplicationInfo, error) {
 	}
 
 	// Get applications from cluster
-	appNames, err := client.GetLabelValues(project, applabels.ApplicationLabel, applabels.ApplicationLabel)
+	appNames, err := client.GetLabelValues(project, labels.ApplicationLabel, labels.ApplicationLabel)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list applications")
 	}
@@ -94,7 +94,7 @@ func List(client *occlient.Client) ([]config.ApplicationInfo, error) {
 func Delete(client *occlient.Client, name string) error {
 	log.Debug("Deleting application %s", name)
 
-	labels := applabels.GetLabels(name, false)
+	labels := labels.GetLabels(name, false)
 
 	// delete application from cluster
 	output, err := client.Delete("all", "", labels)

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	"github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/util"
 
@@ -84,7 +84,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 	targetPodPath := "/opt/app-root/src"
 
 	// Find DeploymentConfig for component
-	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentLabels := labels.GetLabels(componentName, applicationName, false)
 	componentSelector := util.ConvertLabelsToSelector(componentLabels)
 	dc, err := client.GetOneDeploymentConfigFromSelector(componentSelector)
 	if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -52,7 +52,7 @@ func Create(client *occlient.Client, name string, size string, path string, comp
 
 // Remove removes storage from given component of the given application.
 // If no storage name is provided, all storage for the given component is removed
-func Remove(client *occlient.Client, name string, applicationName string, componentName string) error {
+func Remove(client *occlient.Client, name string, componentName string, applicationName string) error {
 
 	// Get DeploymentConfig for the given component
 	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
@@ -90,7 +90,8 @@ func Remove(client *occlient.Client, name string, applicationName string, compon
 
 // List lists all the storage associated with the given component of the given
 // application
-func List(client *occlient.Client, applicationName string, componentName string) ([]StorageInfo, error) {
+func List(client *occlient.Client, componentName string, applicationName string) ([]StorageInfo, error) {
+
 	labels := storagelabels.GetLabels("", componentName, applicationName, false)
 	selector := util.ConvertLabelsToSelector(labels)
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -40,4 +41,21 @@ func GenerateRandomString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Hyphenate applicationName and componentName
+func NamespaceOpenShiftObject(componentName string, applicationName string) (string, error) {
+
+	// Error if it's blank
+	if componentName == "" {
+		return "", errors.New("namespacing: component name cannot be blank")
+	}
+
+	// Error if it's blank
+	if applicationName == "" {
+		return "", errors.New("namespacing: application name cannot be blank")
+	}
+
+	// Return the hyphenated namespaced name
+	return fmt.Sprintf("%s-%s", applicationName, componentName), nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,17 @@
+package util
+
+import "testing"
+
+func TestNamespaceOpenShiftObject(t *testing.T) {
+
+	name, err := NamespaceOpenShiftObject("bar", "foo")
+	if err != nil {
+		t.Fatalf("Error with namespacing: %s", err)
+	}
+
+	if name != "foo-bar" {
+		t.Error("Expected foo-bar")
+		t.Errorf("Actual output: %s", name)
+	}
+
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -234,7 +234,7 @@ var _ = Describe("odo", func() {
 			It("should push the changes", func() {
 
 				// Get IP and port
-				getIP := runCmd("oc get svc nodejs -o go-template='{{.spec.clusterIP}}:{{(index .spec.ports 0).port}}'")
+				getIP := runCmd("oc get svc/usecase5-nodejs -o go-template='{{.spec.clusterIP}}:{{(index .spec.ports 0).port}}'")
 				pingUrl := fmt.Sprintf("http://%s", getIP)
 				pingSvc(pingUrl)
 
@@ -281,14 +281,14 @@ var _ = Describe("odo", func() {
 				Expect(storAdd).To(ContainSubstring("nodejs"))
 
 				// Check against path and name against dc
-				getDc := runCmd("oc get dc/nodejs -o go-template='" +
+				getDc := runCmd("oc get dc/usecase5-nodejs -o go-template='" +
 					"{{range .spec.template.spec.containers}}" +
 					"{{range .volumeMounts}}{{.name}}{{end}}{{end}}'")
 
 				Expect(getDc).To(ContainSubstring("pv1"))
 
 				// Check if the storage is added on the path provided
-				getMntPath := runCmd("oc get dc/nodejs -o go-template='" +
+				getMntPath := runCmd("oc get dc/usecase5-nodejs -o go-template='" +
 					"{{range .spec.template.spec.containers}}" +
 					"{{range .volumeMounts}}{{.mountPath}}{{end}}{{end}}'")
 
@@ -315,14 +315,14 @@ var _ = Describe("odo", func() {
 				Expect(storList).To(ContainSubstring("pv2"))
 
 				// Verify with deploymentconfig
-				getDc := runCmd("oc get dc/php -o go-template='" +
+				getDc := runCmd("oc get dc/usecase5-php -o go-template='" +
 					"{{range .spec.template.spec.containers}}" +
 					"{{range .volumeMounts}}{{.name}}{{end}}{{end}}'")
 
 				Expect(getDc).To(ContainSubstring("pv2"))
 
 				// Check if the storage is added on the path provided
-				getMntPath := runCmd("oc get dc/php -o go-template='" +
+				getMntPath := runCmd("oc get dc/usecase5-php -o go-template='" +
 					"{{range .spec.template.spec.containers}}" +
 					"{{range .volumeMounts}}{{.mountPath}}{{end}}{{end}}'")
 


### PR DESCRIPTION
This commit adds namespacing to each component when deployed.

For example:

```
odo create nodejs
```

With the application "nodeapp"

Will be deployed (within OpenShift) as: `nodeapp-nodejs`