### PR TITLE
Adds io.Writer to FollowBuildLog function

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/redhat-developer/odo/pkg/component"
@@ -47,6 +48,8 @@ A full list of component types that can be deployed is available using: 'odo com
 	`,
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
+
+		stdout := color.Output
 		log.Debugf("Component create called with args: %#v, flags: binary=%s, git=%s, local=%s", strings.Join(args, " "), componentBinary, componentGit, componentLocal)
 
 		client := getOcClient()
@@ -100,7 +103,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			checkError(err, "")
 			fmt.Printf("Component '%s' was created.\n", componentName)
 			fmt.Printf("Triggering build from %s.\n\n", componentGit)
-			err = component.Build(client, componentName, applicationName, true, true)
+			err = component.Build(client, componentName, applicationName, true, true, stdout)
 			checkError(err, "")
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
@@ -115,7 +118,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			err = component.CreateFromPath(client, componentName, componentType, dir, applicationName, "local")
 			checkError(err, "")
 			fmt.Printf("Please wait, creating %s component ...\n", componentName)
-			err = component.Build(client, componentName, applicationName, false, true)
+			err = component.Build(client, componentName, applicationName, false, true, stdout)
 			checkError(err, "")
 			fmt.Printf("Component '%s' was created.\n", componentName)
 			fmt.Printf("To push source code to the component run 'odo push'\n")
@@ -126,7 +129,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			err = component.CreateFromPath(client, componentName, componentType, path, applicationName, "binary")
 			checkError(err, "")
 			fmt.Printf("Please wait, creating %s component ...\n", componentName)
-			err = component.Build(client, componentName, applicationName, false, true)
+			err = component.Build(client, componentName, applicationName, false, true, stdout)
 			checkError(err, "")
 			fmt.Printf("Component '%s' was created.\n", componentName)
 			fmt.Printf("To push source code to the component run 'odo push'\n")
@@ -137,7 +140,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			err = component.CreateFromPath(client, componentName, componentType, dir, applicationName, "local")
 			checkError(err, "")
 			fmt.Printf("Please wait, creating %s component ...\n", componentName)
-			err = component.Build(client, componentName, applicationName, false, true)
+			err = component.Build(client, componentName, applicationName, false, true, stdout)
 			checkError(err, "")
 			fmt.Printf("Component '%s' was created.\n", componentName)
 			fmt.Printf("To push source code to the component run 'odo push'\n")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/project"
@@ -28,6 +29,7 @@ var pushCmd = &cobra.Command{
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		stdout := color.Output
 		client := getOcClient()
 		applicationName, err := application.GetCurrent(client)
 		checkError(err, "")
@@ -88,7 +90,7 @@ var pushCmd = &cobra.Command{
 				fmt.Println("unable to push local directory to component that uses git repository as source")
 				os.Exit(1)
 			}
-			err := component.Build(client, componentName, applicationName, true, true)
+			err := component.Build(client, componentName, applicationName, true, true, stdout)
 			checkError(err, fmt.Sprintf("failed to push component: %v", componentName))
 		}
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -225,7 +225,7 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 // If 'streamLogs' is true than it streams build logs on stdout, set 'wait' to true if you want to return error if build fails.
 // If 'wait' is true than it waits for build to successfully complete.
 // If 'wait' is false than this function won't return error even if build failed.
-func Build(client *occlient.Client, componentName string, applicationName string, streamLogs bool, wait bool) error {
+func Build(client *occlient.Client, componentName string, applicationName string, streamLogs bool, wait bool, stdout io.Writer) error {
 
 	// Namespace the component
 	namespacedOpenShiftObject, err := util.NamespaceOpenShiftObject(componentName, applicationName)
@@ -238,7 +238,7 @@ func Build(client *occlient.Client, componentName string, applicationName string
 		return errors.Wrapf(err, "unable to rebuild %s", componentName)
 	}
 	if streamLogs {
-		if err := client.FollowBuildLog(buildName); err != nil {
+		if err := client.FollowBuildLog(buildName, stdout); err != nil {
 			return errors.Wrapf(err, "unable to follow logs for %s", buildName)
 		}
 	}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -960,7 +960,7 @@ func (c *Client) WaitAndGetPod(selector string) (*corev1.Pod, error) {
 }
 
 // FollowBuildLog stream build log to stdout
-func (c *Client) FollowBuildLog(buildName string) error {
+func (c *Client) FollowBuildLog(buildName string, stdout io.Writer) error {
 	buildLogOptions := buildv1.BuildLogOptions{
 		Follow: true,
 		NoWait: false,
@@ -982,8 +982,6 @@ func (c *Client) FollowBuildLog(buildName string) error {
 	// Set the colour of the stdout output..
 	color.Set(color.FgYellow)
 	defer color.Unset()
-
-	stdout := color.Output
 
 	if _, err = io.Copy(stdout, rd); err != nil {
 		return errors.Wrapf(err, "error streaming logs for %s", buildName)


### PR DESCRIPTION
Adds io.Writer to the FollowBuildLog function. This follows the
convention of only passing in `stdout` from either `color.Output` or
`os.Stdout`.