### PR TITLE
Fixing e2e tests on minishift:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,11 @@ test:
 # Run e2e tests
 .PHONY: test-e2e
 test-e2e:
+ifdef TIMEOUT
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoe2e" -ginkgo.v -timeout $(TIMEOUT)
+else
 	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoe2e" -ginkgo.v
+endif
 
 .PHONY: test-demo
 test-demo:


### PR DESCRIPTION
In this PR, we do away with http calls on IP:Port (which failed on minishift), but instead create a route using `odo url` and then run curl on that url.