### PR TITLE
Porting `Delete` function to client-go

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -65,9 +65,8 @@ var componentDeleteCmd = &cobra.Command{
 		}
 
 		if strings.ToLower(confirmDeletion) == "y" {
-			output, err := component.Delete(client, componentName, applicationName, projectName)
+			err := component.Delete(client, componentName, applicationName, projectName)
 			checkError(err, "")
-			log.Debug(output)
 			fmt.Printf("Component %s from application %s has been deleted\n", componentName, applicationName)
 
 			currentComponent, err := component.GetCurrent(client, applicationName, projectName)

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -97,11 +97,10 @@ func Delete(client *occlient.Client, name string) error {
 	labels := applabels.GetLabels(name, false)
 
 	// delete application from cluster
-	output, err := client.Delete("all,pvc", "", labels)
+	err := client.Delete(labels)
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete application %s", name)
 	}
-	log.Debug("deleted from cluster: \n", output)
 
 	// delete from config
 	cfg, err := config.New()
@@ -115,7 +114,6 @@ func Delete(client *occlient.Client, name string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete application %s", name)
 	}
-	log.Debug("deleted from config: \n", output)
 
 	return nil
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -83,24 +83,24 @@ func CreateFromPath(client *occlient.Client, name string, ctype string, path str
 }
 
 // Delete whole component
-func Delete(client *occlient.Client, name string, applicationName string, projectName string) (string, error) {
+func Delete(client *occlient.Client, name string, applicationName string, projectName string) error {
 
 	cfg, err := config.New()
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to create new configuration to delete %s", name)
+		return errors.Wrapf(err, "unable to create new configuration to delete %s", name)
 	}
 
 	labels := componentlabels.GetLabels(name, applicationName, false)
 
-	output, err := client.Delete("all,pvc", "", labels)
+	err = client.Delete(labels)
 	if err != nil {
-		return "", errors.Wrapf(err, "error deleting component %s", name)
+		return errors.Wrapf(err, "error deleting component %s", name)
 	}
 
 	// Get a list of all active components
 	components, err := List(client, applicationName, projectName)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to retrieve list of components")
+		return errors.Wrapf(err, "unable to retrieve list of components")
 	}
 
 	// We will *only* set a new component if either len(components) is zero, or the
@@ -112,18 +112,18 @@ func Delete(client *occlient.Client, name string, applicationName string, projec
 			err = cfg.SetActiveComponent(components[0].Name, applicationName, projectName)
 
 			if err != nil {
-				return "", errors.Wrapf(err, "unable to set current component to '%s'", name)
+				return errors.Wrapf(err, "unable to set current component to '%s'", name)
 			}
 		} else {
 			// Unset to blank
 			err = cfg.UnsetActiveComponent(applicationName, projectName)
 			if err != nil {
-				return "", errors.Wrapf(err, "error unsetting current component while deleting %s", name)
+				return errors.Wrapf(err, "error unsetting current component while deleting %s", name)
 			}
 		}
 	}
 
-	return output, nil
+	return nil
 }
 
 func SetCurrent(client *occlient.Client, name string, applicationName string, projectName string) error {


### PR DESCRIPTION
Partially fixes #444, This PR will port Delete function to client-go, so that it will remove dependency of `oc` binary
to client-go. so that it will remove dependency of oc binary.