### PR TITLE
Added validation for component and application name

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -33,9 +33,12 @@ var applicationCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Args validation makes sure that there is exactly one argument
 		name := args[0]
+		// validate application name
+		err := validateName(name)
+		checkError(err, "")
 		client := getOcClient()
 		fmt.Printf("Creating application: %v\n", name)
-		err := application.Create(client, name)
+		err = application.Create(client, name)
 		checkError(err, "")
 		err = application.SetCurrent(client, name)
 		checkError(err, "")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -85,7 +85,9 @@ A full list of component types that can be deployed is available using: 'odo com
 		if len(args) == 2 {
 			componentName = args[1]
 		}
-
+		//validate component name
+		err = validateName(componentName)
+		checkError(err, "")
 		exists, err = component.Exists(client, componentName, applicationName, projectName)
 		checkError(err, "")
 		if exists {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/storage"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // printDeleteAppInfo will print things which will be deleted
@@ -68,4 +70,18 @@ func printComponentInfo(currentComponentName string, componentType string, path 
 	for _, store := range appStore {
 		fmt.Println("This Component uses storage", store.Name, "of size", store.Size)
 	}
+}
+
+// validateName will do validation of application & component names
+// Criteria for valid name in kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+func validateName(name string) error {
+
+	errorList := validation.IsDNS1123Label(name)
+
+	if len(errorList) != 0 {
+		return errors.New(fmt.Sprintf("%s is not a valid name:  %s", name, strings.Join(errorList, " ")))
+	}
+
+	return nil
+
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import "testing"
+
+func Test_validateName(t *testing.T) {
+	type args struct {
+		name string
+	}
+
+	tests := []struct {
+		testCase string
+		name     string
+		wantErr  bool
+	}{
+		{
+			testCase: "Test case - 1",
+			name:     "app",
+			wantErr:  false,
+		},
+		{
+			testCase: "Test case - 2",
+			name:     "app123",
+			wantErr:  false,
+		},
+		{
+			testCase: "Test case - 3",
+			name:     "app-123",
+			wantErr:  false,
+		},
+		{
+			testCase: "Test case - 4",
+			name:     "app.123",
+			wantErr:  true,
+		},
+		{
+			testCase: "Test case - 5",
+			name:     "app_123",
+			wantErr:  true,
+		},
+		{
+			testCase: "Test case - 6",
+			name:     "App",
+			wantErr:  true,
+		},
+		{
+			testCase: "Test case - 7",
+			name:     "b7pdkva7ynxf8qoyuh02tbgu2ufcy4jq7udyom7it0g8gouc39x3gy0p1wrsbt6",
+			wantErr:  false,
+		},
+		{
+			testCase: "Test case - 8",
+			name:     "b7pdkva7ynxf8qoyuh02tbgu2ufcy4jq7udyom7it0g8gouc39x3gy0p1wrsbt6p",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Log("Running test", tt.testCase)
+		t.Run(tt.testCase, func(t *testing.T) {
+			if err := validateName(tt.name); (err != nil) != tt.wantErr {
+				t.Errorf("Expected error = %v, But got = %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #431

* Reference taken from Kubernetes: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L3296

* Kubernetes resource name criteria: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/