### PR TITLE
Some outputs should error 1 not error 0

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -81,7 +81,7 @@ var applicationGetCmd = &cobra.Command{
 			return
 		}
 		if app == "" {
-			fmt.Printf("There's no active application.\nYou can create one by running 'odo application create <name>'.\n")
+			fmt.Errorf("There's no active application.\nYou can create one by running 'odo application create <name>'.\n")
 			return
 		}
 		fmt.Printf("The current application is: %v\n", app)
@@ -173,7 +173,7 @@ var applicationSetCmd = &cobra.Command{
 		exists, err := application.Exists(client, appName)
 		checkError(err, "unable to check if application exists")
 		if !exists {
-			fmt.Printf("Application %v does not exist\n", appName)
+			fmt.Errorf("Application %v does not exist\n", appName)
 			os.Exit(1)
 		}
 
@@ -204,7 +204,7 @@ var applicationDescribeCmd = &cobra.Command{
 			exists, err := application.Exists(client, currentApplication)
 			checkError(err, "")
 			if !exists {
-				fmt.Printf("Application with the name %s does not exist\n", currentApplication)
+				fmt.Errorf("Application with the name %s does not exist\n", currentApplication)
 				os.Exit(1)
 			}
 		}
@@ -214,7 +214,7 @@ var applicationDescribeCmd = &cobra.Command{
 		componentList, err := component.List(client, currentApplication, currentProject)
 		checkError(err, "")
 		if len(componentList) == 0 {
-			fmt.Printf("Application %s has no components deployed.\n", currentApplication)
+			fmt.Errorf("Application %s has no components deployed.\n", currentApplication)
 			os.Exit(1)
 		}
 		fmt.Printf("Application %s has:\n", currentApplication)

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -50,7 +50,7 @@ var componentGetCmd = &cobra.Command{
 			fmt.Print(component)
 		} else {
 			if component == "" {
-				fmt.Printf("No component is set as current\n")
+				fmt.Errorf("No component is set as current\n")
 				return
 			}
 			fmt.Printf("The current component is: %v\n", component)
@@ -75,7 +75,7 @@ var componentSetCmd = &cobra.Command{
 		exists, err := component.Exists(client, args[0], applicationName, projectName)
 		checkError(err, "")
 		if !exists {
-			fmt.Printf("Component %s does not exist in the current application\n", args[0])
+			fmt.Errorf("Component %s does not exist in the current application\n", args[0])
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
fmt.Printf errors out with checkout code 0. However, there are some
prompts (this component doens't exist, this application doesn't exist)
that error out with 0, they should error with checkout code 1 (using
fmt.Errorf).

This creates incorrect output for PS1 / `odo utils terminal` code as it
creates scenarios where there is a false error code output:

```sh
if [ $? != 0 ]; then
  APP="Unable to retrieve app"
else
  APP=$(echo $APP_GET | sed "s/The current application is: //g")
fi
```