### PR TITLE
Adding tests for `odo create` with git source

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -219,12 +219,7 @@ var _ = Describe("odoe2e", func() {
 	Describe("creating a component", func() {
 		Context("when application exists", func() {
 			It("should create a component", func() {
-				runCmd("git clone https://github.com/openshift/nodejs-ex " +
-					tmpDir + "/nodejs-ex")
-
-				// TODO: add tests for --git
-				runCmd("odo create nodejs --local " + tmpDir + "/nodejs-ex")
-				runCmd("odo push")
+				runCmd("odo create nodejs --git https://github.com/openshift/nodejs-ex")
 			})
 
 			It("should be the get the component created as active component", func() {
@@ -297,6 +292,14 @@ var _ = Describe("odoe2e", func() {
 
 	Describe("pushing updates", func() {
 		Context("When push is made", func() {
+
+			It("should be able to update the source dir", func() {
+				runCmd("git clone https://github.com/openshift/nodejs-ex " +
+					tmpDir + "/nodejs-ex")
+
+				runCmd("odo update nodejs --local " + tmpDir + "/nodejs-ex")
+			})
+
 			It("should push the changes", func() {
 				// Switch to nodejs component
 				runCmd("odo component set nodejs")


### PR DESCRIPTION
Existing tests have been modified to use git source instead of local source