### PR TITLE
Include imagestreams in current namespace for catalog listing

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -54,10 +54,22 @@ var catalogListComponentCmd = &cobra.Command{
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			fmt.Fprintln(w, "NAME", "\t", "TAGS")
 			for _, component := range catalogList {
-				fmt.Fprintln(w, fmt.Sprintf("%s/%s", component.Namespace, component.Name), "\t", strings.Join(component.Tags, ","))
+				component_name := fmt.Sprintf("%s/%s", component.Namespace, component.Name)
+				if component.Namespace == client.GetCurrentProjectName() {
+					for _, comp1 := range catalogList {
+						if comp1.Name == component.Name && component.Namespace != comp1.Namespace {
+							component_name = fmt.Sprintf("%s (*)", component_name)
+						}
+					}
+				}
+				fmt.Fprintln(w, component_name, "\t", strings.Join(component.Tags, ","))
 			}
 			w.Flush()
-
+			fmt.Println(
+				`NOTE: There might be catalog items in multiple catalogs.
+Those marked with (*) will take precedence.
+In case you want to use an item from a different catalog, please fully qualify it as $namespace/$catalog_name`,
+			)
 		}
 	},
 }

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -71,11 +71,6 @@ var catalogListComponentCmd = &cobra.Command{
 				fmt.Fprintln(w, componentName, "\t", component.Namespace, "\t", strings.Join(component.Tags, ","))
 			}
 			w.Flush()
-			fmt.Println(
-				`NOTE: There might be items in multiple projects.
-Items from the current project (marked with *) will take precedence.
-If you want to use an item from a different namespace, use the full name as <namespace>/<name>`,
-			)
 		}
 	},
 }

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -52,9 +52,9 @@ var catalogListComponentCmd = &cobra.Command{
 		default:
 			currentProject := client.GetCurrentProjectName()
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "NAME", "\t", "NAMESPACE", "\t", "TAGS")
+			fmt.Fprintln(w, "NAME", "\t", "PROJECT", "\t", "TAGS")
 			for _, component := range catalogList {
-				component_name := component.Name
+				componentName := component.Name
 				if component.Namespace == currentProject {
 					/*
 						If current namespace is same as the current component namespace,
@@ -62,17 +62,17 @@ var catalogListComponentCmd = &cobra.Command{
 						If there exists a component with same name but in different namespaces,
 						mark the one from current namespace with (*)
 					*/
-					for _, comp1 := range catalogList {
-						if comp1.Name == component.Name && component.Namespace != comp1.Namespace {
-							component_name = fmt.Sprintf("%s (*)", component.Name)
+					for _, comp := range catalogList {
+						if comp.Name == component.Name && component.Namespace != comp.Namespace {
+							componentName = fmt.Sprintf("%s (*)", component.Name)
 						}
 					}
 				}
-				fmt.Fprintln(w, component_name, "\t", component.Namespace, "\t", strings.Join(component.Tags, ","))
+				fmt.Fprintln(w, componentName, "\t", component.Namespace, "\t", strings.Join(component.Tags, ","))
 			}
 			w.Flush()
 			fmt.Println(
-				`NOTE: There might be items in multiple namespaces.
+				`NOTE: There might be items in multiple project.
 Items from the current project (marked with *) will take precedence.
 In case you want to use an item from a different namespace, please fully qualify it as $namespace/$name`,
 			)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -54,7 +54,7 @@ var catalogListComponentCmd = &cobra.Command{
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			fmt.Fprintln(w, "NAME", "\t", "TAGS")
 			for _, component := range catalogList {
-				fmt.Fprintln(w, component.Name, "\t", strings.Join(component.Tags, ","))
+				fmt.Fprintln(w, fmt.Sprintf("%s/%s", component.Namespace, component.Name), "\t", strings.Join(component.Tags, ","))
 			}
 			w.Flush()
 

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -50,25 +50,31 @@ var catalogListComponentCmd = &cobra.Command{
 		case 0:
 			fmt.Printf("No deployable components found\n")
 		default:
-
+			currentProject := client.GetCurrentProjectName()
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "NAME", "\t", "TAGS")
+			fmt.Fprintln(w, "NAME", "\t", "NAMESPACE", "\t", "TAGS")
 			for _, component := range catalogList {
-				component_name := fmt.Sprintf("%s/%s", component.Namespace, component.Name)
-				if component.Namespace == client.GetCurrentProjectName() {
+				component_name := component.Name
+				if component.Namespace == currentProject {
+					/*
+						 If current namespace is same as the current component namespace,
+						 	Loop through every other component,
+								If there exists a component with same name but in different namespaces,
+									 mark the one from current namespace with (*)
+					*/
 					for _, comp1 := range catalogList {
 						if comp1.Name == component.Name && component.Namespace != comp1.Namespace {
-							component_name = fmt.Sprintf("%s (*)", component_name)
+							component_name = fmt.Sprintf("%s (*)", component.Name)
 						}
 					}
 				}
-				fmt.Fprintln(w, component_name, "\t", strings.Join(component.Tags, ","))
+				fmt.Fprintln(w, component_name, "\t", component.Namespace, "\t", strings.Join(component.Tags, ","))
 			}
 			w.Flush()
 			fmt.Println(
-				`NOTE: There might be catalog items in multiple catalogs.
-Those marked with (*) will take precedence.
-In case you want to use an item from a different catalog, please fully qualify it as $namespace/$catalog_name`,
+				`NOTE: There might be items in multiple namespaces.
+Items from current project (marked with *) will take precedence.
+In case you want to use an item from a different namespace, please fully qualify it as $namespace/$name`,
 			)
 		}
 	},

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -72,9 +72,9 @@ var catalogListComponentCmd = &cobra.Command{
 			}
 			w.Flush()
 			fmt.Println(
-				`NOTE: There might be items in multiple project.
+				`NOTE: There might be items in multiple projects.
 Items from the current project (marked with *) will take precedence.
-In case you want to use an item from a different namespace, please fully qualify it as $namespace/$name`,
+If you want to use an item from a different namespace, use the full name as <namespace>/<name>`,
 			)
 		}
 	},

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -57,10 +57,10 @@ var catalogListComponentCmd = &cobra.Command{
 				component_name := component.Name
 				if component.Namespace == currentProject {
 					/*
-						 If current namespace is same as the current component namespace,
-						 	Loop through every other component,
-								If there exists a component with same name but in different namespaces,
-									 mark the one from current namespace with (*)
+						If current namespace is same as the current component namespace,
+						Loop through every other component,
+						If there exists a component with same name but in different namespaces,
+						mark the one from current namespace with (*)
 					*/
 					for _, comp1 := range catalogList {
 						if comp1.Name == component.Name && component.Namespace != comp1.Namespace {
@@ -73,7 +73,7 @@ var catalogListComponentCmd = &cobra.Command{
 			w.Flush()
 			fmt.Println(
 				`NOTE: There might be items in multiple namespaces.
-Items from current project (marked with *) will take precedence.
+Items from the current project (marked with *) will take precedence.
 In case you want to use an item from a different namespace, please fully qualify it as $namespace/$name`,
 			)
 		}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -85,7 +85,7 @@ A full list of component types that can be deployed is available using: 'odo cat
 		// "Default" values
 		componentImageName := args[0]
 		componentType := args[0]
-		componentName := args[0]
+		componentName := strings.Replace(args[0], "/", "-", -1)
 		componentVersion := "latest"
 
 		// Check if componentType includes ":", if so, then we need to spit it into using versions

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -30,15 +30,8 @@ var componentCreateCmd = &cobra.Command{
 
 If component name is not provided, component type value will be used for the name.
 
-The component type will be chosen by default from current project,
-but if specific version is requested for, it'll be used from either
-* current
-   or
-* openshift
-
-project(with search precendence in same order) where available.
-So, if you would like it to be specifically from openshift project, please fully qualify the
-component type as $project/$component_type:$version.
+By default, builder images will be used from the current namespace.
+You can explicitly supply a namespace by using: odo create namespace/name:version
 If version is not specified by default, latest wil be chosen as the version.
 
 A full list of component types that can be deployed is available using: 'odo catalog list'`,
@@ -54,7 +47,7 @@ A full list of component types that can be deployed is available using: 'odo cat
   # Create new Node.js component with source from remote git repository.
   odo create nodejs --git https://github.com/openshift/nodejs-ex.git
 
-  # Create new Node.js component of version 6 using the builder image specifically from 'openshift' namespace
+  # Create a new Node.js component of version 6 from the 'openshift' namespace
   odo create openshift/nodejs:6 --local /nodejs-ex
 
   # Create new Wildfly component with binary named sample.war in './downloads' directory
@@ -189,13 +182,11 @@ A full list of component types that can be deployed is available using: 'odo cat
 	},
 }
 
-/*
- parseCreateCmdArgs returns
- 1. image name
- 2. component type i.e, builder image name
- 3. component name default value is component type else the user requested component name
- 4. component version which is by default latest else version passed with builder image name
-*/
+// parseCreateCmdArgs returns
+// 1. image name
+// 2. component type i.e, builder image name
+// 3. component name default value is component type else the user requested component name
+// 4. component version which is by default latest else version passed with builder image name
 func parseCreateCmdArgs(args []string) (string, string, string, string) {
 	// We don't have to check it anymore, Args check made sure that args has at least one item
 	// and no more than two

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -30,8 +30,19 @@ var componentCreateCmd = &cobra.Command{
 
 If component name is not provided, component type value will be used for the name.
 
+The component type will be chosen by default from current project,
+but if specific version is requested for, it'll be used from either
+* current
+   or
+* openshift
+
+project(with search precendence in same order) where available.
+So, if you would like it to be specifically from openshift project, please fully qualify the
+component type as $project/$component_type:$version.
+If version is not specified by default, latest wil be chosen as the version.
+
 A full list of component types that can be deployed is available using: 'odo catalog list'`,
-	Example: `  # Create new Node.js component with the source in current directory. 
+	Example: `  # Create new Node.js component with the source in current directory.
   odo create nodejs
 
   # A specific image version may also be specified
@@ -42,6 +53,9 @@ A full list of component types that can be deployed is available using: 'odo cat
 
   # Create new Node.js component with source from remote git repository.
   odo create nodejs --git https://github.com/openshift/nodejs-ex.git
+
+  # Create new Node.js component of version 6 using the builder image specifically from 'openshift' namespace
+  odo create openshift/nodejs:6 --local /nodejs-ex
 
   # Create new Wildfly component with binary named sample.war in './downloads' directory
   odo create wildfly wildly --binary ./downloads/sample.war

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -30,8 +30,7 @@ var componentCreateCmd = &cobra.Command{
 
 If component name is not provided, component type value will be used for the name.
 
-By default, builder images will be used from the current namespace.
-You can explicitly supply a namespace by using: odo create namespace/name:version
+By default, builder images will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version
 If version is not specified by default, latest wil be chosen as the version.
 
 A full list of component types that can be deployed is available using: 'odo catalog list'`,
@@ -87,7 +86,7 @@ A full list of component types that can be deployed is available using: 'odo cat
 			os.Exit(1)
 		}
 
-		componentImageName, componentType, componentName, componentVersion := parseCreateCmdArgs(args)
+		componentImageName, componentType, componentName, componentVersion := util.ParseCreateCmdArgs(args)
 
 		// Check to see if the catalog type actually exists
 		exists, err := catalog.Exists(client, componentType)
@@ -180,31 +179,6 @@ A full list of component types that can be deployed is available using: 'odo cat
 		checkError(err, "")
 		fmt.Printf("\nComponent '%s' is now set as active component.\n", componentName)
 	},
-}
-
-// parseCreateCmdArgs returns
-// 1. image name
-// 2. component type i.e, builder image name
-// 3. component name default value is component type else the user requested component name
-// 4. component version which is by default latest else version passed with builder image name
-func parseCreateCmdArgs(args []string) (string, string, string, string) {
-	// We don't have to check it anymore, Args check made sure that args has at least one item
-	// and no more than two
-
-	// "Default" values
-	componentImageName := args[0]
-	componentType := args[0]
-	componentName := util.ExtractComponentType(componentType)
-	componentVersion := "latest"
-
-	// Check if componentType includes ":", if so, then we need to spit it into using versions
-	if strings.ContainsAny(componentImageName, ":") {
-		versionSplit := strings.Split(args[0], ":")
-		componentType = versionSplit[0]
-		componentName = util.ExtractComponentType(componentType)
-		componentVersion = versionSplit[1]
-	}
-	return componentImageName, componentType, componentName, componentVersion
 }
 
 func init() {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -80,22 +80,7 @@ A full list of component types that can be deployed is available using: 'odo cat
 			os.Exit(1)
 		}
 
-		// We don't have to check it anymore, Args check made sure that args has at least one item
-		// and no more than two
-
-		// "Default" values
-		componentImageName := args[0]
-		componentType := args[0]
-		componentName := util.ExtractComponentType(componentType)
-		componentVersion := "latest"
-
-		// Check if componentType includes ":", if so, then we need to spit it into using versions
-		if strings.ContainsAny(componentImageName, ":") {
-			versionSplit := strings.Split(args[0], ":")
-			componentType = versionSplit[0]
-			componentName = util.ExtractComponentType(componentType)
-			componentVersion = versionSplit[1]
-		}
+		componentImageName, componentType, componentName, componentVersion := parseCreateCmdArgs(args)
 
 		// Check to see if the catalog type actually exists
 		exists, err := catalog.Exists(client, componentType)
@@ -188,6 +173,33 @@ A full list of component types that can be deployed is available using: 'odo cat
 		checkError(err, "")
 		fmt.Printf("\nComponent '%s' is now set as active component.\n", componentName)
 	},
+}
+
+/*
+ parseCreateCmdArgs returns
+ 1. image name
+ 2. component type i.e, builder image name
+ 3. component name default value is component type else the user requested component name
+ 4. component version which is by default latest else version passed with builder image name
+*/
+func parseCreateCmdArgs(args []string) (string, string, string, string) {
+	// We don't have to check it anymore, Args check made sure that args has at least one item
+	// and no more than two
+
+	// "Default" values
+	componentImageName := args[0]
+	componentType := args[0]
+	componentName := util.ExtractComponentType(componentType)
+	componentVersion := "latest"
+
+	// Check if componentType includes ":", if so, then we need to spit it into using versions
+	if strings.ContainsAny(componentImageName, ":") {
+		versionSplit := strings.Split(args[0], ":")
+		componentType = versionSplit[0]
+		componentName = util.ExtractComponentType(componentType)
+		componentVersion = versionSplit[1]
+	}
+	return componentImageName, componentType, componentName, componentVersion
 }
 
 func init() {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/project"
+	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -85,14 +86,14 @@ A full list of component types that can be deployed is available using: 'odo cat
 		// "Default" values
 		componentImageName := args[0]
 		componentType := args[0]
-		componentName := strings.Replace(args[0], "/", "-", -1)
+		componentName := util.ExtractComponentType(componentType)
 		componentVersion := "latest"
 
 		// Check if componentType includes ":", if so, then we need to spit it into using versions
 		if strings.ContainsAny(componentImageName, ":") {
 			versionSplit := strings.Split(args[0], ":")
 			componentType = versionSplit[0]
-			componentName = versionSplit[0]
+			componentName = util.ExtractComponentType(componentType)
 			componentVersion = versionSplit[1]
 		}
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,10 +125,10 @@ Note:
 By default builder imagestreams from current project are used for building your application.
 But, if the builder imagestream corresponding to the type of requested component does not exist in the current project,
 builder imagestreams from openshift namespace are also considered. But if you would like to specifically use the default
-builder imagestream, you can fully qualify the component type using $project/$component_type:$version.
+builder imagestream, you can fully qualify the component type using `$project/$component_type:$version`.
 Accordingly following commands can also be used:
-* odo create openshift/nodejs:6 --local=.
-* odo create nodejs:6 --local=.
+* `odo create openshift/nodejs:6 --local=.`
+* `odo create nodejs:6 --local=.`
 
 For more details please refer https://github.com/redhat-developer/odo/blob/master/docs/cli-reference.md#create
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,14 +122,8 @@ Component 'nodejs' is now set as active component.
 
 Note:
 
-By default builder imagestreams from current project are used for building your application.
-But, if the builder imagestream corresponding to the type of requested component does not exist in the current project,
-builder imagestreams from openshift namespace are also considered. But if you would like to specifically use the default
-builder imagestream, you can fully qualify the component type using `$project/$component_type:$version`.
-Accordingly following commands can also be used:
-* `odo create openshift/nodejs:6 --local=.`
-* `odo create nodejs:6 --local=.`
-
+By default, builder images will be used from the default OpenShift namespace.
+You can explicitly supply a namespace by using: `odo create opesnshift/nodejs:8`
 For more details please refer https://github.com/redhat-developer/odo/blob/master/docs/cli-reference.md#create
 
 Now that a component is running we'll go ahead and push our initial source code!

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,6 +120,18 @@ To push source code to the component run 'odo push'
 Component 'nodejs' is now set as active component.
 ```
 
+Note:
+
+By default builder imagestreams from current project are used for building your application.
+But, if the builder imagestream corresponding to the type of requested component does not exist in the current project,
+builder imagestreams from openshift namespace are also considered. But if you would like to specifically use the default
+builder imagestream, you can fully qualify the component type using $project/$component_type:$version.
+Accordingly following commands can also be used:
+* odo create openshift/nodejs:6 --local=.
+* odo create nodejs:6 --local=.
+
+For more details please refer https://github.com/redhat-developer/odo/blob/master/docs/cli-reference.md#create
+
 Now that a component is running we'll go ahead and push our initial source code!
 
 ```sh

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
@@ -54,7 +55,7 @@ func Exists(client *occlient.Client, componentType string) (bool, error) {
 	}
 
 	for _, supported := range catalogList {
-		if componentType == supported.Name {
+		if componentType == supported.Name || componentType == fmt.Sprintf("%s/%s", supported.Namespace, supported.Name) {
 			return true, nil
 		}
 	}
@@ -72,7 +73,7 @@ func VersionExists(client *occlient.Client, componentType string, componentVersi
 
 	// Find the component and then return true if the version has been found
 	for _, supported := range catalogList {
-		if componentType == supported.Name {
+		if componentType == supported.Name || componentType == fmt.Sprintf("%s/%s", supported.Namespace, supported.Name) {
 			// Now check to see if that version matches that components tag
 			for _, tag := range supported.Tags {
 				if componentVersion == tag {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -103,7 +103,7 @@ func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 		// We may get the imagestreams from other Namespaces
 		err = errors.Wrapf(e, "unable to get Image Streams from namespace %s", occlient.OpenShiftNameSpace)
 		// log it for debugging purposes
-		log.Debugf("Unable to get Image Streams from namespace %s. Error %s", occlient.OpenShiftNameSpace, e.Error())
+		glog.V(4).Infof("Unable to get Image Streams from namespace %s. Error %s", occlient.OpenShiftNameSpace, e.Error())
 	}
 
 	// Fetch imagestreams from current namespace
@@ -117,7 +117,7 @@ func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 		// But may be required for debugging purposes
 		err = errors.Wrapf(e, "unable to get Image Streams from namespace %s", currentNamespace)
 		// log it for debugging purposes
-		log.Debugf("Unable to get Image Streams from namespace %s. Error %s", currentNamespace, e.Error())
+		glog.V(4).Infof("Unable to get Image Streams from namespace %s. Error %s", currentNamespace, e.Error())
 	}
 
 	// Resultant imagestreams is list of imagestreams from current and openshift namespaces

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -90,7 +90,7 @@ func VersionExists(client *occlient.Client, componentType string, componentVersi
 }
 
 // getDefaultBuilderImages returns the default builder images available in the
-// openshift namespace
+// openshift and the current namespaces
 func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 	var imageStreams []imagev1.ImageStream
 	currentNamespace := client.GetCurrentProjectName()
@@ -102,6 +102,8 @@ func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 		// Tolerate the error as it might only be a partial failure
 		// We may get the imagestreams from other Namespaces
 		err = errors.Wrapf(e, "unable to get Image Streams from namespace %s", occlient.OpenShiftNameSpace)
+		// log it for debugging purposes
+		log.Debugf("Unable to get Image Streams from namespace %s. Error %s", occlient.OpenShiftNameSpace, e.Error())
 	}
 
 	// Fetch imagestreams from current namespace
@@ -114,6 +116,8 @@ func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 		// It is possible that the current namespace has no imagestreams -- a valid scenario
 		// But may be required for debugging purposes
 		err = errors.Wrapf(e, "unable to get Image Streams from namespace %s", currentNamespace)
+		// log it for debugging purposes
+		log.Debugf("Unable to get Image Streams from namespace %s. Error %s", currentNamespace, e.Error())
 	}
 
 	// Resultant imagestreams is list of imagestreams from current and openshift namespaces

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -97,27 +97,27 @@ func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 	var err error
 
 	// Fetch imagestreams from default openshift namespace
-	openshiftNSImageStreams, e := client.GetImageStreams(occlient.OpenShiftNameSpace)
-	if e != nil {
+	openshiftNSImageStreams, possibleError := client.GetImageStreams(occlient.OpenShiftNameSpace)
+	if possibleError != nil {
 		// Tolerate the error as it might only be a partial failure
 		// We may get the imagestreams from other Namespaces
-		err = errors.Wrapf(e, "unable to get Image Streams from namespace %s", occlient.OpenShiftNameSpace)
+		err = errors.Wrapf(possibleError, "unable to get Image Streams from namespace %s", occlient.OpenShiftNameSpace)
 		// log it for debugging purposes
-		glog.V(4).Infof("Unable to get Image Streams from namespace %s. Error %s", occlient.OpenShiftNameSpace, e.Error())
+		glog.V(4).Infof("Unable to get Image Streams from namespace %s. Error %s", occlient.OpenShiftNameSpace, possibleError.Error())
 	}
 
 	// Fetch imagestreams from current namespace
-	currentNSImageStreams, e := client.GetImageStreams(currentNamespace)
-	if e != nil {
+	currentNSImageStreams, possibleError := client.GetImageStreams(currentNamespace)
+	if possibleError != nil {
 		if err != nil {
 			// Failure to fetch images from any namespace, error out
-			return nil, errors.Wrapf(e, "%s. unable to get Image Streams from namespace %s", err.Error(), currentNamespace)
+			return nil, errors.Wrapf(possibleError, "%s. unable to get Image Streams from namespace %s", err.Error(), currentNamespace)
 		}
 		// It is possible that the current namespace has no imagestreams -- a valid scenario
 		// But may be required for debugging purposes
-		err = errors.Wrapf(e, "unable to get Image Streams from namespace %s", currentNamespace)
+		err = errors.Wrapf(possibleError, "unable to get Image Streams from namespace %s", currentNamespace)
 		// log it for debugging purposes
-		glog.V(4).Infof("Unable to get Image Streams from namespace %s. Error %s", currentNamespace, e.Error())
+		glog.V(4).Infof("Unable to get Image Streams from namespace %s. Error %s", currentNamespace, possibleError.Error())
 	}
 
 	// Resultant imagestreams is list of imagestreams from current and openshift namespaces

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -137,7 +137,7 @@ func TestList(t *testing.T) {
 			wantTags: []string{},
 		},
 		{
-			name: "Case 4: Valid image with output tags from current namespace",
+			name: "Case 4: Valid image with output tags from a different namespace",
 			args: args{
 				name:      "foobar",
 				namespace: "foo",

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -67,6 +67,9 @@ func TestVersionExist(t *testing.T) {
 				return true, testingutil.FakeImageStreams(tt.args.name, tt.args.namespace, tt.args.tags), nil
 			})
 
+			fakeClientSet.ImageClientset.PrependReactor("list", "imagestreams", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, testingutil.FakeImageStreams(tt.args.name, "openshift", tt.args.tags), nil
+			})
 			// The function we are testing
 			doesItExist, err := VersionExists(client, tt.args.componentType, tt.args.componentVersion)
 
@@ -131,6 +134,16 @@ func TestList(t *testing.T) {
 			},
 			wantErr:  true,
 			wantTags: []string{},
+		},
+		{
+			name: "Case 4: Valid image with output tags from current namespace",
+			args: args{
+				name:      "foobar",
+				namespace: "foo",
+				tags:      []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+			},
+			wantErr:  false,
+			wantTags: []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
 		},
 	}
 

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -67,9 +67,6 @@ func TestVersionExist(t *testing.T) {
 				return true, testingutil.FakeImageStreams(tt.args.name, tt.args.namespace, tt.args.tags), nil
 			})
 
-			fakeClientSet.ImageClientset.PrependReactor("list", "imagestreams", func(action ktesting.Action) (bool, runtime.Object, error) {
-				return true, testingutil.FakeImageStreams(tt.args.name, "openshift", tt.args.tags), nil
-			})
 			// The function we are testing
 			doesItExist, err := VersionExists(client, tt.args.componentType, tt.args.componentVersion)
 
@@ -80,6 +77,10 @@ func TestVersionExist(t *testing.T) {
 			// Checks for error in positive cases
 			if tt.wantErr && doesItExist {
 				t.Errorf("VersionExist() unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if len(fakeClientSet.ImageClientset.Actions()) != 2 { // 1 call for current project + 1 call from openshift project
+				t.Errorf("expected 2 ImageClientset.Actions() in VersionExist, got: %v", fakeClientSet.ImageClientset.Actions())
 			}
 
 			// Check if the output is the same as what's expected (tags)
@@ -162,6 +163,10 @@ func TestList(t *testing.T) {
 			//Checks for error in positive cases
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("component List() unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if len(fakeClientSet.ImageClientset.Actions()) != 2 { // 1 call for current project + 1 call from openshift project
+				t.Errorf("expected 2 ImageClientset.Actions() in List, got: %v", fakeClientSet.ImageClientset.Actions())
 			}
 
 			// Check if the output is the same as what's expected (tags)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -52,7 +52,7 @@ func CreateFromGit(client *occlient.Client, name string, componentImageType stri
 	labels := componentlabels.GetLabels(name, applicationName, true)
 
 	// Parse componentImageType before adding to labels
-	imageName, imageTag, _, err := occlient.ParseImageName(componentImageType)
+	_, imageName, imageTag, _, err := occlient.ParseImageName(componentImageType)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse image name")
 	}
@@ -103,7 +103,7 @@ func CreateFromPath(client *occlient.Client, name string, componentImageType str
 	labels := componentlabels.GetLabels(name, applicationName, true)
 
 	// Parse componentImageType before adding to labels
-	imageName, imageTag, _, err := occlient.ParseImageName(componentImageType)
+	_, imageName, imageTag, _, err := occlient.ParseImageName(componentImageType)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse image name")
 	}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -699,7 +699,6 @@ func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labe
 		if err != nil {
 			return errors.Wrapf(err, "unable to bootstrap s2i supervisored for %s", name)
 		}
-		imageNS = imageStream.ObjectMeta.Namespace
 		containerPorts, err = getContainerPortsFromStrings(inputPorts)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get container ports from %v", inputPorts)

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -391,13 +391,17 @@ func (c *Client) GetImageStreamsNames(namespace string) ([]string, error) {
 	return names, nil
 }
 
+// isTagInImageStream takes a imagestream and a tag and checks if the tag is present in the imagestream's status attribute
 func isTagInImageStream(is imagev1.ImageStream, imageTag string) bool {
+	// Loop through the tags in the imagestream's status attribute
 	for _, tag := range is.Status.Tags {
-		// look for matching tag
+		// look for a matching tag
 		if tag.Tag == imageTag {
+			// Return true if found
 			return true
 		}
 	}
+	// Return false if not found.
 	return false
 }
 

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -401,7 +401,11 @@ func isTagInImageStream(is imagev1.ImageStream, imageTag string) bool {
 	return false
 }
 
-// GetImageNS returns the imagestream using image details
+// GetImageNS returns the imagestream using image details like imageNS, imageName and imageTag
+// imageNS can be empty in which case, this function searches currentNamespace on priority. If
+// imagestream of required tag not found in current namespace, then searches openshift namespace.
+// If not found, error out. If imageNS is not empty string, then, the requested imageNS only is searched
+// for requested imagestream
 func (c *Client) GetImageStream(imageNS string, imageName string, imageTag string) (*imagev1.ImageStream, error) {
 	var err error
 	var imageStream *imagev1.ImageStream
@@ -448,7 +452,7 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 		}
 
 		// Required tag not in openshift and current namespaces
-		return nil, errors.Errorf("image stream %s with tag %s not found in openshift and %s namespaces", imageName, imageTag, currentProjectName)
+		return nil, fmt.Errorf("image stream %s with tag %s not found in openshift and %s namespaces", imageName, imageTag, currentProjectName)
 
 	} else {
 
@@ -460,7 +464,7 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 			)
 		}
 		if !isTagInImageStream(*imageStream, imageTag) {
-			return nil, errors.Errorf("image stream %s with tag %s not found in %s namespaces", imageName, imageTag, currentProjectName)
+			return nil, fmt.Errorf("image stream %s with tag %s not found in %s namespaces", imageName, imageTag, currentProjectName)
 		}
 	}
 
@@ -468,68 +472,47 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 }
 
 // GetExposedPorts retruns image namespace and list of ContainerPorts that are exposed by given image
-func (c *Client) GetExposedPorts(imageNS string, imageName string, imageTag string) (string, []corev1.ContainerPort, error) {
+func (c *Client) GetExposedPorts(imageStream *imagev1.ImageStream, imageTag string) ([]corev1.ContainerPort, error) {
 	var containerPorts []corev1.ContainerPort
-	var err error
-	var imageStream *imagev1.ImageStream
 
 	glog.V(4).Infof("Checking for exact match of builderImage with ImageStream")
-	imageStream, err = c.GetImageStream(imageNS, imageName, imageTag)
-	if err != nil {
-		glog.V(4).Infof("No exact match found: %s", err.Error())
-		return "", nil, errors.Wrapf(err, "unable to find matching builder image %s", imageName)
-	}
-	imageNS = imageStream.ObjectMeta.Namespace
+	imageNS := imageStream.ObjectMeta.Namespace
+	imageName := imageStream.ObjectMeta.Name
 
 	tagFound := false
+
 	for _, tag := range imageStream.Status.Tags {
 		// look for matching tag
 		if tag.Tag == imageTag {
 			tagFound = true
 			glog.V(4).Infof("Found exact image tag match for %s:%s", imageName, imageTag)
 
-			// ImageStream holds tag history
-			// first item is the latest one
-			imageStreamImageName := imageName
 			if len(tag.Items) > 0 {
 				tagDigest := tag.Items[0].Image
-				imageStreamImageName = fmt.Sprintf("%s@%s", imageName, tagDigest)
-			}
+				imageStreamImageName := fmt.Sprintf("%s@%s", imageName, tagDigest)
 
-			// look for imageStreamImage for given tag (reference by digest)
-			imageStreamImage, e := c.imageClient.ImageStreamImages(imageNS).Get(imageStreamImageName, metav1.GetOptions{})
-			if e != nil {
+				// look for imageStreamImage for given tag (reference by digest)
+				imageStreamImage, err := c.imageClient.ImageStreamImages(imageNS).Get(imageStreamImageName, metav1.GetOptions{})
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to find ImageStreamImage with  %s digest", imageStreamImageName)
+				}
 
-				// May get success in other namespace, patiently wait with error accumulated and error logged as debug
-				// If fails in all namespaces, return with complete failure(accumulated error msgs)
-				err = errors.Wrapf(e, "%v\n Failed to fetch : %s in namespace %s", err, imageStreamImageName, imageNS)
-				glog.V(4).Infof("Error trying to fetch imagestream %s from namespace %s. Err: %v", imageStreamImageName, imageNS, err)
-			}
-
-			// If it reaches here, succesfully an image was found in namespace of current iteration
-			// Unset the already logged error
-			err = nil
-			containerPorts, err = getExposedPortsFromISI(imageStreamImage)
-			if err != nil {
-
-				// May get success in other namespace, patiently wait with error accumulated and error logged as debug
-				// If fails in all namespaces, return with complete failure(accumulated error msgs)
-				// Todo(anmolbabu): Solve nil concatenation problem in error concatenation
-				err = errors.Wrapf(err, "%v unable to get exported ports from %s:%s image in namespace %s", err, imageName, imageTag, imageNS)
-				glog.V(4).Infof("Unable to get exported ports from %s:%s image in namespace %s", imageName, imageTag, imageNS)
+				// get ports that are exported by image
+				containerPorts, err = getExposedPortsFromISI(imageStreamImage)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to get exported ports from %s:%s image", imageName, imageTag)
+				}
+			} else {
+				return nil, fmt.Errorf("unable to find tag %s for image %s", imageTag, imageName)
 			}
 		}
 	}
 
 	if !tagFound {
-		return "", nil, errors.Wrapf(err, "unable to find tag %s for image", imageTag, imageName)
+		return nil, fmt.Errorf("unable to find tag %s for image %s", imageTag, imageName)
 	}
 
-	if err != nil {
-		return "", nil, err
-	}
-
-	return imageNS, containerPorts, nil
+	return containerPorts, nil
 }
 
 func getAppRootVolumeName(dcName string) string {
@@ -545,15 +528,23 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 	if err != nil {
 		return errors.Wrap(err, "unable to parse image name")
 	}
+	imageStream, err := c.GetImageStream(imageNS, imageName, imageTag)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create new app")
+	}
+	/*
+	 Set imageNS to the namespace of above fetched imagestream because, the namespace passed here can potentially be emptystring
+	 in which case, GetImageStream function resolves to correct namespace in accordance with priorities in GetImageStream
+	*/
+	imageNS = imageStream.ObjectMeta.Namespace
 
 	var containerPorts []corev1.ContainerPort
 	if len(inputPorts) == 0 {
-		imageNS, containerPorts, err = c.GetExposedPorts(imageNS, imageName, imageTag)
+		containerPorts, err = c.GetExposedPorts(imageStream, imageTag)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get exposed ports for %s:%s", imageName, imageTag)
 		}
 	} else {
-		imageStream, err := c.GetImageStream(imageNS, imageName, imageTag)
 		if err != nil {
 			return errors.Wrapf(err, "unable to create s2i app for %s", name)
 		}
@@ -688,15 +679,23 @@ func (c *Client) BootstrapSupervisoredS2I(name string, builderImage string, labe
 	if err != nil {
 		return errors.Wrap(err, "unable to create new s2i git build ")
 	}
+	imageStream, err := c.GetImageStream(imageNS, imageName, imageTag)
+	if err != nil {
+		return errors.Wrap(err, "Failed to bootstrap supervisored")
+	}
+	/*
+	 Set imageNS to the namespace of above fetched imagestream because, the namespace passed here can potentially be emptystring
+	 in which case, GetImageStream function resolves to correct namespace in accordance with priorities in GetImageStream
+	*/
+	imageNS = imageStream.ObjectMeta.Namespace
 
 	var containerPorts []corev1.ContainerPort
 	if len(inputPorts) == 0 {
-		imageNS, containerPorts, err = c.GetExposedPorts(imageNS, imageName, imageTag)
+		containerPorts, err = c.GetExposedPorts(imageStream, imageTag)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get exposed ports for %s:%s", imageName, imageTag)
 		}
 	} else {
-		imageStream, err := c.GetImageStream(imageNS, imageName, imageTag)
 		if err != nil {
 			return errors.Wrapf(err, "unable to bootstrap s2i supervisored for %s", name)
 		}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -1976,7 +1976,7 @@ func TestNewAppS2I(t *testing.T) {
 	}
 }
 
-func TestisTagInImageStream(t *testing.T) {
+func TestIsTagInImageStream(t *testing.T) {
 	tests := []struct {
 		name        string
 		imagestream imagev1.ImageStream

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -732,26 +732,26 @@ func TestParseImageName(t *testing.T) {
 
 	tests := []struct {
 		arg     string
-		want0   string
 		want1   string
 		want2   string
 		want3   string
+		want4   string
 		wantErr bool
 	}{
 		{
 			arg:     "nodejs:8",
-			want0:   "",
-			want1:   "nodejs",
-			want2:   "8",
-			want3:   "",
+			want1:   "",
+			want2:   "nodejs",
+			want3:   "8",
+			want4:   "",
 			wantErr: false,
 		},
 		{
 			arg:     "nodejs@sha256:7e56ca37d1db225ebff79dd6d9fd2a9b8f646007c2afc26c67962b85dd591eb2",
-			want1:   "nodejs",
-			want0:   "",
-			want2:   "",
-			want3:   "sha256:7e56ca37d1db225ebff79dd6d9fd2a9b8f646007c2afc26c67962b85dd591eb2",
+			want2:   "nodejs",
+			want1:   "",
+			want3:   "",
+			want4:   "sha256:7e56ca37d1db225ebff79dd6d9fd2a9b8f646007c2afc26c67962b85dd591eb2",
 			wantErr: false,
 		},
 		{
@@ -768,10 +768,10 @@ func TestParseImageName(t *testing.T) {
 		},
 		{
 			arg:     "nodejs",
-			want0:   "",
-			want1:   "nodejs",
-			want2:   "latest",
-			want3:   "",
+			want1:   "",
+			want2:   "nodejs",
+			want3:   "latest",
+			want4:   "",
 			wantErr: false,
 		},
 		{
@@ -784,23 +784,20 @@ func TestParseImageName(t *testing.T) {
 		},
 		{
 			arg:     "myproject/nodejs:8",
-			want0:   "myproject",
-			want1:   "nodejs",
-			want2:   "8",
-			want3:   "",
+			want1:   "myproject",
+			want2:   "nodejs",
+			want3:   "8",
+			want4:   "",
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		name := fmt.Sprintf("image name: '%s'", tt.arg)
 		t.Run(name, func(t *testing.T) {
-			got0, got1, got2, got3, err := ParseImageName(tt.arg)
+			got1, got2, got3, got4, err := ParseImageName(tt.arg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseImageName() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if got0 != tt.want0 {
-				t.Errorf("ParseImageName() got0 = %v, want %v", got0, tt.want0)
 			}
 			if got1 != tt.want1 {
 				t.Errorf("ParseImageName() got1 = %v, want %v", got1, tt.want1)
@@ -810,6 +807,9 @@ func TestParseImageName(t *testing.T) {
 			}
 			if got3 != tt.want3 {
 				t.Errorf("ParseImageName() got3 = %v, want %v", got3, tt.want3)
+			}
+			if got4 != tt.want4 {
+				t.Errorf("ParseImageName() got4 = %v, want %v", got4, tt.want4)
 			}
 		})
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2081,7 +2081,7 @@ func TestGetExposedPorts(t *testing.T) {
 			}
 
 			if len(fkclientset.ImageClientset.Actions()) != tt.wantActionCnt {
-				t.Errorf("expected 1 ImageClientset.Actions() in GetExposedPorts, got: %v", fkclientset.ImageClientset.Actions())
+				t.Errorf("expected %d ImageClientset.Actions() in GetExposedPorts, got: %v", tt.wantActionCnt, fkclientset.ImageClientset.Actions())
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {
@@ -2169,7 +2169,7 @@ func TestGetImageStream(t *testing.T) {
 
 			got, err := fkclient.GetImageStream(tt.imageNS, tt.imageName, tt.imageTag)
 			if len(fkclientset.ImageClientset.Actions()) != tt.wantActionsCnt {
-				t.Errorf("expected 1 ImageClientset.Actions() in GetImageStream, got %v", fkclientset.ImageClientset.Actions())
+				t.Errorf("expected %d ImageClientset.Actions() in GetImageStream, got %v", tt.wantActionsCnt, fkclientset.ImageClientset.Actions())
 			}
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("\nclient.GetImageStream(imageNS, imageName, imageTag) unexpected error %v, wantErr %v", err, tt.wantErr)

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -726,6 +726,7 @@ func TestParseImageName(t *testing.T) {
 
 	tests := []struct {
 		arg     string
+		want0   string
 		want1   string
 		want2   string
 		want3   string
@@ -733,6 +734,7 @@ func TestParseImageName(t *testing.T) {
 	}{
 		{
 			arg:     "nodejs:8",
+			want0:   "",
 			want1:   "nodejs",
 			want2:   "8",
 			want3:   "",
@@ -741,6 +743,7 @@ func TestParseImageName(t *testing.T) {
 		{
 			arg:     "nodejs@sha256:7e56ca37d1db225ebff79dd6d9fd2a9b8f646007c2afc26c67962b85dd591eb2",
 			want1:   "nodejs",
+			want0:   "",
 			want2:   "",
 			want3:   "sha256:7e56ca37d1db225ebff79dd6d9fd2a9b8f646007c2afc26c67962b85dd591eb2",
 			wantErr: false,
@@ -759,6 +762,7 @@ func TestParseImageName(t *testing.T) {
 		},
 		{
 			arg:     "nodejs",
+			want0:   "",
 			want1:   "nodejs",
 			want2:   "latest",
 			want3:   "",
@@ -772,14 +776,25 @@ func TestParseImageName(t *testing.T) {
 			arg:     ":",
 			wantErr: true,
 		},
+		{
+			arg:     "myproject/nodejs:8",
+			want0:   "myproject",
+			want1:   "nodejs",
+			want2:   "8",
+			want3:   "",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		name := fmt.Sprintf("image name: '%s'", tt.arg)
 		t.Run(name, func(t *testing.T) {
-			got1, got2, got3, err := ParseImageName(tt.arg)
+			got0, got1, got2, got3, err := ParseImageName(tt.arg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseImageName() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if got0 != tt.want0 {
+				t.Errorf("ParseImageName() got0 = %v, want %v", got0, tt.want0)
 			}
 			if got1 != tt.want1 {
 				t.Errorf("ParseImageName() got1 = %v, want %v", got1, tt.want1)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -62,13 +62,11 @@ func NamespaceOpenShiftObject(componentName string, applicationName string) (str
 }
 
 // ExtractComponentType returns only component type part from passed component type(default unqualified, fully qualified, versioned, etc...and their combinations) for use as component name
+// Possible types of parameters:
+// 1. "myproject/python:3.5" -- Return python
+// 2. "python:3.5" -- Return python
+// 3. nodejs -- Return nodejs
 func ExtractComponentType(namespacedVersionedComponentType string) string {
-	/*
-		Possible types of parameters:
-		1. "myproject/python:3.5" -- Return python
-		2. "python:3.5" -- Return python
-		3. nodejs -- Return nodejs
-	*/
 	s := strings.Split(namespacedVersionedComponentType, "/")
 	versionedString := s[0]
 	if len(s) == 2 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -75,3 +75,28 @@ func ExtractComponentType(namespacedVersionedComponentType string) string {
 	s = strings.Split(versionedString, ":")
 	return s[0]
 }
+
+// parseCreateCmdArgs returns
+// 1. image name
+// 2. component type i.e, builder image name
+// 3. component name default value is component type else the user requested component name
+// 4. component version which is by default latest else version passed with builder image name
+func ParseCreateCmdArgs(args []string) (string, string, string, string) {
+	// We don't have to check it anymore, Args check made sure that args has at least one item
+	// and no more than two
+
+	// "Default" values
+	componentImageName := args[0]
+	componentType := args[0]
+	componentName := ExtractComponentType(componentType)
+	componentVersion := "latest"
+
+	// Check if componentType includes ":", if so, then we need to spit it into using versions
+	if strings.ContainsAny(componentImageName, ":") {
+		versionSplit := strings.Split(args[0], ":")
+		componentType = versionSplit[0]
+		componentName = ExtractComponentType(componentType)
+		componentVersion = versionSplit[1]
+	}
+	return componentImageName, componentType, componentName, componentVersion
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -60,3 +60,20 @@ func NamespaceOpenShiftObject(componentName string, applicationName string) (str
 	// Return the hyphenated namespaced name
 	return fmt.Sprintf("%s-%s", strings.Replace(componentName, "/", "-", -1), applicationName), nil
 }
+
+// ExtractComponentType returns only component type part from passed component type(default unqualified, fully qualified, versioned, etc...and their combinations) for use as component name
+func ExtractComponentType(namespacedVersionedComponentType string) string {
+	/*
+		Possible types of parameters:
+		1. "myproject/python:3.5" -- Return python
+		2. "python:3.5" -- Return python
+		3. nodejs -- Return nodejs
+	*/
+	s := strings.Split(namespacedVersionedComponentType, "/")
+	versionedString := s[0]
+	if len(s) == 2 {
+		versionedString = s[1]
+	}
+	s = strings.Split(versionedString, ":")
+	return s[0]
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -57,5 +58,5 @@ func NamespaceOpenShiftObject(componentName string, applicationName string) (str
 	}
 
 	// Return the hyphenated namespaced name
-	return fmt.Sprintf("%s-%s", componentName, applicationName), nil
+	return fmt.Sprintf("%s-%s", strings.Replace(componentName, "/", "-", -1), applicationName), nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -90,3 +90,57 @@ func TestExtractComponentType(t *testing.T) {
 	}
 
 }
+
+func TestParseCreateCmdArgs(t *testing.T) {
+
+	tests := []struct {
+		testName string
+		args     []string
+		want1    string
+		want2    string
+		want3    string
+		want4    string
+	}{
+		{
+			testName: "Case1: Version not specified",
+			args: []string{
+				"nodejs",
+			},
+			want1: "nodejs",
+			want2: "nodejs",
+			want3: "nodejs",
+			want4: "latest",
+		},
+		{
+			testName: "Case1: Version not specified",
+			args: []string{
+				"python:3.5",
+			},
+			want1: "python:3.5",
+			want2: "python",
+			want3: "python",
+			want4: "3.5",
+		},
+	}
+
+	// Test that it "joins"
+
+	for _, tt := range tests {
+		t.Log("Running test: ", tt.testName)
+		t.Run(tt.testName, func(t *testing.T) {
+			got1, got2, got3, got4 := ParseCreateCmdArgs(tt.args)
+			if tt.want1 != got1 {
+				t.Errorf("Expected imagename to be: %s, got %s", tt.want1, got1)
+			}
+			if tt.want2 != got2 {
+				t.Errorf("Expected component type to be: %s, got %s", tt.want2, got2)
+			}
+			if tt.want3 != got3 {
+				t.Errorf("Expected component name to be: %s, got %s", tt.want3, got3)
+			}
+			if tt.want4 != got4 {
+				t.Errorf("Expected component version to be: %s, got %s", tt.want4, got4)
+			}
+		})
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -51,3 +51,42 @@ func TestNamespaceOpenShiftObject(t *testing.T) {
 	}
 
 }
+
+func TestExtractComponentType(t *testing.T) {
+
+	tests := []struct {
+		testName      string
+		componentType string
+		want          string
+		wantErr       bool
+	}{
+		{
+			testName:      "Test namespacing and versioning",
+			componentType: "myproject/foo:3.5",
+			want:          "foo",
+		},
+		{
+			testName:      "Test versioning",
+			componentType: "foo:3.5",
+			want:          "foo",
+		},
+		{
+			testName:      "Test plain component type",
+			componentType: "foo",
+			want:          "foo",
+		},
+	}
+
+	// Test that it "joins"
+
+	for _, tt := range tests {
+		t.Log("Running test: ", tt.testName)
+		t.Run(tt.testName, func(t *testing.T) {
+			name := ExtractComponentType(tt.componentType)
+			if tt.want != name {
+				t.Errorf("Expected %s, got %s", tt.want, name)
+			}
+		})
+	}
+
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"strconv"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -11,7 +13,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os/exec"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -182,12 +183,23 @@ var _ = Describe("odoe2e", func() {
 
 	Describe("creating a component", func() {
 		Context("when application exists", func() {
+			It("should be able to create new imagestream and find it in catalog list", func() {
+				curProj = strings.TrimSuffix(runCmd("oc project -q"), "\n")
+				cmd := fmt.Sprintf("oc create -f https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json -n %s", curProj)
+				runCmd(cmd)
+				cmpList := runCmd("odo catalog list")
+				Expect(cmpList).To(ContainSubstring(curProj))
+			})
+
 			It("should create a component", func() {
 				runCmd("git clone https://github.com/openshift/nodejs-ex " +
 					tmpDir + "/nodejs-ex")
 
 				// TODO: add tests for --git
-				runCmd("odo create nodejs --local " + tmpDir + "/nodejs-ex")
+				curProj = strings.TrimSuffix(runCmd("oc project -q"), "\n")
+				// Sleep until status tags and their annotations are created
+				time.Sleep(15 * time.Second)
+				runCmd("odo create " + curProj + "/nodejs --local " + tmpDir + "/nodejs-ex")
 				runCmd("odo push")
 			})
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 var t = strconv.FormatInt(time.Now().Unix(), 10)
 var projName = fmt.Sprintf("odo-%s", t)
 var curProj string
+var testNamespacedImage = "https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json"
 
 const appTestName = "testing"
 
@@ -185,7 +186,7 @@ var _ = Describe("odoe2e", func() {
 		Context("when application exists", func() {
 			It("should be able to create new imagestream and find it in catalog list", func() {
 				curProj = strings.TrimSuffix(runCmd("oc project -q"), "\n")
-				cmd := fmt.Sprintf("oc create -f https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json -n %s", curProj)
+				cmd := fmt.Sprintf("oc create -f "+testNamespacedImage+" -n %s", curProj)
 				runCmd(cmd)
 				cmpList := runCmd("odo catalog list components")
 				Expect(cmpList).To(ContainSubstring(curProj))

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -187,7 +187,7 @@ var _ = Describe("odoe2e", func() {
 				curProj = strings.TrimSuffix(runCmd("oc project -q"), "\n")
 				cmd := fmt.Sprintf("oc create -f https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json -n %s", curProj)
 				runCmd(cmd)
-				cmpList := runCmd("odo catalog list")
+				cmpList := runCmd("odo catalog list components")
 				Expect(cmpList).To(ContainSubstring(curProj))
 			})
 


### PR DESCRIPTION
This PR considers imagestream in current namespace along with
imagestreams in openshift namespace for:
1. catalog listing i.e, `odo catalog list` is now expected to show items in local
namespace along with those in openshift namespace
2. component create i.e `odo create <comp_name> --git <git_url>` is expected
to work even if comp_name is present in current namespace but not in openshift
namespace

fixes #566
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>