### PR TITLE
Add support for creating component from service catalog

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/golang/glog"
+	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/project"
+	svc "github.com/redhat-developer/odo/pkg/service"
+	"github.com/spf13/cobra"
+)
+
+var serviceForceDeleteFlag bool
+
+// serviceCmd represents the service command
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Perform service catalog operations",
+	Long:  ` Perform service catalog operations, Limited to template service broker only.`,
+	Example: fmt.Sprintf("%s\n%s\n%s",
+		serviceCreateCmd.Example,
+		serviceDeleteCmd.Example,
+		serviceListCmd.Example),
+	Args: cobra.RangeArgs(1, 3),
+}
+
+var serviceCreateCmd = &cobra.Command{
+	Use:   "create <service_type> [service_name]",
+	Short: "Create a new service",
+	Long: `Create a new service from service catalog to deploy on OpenShift.
+
+If service name is not provided, service type value will be used.
+
+A full list of service types that can be deployed is available using: 'odo service catalog'`,
+	Example: `  # Create new mysql-persistent service from service catalog.
+  odo service create mysql-persistent
+	`,
+	Args: cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+		applicationName, err := application.GetCurrentOrGetCreateSetDefault(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
+		serviceType := args[0]
+		exists, err := svc.SvcTypeExists(client, serviceType)
+		checkError(err, "unable to create service because Service Catalog is not enabled in your cluster")
+		if !exists {
+			fmt.Printf("Service %v doesn't exist\nRun 'odo service catalog' to see a list of supported services.\n", serviceType)
+			os.Exit(1)
+		}
+		// if only one arg is given, then it is considered as service name and service type both
+		serviceName := args[0]
+		// if two args are given, first is service type and second one is service name
+		if len(args) == 2 {
+			serviceName = args[1]
+		}
+		//validate service name
+		err = validateName(serviceName)
+		checkError(err, "")
+		exists, err = svc.SvcExists(client, serviceName, applicationName, projectName)
+		checkError(err, "")
+		if exists {
+			fmt.Printf("Service with the name %s already exists in the current application.\n", serviceName)
+			os.Exit(1)
+		}
+		err = svc.CreateService(client, serviceName, serviceType, applicationName)
+		checkError(err, "")
+		fmt.Printf("Service '%s' was created.\n", serviceName)
+	},
+}
+
+var serviceDeleteCmd = &cobra.Command{
+	Use:   "delete <service_name>",
+	Short: "Delete an existing service",
+	Long:  "Delete an existing service",
+	Example: `  # Delete service named 'mysql-persistent'
+  odo service delete mysql-persistent
+	`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		glog.V(4).Infof("service delete called")
+		glog.V(4).Infof("args: %#v", strings.Join(args, " "))
+		client := getOcClient()
+
+		// Get all necessary names (current application + project)
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
+		serviceName := args[0]
+
+		// Checks to see if the service actually exists
+		exists, err := svc.SvcExists(client, serviceName, applicationName, projectName)
+		checkError(err, "unable to delete service because Service Catalog is not enabled in your cluster")
+		if !exists {
+			fmt.Printf("Service with the name %s does not exist in the current application\n", serviceName)
+			os.Exit(1)
+		}
+
+		var confirmDeletion string
+		if serviceForceDeleteFlag {
+			confirmDeletion = "y"
+		} else {
+			fmt.Printf("Are you sure you want to delete %v from %v? [y/N] ", serviceName, applicationName)
+			fmt.Scanln(&confirmDeletion)
+		}
+
+		if strings.ToLower(confirmDeletion) == "y" {
+			err := svc.DeleteService(client, serviceName, applicationName, projectName)
+			checkError(err, "")
+			fmt.Printf("Service %s from application %s has been deleted\n", serviceName, applicationName)
+
+		} else {
+			fmt.Printf("Aborting deletion of service: %v\n", serviceName)
+		}
+	},
+}
+
+//var serviceCatalogCmd = &cobra.Command{
+//	Use:   "catalog",
+//	Short: "Lists all the services from service catalog",
+//	Long:  "Lists all the services from service catalog",
+//	Example: `  # List all services
+//  odo service catalog
+//	`,
+//	Args: cobra.ExactArgs(0),
+//	Run: func(cmd *cobra.Command, args []string) {
+//		client := getOcClient()
+//		catalogList, err := svc.ListCatalog(client)
+//		checkError(err, "unable to list services because Service Catalog is not enabled in your cluster")
+//		switch len(catalogList) {
+//		case 0:
+//			fmt.Printf("No deployable services found\n")
+//		default:
+//			fmt.Println("The following services can be deployed:")
+//			for _, service := range catalogList {
+//				fmt.Printf("- %v\n", service)
+//			}
+//		}
+//	},
+//}
+
+var serviceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all services in the current application",
+	Long:  "List all services in the current application",
+	Example: `  # List all services in the application
+  odo service list
+	`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
+		services, err := svc.List(client, applicationName, projectName)
+		checkError(err, "Service Catalog is not enabled in your cluster")
+
+		if len(services) == 0 {
+			fmt.Println("There are no services deployed for this application")
+			return
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "STATUS")
+		for _, comp := range services {
+			fmt.Fprintln(w, comp.Name, "\t", comp.Type, "\t", comp.Status)
+		}
+		w.Flush()
+	},
+}
+
+func init() {
+	serviceDeleteCmd.Flags().BoolVarP(&serviceForceDeleteFlag, "force", "f", false, "Delete service without prompting")
+
+	// Add a defined annotation in order to appear in the help menu
+	serviceCmd.Annotations = map[string]string{"command": "other"}
+	serviceCmd.SetUsageTemplate(cmdUsageTemplate)
+	serviceCmd.AddCommand(serviceCreateCmd)
+	serviceCmd.AddCommand(serviceDeleteCmd)
+	//serviceCmd.AddCommand(serviceCatalogCmd)
+	serviceCmd.AddCommand(serviceListCmd)
+	rootCmd.AddCommand(serviceCmd)
+}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -118,30 +118,6 @@ var serviceDeleteCmd = &cobra.Command{
 	},
 }
 
-//var serviceCatalogCmd = &cobra.Command{
-//	Use:   "catalog",
-//	Short: "Lists all the services from service catalog",
-//	Long:  "Lists all the services from service catalog",
-//	Example: `  # List all services
-//  odo service catalog
-//	`,
-//	Args: cobra.ExactArgs(0),
-//	Run: func(cmd *cobra.Command, args []string) {
-//		client := getOcClient()
-//		catalogList, err := svc.ListCatalog(client)
-//		checkError(err, "unable to list services because Service Catalog is not enabled in your cluster")
-//		switch len(catalogList) {
-//		case 0:
-//			fmt.Printf("No deployable services found\n")
-//		default:
-//			fmt.Println("The following services can be deployed:")
-//			for _, service := range catalogList {
-//				fmt.Printf("- %v\n", service)
-//			}
-//		}
-//	},
-//}
-
 var serviceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all services in the current application",

--- a/pkg/occlient/fakeclient.go
+++ b/pkg/occlient/fakeclient.go
@@ -1,6 +1,7 @@
 package occlient
 
 import (
+	fakeServiceCatalogClientSet "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
 	fakeAppsClientset "github.com/openshift/client-go/apps/clientset/versioned/fake"
 	fakeBuildClientset "github.com/openshift/client-go/build/clientset/versioned/fake"
 	fakeImageClientset "github.com/openshift/client-go/image/clientset/versioned/fake"
@@ -12,12 +13,13 @@ import (
 // FakeClientSet holds fake ClientSets
 // this is returned by FakeNew to access methods of fake client sets
 type FakeClientset struct {
-	Kubernetes     *fakeKubeClientset.Clientset
-	AppsClientset  *fakeAppsClientset.Clientset
-	BuildClientset *fakeBuildClientset.Clientset
-	ImageClientset *fakeImageClientset.Clientset
-	RouteClientset *fakeRouteClientset.Clientset
-	ProjClientset  *fakeProjClientset.Clientset
+	Kubernetes              *fakeKubeClientset.Clientset
+	AppsClientset           *fakeAppsClientset.Clientset
+	BuildClientset          *fakeBuildClientset.Clientset
+	ImageClientset          *fakeImageClientset.Clientset
+	RouteClientset          *fakeRouteClientset.Clientset
+	ProjClientset           *fakeProjClientset.Clientset
+	ServiceCatalogClientSet *fakeServiceCatalogClientSet.Clientset
 }
 
 // FakeNew creates new fake client for testing
@@ -47,6 +49,9 @@ func FakeNew() (*Client, *FakeClientset) {
 
 	fkclientset.BuildClientset = fakeBuildClientset.NewSimpleClientset()
 	client.buildClient = fkclientset.BuildClientset.Build()
+
+	fkclientset.ServiceCatalogClientSet = fakeServiceCatalogClientSet.NewSimpleClientset()
+	client.serviceCatalogClient = fkclientset.ServiceCatalogClientSet.Servicecatalog()
 
 	return &client, &fkclientset
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1223,8 +1223,7 @@ func (c *Client) GetBuildConfigFromName(name string, project string) (*buildv1.B
 
 // GetClusterServiceClasses queries the service service catalog to get available clusterServiceClasses
 func (c *Client) GetClusterServiceClasses() ([]scv1beta1.ClusterServiceClass, error) {
-	// TODO: Remove `FieldSelector` from ListOptions when we are confident with Ansible Service Broker
-	classList, err := c.serviceCatalogClient.ClusterServiceClasses().List(metav1.ListOptions{FieldSelector: "spec.clusterServiceBrokerName=template-service-broker"})
+	classList, err := c.serviceCatalogClient.ClusterServiceClasses().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list cluster service classes")
 	}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1155,16 +1155,16 @@ func (c *Client) DeleteServiceInstance(labels map[string]string) error {
 	// Service Instance
 	glog.V(4).Infof("Deleting Service Instance")
 	// Listing out serviceInstance because `DeleteCollection` method don't work on serviceInstance
-	svcCatList, err := c.serviceCatalogClient.ServiceInstances(c.namespace).List(metav1.ListOptions{LabelSelector: selector})
+	svcCatList, err := c.GetServiceInstanceList(c.namespace, selector)
 	if err != nil {
 		return errors.Wrap(err, "unable to list service instance")
 	}
 
 	// Iterating over serviceInstance List and deleting one by one
-	for _, svc := range svcCatList.Items {
+	for _, svc := range svcCatList {
 		err = c.serviceCatalogClient.ServiceInstances(c.namespace).Delete(svc.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			return errors.Wrap(err, "unable to delete serviceInstace")
+			return errors.Wrap(err, "unable to delete serviceInstance")
 		}
 	}
 
@@ -1201,9 +1201,9 @@ func (c *Client) GetLabelValues(project string, label string, selector string) (
 }
 
 // GetServiceInstanceList returns list service instances
-func (c *Client) GetServiceInstanceList(project string, selector string) ([]scv1beta1.ServiceInstance, error) {
+func (c *Client) GetServiceInstanceList(namespace string, selector string) ([]scv1beta1.ServiceInstance, error) {
 	// List ServiceInstance according to given selectors
-	svcList, err := c.serviceCatalogClient.ServiceInstances(project).List(metav1.ListOptions{LabelSelector: selector})
+	svcList, err := c.serviceCatalogClient.ServiceInstances(namespace).List(metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list ServiceInstances")
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2583,7 +2583,7 @@ func TestCreateServiceInstance(t *testing.T) {
 			if !reflect.DeepEqual(createdServiceInstance.Labels, tt.args.labels) {
 				t.Errorf("labels in created serviceInstance is not matching expected labels, expected: %v, got: %v", tt.args.labels, createdServiceInstance.Labels)
 			}
-			if !reflect.DeepEqual(createdServiceInstance.Name, tt.args.componentName) {
+			if createdServiceInstance.Name != tt.args.componentName {
 				t.Errorf("labels in created serviceInstance is not matching expected labels, expected: %v, got: %v", tt.args.componentName, createdServiceInstance.Name)
 			}
 			if !reflect.DeepEqual(createdServiceInstance.Spec.ClusterServiceClassExternalName, tt.args.componentType) {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"github.com/pkg/errors"
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/util"
+)
+
+// ServiceInfo holds all important information about one service
+type ServiceInfo struct {
+	Name   string
+	Type   string
+	Status string
+}
+
+// ListCatalog lists all the available service types
+func ListCatalog(client *occlient.Client) ([]string, error) {
+
+	clusterServiceClasses, err := client.GetClusterServiceClassExternalNames()
+	if err != nil {
+		return []string{}, errors.Wrapf(err, "unable to get cluster serviceClassExternalName")
+	}
+
+	return clusterServiceClasses, nil
+}
+
+// CreateService creates new service from serviceCatalog
+func CreateService(client *occlient.Client, serviceName string, serviceType string, applicationName string) error {
+	labels := componentlabels.GetLabels(serviceName, applicationName, true)
+	// save service type as label
+	labels[componentlabels.ComponentTypeLabel] = serviceType
+	err := client.CreateServiceInstance(serviceName, serviceType, labels)
+	if err != nil {
+		return errors.Wrap(err, "unable to create service instance")
+
+	}
+	return nil
+}
+
+// DeleteService will delete the service with the provided `name`
+func DeleteService(client *occlient.Client, name string, applicationName string, projectName string) error {
+
+	labels := componentlabels.GetLabels(name, applicationName, false)
+	err := client.DeleteServiceInstance(labels)
+	if err != nil {
+		return errors.Wrapf(err, "unable to retrieve list of services")
+	}
+	return nil
+
+}
+
+// List lists all the deployed services
+func List(client *occlient.Client, applicationName string, projectName string) ([]ServiceInfo, error) {
+	labels := map[string]string{
+		applabels.ApplicationLabel: applicationName,
+	}
+	//since, service is associated with application, it consist of application label as well
+	// which we can give as a selector
+	applicationSelector := util.ConvertLabelsToSelector(labels)
+	// get service instance list based on given selector
+	serviceInstanceList, err := client.GetServiceInstanceList(projectName, applicationSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to list services")
+	}
+
+	var services []ServiceInfo
+	// Iterate through serviceInstanceList and add to service
+	for _, elem := range serviceInstanceList {
+		services = append(services, ServiceInfo{Name: elem.Labels[componentlabels.ComponentLabel], Type: elem.Labels[componentlabels.ComponentTypeLabel], Status: elem.Status.Conditions[0].Reason})
+	}
+
+	return services, nil
+}
+
+// SvcTypeExists returns true if the given service type is valid, false if not
+func SvcTypeExists(client *occlient.Client, serviceType string) (bool, error) {
+	catalogList, err := ListCatalog(client)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to list catalog")
+	}
+
+	for _, supported := range catalogList {
+		if serviceType == supported {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// SvcExists Checks whether a service with the given name exists in the current application or not
+// serviceName is the service name to perform check for
+// The first returned parameter is a bool indicating if a service with the given name already exists or not
+// The second returned parameter is the error that might occurs while execution
+func SvcExists(client *occlient.Client, serviceName, applicationName, projectName string) (bool, error) {
+
+	serviceList, err := List(client, applicationName, projectName)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to get the service list")
+	}
+	for _, service := range serviceList {
+		if service.Name == serviceName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -6,6 +6,7 @@ import (
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/util"
+	"strings"
 )
 
 // ServiceInfo holds all important information about one service
@@ -24,6 +25,24 @@ func ListCatalog(client *occlient.Client) ([]string, error) {
 	}
 
 	return clusterServiceClasses, nil
+}
+
+// Search searches for the services
+func Search(client *occlient.Client, name string) ([]string, error) {
+	var result []string
+	serviceList, err := ListCatalog(client)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list services")
+	}
+
+	// do a partial search in all the services
+	for _, service := range serviceList {
+		if strings.Contains(service, name) {
+			result = append(result, service)
+		}
+	}
+
+	return result, nil
 }
 
 // CreateService creates new service from serviceCatalog

--- a/tests/e2e/demo_test.go
+++ b/tests/e2e/demo_test.go
@@ -38,7 +38,7 @@ var _ = Describe("katacodaDemo", func() {
 
 	Context("odo component creation", func() {
 		It("should list the components in the catalog", func() {
-			getProj := runCmd("odo catalog list")
+			getProj := runCmd("odo catalog list components")
 			Expect(getProj).To(ContainSubstring("wildfly"))
 			Expect(getProj).To(ContainSubstring("ruby"))
 		})


### PR DESCRIPTION
Fixes #266

Signed-off-by: Suraj Narwade <surajnarwade353@gmail.com>

This PR adds the support for creating services from service catalog. for this support, we have used
client from [kubernetes-incubator/service-catalog](https://github.com/kubernetes-incubator/service-catalog).
Currently, we are supporting template service broker only. In future, we will add support for
other brokers as well.

We have added entire new command set for this purpose.

* to check available services in service catalog

```
$ odo service catalog
```

* to create service,

```
$ odo service create mysql-persistent
```

* to delete service,

```
$ odo service delete mysql-persistent
```

* to list the current provisioned services with their status

```
$ odo service list
```