### PR TITLE
Adds DeploymentConfig log functionality to Odo

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/project"
+	"github.com/spf13/cobra"
+)
+
+var logCmd = &cobra.Command{
+	Use:   "log [component_name]",
+	Short: "Retrieve the log for the given component.",
+	Long:  `Retrieve the log for the given component.`,
+	Example: `  # Get the logs for the nodejs component,
+  odo log nodejs
+	`,
+	Args: cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// Retrieve stdout / io.Writer
+		stdout := os.Stdout
+
+		// Retrieve the client
+		client := getOcClient()
+
+		// Application
+		currentApplication, err := application.GetCurrent(client)
+		checkError(err, "")
+
+		// Project
+		currentProject := project.GetCurrent(client)
+
+		var argComponent string
+
+		if len(args) == 1 {
+			argComponent = args[0]
+		}
+
+		// Retrieve and set the currentComponent
+		currentComponent := getComponent(client, argComponent, currentApplication, currentProject)
+
+		err = component.GetLogs(client, currentComponent, stdout)
+		checkError(err, "Unable to retrieve logs, does your component exist?")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(logCmd)
+
+}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -446,3 +446,15 @@ func GetComponentDesc(client *occlient.Client, currentComponent string, currentA
 
 	return componentType, path, componentURL, appStore, nil
 }
+
+// Get Component logs
+func GetLogs(client *occlient.Client, applicationName string, stdout io.Writer) error {
+
+	// Retrieve the logs
+	err := client.DisplayDeploymentConfigLog(applicationName, stdout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -226,6 +226,12 @@ var _ = Describe("odoe2e", func() {
 				cmpSet := runCmd("odo component set nodejs")
 				Expect(cmpSet).To(ContainSubstring("nodejs"))
 			})
+
+			It("should be able to retrieve logs", func() {
+				runCmd("odo log")
+				runCmd("odo log nodejs")
+			})
+
 		})
 	})
 


### PR DESCRIPTION
This adds a new command `odo log` which will display the
DeploymentConfig logs for that particular component.

For example:

```sh
github.com/redhat-developer/odo  add-logs ✔                                                                                                                                                                                                                                                                                                                         15h55m
▶ ./odo list
ACTIVE     NAME        TYPE
*          nodejs3     nodejs

github.com/redhat-developer/odo  add-logs ✔                                                                                                                                                                                                                                                                                                                         15h57m
▶ ./odo log
Environment:
        DEV_MODE=false
        NODE_ENV=production
        DEBUG_PORT=5858
Launching via npm...
npm info it worked if it ends with ok
npm info using npm@3.10.9
npm info using node@v6.11.3
npm info lifecycle nodejs-ex@0.0.1~prestart: nodejs-ex@0.0.1
npm info lifecycle nodejs-ex@0.0.1~start: nodejs-ex@0.0.1

> nodejs-ex@0.0.1 start /opt/app-root/src
> node server.js

Server running on http://0.0.0.0:8080
```