### PR TITLE
Add empty image name validation

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -171,12 +171,18 @@ func parseImageName(image string) (string, string, string, error) {
 	digestParts := strings.Split(image, "@")
 	if len(digestParts) == 2 {
 		// image is references digest
-		return digestParts[0], "", digestParts[1], nil
-	} else if len(digestParts) == 1 {
+		// Safe path image name and digest are non empty, else error
+		if digestParts[0] != "" && digestParts[1] != "" {
+			return digestParts[0], "", digestParts[1], nil
+		}
+	} else if len(digestParts) == 1 && digestParts[0] != "" { // Filter out empty image name
 		tagParts := strings.Split(image, ":")
 		if len(tagParts) == 2 {
-			// image references tag
-			return tagParts[0], tagParts[1], "", nil
+			// ":1.0.0 is invalid image name"
+			if tagParts[0] != "" {
+				// image references tag
+				return tagParts[0], tagParts[1], "", nil
+			}
 		} else if len(tagParts) == 1 {
 			return tagParts[0], "latest", "", nil
 		}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -507,9 +507,17 @@ func Test_parseImageName(t *testing.T) {
 			want3:   "",
 			wantErr: false,
 		},
+		{
+			arg:     "",
+			wantErr: true,
+		},
+		{
+			arg:     ":",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
-		name := fmt.Sprintf("image name: %s", tt.arg)
+		name := fmt.Sprintf("image name: '%s'", tt.arg)
 		t.Run(name, func(t *testing.T) {
 			got1, got2, got3, err := parseImageName(tt.arg)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
Most validations for the image name were being made by the parseImageName
func of occlient.go. However, the case for its emptyness and incompleteness
with just a separator were accidentally left out.
This PR adds the validations for the same and also adds UT cases to validate
the validations are as intended.

fixes #581
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>