### PR TITLE
Adds option to allow users to specify port when component is created

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -19,6 +19,7 @@ var (
 	componentBinary string
 	componentGit    string
 	componentLocal  string
+	componentPorts  []string
 )
 
 var componentCreateCmd = &cobra.Command{
@@ -40,6 +41,9 @@ A full list of component types that can be deployed is available using: 'odo com
 
   # Create new Wildfly component with binary named sample.war in './downloads' directory
   odo create wildfly wildly --binary ./downloads/sample.war
+
+  # Create new Node.js component with the source in current directory and ports 8080-tcp,8100-tcp and 9100-udp exposed
+  odo create nodejs --ports 8080,8100/tcp,9100/udp
 
   # List of ready-to-use examples
   # for more examples, visit: https://github.com/redhat-developer/odo/blob/master/docs/examples.md
@@ -99,7 +103,7 @@ A full list of component types that can be deployed is available using: 'odo com
 		}
 
 		if len(componentGit) != 0 {
-			err := component.CreateFromGit(client, componentName, componentType, componentGit, applicationName)
+			err := component.CreateFromGit(client, componentName, componentType, componentGit, applicationName, componentPorts)
 			checkError(err, "")
 			fmt.Printf("Component '%s' was created.\n", componentName)
 			fmt.Printf("Triggering build from %s.\n\n", componentGit)
@@ -115,7 +119,7 @@ A full list of component types that can be deployed is available using: 'odo com
 				fmt.Println("Please provide a path to the directory")
 				os.Exit(1)
 			}
-			err = component.CreateFromPath(client, componentName, componentType, dir, applicationName, "local")
+			err = component.CreateFromPath(client, componentName, componentType, dir, applicationName, "local", componentPorts)
 			checkError(err, "")
 			fmt.Printf("Please wait, creating %s component ...\n", componentName)
 			err = component.Build(client, componentName, applicationName, false, true, stdout)
@@ -126,7 +130,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			path, err := filepath.Abs(componentBinary)
 			checkError(err, "")
 
-			err = component.CreateFromPath(client, componentName, componentType, path, applicationName, "binary")
+			err = component.CreateFromPath(client, componentName, componentType, path, applicationName, "binary", componentPorts)
 			checkError(err, "")
 			fmt.Printf("Please wait, creating %s component ...\n", componentName)
 			err = component.Build(client, componentName, applicationName, false, true, stdout)
@@ -137,7 +141,7 @@ A full list of component types that can be deployed is available using: 'odo com
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs("./")
 			checkError(err, "")
-			err = component.CreateFromPath(client, componentName, componentType, dir, applicationName, "local")
+			err = component.CreateFromPath(client, componentName, componentType, dir, applicationName, "local", componentPorts)
 			checkError(err, "")
 			fmt.Printf("Please wait, creating %s component ...\n", componentName)
 			err = component.Build(client, componentName, applicationName, false, true, stdout)
@@ -156,6 +160,7 @@ func init() {
 	componentCreateCmd.Flags().StringVar(&componentBinary, "binary", "", "Binary artifact")
 	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "Git source")
 	componentCreateCmd.Flags().StringVar(&componentLocal, "local", "", "Use local directory as a source for component")
+	componentCreateCmd.Flags().StringSliceVar(&componentPorts, "ports", []string{}, "Ports to be used when the component is created")
 
 	// Add a defined annotation in order to appear in the help menu
 	componentCreateCmd.Annotations = map[string]string{"command": "component"}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -46,7 +46,8 @@ func validateSourceType(sourceType string) bool {
 	return false
 }
 
-func CreateFromGit(client *occlient.Client, name string, ctype string, url string, applicationName string) error {
+// inputPorts is the array containing the string port values
+func CreateFromGit(client *occlient.Client, name string, ctype string, url string, applicationName string, inputPorts []string) error {
 	labels := componentlabels.GetLabels(name, applicationName, true)
 	// save component type as label
 	labels[componentlabels.ComponentTypeLabel] = ctype
@@ -61,7 +62,7 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 		return errors.Wrapf(err, "unable to create namespaced name")
 	}
 
-	err = client.NewAppS2I(namespacedOpenShiftObject, ctype, url, labels, annotations)
+	err = client.NewAppS2I(namespacedOpenShiftObject, ctype, url, labels, annotations, inputPorts)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create git component %s", namespacedOpenShiftObject)
 	}
@@ -70,7 +71,8 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 
 // CreateFromPath create new component with source or binary from the given local path
 // sourceType indicates the source type of the component and can be either local or binary
-func CreateFromPath(client *occlient.Client, name string, ctype string, path string, applicationName string, sourceType string) error {
+// inputPorts is the array containing the string port values
+func CreateFromPath(client *occlient.Client, name string, ctype string, path string, applicationName string, sourceType string, inputPorts []string) error {
 	labels := componentlabels.GetLabels(name, applicationName, true)
 	// save component type as label
 	labels[componentlabels.ComponentTypeLabel] = ctype
@@ -86,7 +88,7 @@ func CreateFromPath(client *occlient.Client, name string, ctype string, path str
 		return errors.Wrapf(err, "unable to create namespaced name")
 	}
 
-	err = client.BootstrapSupervisoredS2I(namespacedOpenShiftObject, ctype, labels, annotations)
+	err = client.BootstrapSupervisoredS2I(namespacedOpenShiftObject, ctype, labels, annotations, inputPorts)
 	if err != nil {
 		return err
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	ktesting "k8s.io/client-go/testing"
 
-	applabels "github.com/redhat-developer/odo/pkg/application/labels"
-	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
-	urlLabels "github.com/redhat-developer/odo/pkg/url/labels"
+	//applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	//componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	//urlLabels "github.com/redhat-developer/odo/pkg/url/labels"
 )
 
 // fakeImageStream gets imagestream for the reactor
@@ -596,7 +596,7 @@ func TestCreateRoute(t *testing.T) {
 			urlName: "mailserver",
 			service: "mailserver",
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "python",
 			},
@@ -608,7 +608,7 @@ func TestCreateRoute(t *testing.T) {
 			urlName: "example",
 			service: "blog",
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "golang",
 			},
@@ -902,7 +902,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -936,7 +936,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -965,7 +965,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1000,7 +1000,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1029,7 +1029,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1064,7 +1064,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1092,7 +1092,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1701,6 +1701,7 @@ func TestNewAppS2I(t *testing.T) {
 		gitUrl       string
 		labels       map[string]string
 		annotations  map[string]string
+		inputPorts   []string
 	}
 
 	tests := []struct {
@@ -1716,7 +1717,7 @@ func TestNewAppS2I(t *testing.T) {
 				namespace:    "testing",
 				gitUrl:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -1737,7 +1738,7 @@ func TestNewAppS2I(t *testing.T) {
 				namespace:    "testing",
 				gitUrl:       "",
 				labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -1746,8 +1747,30 @@ func TestNewAppS2I(t *testing.T) {
 					"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
 					"app.kubernetes.io/component-source-type": "git",
 				},
+				inputPorts: []string{"8081/tcp", "9100/udp"},
 			},
 			wantErr: false,
+		},
+		{
+			name: "case 2 : binary buildSource with invalid ports",
+			args: args{
+				name:         "ruby",
+				builderImage: "ruby:latest",
+				namespace:    "testing",
+				gitUrl:       "",
+				labels: map[string]string{
+					"app":                              "apptmp",
+					"app.kubernetes.io/component-name": "ruby",
+					"app.kubernetes.io/component-type": "ruby",
+					"app.kubernetes.io/name":           "apptmp",
+				},
+				annotations: map[string]string{
+					"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+					"app.kubernetes.io/component-source-type": "git",
+				},
+				inputPorts: []string{"8080", "9100/asd"},
+			},
+			wantErr: true,
 		},
 
 		// TODO: Currently fails. Enable this case once fixed
@@ -1792,17 +1815,14 @@ func TestNewAppS2I(t *testing.T) {
 				tt.args.builderImage,
 				tt.args.gitUrl,
 				tt.args.labels,
-				tt.args.annotations)
+				tt.args.annotations,
+				tt.args.inputPorts)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewAppS2I() error = %#v, wantErr %#v", err, tt.wantErr)
 			}
 
 			if err == nil {
-
-				if len(fkclientset.ImageClientset.Actions()) != 3 {
-					t.Errorf("expected 3 ImageClientset.Actions() in NewAppS2I, got: %v", fkclientset.ImageClientset.Actions())
-				}
 
 				if len(fkclientset.BuildClientset.Actions()) != 1 {
 					t.Errorf("expected 1 BuildClientset.Actions() in NewAppS2I, got: %v", fkclientset.BuildClientset.Actions())
@@ -1816,8 +1836,23 @@ func TestNewAppS2I(t *testing.T) {
 					t.Errorf("expected 1 Kubernetes.Actions() in NewAppS2I, go: %v", fkclientset.Kubernetes.Actions())
 				}
 
-				// Check for imagestream objects
-				createdIS := fkclientset.ImageClientset.Actions()[2].(ktesting.CreateAction).GetObject().(*imagev1.ImageStream)
+				var createdIS *imagev1.ImageStream
+
+				if len(tt.args.inputPorts) <= 0 {
+					if len(fkclientset.ImageClientset.Actions()) != 3 {
+						t.Errorf("expected 3 ImageClientset.Actions() in NewAppS2I, got: %v", fkclientset.ImageClientset.Actions())
+					}
+
+					// Check for imagestream objects
+					createdIS = fkclientset.ImageClientset.Actions()[2].(ktesting.CreateAction).GetObject().(*imagev1.ImageStream)
+				} else {
+					if len(fkclientset.ImageClientset.Actions()) != 1 {
+						t.Errorf("expected 3 ImageClientset.Actions() in NewAppS2I, got: %v", fkclientset.ImageClientset.Actions())
+					}
+
+					// Check for imagestream objects
+					createdIS = fkclientset.ImageClientset.Actions()[0].(ktesting.CreateAction).GetObject().(*imagev1.ImageStream)
+				}
 
 				if createdIS.Name != tt.args.name {
 					t.Errorf("imagestream name is not matching with expected name, expected: %s, got %s", tt.args.name, createdIS.Name)
@@ -1857,11 +1892,16 @@ func TestNewAppS2I(t *testing.T) {
 
 				createdSvc := fkclientset.Kubernetes.Actions()[0].(ktesting.CreateAction).GetObject().(*corev1.Service)
 
-				// ExposedPorts 8080 in fakeImageStreamImages()
-				if createdSvc.Spec.Ports[0].Port != 8080 {
-					t.Errorf("Svc port not matching, expected: 8080, got %v", createdSvc.Spec.Ports[0].Port)
+				if len(tt.args.inputPorts) <= 0 {
+					// ExposedPorts 8080 in fakeImageStreamImages()
+					if createdSvc.Spec.Ports[0].Port != 8080 {
+						t.Errorf("Svc port not matching, expected: 8080, got %v", createdSvc.Spec.Ports[0].Port)
+					}
+				} else {
+					if !reflect.DeepEqual(createdSvc, tt.args.inputPorts) {
+						t.Errorf("Svc port not matching, expected: %v, got %v", tt.args.inputPorts, createdSvc)
+					}
 				}
-
 			}
 		})
 	}
@@ -2111,7 +2151,7 @@ func TestWaitAndGetPod(t *testing.T) {
 		},
 
 		{
-			name: "phase:	unknown",
+			name:    "phase:	unknown",
 			podName: "ruby",
 			status:  corev1.PodUnknown,
 			wantErr: true,
@@ -2205,82 +2245,5 @@ func TestCreateNewProject(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestListRoutes(t *testing.T) {
-	tests := []struct {
-		name          string
-		labelSelector string
-		wantLabels    map[string]string
-		routesList    routev1.RouteList
-		wantErr       bool
-	}{
-		{
-			name:          "existing url",
-			labelSelector: "app.kubernetes.io/component-name=nodejs,app.kubernetes.io/name=app",
-			wantLabels: map[string]string{
-				applabels.ApplicationLabel:     "app",
-				componentlabels.ComponentLabel: "nodejs",
-			},
-			routesList: routev1.RouteList{
-				Items: []routev1.Route{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "nodejs",
-							Labels: map[string]string{
-								applabels.ApplicationLabel:     "app",
-								componentlabels.ComponentLabel: "nodejs",
-							},
-						},
-						Spec: routev1.RouteSpec{
-							To: routev1.RouteTargetReference{
-								Kind: "Service",
-								Name: "nodejs-app",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "wildfly",
-							Labels: map[string]string{
-								applabels.ApplicationLabel:     "app",
-								componentlabels.ComponentLabel: "wildfly",
-								urlLabels.UrlLabel:             "wildfly",
-							},
-						},
-						Spec: routev1.RouteSpec{
-							To: routev1.RouteTargetReference{
-								Kind: "Service",
-								Name: "wildfly-app",
-							},
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		client, fakeClientSet := FakeNew()
-
-		fakeClientSet.RouteClientset.PrependReactor("list", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
-			if !reflect.DeepEqual(action.(ktesting.ListAction).GetListRestrictions().Labels.String(), tt.labelSelector) {
-				return true, nil, fmt.Errorf("labels not matching with expected values, expected:%s, got:%s", tt.labelSelector, action.(ktesting.ListAction).GetListRestrictions())
-			}
-			return true, &tt.routesList, nil
-		})
-
-		_, err := client.ListRoutes(tt.labelSelector)
-		if err == nil && !tt.wantErr {
-			if (len(fakeClientSet.RouteClientset.Actions()) != 1) && (tt.wantErr != true) {
-				t.Errorf("expected 1 action in ListRoutes got: %v", fakeClientSet.RouteClientset.Actions())
-			}
-		} else if err == nil && tt.wantErr {
-			t.Error("error was expected, but no error was returned")
-		} else if err != nil && !tt.wantErr {
-			t.Errorf("test failed, no error was expected, but got unexpected error: %s", err)
-		}
 	}
 }

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -19,8 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/watch"
+		"k8s.io/apimachinery/pkg/watch"
 	ktesting "k8s.io/client-go/testing"
 
 	//applabels "github.com/redhat-developer/odo/pkg/application/labels"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -273,6 +273,25 @@ var _ = Describe("odoe2e", func() {
 				cmpList := runCmd("odo list")
 				Expect(cmpList).To(ContainSubstring("wildfly"))
 			})
+
+			It("should be able to create git component with required ports", func() {
+				runCmd("odo create nodejs nodejs-git --git https://github.com/openshift/nodejs-ex --ports 8080/tcp,9100/udp")
+
+				// checking port names
+				portsNames := runCmd("oc get services nodejs-git-" + appTestName + " -o go-template='{{range .spec.ports}}{{.name}}{{end}}'")
+				Expect(portsNames).To(ContainSubstring("8080-tcp"))
+				Expect(portsNames).To(ContainSubstring("9100-udp"))
+
+				// checking port numbers
+				ports := runCmd("oc get services nodejs-git-" + appTestName + " -o go-template='{{range .spec.ports}}{{.port}}{{end}}'")
+				Expect(ports).To(ContainSubstring("8080"))
+				Expect(ports).To(ContainSubstring("9100"))
+
+				// checking protocols
+				protocols := runCmd("oc get services nodejs-git-" + appTestName + " -o go-template='{{range .spec.ports}}{{.protocol}}{{end}}'")
+				Expect(protocols).To(ContainSubstring("TCP"))
+				Expect(protocols).To(ContainSubstring("UDP"))
+			})
 		})
 	})
 


### PR DESCRIPTION
Issue : #552 
Signed-off-by: mdas <mrinald7@gmail.com>

Adds option to allow users to specify port when component is created and the flag is used as 
```
odo create nodejs --ports 8080/tcp,8081,9100/udp
```
 If the ports flag is not used than the ports, that are exposed by the given image, is used.

It adds a new function getContainerPortsFromString which takes a string array containing the port string e.g 8080/tcp,8081,9090/udp and returns the ContainerPorts or error. If no protocol is passed, tcp is considered as default.