### PR TITLE
Retrieve labels via DeploymentConfig not BuildConfig

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -313,6 +313,7 @@ func List(client *occlient.Client, applicationName string, projectName string) (
 // GetComponentSource what source type given component uses
 // The first returned string is component source type ("git" or "local" or "binary")
 // The second returned string is a source (url to git repository or local path or path to binary)
+// we retrieve the source type by looking up the DeploymentConfig that's deployed
 func GetComponentSource(client *occlient.Client, componentName string, applicationName string, projectName string) (string, string, error) {
 
 	// Namespace the application
@@ -321,13 +322,13 @@ func GetComponentSource(client *occlient.Client, componentName string, applicati
 		return "", "", errors.Wrapf(err, "unable to create namespaced name")
 	}
 
-	bc, err := client.GetBuildConfig(namespacedOpenShiftObject, projectName)
+	deploymentConfig, err := client.GetDeploymentConfigFromName(namespacedOpenShiftObject, projectName)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "unable to get source path for component %s", namespacedOpenShiftObject)
 	}
 
-	sourcePath := bc.ObjectMeta.Annotations[componentSourceURLAnnotation]
-	sourceType := bc.ObjectMeta.Annotations[componentSourceTypeAnnotation]
+	sourcePath := deploymentConfig.ObjectMeta.Annotations[componentSourceURLAnnotation]
+	sourceType := deploymentConfig.ObjectMeta.Annotations[componentSourceTypeAnnotation]
 
 	if !validateSourceType(sourceType) {
 		return "", "", fmt.Errorf("unsupported component source type %s", sourceType)

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -1494,7 +1494,7 @@ func TestCleanupAfterSupervisor(t *testing.T) {
 	}
 }
 
-func TestGetBuildConfig(t *testing.T) {
+func TestGetBuildConfigFromName(t *testing.T) {
 	tests := []struct {
 		name                string
 		buildName           string
@@ -1526,14 +1526,14 @@ func TestGetBuildConfig(t *testing.T) {
 				return true, &tt.returnedBuildConfig, nil
 			})
 
-			build, err := fkclient.GetBuildConfig(tt.buildName, tt.projectName)
+			build, err := fkclient.GetBuildConfigFromName(tt.buildName, tt.projectName)
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
 				if (len(fkclientset.BuildClientset.Actions()) != 1) && (tt.wantErr != true) {
-					t.Errorf("expected 1 action in GetBuildConfig got: %v", fkclientset.AppsClientset.Actions())
+					t.Errorf("expected 1 action in GetBuildConfigFromName got: %v", fkclientset.AppsClientset.Actions())
 				}
 				if build.Name != tt.buildName {
-					t.Errorf("wrong GetBuildConfig got: %v, expected: %v", build.Name, tt.buildName)
+					t.Errorf("wrong GetBuildConfigFromName got: %v, expected: %v", build.Name, tt.buildName)
 				}
 			} else if err == nil && tt.wantErr {
 				t.Error("error was expected, but no error was returned")
@@ -1671,7 +1671,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
 				if (len(fkclientset.BuildClientset.Actions()) != 2) && (tt.wantErr != true) {
-					t.Errorf("expected 2 action in GetBuildConfig got: %v", fkclientset.BuildClientset.Actions())
+					t.Errorf("expected 2 action in GetBuildConfigFromName got: %v", fkclientset.BuildClientset.Actions())
 				}
 
 				updatedDc := fkclientset.BuildClientset.Actions()[1].(ktesting.UpdateAction).GetObject().(*buildv1.BuildConfig)


### PR DESCRIPTION
This:
 - Changes label retrieval for GetComponentSource from usin BuildConfig
 to DeploymentConfig (not all deployments use BuildConfig)
 - Renames GetBuildConfig to GetBuildConfigFromName
 - Adds project param to GetDeploymentConfigFromName function in order
 to be similar / the same as GetBuildConfigFromName