### PR TITLE
Update description for odo app list

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -130,9 +130,9 @@ var applicationDeleteCmd = &cobra.Command{
 
 var applicationListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Lists all the applications",
-	Long:  "Lists all the applications",
-	Example: `  # List all applications
+	Short: "List all applications in the current project",
+	Long:  "List all applications in the current project.",
+	Example: `  # List all applications in the current project 
   odo app list
 	`,
 	Args: cobra.ExactArgs(0),


### PR DESCRIPTION
Modifies the help description to keep in-line with `odo list`

Closes: https://github.com/redhat-developer/odo/issues/644