### PR TITLE
Added vendor-update command to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,8 @@ packages:
 .PHONY: upload-packages
 upload-packages:
 	./scripts/upload-packages.sh
+
+# Update vendoring
+.PHONY: vendor-update
+vendor-update:
+	glide update --strip-vendor


### PR DESCRIPTION
This PR adds vendor-update command to Make, so that
we can simply update vendor using `make vendor-update` command