### PR TITLE
enable macos install test and fix test-install.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,12 @@ jobs:
       script:
         ./scripts/test-install.sh
     # test installation script on macOS
-    # disabled after rename to odo, can be enabled after next release
-    # - state: test
-    #   os: osx
-    #   install:
-    #     - true
-    #   script:
-    #     ./scripts/install.sh
+    - state: test
+      os: osx
+      install:
+        - true
+      script:
+        ./scripts/install.sh
 
     - stage: deploy
       go_import_path:  github.com/redhat-developer/odo

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -32,6 +32,7 @@ if [ -n "$FAILED_INSTALL" ]; then
     echo "TEST FAILED!!"
     echo "Instalation script failed in following images:"
     echo "$FAILED_INSTALL"
+    exit 1
 else
     echo "ALL TESTS SUCCEEDED"
 fi


### PR DESCRIPTION
`test-install.sh` was not returning error exit code when something failed