### PR TITLE
fixed newline in `odo app`

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -81,7 +81,7 @@ var applicationGetCmd = &cobra.Command{
 			return
 		}
 		if app == "" {
-			fmt.Printf("There's no active application.\nYou can create one by running 'odo application create <name>'.")
+			fmt.Printf("There's no active application.\nYou can create one by running 'odo application create <name>'.\n")
 			return
 		}
 		fmt.Printf("The current application is: %v\n", app)


### PR DESCRIPTION
As of now,

```
$ odo app
There's no active application.
You can create one by running 'odo application create <name>'.✔ ~/go/src/github.com/redhat-developer/odo [without-storage-name L|⚑ 20]
```

This PR will add newline here so that output will be like,

```
$ odo app
There's no active application.
You can create one by running 'odo application create <name>'.
✔ ~/go/src/github.com/redhat-developer/odo [without-storage-name L|⚑ 20]
```