### PR TITLE
Improve CLI --help documentation

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -241,5 +241,9 @@ func init() {
 	applicationCmd.AddCommand(applicationSetCmd)
 	applicationCmd.AddCommand(applicationDescribeCmd)
 
+	// Add a defined annotation in order to appear in the help menu
+	applicationCmd.Annotations = map[string]string{"command": "other"}
+	applicationCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(applicationCmd)
 }

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -75,5 +75,10 @@ components.
 func init() {
 	catalogCmd.AddCommand(catalogSearchCmd)
 	catalogCmd.AddCommand(catalogListCmd)
+
+	// Add a defined annotation in order to appear in the help menu
+	catalogCmd.Annotations = map[string]string{"command": "other"}
+	catalogCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(catalogCmd)
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -58,6 +58,10 @@ func Generate(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
+	// Add a defined annotation in order to appear in the help menu
+	completionCmd.Annotations = map[string]string{"command": "utility"}
+	completionCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(completionCmd)
 }
 

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -95,5 +95,9 @@ func init() {
 	componentCmd.AddCommand(componentGetCmd)
 	componentCmd.AddCommand(componentSetCmd)
 
+	// Add a defined annotation in order to appear in the help menu
+	componentCmd.Annotations = map[string]string{"command": "component"}
+	componentCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(componentCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -155,5 +155,9 @@ func init() {
 	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "Git source")
 	componentCreateCmd.Flags().StringVar(&componentLocal, "local", "", "Use local directory as a source for component")
 
+	// Add a defined annotation in order to appear in the help menu
+	componentCreateCmd.Annotations = map[string]string{"command": "component"}
+	componentCreateCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(componentCreateCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -86,5 +86,10 @@ var componentDeleteCmd = &cobra.Command{
 
 func init() {
 	componentDeleteCmd.Flags().BoolVarP(&componentForceDeleteFlag, "force", "f", false, "Delete component without prompting")
+
+	// Add a defined annotation in order to appear in the help menu
+	componentDeleteCmd.Annotations = map[string]string{"command": "component"}
+	componentDeleteCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(componentDeleteCmd)
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -48,5 +48,9 @@ var describeCmd = &cobra.Command{
 }
 
 func init() {
+	// Add a defined annotation in order to appear in the help menu
+	describeCmd.Annotations = map[string]string{"command": "component"}
+	describeCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(describeCmd)
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -65,5 +65,10 @@ printed to STDOUT.
 
 func init() {
 	linkCmd.PersistentFlags().StringVar(&linkComponent, "component", "", "Component to add link to, defaults to active component")
+
+	// Add a defined annotation in order to appear in the help menu
+	linkCmd.Annotations = map[string]string{"command": "component"}
+	linkCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(linkCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,5 +50,8 @@ var componentListCmd = &cobra.Command{
 }
 
 func init() {
+	// Add a defined annotation in order to appear in the help menu
+	componentListCmd.Annotations = map[string]string{"command": "component"}
+
 	rootCmd.AddCommand(componentListCmd)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -47,6 +47,9 @@ var logCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(logCmd)
+	// Add a defined annotation in order to appear in the help menu
+	logCmd.Annotations = map[string]string{"command": "component"}
+	logCmd.SetUsageTemplate(cmdUsageTemplate)
 
+	rootCmd.AddCommand(logCmd)
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -136,5 +136,10 @@ func init() {
 	projectCmd.AddCommand(projectSetCmd)
 	projectCmd.AddCommand(projectCreateCmd)
 	projectCmd.AddCommand(projectListCmd)
+
+	// Add a defined annotation in order to appear in the help menu
+	projectCmd.Annotations = map[string]string{"command": "other"}
+	projectCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(projectCmd)
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -99,5 +99,9 @@ var pushCmd = &cobra.Command{
 func init() {
 	pushCmd.Flags().StringVar(&componentLocal, "local", "", "Use given local directory as a source for component. (It must be a local component)")
 
+	// Add a defined annotation in order to appear in the help menu
+	pushCmd.Annotations = map[string]string{"command": "component"}
+	pushCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(pushCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,65 @@ var (
 	GlobalVerbose bool
 )
 
+// Templates
+var rootUsageTemplate = `Usage:{{if .Runnable}}
+  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Component Commands:{{range .Commands}}{{if eq .Annotations.command "component"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+Other Commands:{{range .Commands}}{{if eq .Annotations.command "other"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+Utility Commands:{{range .Commands}}{{if or (eq .Annotations.command "utility") (eq .Name "help") }}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
+var cmdUsageTemplate = `Usage:{{if .Runnable}}
+  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "odo",
@@ -65,6 +124,8 @@ func init() {
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
 	rootCmd.PersistentFlags().BoolVarP(&GlobalVerbose, "verbose", "v", false, "Verbose output")
+
+	rootCmd.SetUsageTemplate(rootUsageTemplate)
 }
 
 func getLatestReleaseInfo(info chan<- string) {

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -254,5 +254,9 @@ func init() {
 	storageCmd.AddCommand(storageListCmd)
 	storageCmd.AddCommand(storageMountCmd)
 
+	// Add a defined annotation in order to appear in the help menu
+	storageCmd.Annotations = map[string]string{"command": "other"}
+	storageCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(storageCmd)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -115,5 +115,9 @@ func init() {
 	updateCmd.Flags().StringVar(&componentGit, "git", "", "git source")
 	updateCmd.Flags().StringVar(&componentLocal, "local", "", "Use local directory as a source for component.")
 
+	// Add a defined annotation in order to appear in the help menu
+	updateCmd.Annotations = map[string]string{"command": "component"}
+	updateCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(updateCmd)
 }

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -144,5 +144,10 @@ func init() {
 	urlCmd.AddCommand(urlListCmd)
 	urlCmd.AddCommand(urlDeleteCmd)
 	urlCmd.AddCommand(urlCreateCmd)
+
+	// Add a defined annotation in order to appear in the help menu
+	urlCmd.Annotations = map[string]string{"command": "other"}
+	urlCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(urlCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -54,5 +54,9 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
+	// Add a defined annotation in order to appear in the help menu
+	versionCmd.Annotations = map[string]string{"command": "utility"}
+	versionCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -77,5 +77,9 @@ var watchCmd = &cobra.Command{
 }
 
 func init() {
+	// Add a defined annotation in order to appear in the help menu
+	watchCmd.Annotations = map[string]string{"command": "component"}
+	watchCmd.SetUsageTemplate(cmdUsageTemplate)
+
 	rootCmd.AddCommand(watchCmd)
 }


### PR DESCRIPTION
Separates the commands into appropriate categories.

Example:

```sh
Usage:
  odo [command]

Examples:
  # Creating and deploying a Node.js project
  git clone https://github.com/openshift/nodejs-ex && cd nodejs-ex
  odo create nodejs
  odo push

  # Accessing your Node.js component
  odo url create

Component Commands:
  component   Components of application.
  create      Create a new component
  delete      Delete an existing component
  describe    Describe the given component
  link        Link target component to source component
  list        List all components in the current application
  log         Retrieve the log for the given component.
  push        Push source code to a component
  update      Update the source code path of a component
  watch       Watch for changes, update component on change

Other Commands:
  app         Perform application operations
  catalog     Catalog related operations
  project     Perform project operations
  storage     Perform storage operations
  url         Expose component to the outside world

Utility Commands:
  completion  Output shell completion code
  help        Help about any command
  version     Print the client version information

Flags:
  -h, --help      help for odo
  -v, --verbose   Verbose output

Use "odo [command] --help" for more information about a command.
```