### PR TITLE
Refactoring code and added flags `project`, `application` &  `component` 

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -72,12 +72,12 @@ If no app name is passed, a default app name will be auto-generated.
 		// validate application name
 		err := validateName(appName)
 		checkError(err, "")
-		fmt.Printf("Creating application: %v in project: %v \n", appName, projectName)
+		fmt.Printf("Creating application: %v in project: %v\n", appName, projectName)
 		err = application.Create(client, appName)
 		checkError(err, "")
 		err = application.SetCurrent(client, appName)
 		checkError(err, "")
-		fmt.Printf("Switched to application: %v in project\n", appName, projectName)
+		fmt.Printf("Switched to application: %v in project: %v\n", appName, projectName)
 	},
 }
 
@@ -102,7 +102,7 @@ var applicationGetCmd = &cobra.Command{
 			fmt.Printf("There's no active application.\nYou can create one by running 'odo application create <name>'.\n")
 			return
 		}
-		fmt.Printf("The current application is: %v\n", app)
+		fmt.Printf("The current application is: %v in project: %v\n", app, projectName)
 	},
 }
 
@@ -137,14 +137,14 @@ var applicationDeleteCmd = &cobra.Command{
 		if applicationForceDeleteFlag {
 			confirmDeletion = "y"
 		} else {
-			fmt.Printf("Are you sure you want to delete the application: %v? [y/N] ", appName)
+			fmt.Printf("Are you sure you want to delete the application: %v from project: %v? [y/N] ", appName, projectName)
 			fmt.Scanln(&confirmDeletion)
 		}
 
 		if strings.ToLower(confirmDeletion) == "y" {
 			err := application.Delete(client, appName)
 			checkError(err, "")
-			fmt.Printf("Deleted application: %s\n", appName)
+			fmt.Printf("Deleted application: %s from project: %v\n", appName, projectName)
 		} else {
 			fmt.Printf("Aborting deletion of application: %v\n", appName)
 		}
@@ -205,7 +205,7 @@ var applicationSetCmd = &cobra.Command{
 		client := getOcClient()
 		appName := args[0]
 
-		getAndSetNamespace(client)
+		projectName := getAndSetNamespace(client)
 		// error if application does not exist
 		exists, err := application.Exists(client, appName)
 		checkError(err, "unable to check if application exists")
@@ -216,7 +216,7 @@ var applicationSetCmd = &cobra.Command{
 
 		err = application.SetCurrent(client, appName)
 		checkError(err, "")
-		fmt.Printf("Switched to application: %v\n", args[0])
+		fmt.Printf("Switched to application: %v in project: %v\n", args[0], projectName)
 	},
 }
 
@@ -237,7 +237,7 @@ var applicationDescribeCmd = &cobra.Command{
 			appName, err = application.GetCurrent(projectName)
 			checkError(err, "")
 			if appName == "" {
-				fmt.Printf("There's no active application in projectName %v", projectName)
+				fmt.Printf("There's no active application in project: %v", projectName)
 				os.Exit(1)
 			}
 		} else {
@@ -246,7 +246,7 @@ var applicationDescribeCmd = &cobra.Command{
 			exists, err := application.Exists(client, appName)
 			checkError(err, "")
 			if !exists {
-				fmt.Printf("Application with the name %s does not exist\n", appName)
+				fmt.Printf("Application with the name %s does not exist in %s \n", appName, projectName)
 				os.Exit(1)
 			}
 		}

--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -176,11 +176,8 @@ func printUnmountedStorage(client *occlient.Client, applicationName string) {
 func getAppName(client *occlient.Client) string {
 	// applicationFlag is `--application` flag
 	if applicationFlag != "" {
-
 		_, err := application.Exists(client, applicationFlag)
-		if err != nil {
-			checkError(err, "")
-		}
+		checkError(err, "")
 		return applicationFlag
 	}
 	applicationName, err := application.GetCurrent(client.Namespace)
@@ -197,9 +194,7 @@ func getAndSetNamespace(client *occlient.Client) string {
 	// projectFlag is `--project` flag
 	if projectFlag != "" {
 		_, err := project.Exists(client, projectFlag)
-		if err != nil {
-			checkError(err, "")
-		}
+		checkError(err, "")
 		client.Namespace = projectFlag
 		return projectFlag
 	}

--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -18,14 +18,14 @@ import (
 )
 
 // printDeleteAppInfo will print things which will be deleted
-func printDeleteAppInfo(client *occlient.Client, appName string, projectName string) error {
-	componentList, err := component.List(client, appName, projectName)
+func printDeleteAppInfo(client *occlient.Client, appName string) error {
+	componentList, err := component.List(client, appName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Component list")
 	}
 
 	for _, currentComponent := range componentList {
-		_, _, componentURL, appStore, err := component.GetComponentDesc(client, currentComponent.Name, appName, projectName)
+		_, _, componentURL, appStore, err := component.GetComponentDesc(client, currentComponent.Name, appName)
 		if err != nil {
 			return errors.Wrap(err, "unable to get component description")
 		}
@@ -46,9 +46,9 @@ func printDeleteAppInfo(client *occlient.Client, appName string, projectName str
 // getComponent returns the component to be used for the operation. If an input
 // component is specified, then it is returned if it exists, if not,
 // the current component is fetched and returned. If no component set, throws error
-func getComponent(client *occlient.Client, inputComponent string, applicationName string, projectName string) string {
+func getComponent(client *occlient.Client, inputComponent string, applicationName string) string {
 	if len(inputComponent) == 0 {
-		c, err := component.GetCurrent(applicationName, projectName)
+		c, err := component.GetCurrent(applicationName, client.Namespace)
 		checkError(err, "Could not get current component")
 		if c == "" {
 			fmt.Println("There is no component set")
@@ -56,7 +56,7 @@ func getComponent(client *occlient.Client, inputComponent string, applicationNam
 		}
 		return c
 	}
-	exists, err := component.Exists(client, inputComponent, applicationName, projectName)
+	exists, err := component.Exists(client, inputComponent, applicationName)
 	checkError(err, "")
 	if !exists {
 		fmt.Printf("Component %v does not exist\n", inputComponent)
@@ -137,8 +137,8 @@ func printMountedStorageInComponent(client *occlient.Client, componentName strin
 }
 
 // printMountedStorageInAllComponent prints all the mounted storage in all the components of the application and project
-func printMountedStorageInAllComponent(client *occlient.Client, applicationName string, projectName string) {
-	componentList, err := component.List(client, applicationName, projectName)
+func printMountedStorageInAllComponent(client *occlient.Client, applicationName string) {
+	componentList, err := component.List(client, applicationName)
 	checkError(err, "could not get component list")
 
 	// iterating over all the components in the given aplication and project
@@ -189,10 +189,11 @@ func getAppName(client *occlient.Client) string {
 	return applicationName
 }
 
-// setNamespace checks whether project flag is provided,
+// getAndSetNamespace checks whether project flag is provided,
 // if provided, it validates the name and sets it as namespace for further operations
 // if not provided, it fetches current namespace and sets it as namespace for further operations
-func setNamespace(client *occlient.Client) string {
+// getAndSetNamespace also return the project name
+func getAndSetNamespace(client *occlient.Client) string {
 	// projectFlag is `--project` flag
 	if projectFlag != "" {
 		_, err := project.Exists(client, projectFlag)

--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -209,13 +209,13 @@ func getAndSetNamespace(client *occlient.Client) string {
 }
 
 func addProjectFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&projectFlag, "project", "p", "", "Project, defaults to active project")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "Project, defaults to active project")
 }
 
 func addComponentFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&componentFlag, "component", "c", "", "Component, defaults to active component.")
+	cmd.Flags().StringVar(&componentFlag, "component", "", "Component, defaults to active component.")
 }
 
 func addApplicationFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&applicationFlag, "application", "", "Application, defaults to active application")
+	cmd.Flags().StringVar(&applicationFlag, "app", "", "Application, defaults to active application")
 }

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -39,7 +39,7 @@ var componentGetCmd = &cobra.Command{
 		glog.V(4).Infof("component get called")
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		component, err := component.GetCurrent(applicationName, projectName)
@@ -67,10 +67,10 @@ var componentSetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
-		exists, err := component.Exists(client, args[0], applicationName, projectName)
+		exists, err := component.Exists(client, args[0], applicationName)
 		checkError(err, "")
 		if !exists {
 			fmt.Printf("Component %s does not exist in the current application\n", args[0])

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -69,7 +69,7 @@ A full list of component types that can be deployed is available using: 'odo cat
 
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		var applicationName string
 		var err error
 		if applicationFlag != "" && projectFlag != "" {
@@ -110,7 +110,7 @@ A full list of component types that can be deployed is available using: 'odo cat
 		componentImageName, componentType, _, componentVersion := util.ParseCreateCmdArgs(args)
 
 		// Fetch list of existing components in-order to attempt generation of unique component name
-		componentList, err := component.List(client, applicationName, projectName)
+		componentList, err := component.List(client, applicationName)
 		checkError(err, "")
 
 		// Generate unique name for component
@@ -146,7 +146,7 @@ A full list of component types that can be deployed is available using: 'odo cat
 		// Validate component name
 		err = validateName(componentName)
 		checkError(err, "")
-		exists, err = component.Exists(client, componentName, applicationName, projectName)
+		exists, err = component.Exists(client, componentName, applicationName)
 		checkError(err, "")
 		if exists {
 			fmt.Printf("component with the name %s already exists in the current application\n", componentName)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -215,11 +215,10 @@ A full list of component types that can be deployed is available using: 'odo cat
 		if len(componentGit) == 0 {
 			fmt.Printf("To push source code to the component run 'odo push'\n")
 		}
-
 		// after component is successfully created, set is as active
-		err = component.SetCurrent(componentName, applicationName, projectName)
-		checkError(err, "")
 		err = application.SetCurrent(client, applicationName)
+		checkError(err, "")
+		err = component.SetCurrent(componentName, applicationName, projectName)
 		checkError(err, "")
 		fmt.Printf("\nComponent '%s' is now set as active component.\n", componentName)
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -28,7 +28,7 @@ var componentDeleteCmd = &cobra.Command{
 		glog.V(4).Infof("args: %#v", strings.Join(args, " "))
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		// Get the current component if no arguments have been passed
@@ -37,13 +37,13 @@ var componentDeleteCmd = &cobra.Command{
 		// If no arguments have been passed, get the current component
 		// else, use the first argument and check to see if it exists
 		if len(args) == 0 {
-			componentName = getComponent(client, "", applicationName, projectName)
+			componentName = getComponent(client, "", applicationName)
 		} else {
 
 			componentName = args[0]
 
 			// Checks to see if the component actually exists
-			exists, err := component.Exists(client, componentName, applicationName, projectName)
+			exists, err := component.Exists(client, componentName, applicationName)
 			checkError(err, "")
 			if !exists {
 				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
@@ -60,7 +60,7 @@ var componentDeleteCmd = &cobra.Command{
 		}
 
 		if strings.ToLower(confirmDeletion) == "y" {
-			err := component.Delete(client, componentName, applicationName, projectName)
+			err := component.Delete(client, componentName, applicationName)
 			checkError(err, "")
 			fmt.Printf("Component %s from application %s has been deleted\n", componentName, applicationName)
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -6,9 +6,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
 )
 
@@ -30,10 +28,8 @@ var componentDeleteCmd = &cobra.Command{
 		glog.V(4).Infof("args: %#v", strings.Join(args, " "))
 		client := getOcClient()
 
-		// Get all necessary names (current application + project)
-		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
-		projectName := project.GetCurrent(client)
+		projectName := setNamespace(client)
+		applicationName := getAppName(client)
 
 		// Get the current component if no arguments have been passed
 		var componentName string
@@ -68,7 +64,7 @@ var componentDeleteCmd = &cobra.Command{
 			checkError(err, "")
 			fmt.Printf("Component %s from application %s has been deleted\n", componentName, applicationName)
 
-			currentComponent, err := component.GetCurrent(client, applicationName, projectName)
+			currentComponent, err := component.GetCurrent(applicationName, projectName)
 			checkError(err, "Unable to get current component")
 
 			if currentComponent == "" {
@@ -89,6 +85,11 @@ func init() {
 	// Add a defined annotation in order to appear in the help menu
 	componentDeleteCmd.Annotations = map[string]string{"command": "component"}
 	componentDeleteCmd.SetUsageTemplate(cmdUsageTemplate)
+
+	//Adding `--project` flag
+	addProjectFlag(componentDeleteCmd)
+	//Adding `--application` flag
+	addApplicationFlag(componentDeleteCmd)
 
 	rootCmd.AddCommand(componentDeleteCmd)
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -19,26 +19,25 @@ var describeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		var componentName string
 		if len(args) == 0 {
-			componentName = getComponent(client, "", applicationName, projectName)
+			componentName = getComponent(client, "", applicationName)
 		} else {
 
 			componentName = args[0]
 
 			// Checks to see if the component actually exists
-			exists, err := component.Exists(client, componentName, applicationName, projectName)
+			exists, err := component.Exists(client, componentName, applicationName)
 			checkError(err, "")
 			if !exists {
 				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
 				os.Exit(1)
 			}
 		}
-		// currentComponent := getComponent(client, componentName, Application, Project)
-		componentType, path, componentURL, appStore, err := component.GetComponentDesc(client, componentName, applicationName, projectName)
+		componentType, path, componentURL, appStore, err := component.GetComponentDesc(client, componentName, applicationName)
 		checkError(err, "")
 		printComponentInfo(componentName, componentType, path, componentURL, appStore)
 	},

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -29,13 +29,12 @@ is injected into the component.
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
-
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 		serviceName := args[0]
 
-		exists, err := component.Exists(client, componentName, applicationName, projectName)
+		exists, err := component.Exists(client, componentName, applicationName)
 		checkError(err, "")
 		if !exists {
 			fmt.Printf("Component %v does not exist\n", componentName)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,12 +20,12 @@ var componentListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		currentComponent, err := component.GetCurrent(applicationName, projectName)
 		checkError(err, "")
-		components, err := component.List(client, applicationName, projectName)
+		components, err := component.List(client, applicationName)
 		checkError(err, "")
 
 		if len(components) == 0 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,9 +5,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
 )
 
@@ -21,10 +19,11 @@ var componentListCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
-		projectName := project.GetCurrent(client)
-		currentComponent, err := component.GetCurrent(client, applicationName, projectName)
+
+		projectName := setNamespace(client)
+		applicationName := getAppName(client)
+
+		currentComponent, err := component.GetCurrent(applicationName, projectName)
 		checkError(err, "")
 		components, err := component.List(client, applicationName, projectName)
 		checkError(err, "")
@@ -52,6 +51,11 @@ var componentListCmd = &cobra.Command{
 func init() {
 	// Add a defined annotation in order to appear in the help menu
 	componentListCmd.Annotations = map[string]string{"command": "component"}
+
+	//Adding `--project` flag
+	addProjectFlag(componentListCmd)
+	//Adding `--application` flag
+	addApplicationFlag(componentListCmd)
 
 	rootCmd.AddCommand(componentListCmd)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
 )
 
@@ -29,12 +27,8 @@ var logCmd = &cobra.Command{
 		// Retrieve the client
 		client := getOcClient()
 
-		// Application
-		currentApplication, err := application.GetCurrent(client)
-		checkError(err, "")
-
-		// Project
-		currentProject := project.GetCurrent(client)
+		projectName := setNamespace(client)
+		applicationName := getAppName(client)
 
 		var argComponent string
 
@@ -43,10 +37,10 @@ var logCmd = &cobra.Command{
 		}
 
 		// Retrieve and set the currentComponent
-		currentComponent := getComponent(client, argComponent, currentApplication, currentProject)
+		currentComponent := getComponent(client, argComponent, applicationName, projectName)
 
 		// Retrieve the log
-		err = component.GetLogs(client, currentComponent, currentApplication, logFollow, stdout)
+		err := component.GetLogs(client, currentComponent, applicationName, logFollow, stdout)
 		checkError(err, "Unable to retrieve logs, does your component exist?")
 	},
 }
@@ -57,6 +51,11 @@ func init() {
 	// Add a defined annotation in order to appear in the help menu
 	logCmd.Annotations = map[string]string{"command": "component"}
 	logCmd.SetUsageTemplate(cmdUsageTemplate)
+
+	//Adding `--project` flag
+	addProjectFlag(logCmd)
+	//Adding `--application` flag
+	addApplicationFlag(logCmd)
 
 	rootCmd.AddCommand(logCmd)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -27,7 +27,7 @@ var logCmd = &cobra.Command{
 		// Retrieve the client
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		var argComponent string
@@ -37,7 +37,7 @@ var logCmd = &cobra.Command{
 		}
 
 		// Retrieve and set the currentComponent
-		currentComponent := getComponent(client, argComponent, applicationName, projectName)
+		currentComponent := getComponent(client, argComponent, applicationName)
 
 		// Retrieve the log
 		err := component.GetLogs(client, currentComponent, applicationName, logFollow, stdout)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -181,12 +181,12 @@ var projectListCmd = &cobra.Command{
 			return
 		}
 		fmt.Printf("ACTIVE   NAME\n")
-		for _, app := range projects {
+		for _, project := range projects {
 			activeMark := " "
-			if app.Active {
+			if project.Active {
 				activeMark = "*"
 			}
-			fmt.Printf("  %s      %s\n", activeMark, app.Name)
+			fmt.Printf("  %s      %s\n", activeMark, project.Name)
 		}
 	},
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -34,7 +34,7 @@ var pushCmd = &cobra.Command{
 		stdout := color.Output
 		client := getOcClient()
 
-		projectName := getAndSetNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		var inputName string
@@ -46,7 +46,7 @@ var pushCmd = &cobra.Command{
 		componentName := getComponent(client, inputName, applicationName)
 		fmt.Printf("Pushing changes to component: %v\n", componentName)
 
-		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName, projectName)
+		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName)
 		checkError(err, "unable to get component source")
 		switch sourceType {
 		case "local", "binary":

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -34,7 +34,7 @@ var pushCmd = &cobra.Command{
 		stdout := color.Output
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		var inputName string
@@ -43,7 +43,7 @@ var pushCmd = &cobra.Command{
 		} else {
 			inputName = args[0]
 		}
-		componentName := getComponent(client, inputName, applicationName, projectName)
+		componentName := getComponent(client, inputName, applicationName)
 		fmt.Printf("Pushing changes to component: %v\n", componentName)
 
 		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName, projectName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,9 @@ import (
 // Global variables
 var (
 	GlobalSkipConnectionCheck bool
+	projectFlag               string
+	applicationFlag           string
+	componentFlag             string
 )
 
 // Templates

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -46,7 +46,7 @@ A full list of service types that can be deployed are available using: 'odo cata
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		setNamespace(client)
+		getAndSetNamespace(client)
 		var applicationName string
 		var err error
 		if applicationFlag != "" && projectFlag != "" {
@@ -126,7 +126,7 @@ var serviceDeleteCmd = &cobra.Command{
 
 		client := getOcClient()
 
-		setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		serviceName := args[0]
@@ -169,7 +169,7 @@ var serviceListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		services, err := svc.List(client, applicationName)

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -39,9 +39,9 @@ var storageCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 
 		var storageName string
 		if len(args) != 0 {
@@ -82,9 +82,9 @@ var storageUnmountCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 
 		var storageName string
 		var err error
@@ -129,7 +129,7 @@ var storageDeleteCmd = &cobra.Command{
 
 		storageName := args[0]
 
-		setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		exists, err := storage.Exists(client, storageName, applicationName)
@@ -183,7 +183,7 @@ var storageListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		if storageAllListflag {
@@ -191,10 +191,10 @@ var storageListCmd = &cobra.Command{
 				fmt.Println("Invalid arguments. Component name is not needed")
 				os.Exit(1)
 			}
-			printMountedStorageInAllComponent(client, applicationName, projectName)
+			printMountedStorageInAllComponent(client, applicationName)
 		} else {
 			// storageComponent is the input component name
-			componentName := getComponent(client, componentFlag, applicationName, projectName)
+			componentName := getComponent(client, componentFlag, applicationName)
 			printMountedStorageInComponent(client, componentName, applicationName)
 		}
 		printUnmountedStorage(client, applicationName)
@@ -215,9 +215,9 @@ var storageMountCmd = &cobra.Command{
 
 		storageName := args[0]
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 
 		exists, err := storage.Exists(client, storageName, applicationName)
 		checkError(err, "unable to check if the storage exists in the current application")
@@ -239,7 +239,6 @@ var storageMountCmd = &cobra.Command{
 
 func init() {
 	storageCreateCmd.Flags().StringVar(&storageSize, "size", "", "Size of storage to add")
-	//storageCreateCmd.Flags().StringVar(&storageComponent, "component", "", "Component to add storage to. Defaults to active component.")
 	storageCreateCmd.Flags().StringVar(&storagePath, "path", "", "Path to mount the storage on")
 	storageCreateCmd.MarkFlagRequired("path")
 	storageCreateCmd.MarkFlagRequired("size")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ var updateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		stdout := color.Output
@@ -60,7 +60,7 @@ var updateCmd = &cobra.Command{
 			componentName string
 		)
 
-		projectName = setNamespace(client)
+		projectName = getAndSetNamespace(client)
 		if len(args) == 0 {
 			componentName, err := component.GetCurrent(applicationName, projectName)
 			checkError(err, "unable to get current component")
@@ -74,7 +74,7 @@ var updateCmd = &cobra.Command{
 			}
 		} else {
 			componentName = args[0]
-			exists, err := component.Exists(client, componentName, applicationName, projectName)
+			exists, err := component.Exists(client, componentName, applicationName)
 			checkError(err, "")
 			if !exists {
 				fmt.Printf("Component with name %s does not exist in the current application\n", componentName)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -56,11 +56,8 @@ var updateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		var (
-			componentName string
-		)
+		var componentName string
 
-		projectName = getAndSetNamespace(client)
 		if len(args) == 0 {
 			componentName, err := component.GetCurrent(applicationName, projectName)
 			checkError(err, "unable to get current component")

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -51,9 +51,9 @@ The created URL can be used to access the specified component from outside the O
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 
 		var urlName string
 		switch len(args) {
@@ -94,9 +94,9 @@ var urlDeleteCmd = &cobra.Command{
 		// Initialization
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 
 		urlName := args[0]
 
@@ -138,9 +138,9 @@ var urlListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		getAndSetNamespace(client)
 		applicationName := getAppName(client)
-		componentName := getComponent(client, componentFlag, applicationName, projectName)
+		componentName := getComponent(client, componentFlag, applicationName)
 
 		urls, err := url.List(client, componentName, applicationName)
 		checkError(err, "")

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -51,7 +51,7 @@ var watchCmd = &cobra.Command{
 			componentName = args[0]
 		}
 
-		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName, projectName)
+		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName)
 		checkError(err, "Unable to get source for %s component.", componentName)
 
 		if sourceType != "binary" && sourceType != "local" {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -6,9 +6,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/redhat-developer/odo/pkg/util"
 
 	"github.com/golang/glog"
@@ -34,15 +32,15 @@ var watchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		stdout := os.Stdout
 		client := getOcClient()
-		projectName := project.GetCurrent(client)
-		applicationName, err := application.GetCurrent(client)
-		checkError(err, "Unable to get current application.")
+
+		projectName := setNamespace(client)
+		applicationName := getAppName(client)
 
 		var componentName string
 		if len(args) == 0 {
 			var err error
 			glog.V(4).Info("No component name passed, assuming current component")
-			componentName, err = component.GetCurrent(client, applicationName, projectName)
+			componentName, err = component.GetCurrent(applicationName, projectName)
 			checkError(err, "")
 			if componentName == "" {
 				fmt.Println("No component is set as active.")
@@ -83,6 +81,12 @@ func init() {
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(cmdUsageTemplate)
+
+	//Adding `--application` flag
+	addApplicationFlag(watchCmd)
+
+	//Adding `--project` flag
+	addProjectFlag(watchCmd)
 
 	rootCmd.AddCommand(watchCmd)
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -33,7 +33,7 @@ var watchCmd = &cobra.Command{
 		stdout := os.Stdout
 		client := getOcClient()
 
-		projectName := setNamespace(client)
+		projectName := getAndSetNamespace(client)
 		applicationName := getAppName(client)
 
 		var componentName string

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -171,8 +171,7 @@ func GetCurrent(projectName string) (string, error) {
 // Do not use for read operations like get, list; only for write operations like
 // create
 func GetCurrentOrGetCreateSetDefault(client *occlient.Client) (string, error) {
-	projectName := project.GetCurrent(client)
-	currentApp, err := GetCurrent(projectName)
+	currentApp, err := GetCurrent(client.Namespace)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get active application")
 	}
@@ -201,6 +200,11 @@ func GetCurrentOrGetCreateSetDefault(client *occlient.Client) (string, error) {
 
 // SetCurrent set application as active
 func SetCurrent(client *occlient.Client, appName string) error {
+	// also sets project to the given project
+	err := project.SetCurrent(client, client.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "unable to set current project")
+	}
 	glog.V(4).Infof("Setting application %s as current.\n", appName)
 
 	cfg, err := config.New()

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -55,15 +55,12 @@ func GetDefaultAppName(existingApps []config.ApplicationInfo) (string, error) {
 }
 
 // Create a new application
-func Create(client *occlient.Client, applicationName string) error {
-	project := project.GetCurrent(client)
+func Create(client *occlient.Client, appName string) error {
 
-	exists, err := Exists(client, applicationName)
-	if err != nil {
-		return errors.Wrap(err, "unable to create new application")
-	}
+	exists, _ := Exists(client, appName)
+
 	if exists {
-		return fmt.Errorf("unable to create new application, %s application already exists", applicationName)
+		return fmt.Errorf("unable to create new application, %s application already exists", appName)
 	}
 
 	cfg, err := config.New()
@@ -71,7 +68,7 @@ func Create(client *occlient.Client, applicationName string) error {
 		return errors.Wrap(err, "unable to create new application")
 	}
 
-	err = cfg.AddApplication(applicationName, project)
+	err = cfg.AddApplication(appName, client.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "unable to create new application")
 	}
@@ -80,15 +77,15 @@ func Create(client *occlient.Client, applicationName string) error {
 
 // List all applications in current project
 func List(client *occlient.Client) ([]config.ApplicationInfo, error) {
-	return ListInProject(client, project.GetCurrent(client))
+	return ListInProject(client)
 }
 
 // ListInProject lists all applications in given project
 // Queries cluster and config file.
 // Shows also empty applications (empty applications are those that are just
 // mentioned in config file but don't have any object associated with it on cluster).
-func ListInProject(client *occlient.Client, project string) ([]config.ApplicationInfo, error) {
-	applications := []config.ApplicationInfo{}
+func ListInProject(client *occlient.Client) ([]config.ApplicationInfo, error) {
+	var applications []config.ApplicationInfo
 
 	cfg, err := config.New()
 	if err != nil {
@@ -97,13 +94,13 @@ func ListInProject(client *occlient.Client, project string) ([]config.Applicatio
 
 	// All applications of the current project from config file
 	for i := range cfg.ActiveApplications {
-		if cfg.ActiveApplications[i].Project == project {
+		if cfg.ActiveApplications[i].Project == client.Namespace {
 			applications = append(applications, cfg.ActiveApplications[i])
 		}
 	}
 
 	// Get applications from cluster
-	appNames, err := client.GetLabelValues(project, applabels.ApplicationLabel, applabels.ApplicationLabel)
+	appNames, err := client.GetLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list applications")
 	}
@@ -112,7 +109,7 @@ func ListInProject(client *occlient.Client, project string) ([]config.Applicatio
 		// skip applications that are already in the list (they were mentioned in config file)
 		found := false
 		for _, app := range applications {
-			if app.Project == project && app.Name == name {
+			if app.Project == client.Namespace && app.Name == name {
 				found = true
 			}
 		}
@@ -121,7 +118,7 @@ func ListInProject(client *occlient.Client, project string) ([]config.Applicatio
 				Name: name,
 				// if this application is not in config file, it can't be active
 				Active:  false,
-				Project: project,
+				Project: client.Namespace,
 			})
 		}
 	}
@@ -147,9 +144,7 @@ func Delete(client *occlient.Client, name string) error {
 		return errors.Wrapf(err, "unable to delete application %s", name)
 	}
 
-	project := project.GetCurrent(client)
-
-	err = cfg.DeleteApplication(name, project)
+	err = cfg.DeleteApplication(name, client.Namespace)
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete application %s", name)
 	}
@@ -159,15 +154,13 @@ func Delete(client *occlient.Client, name string) error {
 
 // GetCurrent returns currently active application.
 // If no application is active this functions returns empty string
-func GetCurrent(client *occlient.Client) (string, error) {
-	project := project.GetCurrent(client)
-
+func GetCurrent(projectName string) (string, error) {
 	cfg, err := config.New()
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get active application")
 	}
 
-	app := cfg.GetActiveApplication(project)
+	app := cfg.GetActiveApplication(projectName)
 	return app, nil
 }
 
@@ -178,11 +171,11 @@ func GetCurrent(client *occlient.Client) (string, error) {
 // Do not use for read operations like get, list; only for write operations like
 // create
 func GetCurrentOrGetCreateSetDefault(client *occlient.Client) (string, error) {
-	currentApp, err := GetCurrent(client)
+	projectName := project.GetCurrent(client)
+	currentApp, err := GetCurrent(projectName)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get active application")
 	}
-
 	// if no Application is active use default
 	if currentApp == "" {
 		// get default application name
@@ -192,10 +185,7 @@ func GetCurrentOrGetCreateSetDefault(client *occlient.Client) (string, error) {
 		}
 		currentApp = defaultName
 		// create if default application does not exist
-		exists, err := Exists(client, currentApp)
-		if err != nil {
-			return "", errors.Wrapf(err, "unable to check if app %v exists", currentApp)
-		}
+		exists, _ := Exists(client, currentApp)
 		if !exists {
 			if err := Create(client, currentApp); err != nil {
 				return "", errors.Wrapf(err, "unable to create app %v", currentApp)
@@ -210,22 +200,20 @@ func GetCurrentOrGetCreateSetDefault(client *occlient.Client) (string, error) {
 }
 
 // SetCurrent set application as active
-func SetCurrent(client *occlient.Client, name string) error {
-	glog.V(4).Infof("Setting application %s as current.\n", name)
-
-	project := project.GetCurrent(client)
+func SetCurrent(client *occlient.Client, appName string) error {
+	glog.V(4).Infof("Setting application %s as current.\n", appName)
 
 	cfg, err := config.New()
 	if err != nil {
 		return errors.Wrap(err, "unable to set current application")
 	}
 
-	exists, err := Exists(client, name)
+	exists, err := Exists(client, appName)
 	if err != nil {
 		return errors.Wrap(err, "unable to set current application")
 	}
 	if !exists {
-		return fmt.Errorf("application %s doesn't exist", name)
+		return fmt.Errorf("application %s doesn't exist", appName)
 	}
 
 	// There might be a situation where application is not defined in local config
@@ -233,16 +221,19 @@ func SetCurrent(client *occlient.Client, name string) error {
 	// In that case we need to add application back to the the config before we set it as active.
 	found := false
 	for _, cfgApp := range cfg.ActiveApplications {
-		if cfgApp.Project == project && cfgApp.Name == name {
+		if cfgApp.Project == client.Namespace && cfgApp.Name == appName {
 			found = true
 			break
 		}
 	}
 	if !found {
-		cfg.AddApplication(name, project)
+		err := cfg.AddApplication(appName, client.Namespace)
+		if err != nil {
+			return errors.Wrap(err, "unable to add application")
+		}
 	}
 
-	err = cfg.SetActiveApplication(name, project)
+	err = cfg.SetActiveApplication(appName, client.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "unable to set current application")
 	}
@@ -250,16 +241,15 @@ func SetCurrent(client *occlient.Client, name string) error {
 	return nil
 }
 
-// Exists returns true if given application name exist
-func Exists(client *occlient.Client, name string) (bool, error) {
-	apps, err := List(client)
+func Exists(client *occlient.Client, appName string) (bool, error) {
+	apps, err := ListInProject(client)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to list applications")
 	}
 	for _, app := range apps {
-		if app.Name == name {
+		if app.Name == appName {
 			return true, nil
 		}
 	}
-	return false, nil
+	return false, errors.Errorf("application %v does not exist in project %v", appName, client.Namespace)
 }

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -241,6 +241,7 @@ func SetCurrent(client *occlient.Client, appName string) error {
 	return nil
 }
 
+// Exists returns true if given application (appName) exists
 func Exists(client *occlient.Client, appName string) (bool, error) {
 	apps, err := ListInProject(client)
 	if err != nil {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -291,8 +291,7 @@ func Delete(client *occlient.Client, componentName string, applicationName strin
 	return nil
 }
 
-// SetCurrent sets the given component to active in odo config file
-
+// SetCurrent sets the given componentName as active component
 func SetCurrent(componentName string, applicationName string, projectName string) error {
 	cfg, err := config.New()
 	if err != nil {
@@ -457,7 +456,7 @@ func List(client *occlient.Client, applicationName string) ([]ComponentInfo, err
 // The first returned string is component source type ("git" or "local" or "binary")
 // The second returned string is a source (url to git repository or local path or path to binary)
 // we retrieve the source type by looking up the DeploymentConfig that's deployed
-func GetComponentSource(client *occlient.Client, componentName string, applicationName string, projectName string) (string, string, error) {
+func GetComponentSource(client *occlient.Client, componentName string, applicationName string) (string, string, error) {
 
 	// Namespace the application
 	namespacedOpenShiftObject, err := util.NamespaceOpenShiftObject(componentName, applicationName)
@@ -492,7 +491,7 @@ func Update(client *occlient.Client, componentName string, applicationName strin
 	// STEP 1. Create the common Object Meta for updating.
 
 	// Retrieve the old source type
-	oldSourceType, _, err := GetComponentSource(client, componentName, applicationName, client.Namespace)
+	oldSourceType, _, err := GetComponentSource(client, componentName, applicationName)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get source of %s component", componentName)
 	}
@@ -731,7 +730,7 @@ func GetComponentDesc(client *occlient.Client, componentName string, application
 		return "", "", "", nil, errors.Wrap(err, "unable to get source path")
 	}
 	// Source
-	_, path, err = GetComponentSource(client, componentName, applicationName, client.Namespace)
+	_, path, err = GetComponentSource(client, componentName, applicationName)
 	if err != nil {
 		return "", "", "", nil, errors.Wrap(err, "unable to get source path")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,13 +173,13 @@ func (c *ConfigInfo) GetNamePrefix() string {
 
 // SetActiveComponent sets active component for given project and application.
 // application must exist
-func (c *ConfigInfo) SetActiveComponent(component string, application string, project string) error {
+func (c *ConfigInfo) SetActiveComponent(componentName string, applicationName string, projectName string) error {
 	found := false
 
 	if c.ActiveApplications != nil {
 		for i, app := range c.ActiveApplications {
-			if app.Project == project && app.Name == application {
-				c.ActiveApplications[i].ActiveComponent = component
+			if app.Project == projectName && app.Name == applicationName {
+				c.ActiveApplications[i].ActiveComponent = componentName
 				found = true
 				break
 			}
@@ -187,12 +187,12 @@ func (c *ConfigInfo) SetActiveComponent(component string, application string, pr
 	}
 
 	if !found {
-		return errors.Errorf("unable to set %s component as active, application %s in %s project doesn't exists", component, application, project)
+		return errors.Errorf("unable to set %s componentName as active, applicationName %s in %s projectName doesn't exists", componentName, applicationName, projectName)
 	}
 
 	err := c.writeToFile()
 	if err != nil {
-		return errors.Wrapf(err, "unable to set %s as active component", component)
+		return errors.Wrapf(err, "unable to set %s as active componentName", componentName)
 	}
 	return nil
 }

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -3639,7 +3639,7 @@ func TestGetEnvVarsFromDC(t *testing.T) {
 				return true, &tt.returnedDC, nil
 			})
 
-			envVars, err := fakeClient.GetEnvVarsFromDC(tt.dcName, tt.projectName)
+			envVars, err := fakeClient.GetEnvVarsFromDC(tt.dcName)
 
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -671,7 +671,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "mailserver",
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "python",
 			},
@@ -684,7 +684,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "blog",
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "golang",
 			},
@@ -994,7 +994,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1028,7 +1028,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1056,7 +1056,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1091,7 +1091,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1119,7 +1119,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1154,7 +1154,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1181,7 +1181,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1640,51 +1640,6 @@ func TestUpdateBuildConfig(t *testing.T) {
 		wantErr             bool
 	}{
 		{
-			name:            "git to local with proper parameters",
-			buildConfigName: "nodejs",
-			gitURL:          "",
-			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
-				"app.kubernetes.io/component-source-type": "local",
-			},
-			existingBuildConfig: buildv1.BuildConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "nodejs",
-				},
-				Spec: buildv1.BuildConfigSpec{
-					CommonSpec: buildv1.CommonSpec{
-						Source: buildv1.BuildSource{
-							Git: &buildv1.GitBuildSource{
-								URI: "https://github.com/sclorg/nodejs-ex",
-							},
-							Type: buildv1.BuildSourceGit,
-						},
-					},
-				},
-			},
-			updatedBuildConfig: buildv1.BuildConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "nodejs",
-					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
-						"app.kubernetes.io/component-source-type": "local",
-					},
-				},
-				Spec: buildv1.BuildConfigSpec{
-					CommonSpec: buildv1.CommonSpec{
-						Source: buildv1.BuildSource{
-							Git: &buildv1.GitBuildSource{
-								URI: bootstrapperURI,
-								Ref: bootstrapperRef,
-							},
-							Type: buildv1.BuildSourceGit,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name:            "local to git with proper parameters",
 			buildConfigName: "nodejs",
 			gitURL:          "https://github.com/sclorg/nodejs-ex",
@@ -1790,7 +1745,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1816,7 +1771,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1843,7 +1798,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1870,7 +1825,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -2828,7 +2783,7 @@ func TestCreateService(t *testing.T) {
 			commonObjectMeta: metav1.ObjectMeta{
 				Name: "nodejs",
 				Labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -671,7 +671,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "mailserver",
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
-				"SLA":                              "High",
+				"SLA": "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "python",
 			},
@@ -684,7 +684,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "blog",
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
-				"SLA":                              "High",
+				"SLA": "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "golang",
 			},
@@ -980,7 +980,6 @@ func TestSetupForSupervisor(t *testing.T) {
 	tests := []struct {
 		name        string
 		dcName      string
-		projectName string
 		annotations map[string]string
 		labels      map[string]string
 		existingDc  appsv1.DeploymentConfig
@@ -988,15 +987,14 @@ func TestSetupForSupervisor(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "setup with normal correct values",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "setup with normal correct values",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1030,7 +1028,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1051,15 +1049,14 @@ func TestSetupForSupervisor(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "setup with wrong pvc name",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "setup with wrong pvc name",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1094,7 +1091,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1115,15 +1112,14 @@ func TestSetupForSupervisor(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:        "setup with wrong pvc specs",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "setup with wrong pvc specs",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1158,7 +1154,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1178,15 +1174,14 @@ func TestSetupForSupervisor(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:        "setup with non existing dc",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "setup with non existing dc",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1233,7 +1228,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				return true, &tt.createdPVC, nil
 			})
 
-			err := fkclient.SetupForSupervisor(tt.dcName, tt.projectName, tt.annotations, tt.labels)
+			err := fkclient.SetupForSupervisor(tt.dcName, tt.annotations, tt.labels)
 
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
@@ -1280,16 +1275,14 @@ func TestCleanupAfterSupervisor(t *testing.T) {
 	tests := []struct {
 		name        string
 		dcName      string
-		projectName string
 		annotations map[string]string
 		existingDc  appsv1.DeploymentConfig
 		pvcName     string
 		wantErr     bool
 	}{
 		{
-			name:        "proper parameters and one volume,volumeMount and initContainer",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "proper parameters and one volume,volumeMount and initContainer",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
@@ -1349,9 +1342,8 @@ func TestCleanupAfterSupervisor(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "proper parameters and two volume,volumeMount and initContainer",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "proper parameters and two volume,volumeMount and initContainer",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
@@ -1426,9 +1418,8 @@ func TestCleanupAfterSupervisor(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "proper parameters and one volume,volumeMount and initContainer and non existing dc",
-			dcName:      "wildfly",
-			projectName: "project-testing",
+			name:   "proper parameters and one volume,volumeMount and initContainer and non existing dc",
+			dcName: "wildfly",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
@@ -1519,7 +1510,7 @@ func TestCleanupAfterSupervisor(t *testing.T) {
 				return true, nil, nil
 			})
 
-			err := fkclient.CleanupAfterSupervisor(tt.dcName, tt.projectName, tt.annotations)
+			err := fkclient.CleanupAfterSupervisor(tt.dcName, tt.annotations)
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
 				if (len(fkclientset.AppsClientset.Actions()) != 2) && (tt.wantErr != true) {
@@ -1594,14 +1585,12 @@ func TestGetBuildConfigFromName(t *testing.T) {
 	tests := []struct {
 		name                string
 		buildName           string
-		projectName         string
 		returnedBuildConfig buildv1.BuildConfig
 		wantErr             bool
 	}{
 		{
-			name:        "buildConfig with existing bc",
-			buildName:   "nodejs",
-			projectName: "project-app",
+			name:      "buildConfig with existing bc",
+			buildName: "nodejs",
 			returnedBuildConfig: buildv1.BuildConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs",
@@ -1622,7 +1611,7 @@ func TestGetBuildConfigFromName(t *testing.T) {
 				return true, &tt.returnedBuildConfig, nil
 			})
 
-			build, err := fkclient.GetBuildConfigFromName(tt.buildName, tt.projectName)
+			build, err := fkclient.GetBuildConfigFromName(tt.buildName)
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
 				if (len(fkclientset.BuildClientset.Actions()) != 1) && (tt.wantErr != true) {
@@ -1644,7 +1633,6 @@ func TestUpdateBuildConfig(t *testing.T) {
 	tests := []struct {
 		name                string
 		buildConfigName     string
-		projectName         string
 		gitURL              string
 		annotations         map[string]string
 		existingBuildConfig buildv1.BuildConfig
@@ -1652,9 +1640,53 @@ func TestUpdateBuildConfig(t *testing.T) {
 		wantErr             bool
 	}{
 		{
+			name:            "git to local with proper parameters",
+			buildConfigName: "nodejs",
+			gitURL:          "",
+			annotations: map[string]string{
+				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.kubernetes.io/component-source-type": "local",
+			},
+			existingBuildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nodejs",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Source: buildv1.BuildSource{
+							Git: &buildv1.GitBuildSource{
+								URI: "https://github.com/sclorg/nodejs-ex",
+							},
+							Type: buildv1.BuildSourceGit,
+						},
+					},
+				},
+			},
+			updatedBuildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nodejs",
+					Annotations: map[string]string{
+						"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+						"app.kubernetes.io/component-source-type": "local",
+					},
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Source: buildv1.BuildSource{
+							Git: &buildv1.GitBuildSource{
+								URI: bootstrapperURI,
+								Ref: bootstrapperRef,
+							},
+							Type: buildv1.BuildSourceGit,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:            "local to git with proper parameters",
 			buildConfigName: "nodejs",
-			projectName:     "app",
 			gitURL:          "https://github.com/sclorg/nodejs-ex",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "https://github.com/sclorg/nodejs-ex",
@@ -1709,7 +1741,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 				return true, &tt.updatedBuildConfig, nil
 			})
 
-			err := fkclient.UpdateBuildConfig(tt.buildConfigName, tt.projectName, tt.gitURL, tt.annotations)
+			err := fkclient.UpdateBuildConfig(tt.buildConfigName, tt.gitURL, tt.annotations)
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
 				if (len(fkclientset.BuildClientset.Actions()) != 2) && (tt.wantErr != true) {
@@ -1758,7 +1790,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1784,7 +1816,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1811,7 +1843,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1838,7 +1870,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -2796,7 +2828,7 @@ func TestCreateService(t *testing.T) {
 			commonObjectMeta: metav1.ObjectMeta{
 				Name: "nodejs",
 				Labels: map[string]string{
-					"app":                              "apptmp",
+					"app": "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -3112,7 +3144,7 @@ func TestGetServiceInstanceList(t *testing.T) {
 			return true, &tt.serviceList, nil
 		})
 
-		svcInstanceList, err := client.GetServiceInstanceList(tt.args.Project, tt.args.Selector)
+		svcInstanceList, err := client.GetServiceInstanceList(tt.args.Selector)
 
 		if !reflect.DeepEqual(tt.output, svcInstanceList) {
 			t.Errorf("expected output: %#v,got: %#v", tt.serviceList, svcInstanceList)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -15,12 +15,14 @@ type ProjectInfo struct {
 	Active bool
 }
 
+// GetCurrent return current project
 func GetCurrent(client *occlient.Client) string {
 	project := client.GetCurrentProjectName()
 	return project
 }
 
-func SetCurrent(client *occlient.Client, project string) error {
+// SetCurrent sets the projectName as current project
+func SetCurrent(client *occlient.Client, projectName string) error {
 	currentProject := GetCurrent(client)
 
 	cfg, err := config.New()
@@ -29,16 +31,16 @@ func SetCurrent(client *occlient.Client, project string) error {
 	}
 	err = cfg.UnsetActiveApplication(currentProject)
 	if err != nil {
-		return errors.Wrap(err, "unable to unset active application of current project "+project)
+		return errors.Wrap(err, "unable to unset active application of current project "+projectName)
 	}
 	err = cfg.UnsetActiveComponent(currentProject)
 	if err != nil {
-		return errors.Wrap(err, "unable to unset active component of current project "+project)
+		return errors.Wrap(err, "unable to unset active component of current project "+projectName)
 	}
 
-	err = client.SetCurrentProject(project)
+	err = client.SetCurrentProject(projectName)
 	if err != nil {
-		return errors.Wrap(err, "unable to set current project to"+project)
+		return errors.Wrap(err, "unable to set current project to"+projectName)
 	}
 	return nil
 }
@@ -111,7 +113,7 @@ func List(client *occlient.Client) ([]ProjectInfo, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get all the projects")
 	}
-	projects := []ProjectInfo{}
+	var projects []ProjectInfo
 	for _, project := range allProjects {
 		isActive := false
 		if project == currentProject {
@@ -139,5 +141,5 @@ func Exists(client *occlient.Client, projectName string) (bool, error) {
 			return true, nil
 		}
 	}
-	return false, nil
+	return false, errors.Errorf(" %v project does not exist", projectName)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -81,7 +81,7 @@ func DeleteService(client *occlient.Client, name string, applicationName string)
 }
 
 // List lists all the deployed services
-func List(client *occlient.Client, applicationName string, projectName string) ([]ServiceInfo, error) {
+func List(client *occlient.Client, applicationName string) ([]ServiceInfo, error) {
 	labels := map[string]string{
 		applabels.ApplicationLabel: applicationName,
 	}
@@ -91,7 +91,7 @@ func List(client *occlient.Client, applicationName string, projectName string) (
 	applicationSelector := util.ConvertLabelsToSelector(labels)
 
 	// get service instance list based on given selector
-	serviceInstanceList, err := client.GetServiceInstanceList(projectName, applicationSelector)
+	serviceInstanceList, err := client.GetServiceInstanceList(applicationSelector)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to list services")
 	}
@@ -124,9 +124,9 @@ func GetSvcByType(client *occlient.Client, serviceType string) (*occlient.Servic
 // serviceName is the service name to perform check for
 // The first returned parameter is a bool indicating if a service with the given name already exists or not
 // The second returned parameter is the error that might occurs while execution
-func SvcExists(client *occlient.Client, serviceName, applicationName, projectName string) (bool, error) {
+func SvcExists(client *occlient.Client, serviceName, applicationName string) (bool, error) {
 
-	serviceList, err := List(client, applicationName, projectName)
+	serviceList, err := List(client, applicationName)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to get the service list")
 	}


### PR DESCRIPTION
This PR does:

* Adds flags `project`, `application` and `component` flag to respective commands

* added `getProjectName` and `getAppName` reusable functions which looks for `project` or `application` flag first, if not provided then it gives current value by default.

* Provide comments to some of the exported functions

* Refactors the way we provide `namespace` value for methods in `occlient.go`.
(No method will accept namespace as a argument, whenever needed we will use `client.Namespace` value)

* Updated unit tests as per new refactoring


-- edit by @kadel 
https://github.com/redhat-developer/odo/issues/656