### PR TITLE
fix quickstart in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ $ minishift start
 $ git clone https://github.com/openshift/nodejs-ex
 $ cd nodejs-ex
 
+# Create new nodejs component
+$ odo create nodejs
+
 # Now let's deploy your application!
-$ odo create nodejs --local=.
+$ odo push
 
 # Last, we'll create a way to access the application
 $ odo url create


### PR DESCRIPTION
`odo push` has to be run to deploy the code.
`odo create` just creates component that is "empty"