### PR TITLE
Fixes odo update from git to binary/local and vice versa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,17 @@ jobs:
         - oc login -u developer
         - make test-demo
 
+    # Run update e2e tests
+    - <<: *base-test
+      stage: test
+      go: 1.9
+      script:
+        - ./scripts/oc-cluster.sh
+        - make bin
+        - sudo cp odo /usr/bin
+        - oc login -u developer
+        - make test-update-e2e
+
     # test installation script on linux
     # - stage: test
     #   services:

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ test-e2e:
 test-demo:
 	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="katacodaDemo" -ginkgo.v
 
+.PHONY: test-update-e2e
+test-update-e2e:
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="updateE2e" -ginkgo.v
+
 # create deb and rpm packages using fpm in ./dist/pkgs/
 # run make cross before this!
 .PHONY: packages

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/project"
@@ -36,6 +37,8 @@ var updateCmd = &cobra.Command{
 		applicationName, err := application.GetCurrent(client)
 		checkError(err, "")
 		projectName := project.GetCurrent(client)
+
+		stdout := color.Output
 
 		checkFlag := 0
 
@@ -84,7 +87,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if len(componentGit) != 0 {
-			err := component.Update(client, componentName, applicationName, "git", componentGit)
+			err := component.Update(client, componentName, applicationName, "git", componentGit, stdout)
 			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else if len(componentLocal) != 0 {
@@ -97,15 +100,15 @@ var updateCmd = &cobra.Command{
 				fmt.Println("Please provide a path to the directory")
 				os.Exit(1)
 			}
-			err = component.Update(client, componentName, applicationName, "local", dir)
+			err = component.Update(client, componentName, applicationName, "local", dir, stdout)
 			checkError(err, "")
-			fmt.Printf("The component %s was updated successfully\n", componentName)
+			fmt.Printf("The component %s was updated successfully, please use 'odo push' to push your local changes\n", componentName)
 		} else if len(componentBinary) != 0 {
 			path, err := filepath.Abs(componentBinary)
 			checkError(err, "")
-			err = component.Update(client, componentName, applicationName, "binary", path)
+			err = component.Update(client, componentName, applicationName, "binary", path, stdout)
 			checkError(err, "")
-			fmt.Printf("The component %s was updated successfully\n", componentName)
+			fmt.Printf("The component %s was updated successfully, please use 'odo push' to push your local changes\n", componentName)
 		}
 	},
 }

--- a/pkg/occlient/fakeclient.go
+++ b/pkg/occlient/fakeclient.go
@@ -2,6 +2,7 @@ package occlient
 
 import (
 	fakeAppClientset "github.com/openshift/client-go/apps/clientset/versioned/fake"
+	fakeBuildClientset "github.com/openshift/client-go/build/clientset/versioned/fake"
 	fakeRouteClientset "github.com/openshift/client-go/route/clientset/versioned/fake"
 	fakeKubeClientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -12,6 +13,7 @@ type FakeClientset struct {
 	Kubernetes     *fakeKubeClientset.Clientset
 	RouteClientset *fakeRouteClientset.Clientset
 	AppClientset   *fakeAppClientset.Clientset
+	BuildClientset *fakeBuildClientset.Clientset
 }
 
 // FakeNew creates new fake client for testing
@@ -29,6 +31,9 @@ func FakeNew() (*Client, *FakeClientset) {
 
 	fkclientset.AppClientset = fakeAppClientset.NewSimpleClientset()
 	client.appsClient = fkclientset.AppClientset.Apps()
+
+	fkclientset.BuildClientset = fakeBuildClientset.NewSimpleClientset()
+	client.buildClient = fkclientset.BuildClientset.Build()
 
 	return &client, &fkclientset
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -55,6 +55,9 @@ const (
 
 	// The length of the string to be generated for names of resources
 	nameLength = 5
+	// git repository that will be used for bootstraping
+	bootstrapperURI = "https://github.com/kadel/bootstrap-supervisored-s2i"
+	bootstrapperRef = "v0.0.2"
 )
 
 // errorMsg is the message for user when invalid configuration error occurs
@@ -499,8 +502,12 @@ func (c *Client) GetExposedPorts(imageName string, imageTag string) ([]corev1.Co
 	return containerPorts, nil
 }
 
+func getAppRootVolumeName(dcName string) string {
+	return fmt.Sprintf("%s-s2idata", dcName)
+}
+
 // NewAppS2I create new application using S2I
-// if gitUrl is ""  than it creates binary build otherwise uses gitUrl as buildSource
+// gitUrl is the url of the git repo
 func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labels map[string]string, annotations map[string]string) error {
 
 	imageName, imageTag, _, err := parseImageName(builderImage)
@@ -529,19 +536,12 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 		return errors.Wrapf(err, "unable to create ImageStream for %s", name)
 	}
 
-	// generate BuildConfig
-	buildSource := buildv1.BuildSource{
-		Type:   buildv1.BuildSourceBinary,
-		Binary: &buildv1.BinaryBuildSource{},
-	}
 	// if gitUrl set change buildSource to git and use given repo
-	if gitUrl != "" {
-		buildSource = buildv1.BuildSource{
-			Git: &buildv1.GitBuildSource{
-				URI: gitUrl,
-			},
-			Type: buildv1.BuildSourceGit,
-		}
+	buildSource := buildv1.BuildSource{
+		Git: &buildv1.GitBuildSource{
+			URI: gitUrl,
+		},
+		Type: buildv1.BuildSourceGit,
 	}
 
 	bc := buildv1.BuildConfig{
@@ -655,12 +655,6 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 // Supervisor keeps pod running (runs as pid1), so you it is possible to trigger assembly script inside running pod,
 // and than restart application using Supervisor without need to restart whole container.
 func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labels map[string]string, annotations map[string]string) error {
-	// git repository that will be used for bootstraping
-	const bootstrapperURI = "https://github.com/kadel/bootstrap-supervisored-s2i"
-	const bootstrapperRef = "v0.0.2"
-
-	appRootVolumeName := fmt.Sprintf("%s-s2idata", name)
-
 	imageName, imageTag, _, err := parseImageName(builderImage)
 	if err != nil {
 		return errors.Wrap(err, "unable to create new s2i git build ")
@@ -749,39 +743,6 @@ func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labe
 							Image: bc.Spec.Output.To.Name,
 							Name:  name,
 							Ports: containerPorts,
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      appRootVolumeName,
-									MountPath: "/opt/app-root",
-									SubPath:   "app-root",
-								},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: appRootVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: appRootVolumeName,
-								},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:  "copy-files-to-volume",
-							Image: bc.Spec.Output.To.Name,
-							Command: []string{
-								"copy-files-to-volume",
-								"/opt/app-root",
-								"/mnt/app-root"},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      appRootVolumeName,
-									MountPath: "/mnt",
-								},
-							},
 						},
 					},
 				},
@@ -807,6 +768,11 @@ func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labe
 			},
 		},
 	}
+
+	addBootstrapInitContainer(&dc, name)
+	addBootstrapVolume(&dc, name)
+	addBootstrapVolumeMount(&dc, name)
+
 	_, err = c.appsClient.DeploymentConfigs(c.namespace).Create(&dc)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create DeploymentConfig for %s", name)
@@ -838,12 +804,60 @@ func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labe
 		return errors.Wrapf(err, "unable to create Service for %s", name)
 	}
 
-	_, err = c.CreatePVC(appRootVolumeName, "1Gi", labels)
+	_, err = c.CreatePVC(getAppRootVolumeName(name), "1Gi", labels)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create PVC for %s", name)
 	}
 
 	return nil
+}
+
+// AddBootstrapInitContainer adds the bootstrap init container to the deployment config
+// dc is the deployment config to be updated
+// dcName is the name of the deployment config
+func addBootstrapInitContainer(dc *appsv1.DeploymentConfig, dcName string) {
+	dc.Spec.Template.Spec.InitContainers = append(dc.Spec.Template.Spec.InitContainers,
+		corev1.Container{
+			Name:  "copy-files-to-volume",
+			Image: dc.Spec.Template.Spec.Containers[0].Image,
+			Command: []string{
+				"copy-files-to-volume",
+				"/opt/app-root",
+				"/mnt/app-root"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      getAppRootVolumeName(dcName),
+					MountPath: "/mnt",
+				},
+			},
+		})
+}
+
+// addBootstrapVolume adds the bootstrap volume to the deployment config
+// dc is the deployment config to be updated
+// dcName is the name of the deployment config
+func addBootstrapVolume(dc *appsv1.DeploymentConfig, dcName string) {
+	dc.Spec.Template.Spec.Volumes = append(dc.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: getAppRootVolumeName(dcName),
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: getAppRootVolumeName(dcName),
+			},
+		},
+	})
+}
+
+// addBootstrapVolumeMount mounts the bootstrap volume to the deployment config
+// dc is the deployment config to be updated
+// dcName is the name of the deployment config
+func addBootstrapVolumeMount(dc *appsv1.DeploymentConfig, dcName string) {
+	for i := range dc.Spec.Template.Spec.Containers {
+		dc.Spec.Template.Spec.Containers[i].VolumeMounts = append(dc.Spec.Template.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+			Name:      getAppRootVolumeName(dcName),
+			MountPath: "/opt/app-root",
+			SubPath:   "app-root",
+		})
+	}
 }
 
 // UpdateBuildConfig updates the BuildConfig file
@@ -853,15 +867,21 @@ func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labe
 // annotations contains the annotations for the BuildConfig file
 func (c *Client) UpdateBuildConfig(buildConfigName string, projectName string, gitUrl string, annotations map[string]string) error {
 	// generate BuildConfig
-	buildSource := buildv1.BuildSource{
-		Type:   buildv1.BuildSourceBinary,
-		Binary: &buildv1.BinaryBuildSource{},
-	}
+	buildSource := buildv1.BuildSource{}
+
 	// if gitUrl set change buildSource to git and use given repo
 	if gitUrl != "" {
 		buildSource = buildv1.BuildSource{
 			Git: &buildv1.GitBuildSource{
 				URI: gitUrl,
+			},
+			Type: buildv1.BuildSourceGit,
+		}
+	} else {
+		buildSource = buildv1.BuildSource{
+			Git: &buildv1.GitBuildSource{
+				URI: bootstrapperURI,
+				Ref: bootstrapperRef,
 			},
 			Type: buildv1.BuildSourceGit,
 		}
@@ -875,6 +895,93 @@ func (c *Client) UpdateBuildConfig(buildConfigName string, projectName string, g
 	_, err = c.buildClient.BuildConfigs(c.namespace).Update(buildConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to update the component")
+	}
+	return nil
+}
+
+// UpdateDCAnnotations updates the DeploymentConfig file
+// dcName is the name of the DeploymentConfig file to be updated
+// annotations contains the annotations for the DeploymentConfig file
+func (c *Client) UpdateDCAnnotations(dcName string, annotations map[string]string) error {
+	dc, err := c.GetDeploymentConfigFromName(dcName)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get DeploymentConfig %s", dcName)
+	}
+
+	dc.Annotations = annotations
+	_, err = c.appsClient.DeploymentConfigs(c.namespace).Update(dc)
+	if err != nil {
+		return errors.Wrapf(err, "unable to uDeploymentConfig config %s", dcName)
+	}
+	return nil
+}
+
+// SetupForSupervisor adds the supervisor to the deployment config
+// dcName is the name of the deployment config to be updated
+// projectName is the name of the project
+// annotations are the updated annotations for the new deployment config
+// labels are the labels of the PVC created while setting up the supervisor
+func (c *Client) SetupForSupervisor(dcName string, projectName string, annotations map[string]string, labels map[string]string) error {
+	dc, err := c.GetDeploymentConfigFromName(dcName)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get DeploymentConfig %s", dcName)
+	}
+
+	dc.Annotations = annotations
+
+	addBootstrapInitContainer(dc, dcName)
+
+	addBootstrapVolume(dc, dcName)
+
+	addBootstrapVolumeMount(dc, dcName)
+
+	dc, err = c.appsClient.DeploymentConfigs(c.namespace).Update(dc)
+	if err != nil {
+		return errors.Wrapf(err, "unable to uDeploymentConfig config %s", dcName)
+	}
+	_, err = c.CreatePVC(getAppRootVolumeName(dcName), "1Gi", labels)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create PVC for %s", dcName)
+	}
+	return nil
+}
+
+// CleanupAfterSupervisor removes the supervisor from the deployment config
+// dcName is the name of the deployment config to be updated
+// projectName is the name of the project
+// annotations are the updated annotations for the new deployment config
+func (c *Client) CleanupAfterSupervisor(dcName string, projectName string, annotations map[string]string) error {
+	dc, err := c.GetDeploymentConfigFromName(dcName)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get DeploymentConfig %s ", dcName)
+	}
+
+	dc.Annotations = annotations
+
+	found := removeVolumeFromDC(getAppRootVolumeName(dcName), dc)
+	if !found {
+		return errors.Wrapf(err, "unable to find volume in the dc")
+	}
+	found = removeVolumeMountFromDC(getAppRootVolumeName(dcName), dc)
+	if !found {
+		return errors.Wrapf(err, "unable to find volume in the dc")
+	}
+
+	// remove the one bootstrapped init container
+	for i, container := range dc.Spec.Template.Spec.InitContainers {
+		if container.Name == "copy-files-to-volume" {
+			dc.Spec.Template.Spec.InitContainers = append(dc.Spec.Template.Spec.InitContainers[:i], dc.Spec.Template.Spec.InitContainers[i+1:]...)
+		}
+	}
+
+	dc, err = c.appsClient.DeploymentConfigs(c.namespace).Update(dc)
+	if err != nil {
+		return errors.Wrapf(err, "unable to update deployment config %s", dcName)
+	}
+
+	err = c.DeletePVC(getAppRootVolumeName(dcName))
+	if err != nil {
+		return errors.Wrapf(err, "unable to delete S2I data PVC from %s", dcName)
 	}
 	return nil
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -25,6 +25,8 @@ var t = strconv.FormatInt(time.Now().Unix(), 10)
 var projName = fmt.Sprintf("odo-%s", t)
 var curProj string
 
+const appTestName = "testing"
+
 func runCmd(cmdS string) string {
 	cmd := exec.Command("/bin/sh", "-c", cmdS)
 	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmdS)
@@ -103,6 +105,28 @@ func waitForCmdOut(cmd string, expOut string) bool {
 	}
 }
 
+// SourceTest checks the component-source-type and the source url in the annotation of the bc and dc
+// appTestName is the app of the app
+// sourceType is the type of the source of the component i.e git/binary/local
+// source is the source of the component i.e gitUrl or path to the directory or binary file
+func SourceTest(appTestName string, sourceType string, source string) {
+	// checking for source-type in dc
+	getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='{{index .metadata.annotations \"app.kubernetes.io/component-source-type\"}}'")
+	Expect(getDc).To(ContainSubstring(sourceType))
+
+	// checking for source in dc
+	getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='{{index .metadata.annotations \"app.kubernetes.io/url\"}}'")
+	Expect(getDc).To(ContainSubstring(source))
+
+	// checking for source-type in bc
+	getDc = runCmd("oc get bc wildfly-" + appTestName + " -o go-template='{{index .metadata.annotations \"app.kubernetes.io/component-source-type\"}}'")
+	Expect(getDc).To(ContainSubstring(sourceType))
+
+	// checking for source in bc
+	getDc = runCmd("oc get bc wildfly-" + appTestName + " -o go-template='{{index .metadata.annotations \"app.kubernetes.io/url\"}}'")
+	Expect(getDc).To(ContainSubstring(source))
+}
+
 func TestOdo(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "odo test suite")
@@ -118,7 +142,6 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("odoe2e", func() {
-	appTestName := "testing"
 
 	tmpDir, err := ioutil.TempDir("", "odo")
 	if err != nil {
@@ -243,12 +266,21 @@ var _ = Describe("odoe2e", func() {
 				runCmd("odo log nodejs")
 			})
 
+			It("should be able to create binary component", func() {
+				runCmd("curl -o " + tmpDir + "/sample-binary-testing-1.war " +
+					"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
+				runCmd("odo create wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
+				cmpList := runCmd("odo list")
+				Expect(cmpList).To(ContainSubstring("wildfly"))
+			})
 		})
 	})
 
 	Describe("pushing updates", func() {
 		Context("When push is made", func() {
 			It("should push the changes", func() {
+				// Switch to nodejs component
+				runCmd("odo component set nodejs")
 
 				// Get IP and port
 				getIP := runCmd("oc get svc/nodejs-" + appTestName + " -o go-template='{{.spec.clusterIP}}:{{(index .spec.ports 0).port}}'")
@@ -419,6 +451,316 @@ var _ = Describe("odoe2e", func() {
 
 			// TODO: `odo project delete` once implemented
 			runCmd("oc delete project " + projName)
+		})
+	})
+})
+
+var _ = Describe("updateE2e", func() {
+
+	const bootStrapSupervisorURI = "https://github.com/kadel/bootstrap-supervisored-s2i"
+	const initContainerName = "copy-files-to-volume"
+	const wildflyUri1 = "https://github.com/marekjelen/katacoda-odo-backend"
+	const wildflyUri2 = "https://github.com/mik-dass/katacoda-odo-backend"
+	const appRootVolumeName = "-testing-s2idata"
+
+	tmpDir, err := ioutil.TempDir("", "odo")
+	if err != nil {
+		Fail(err.Error())
+	}
+
+	Describe("creating the project", func() {
+		Context("odo project", func() {
+			It("should create a new project", func() {
+				session := runCmd("odo project create " + projName + "-1")
+				Expect(session).To(ContainSubstring(projName))
+			})
+
+			It("should get the project", func() {
+				getProj := runCmd("odo project get --short")
+				Expect(strings.TrimSpace(getProj)).To(Equal(projName + "-1"))
+			})
+		})
+	})
+
+	Describe("creating an application", func() {
+		Context("when application by the same name doesn't exist", func() {
+			It("should create an application", func() {
+				appName := runCmd("odo app create " + appTestName)
+				Expect(appName).To(ContainSubstring(appTestName))
+			})
+		})
+	})
+
+	Context("updating the component", func() {
+		It("should be able to create binary component", func() {
+			runCmd("curl -o " + tmpDir + "/sample-binary-testing-1.war " +
+				"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
+			runCmd("odo create wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
+			cmpList := runCmd("odo list")
+			Expect(cmpList).To(ContainSubstring("wildfly"))
+
+			runCmd("oc get dc")
+			runCmd("oc get bc")
+		})
+
+		It("should update component from binary to binary", func() {
+			runCmd("curl -o " + tmpDir + "/sample-binary-testing-2.war " +
+				"'https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/85354d9ee8583a9c1e64a331425eede235b07a9e/sample%2520(1).war'")
+			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-2.war")
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(bootStrapSupervisorURI))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "binary", "file://"+tmpDir+"/sample-binary-testing-2.war")
+		})
+
+		It("should update component from binary to local", func() {
+			runCmd("git clone " + wildflyUri1 + " " +
+				tmpDir + "/katacoda-odo-backend-1")
+
+			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-1")
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(bootStrapSupervisorURI))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "local", "file://"+tmpDir+"/katacoda-odo-backend-1")
+		})
+
+		It("should update component from local to local", func() {
+			runCmd("git clone " + wildflyUri2 + " " +
+				tmpDir + "/katacoda-odo-backend-2")
+
+			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-2")
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(bootStrapSupervisorURI))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "local", "file://"+tmpDir+"/katacoda-odo-backend-2")
+		})
+
+		It("should update component from local to git", func() {
+			runCmd("odo update wildfly --git " + wildflyUri1)
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(wildflyUri1))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "git", wildflyUri1)
+		})
+
+		It("should update component from git to git", func() {
+			runCmd("odo update wildfly --git " + wildflyUri2)
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(wildflyUri2))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "git", wildflyUri2)
+		})
+
+		It("should update component from git to binary", func() {
+			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(bootStrapSupervisorURI))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "binary", "file://"+tmpDir+"/sample-binary-testing-1.war")
+		})
+
+		It("should update component from binary to git", func() {
+			runCmd("odo update wildfly --git " + wildflyUri1)
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(wildflyUri1))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).NotTo(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "git", wildflyUri1)
+		})
+
+		It("should update component from git to local", func() {
+			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-1")
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(bootStrapSupervisorURI))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "local", "file://"+tmpDir+"/katacoda-odo-backend-1")
+		})
+
+		It("should update component from local to binary", func() {
+			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
+
+			// checking bc for updates
+			getBc := runCmd("oc get bc wildfly-" + appTestName + " -o go-template={{.spec.source.git.uri}}")
+			Expect(getBc).To(Equal(bootStrapSupervisorURI))
+
+			// checking for init containers
+			getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.initContainers}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring(initContainerName))
+
+			// checking for volumes
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.volumes}}" +
+				"{{.name}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			// checking for volumes mounts
+			getDc = runCmd("oc get dc wildfly-" + appTestName + " -o go-template='" +
+				"{{range .spec.template.spec.containers}}{{range .volumeMounts}}{{.name}}" +
+				"{{.name}}{{end}}{{end}}'")
+			Expect(getDc).To(ContainSubstring("wildfly" + appRootVolumeName))
+
+			SourceTest(appTestName, "binary", "file://"+tmpDir+"/sample-binary-testing-1.war")
 		})
 	})
 })


### PR DESCRIPTION
To achieve this, two functions have been added SetupForSupervisor and CleanupAfterSupervisor in occlient.go. Also some other functions are added in occlient to add and remove initContainers, volumeMounts and volumes to the deploymentConfig. Also updateDcAnnotations in occlient is added to update the annotations in the deploymentConfig.

Issue: https://github.com/redhat-developer/odo/issues/439
Signed-off-by: mdas <mrinald7@gmail.com>