### PR TITLE
Handle error when no component is there

### DIFF
--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -45,6 +45,10 @@ func getComponent(client *occlient.Client, inputComponent, applicationName, proj
 	if len(inputComponent) == 0 {
 		c, err := component.GetCurrent(client, applicationName, projectName)
 		checkError(err, "Could not get current component")
+		if c == "" {
+			fmt.Println("There is no component set")
+			os.Exit(1)
+		}
 		return c
 	}
 	exists, err := component.Exists(client, inputComponent, applicationName, projectName)


### PR DESCRIPTION
according to this[0] comment, there is no error handling if there is no current component or there is no any component created.

This PR will resolve this issue.

[0] https://github.com/redhat-developer/odo/pull/541#issuecomment-400564871