### PR TITLE
Fixes the order of componentName and applicationName

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -439,7 +439,7 @@ func GetComponentDesc(client *occlient.Client, currentComponent string, currentA
 		return "", "", "", nil, errors.Wrap(err, "unable to get url list")
 	}
 	//Storage
-	appStore, err = storage.List(client, currentApplication, currentComponent)
+	appStore, err = storage.List(client, currentComponent, currentApplication)
 	if err != nil {
 		return "", "", "", nil, errors.Wrap(err, "unable to get storage list")
 	}


### PR DESCRIPTION
Signed-off-by: mik-dass mrinald7@gmail.com

This PR fixes the order of componentName and applicationName in component.go inside the GetComponentDesc func while calling storage.List()