### PR TITLE
Revamps the URL command and adds support for custom names for url.

### DIFF
--- a/cmd/url.go
+++ b/cmd/url.go
@@ -6,16 +6,15 @@ import (
 	"strings"
 
 	"github.com/redhat-developer/odo/pkg/application"
-	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/redhat-developer/odo/pkg/url"
 	"github.com/spf13/cobra"
 )
 
 var (
-	urlListComponent   string
-	urlListApplication string
-	urlForceDeleteflag bool
+	urlComponent       string
+	urlApplication     string
+	urlForceDeleteFlag bool
 )
 
 var urlCmd = &cobra.Command{
@@ -40,8 +39,11 @@ The created URL can be used to access the specified component from outside the O
 	Example: `  # Create a URL for the current component.
   odo url create
 
-  # Create a URL for a specific component
-  odo url create mycomponent
+  # Create a URL with a specific name
+  odo url create example
+
+  # Create a URL with a specific name for component frontend
+  odo url create example --component frontend
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -50,24 +52,50 @@ The created URL can be used to access the specified component from outside the O
 		checkError(err, "")
 		projectName := project.GetCurrent(client)
 
-		var componentName string
+		var app string
+		var urlName string
+
+		if urlApplication == "" {
+			app, err = application.GetCurrent(client)
+			checkError(err, "")
+		} else {
+			exists, err := application.Exists(client, urlApplication)
+			checkError(err, "unable to check if the application exists or not")
+			if !exists {
+				fmt.Printf("The application %s does not exists in the project %s\n", urlApplication, projectName)
+				os.Exit(1)
+			}
+			app = urlApplication
+		}
+
+		componentName := getComponent(client, urlComponent, app, projectName)
+
 		switch len(args) {
 		case 0:
-			var err error
-			componentName, err = component.GetCurrent(client, applicationName, projectName)
-			checkError(err, "")
+			urlName = componentName
 		case 1:
-			componentName = args[0]
+			urlName = args[0]
 		default:
 			fmt.Println("unable to get component")
 			os.Exit(1)
 		}
 
+		exists, err := url.Exists(client, urlName, "", applicationName)
+
+		if exists {
+			fmt.Printf("The url %s already exists in the application: %s\n", urlName, applicationName)
+			os.Exit(1)
+		}
+
+		if urlComponent != "" {
+			componentName = urlComponent
+		}
+
 		fmt.Printf("Adding URL to component: %v\n", componentName)
-		urlRoute, err := url.Create(client, componentName, applicationName)
+		urlRoute, err := url.Create(client, urlName, componentName, applicationName)
 		checkError(err, "")
 		fmt.Printf("URL created for component: %v\n\n"+
-			"%v - %v\n", componentName, componentName, url.GetUrlString(*urlRoute))
+			"%v - %v\n", componentName, urlRoute.Name, url.GetUrlString(*urlRoute))
 	},
 }
 
@@ -83,11 +111,24 @@ var urlDeleteCmd = &cobra.Command{
 
 		// Initialization
 		client := getOcClient()
+		projectName := project.GetCurrent(client)
 		applicationName, err := application.GetCurrent(client)
 		checkError(err, "")
+
+		componentName := getComponent(client, urlComponent, applicationName, projectName)
+
 		urlName := args[0]
+
+		exists, err := url.Exists(client, urlName, componentName, applicationName)
+		checkError(err, "")
+
+		if !exists {
+			fmt.Printf("The URL %s does not exist within the component %s\n", urlName, componentName)
+			os.Exit(1)
+		}
+
 		var confirmDeletion string
-		if urlForceDeleteflag {
+		if urlForceDeleteFlag {
 			confirmDeletion = "y"
 		} else {
 			fmt.Printf("Are you sure you want to delete the url %v? [y/N] ", urlName)
@@ -95,7 +136,8 @@ var urlDeleteCmd = &cobra.Command{
 		}
 
 		if strings.ToLower(confirmDeletion) == "y" {
-			err := url.Delete(client, urlName, applicationName)
+
+			err = url.Delete(client, urlName, applicationName)
 			checkError(err, "")
 			fmt.Printf("Deleted URL: %v\n", urlName)
 		} else {
@@ -114,17 +156,26 @@ var urlListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
+		projectName := project.GetCurrent(client)
 
 		var app string
-		if urlListApplication == "" {
-			var err error
+		var err error
+
+		if urlApplication == "" {
 			app, err = application.GetCurrent(client)
 			checkError(err, "")
 		} else {
-			app = urlListApplication
+			exists, err := application.Exists(client, urlApplication)
+			checkError(err, "unable to check if the application exists or not")
+			if !exists {
+				fmt.Printf("The application %s does not exists in the project %s\n", urlApplication, projectName)
+				os.Exit(1)
+			}
+			app = urlApplication
 		}
 
-		componentName := urlListComponent
+		componentName := getComponent(client, urlComponent, app, projectName)
+
 		urls, err := url.List(client, componentName, app)
 		checkError(err, "")
 
@@ -140,9 +191,14 @@ var urlListCmd = &cobra.Command{
 }
 
 func init() {
-	urlDeleteCmd.Flags().BoolVarP(&urlForceDeleteflag, "force", "f", false, "Delete url without prompting")
-	urlListCmd.Flags().StringVarP(&urlListApplication, "application", "a", "", "list URLs for application")
-	urlListCmd.Flags().StringVarP(&urlListComponent, "component", "c", "", "list URLs for component")
+	urlCreateCmd.Flags().StringVarP(&urlApplication, "application", "a", "", "create url for application")
+	urlCreateCmd.Flags().StringVarP(&urlComponent, "component", "c", "", "create url for component")
+
+	urlDeleteCmd.Flags().BoolVarP(&urlForceDeleteFlag, "force", "f", false, "Delete url without prompting")
+	urlDeleteCmd.Flags().StringVarP(&urlComponent, "component", "c", "", "delete url for component")
+
+	urlListCmd.Flags().StringVarP(&urlApplication, "application", "a", "", "list URLs for application")
+	urlListCmd.Flags().StringVarP(&urlComponent, "component", "c", "", "list URLs for component")
 
 	urlCmd.AddCommand(urlListCmd)
 	urlCmd.AddCommand(urlDeleteCmd)

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -87,10 +87,6 @@ The created URL can be used to access the specified component from outside the O
 			os.Exit(1)
 		}
 
-		if urlComponent != "" {
-			componentName = urlComponent
-		}
-
 		fmt.Printf("Adding URL to component: %v\n", componentName)
 		urlRoute, err := url.Create(client, urlName, componentName, applicationName)
 		checkError(err, "")

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1227,7 +1227,7 @@ func (c *Client) clusterServiceClassExists(name string) bool {
 
 // CreateRoute creates a route object for the given service and with the given
 // labels
-func (c *Client) CreateRoute(name string, labels map[string]string) (*routev1.Route, error) {
+func (c *Client) CreateRoute(name string, serviceName string, labels map[string]string) (*routev1.Route, error) {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -1236,7 +1236,7 @@ func (c *Client) CreateRoute(name string, labels map[string]string) (*routev1.Ro
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
-				Name: name,
+				Name: serviceName,
 			},
 		},
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2133,9 +2133,9 @@ func TestListRoutes(t *testing.T) {
 				t.Errorf("expected 1 action in ListRoutes got: %v", fakeClientSet.RouteClientset.Actions())
 			}
 		} else if err == nil && tt.wantErr {
-			t.Errorf("test failed, expected: %s, got %s", "false", "true")
+			t.Error("error was expected, but no error was returned")
 		} else if err != nil && !tt.wantErr {
-			t.Errorf("test failed, expected: %s, got %s", "no error", "error:"+err.Error())
+			t.Errorf("test failed, no error was expected, but got unexpected error: %s", err)
 		}
 	}
 }

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	ktesting "k8s.io/client-go/testing"
+
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	urlLabels "github.com/redhat-developer/odo/pkg/url/labels"
 )
 
 // fakeImageStream gets imagestream for the reactor
@@ -445,12 +449,14 @@ func TestDeletePVC(t *testing.T) {
 func TestCreateRoute(t *testing.T) {
 	tests := []struct {
 		name    string
+		urlName string
 		service string
 		labels  map[string]string
 		wantErr bool
 	}{
 		{
 			name:    "Case : mailserver",
+			urlName: "mailserver",
 			service: "mailserver",
 			labels: map[string]string{
 				"SLA": "High",
@@ -461,7 +467,8 @@ func TestCreateRoute(t *testing.T) {
 		},
 
 		{
-			name:    "Case : blog",
+			name:    "Case : blog (urlName is different than service)",
+			urlName: "example",
 			service: "blog",
 			labels: map[string]string{
 				"SLA": "High",
@@ -476,7 +483,7 @@ func TestCreateRoute(t *testing.T) {
 			// initialising the fakeclient
 			fkclient, fkclientset := FakeNew()
 
-			_, err := fkclient.CreateRoute(tt.service, tt.labels)
+			_, err := fkclient.CreateRoute(tt.urlName, tt.service, tt.labels)
 
 			// Checks for error in positive cases
 			if !tt.wantErr == (err != nil) {
@@ -498,9 +505,11 @@ func TestCreateRoute(t *testing.T) {
 				if createdRoute.Spec.To.Name != tt.service {
 					t.Errorf("route is not matching to expected service name, expected: %s, got %s", tt.service, createdRoute)
 				}
-				if createdRoute.Name != tt.service {
-					t.Errorf("route name is not matching to expected name, expected: %s, got %s", tt.service, createdRoute.Name)
-
+				if createdRoute.Name != tt.urlName {
+					t.Errorf("route name is not matching to expected route name, expected: %s, got %s", tt.urlName, createdRoute.Name)
+				}
+				if createdRoute.Spec.To.Name != tt.service {
+					t.Errorf("service name is not matching to expected service name, expected: %s, got %s", tt.service, createdRoute.Spec.To.Name)
 				}
 			}
 		})
@@ -2051,5 +2060,82 @@ func TestCreateNewProject(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestListRoutes(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelSelector string
+		wantLabels    map[string]string
+		routesList    routev1.RouteList
+		wantErr       bool
+	}{
+		{
+			name:          "existing url",
+			labelSelector: "app.kubernetes.io/component-name=nodejs,app.kubernetes.io/name=app",
+			wantLabels: map[string]string{
+				applabels.ApplicationLabel:     "app",
+				componentlabels.ComponentLabel: "nodejs",
+			},
+			routesList: routev1.RouteList{
+				Items: []routev1.Route{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "nodejs",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:     "app",
+								componentlabels.ComponentLabel: "nodejs",
+							},
+						},
+						Spec: routev1.RouteSpec{
+							To: routev1.RouteTargetReference{
+								Kind: "Service",
+								Name: "nodejs-app",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "wildfly",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:     "app",
+								componentlabels.ComponentLabel: "wildfly",
+								urlLabels.UrlLabel:             "wildfly",
+							},
+						},
+						Spec: routev1.RouteSpec{
+							To: routev1.RouteTargetReference{
+								Kind: "Service",
+								Name: "wildfly-app",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := FakeNew()
+
+		fakeClientSet.RouteClientset.PrependReactor("list", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if !reflect.DeepEqual(action.(ktesting.ListAction).GetListRestrictions().Labels.String(), tt.labelSelector) {
+				return true, nil, fmt.Errorf("labels not matching with expected values, expected:%s, got:%s", tt.labelSelector, action.(ktesting.ListAction).GetListRestrictions())
+			}
+			return true, &tt.routesList, nil
+		})
+
+		_, err := client.ListRoutes(tt.labelSelector)
+		if err == nil && !tt.wantErr {
+			if (len(fakeClientSet.RouteClientset.Actions()) != 1) && (tt.wantErr != true) {
+				t.Errorf("expected 1 action in ListRoutes got: %v", fakeClientSet.RouteClientset.Actions())
+			}
+		} else if err == nil && tt.wantErr {
+			t.Errorf("test failed, expected: %s, got %s", "false", "true")
+		} else if err != nil && !tt.wantErr {
+			t.Errorf("test failed, expected: %s, got %s", "no error", "error:"+err.Error())
+		}
 	}
 }

--- a/pkg/url/labels/labels.go
+++ b/pkg/url/labels/labels.go
@@ -1,0 +1,17 @@
+package labels
+
+import (
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+)
+
+// UrlLabel is the label key that is applied to all url resources
+// that are created
+const UrlLabel = "app.kubernetes.io/url-name"
+
+// GetLabels gets the labels to be applied to the given url besides the
+// component labels and application labels.
+func GetLabels(urlName string, componentName string, applicationName string, additional bool) map[string]string {
+	labels := componentlabels.GetLabels(componentName, applicationName, additional)
+	labels[UrlLabel] = urlName
+	return labels
+}

--- a/pkg/url/labels/labels_test.go
+++ b/pkg/url/labels/labels_test.go
@@ -1,0 +1,72 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+)
+
+func TestGetLabels(t *testing.T) {
+	type args struct {
+		urlName         string
+		componentName   string
+		applicationName string
+		additional      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "everything filled",
+			args: args{
+				urlName:         "urlname",
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:     "applicationame",
+				componentlabels.ComponentLabel: "componentname",
+				UrlLabel:                       "urlname",
+			},
+		}, {
+			name: "no storage name",
+			args: args{
+				urlName:         "",
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:     "applicationame",
+				componentlabels.ComponentLabel: "componentname",
+				UrlLabel:                       "",
+			},
+		}, {
+			name: "everything with additional",
+			args: args{
+				urlName:         "urlname",
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      true,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:               "applicationame",
+				applabels.AdditionalApplicationLabels[0]: "applicationame",
+				componentlabels.ComponentLabel:           "componentname",
+				UrlLabel:                                 "urlname",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLabels(tt.args.urlName, tt.args.componentName, tt.args.applicationName, tt.args.additional); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -8,6 +8,7 @@ import (
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
+	urlLabels "github.com/redhat-developer/odo/pkg/url/labels"
 	"github.com/redhat-developer/odo/pkg/util"
 
 	log "github.com/sirupsen/logrus"
@@ -32,23 +33,31 @@ func Delete(client *occlient.Client, urlName string, applicationName string) err
 }
 
 // Create creates a URL
-func Create(client *occlient.Client, componentName, applicationName string) (*URL, error) {
-	labels := componentlabels.GetLabels(componentName, applicationName, false)
+func Create(client *occlient.Client, urlName string, componentName, applicationName string) (*URL, error) {
+	labels := urlLabels.GetLabels(urlName, componentName, applicationName, false)
 
-	// Namespace the component
-	namespacedOpenShiftObject, err := util.NamespaceOpenShiftObject(componentName, applicationName)
+	serviceName, err := util.NamespaceOpenShiftObject(componentName, applicationName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create namespaced name")
 	}
 
+	if urlName == "" {
+		// Namespace the component
+		urlName = serviceName
+	} else {
+		urlName, err = util.NamespaceOpenShiftObject(urlName, applicationName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to create namespaced name")
+		}
+	}
+
 	// Pass in the namespace name, link to the service (componentName) and labels to create a route
-	route, err := client.CreateRoute(namespacedOpenShiftObject, labels)
+	route, err := client.CreateRoute(urlName, serviceName, labels)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create route")
 	}
-
 	return &URL{
-		Name:     route.Labels[componentlabels.ComponentLabel],
+		Name:     route.Labels[urlLabels.UrlLabel],
 		URL:      route.Spec.Host,
 		Protocol: getProtocol(*route),
 	}, nil
@@ -74,7 +83,7 @@ func List(client *occlient.Client, componentName string, applicationName string)
 	var urls []URL
 	for _, r := range routes {
 		urls = append(urls, URL{
-			Name:     r.Labels[componentlabels.ComponentLabel],
+			Name:     r.Labels[urlLabels.UrlLabel],
 			URL:      r.Spec.Host,
 			Protocol: getProtocol(r),
 		})
@@ -93,4 +102,22 @@ func getProtocol(route routev1.Route) string {
 
 func GetUrlString(url URL) string {
 	return url.Protocol + "://" + url.URL
+}
+
+// Exists checks if the url exists in the component or not
+// urlName is the name of the url for checking
+// componentName is the name of the component to which the url's existence is checked
+// applicationName is the name of the application to which the url's existence is checked
+func Exists(client *occlient.Client, urlName string, componentName string, applicationName string) (bool, error) {
+	urls, err := List(client, componentName, applicationName)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to list the urls")
+	}
+
+	for _, url := range urls {
+		if url.Name == urlName {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
Issue: #520 
Signed-off-by: mdas <mrinald7@gmail.com>

This revamps the URL command and adds support for custom names for url. It also adds a component flag to the create command for URL to specify the component. It also changes the behaviour of the odo delete command and now a component flag can be passed to delete the url from or else the current component is used.