### PR TITLE
Show tags / versions when doing odo catalog list

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/spf13/cobra"
 )
@@ -34,10 +38,14 @@ var catalogListCmd = &cobra.Command{
 		case 0:
 			fmt.Printf("No deployable components found\n")
 		default:
-			fmt.Println("The following components can be deployed:")
+
+			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+			fmt.Fprintln(w, "NAME", "\t", "TAGS")
 			for _, component := range catalogList {
-				fmt.Printf("- %v\n", component)
+				fmt.Fprintln(w, component.Name, "\t", strings.Join(component.Tags, ","))
 			}
+			w.Flush()
+
 		}
 	},
 }

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -1,0 +1,82 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/testingutil"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestList(t *testing.T) {
+	type args struct {
+		name      string
+		namespace string
+		tags      []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		wantTags []string
+	}{
+		{
+			name: "Case 1: Valid image output with one tag",
+			args: args{
+				name:      "foobar",
+				namespace: "openshift",
+				tags:      []string{"latest"},
+			},
+			wantErr:  false,
+			wantTags: []string{"latest"},
+		},
+		{
+			name: "Case 2: Valid image output with multiple tags",
+			args: args{
+				name:      "foobar",
+				namespace: "openshift",
+				tags:      []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+			},
+			wantErr:  false,
+			wantTags: []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+		},
+		{
+			name: "Case 3: Invalid image output with no tags",
+			args: args{
+				name:      "foobar",
+				namespace: "foo",
+				tags:      []string{},
+			},
+			wantErr:  true,
+			wantTags: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Fake the client with the appropriate arguments
+			client, fakeClientSet := occlient.FakeNew()
+			fakeClientSet.ImageClientset.PrependReactor("list", "imagestreams", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, testingutil.FakeImageStreams(tt.args.name, tt.args.namespace, tt.args.tags), nil
+			})
+
+			// The function we are testing
+			output, err := List(client)
+
+			//Checks for error in positive cases
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("component List() unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Check if the output is the same as what's expected (tags)
+			// and only if output is more than 0 (something is actually returned)
+			if len(output) > 0 && !(reflect.DeepEqual(output[0].Tags, tt.wantTags)) {
+				t.Errorf("expected tags: %s, got: %s", tt.wantTags, output[0].Tags)
+			}
+
+		})
+	}
+}

--- a/pkg/testingutil/imagestreams.go
+++ b/pkg/testingutil/imagestreams.go
@@ -1,0 +1,43 @@
+package testingutil
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Function taken from occlient_test.go
+// fakeImageStream gets imagestream for the reactor
+func fakeImageStream(imageName string, namespace string, tags []string) *imagev1.ImageStream {
+	image := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imageName,
+			Namespace: namespace,
+		},
+		Status: imagev1.ImageStreamStatus{
+			Tags: []imagev1.NamedTagEventList{
+				{
+					Tag: "latest",
+					Items: []imagev1.TagEvent{
+						{DockerImageReference: "example/" + imageName + ":latest"},
+						{Generation: 1},
+						{Image: imageName + "@sha256:9579a93ee"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tag := range tags {
+		imageTag := imagev1.TagReference{Name: tag, Annotations: map[string]string{"tags": "builder"}}
+		image.Spec.Tags = append(image.Spec.Tags, imageTag)
+	}
+
+	return image
+}
+
+// FakeImageStreams lists the imagestreams for the reactor
+func FakeImageStreams(imageName string, namespace string, tags []string) *imagev1.ImageStreamList {
+	return &imagev1.ImageStreamList{
+		Items: []imagev1.ImageStream{*fakeImageStream(imageName, namespace, tags)},
+	}
+}


### PR DESCRIPTION
When using `odo catalog list` the tags will now be listed:

```
github.com/redhat-developer/odo  add-versioning ✗                                                                                                                                                                                                                                                                                                                    7d ⚑  ⍉
▶ ./odo catalog list
NAME        TAGS
dotnet      2.0,latest
httpd       2.4,latest
nginx       1.10,1.12,1.8,latest
nodejs      0.10,4,6,8,latest
perl        5.16,5.20,5.24,latest
php         5.5,5.6,7.0,7.1,latest
python      2.7,3.3,3.4,3.5,3.6,latest
ruby        2.0,2.2,2.3,2.4,latest
wildfly     10.0,10.1,8.1,9.0,latest

```