### PR TITLE
enable codecov.io coverage checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,11 +4,9 @@ coverage:
   status:
     project:
       default:
-        # target: auto
-        # disable for now, we have only e2e tests
-        target: 0%
+        target: auto
         base: auto
     patch:
       default:
-        target: 0%
+        target: auto
         base: auto


### PR DESCRIPTION
Enable code coverage checks.
Let's start with auto settings, we can adjust as we go.