### PR TITLE
Added consistency in commands for project, application & components

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -22,8 +22,21 @@ var applicationCmd = &cobra.Command{
 	Use:     "app",
 	Short:   "Perform application operations",
 	Aliases: []string{"application"},
-	// 'odo application' is the same as 'odo application get'
-	Run: applicationGetCmd.Run,
+	Example: `  # Get current application,
+  odo app 
+  
+  # Set webapp to current application,
+  odo app webapp
+	`,
+	// 'odo app' is the same as 'odo app get'
+	// 'odo app <application_name>' is the same as 'odo app set <application_name>'
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 && args[0] != "get" && args[0] != "set" {
+			applicationSetCmd.Run(cmd, args)
+		} else {
+			applicationGetCmd.Run(cmd, args)
+		}
+	},
 }
 
 var applicationCreateCmd = &cobra.Command{

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,20 +2,27 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/project"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // componentCmd represents the component command
 var componentCmd = &cobra.Command{
 	Use:   "component",
-	Short: "Components of an application",
+	Short: "Components of application.",
+	Example: `  # Get current component,
+  odo component 
+
+  # Set nodejs to current component,
+  odo component nodejs
+	`,
 	// 'odo component' is the same as 'odo component get'
+	// 'odo component <component_name>' is the same as 'odo component set <component_name>'
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 && args[0] != "get" && args[0] != "set" {
 			componentSetCmd.Run(cmd, args)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (
@@ -15,7 +15,21 @@ var (
 var projectCmd = &cobra.Command{
 	Use:   "project [options]",
 	Short: "Perform project operations",
-	Run:   projectGetCmd.Run,
+	Example: `  # Get current project,
+  odo project 
+  
+  # Set myproject to current project,
+  odo project myproject
+	`,
+	// 'odo project' is the same as 'odo project get'
+	// 'odo project <project_name>' is the same as 'odo project set <project_name>'
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 && args[0] != "get" && args[0] != "set" {
+			projectSetCmd.Run(cmd, args)
+		} else {
+			projectGetCmd.Run(cmd, args)
+		}
+	},
 }
 
 var projectSetCmd = &cobra.Command{
@@ -42,7 +56,7 @@ var projectSetCmd = &cobra.Command{
 			if current == projectName {
 				fmt.Printf("Already on project : %v\n", projectName)
 			} else {
-				fmt.Printf("Now using project : %v\n", projectName)
+				fmt.Printf("Switched to project : %v\n", projectName)
 			}
 		}
 	},

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -42,15 +42,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/retry"
-
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/version"
 )
 
 const (


### PR DESCRIPTION
Fixes #274

Now,

```
odo project xyz

odo component abc

odo application pqr
```

they will work same as `set` operation.