### PR TITLE
Fixes the color issue on Windows for odo push.

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -237,7 +237,9 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 		scanner := bufio.NewScanner(pipeReader)
 		for scanner.Scan() {
 			line := scanner.Text()
-			yellowFprintln(out, line)
+			// color.Output is temporarily used as there is a error when passing in color.Output from cmd/create.go and casting to io.writer in windows
+			// TODO: Fix this in the future, more upstream in the code at cmd/create.go rather than within this function.
+			yellowFprintln(color.Output, line)
 		}
 	}()
 


### PR DESCRIPTION
Fixes #402 

Switching to color.output in PushLocal as color.output passed to the function and cast to io.writer is not working on windows. Will solve this in future by moving this more upstream in code at cmd/create.go.

Note : Windows Power Shell doesn't seem to support **FgYellow** color and so the text in not colored in case of power shell but the weird unknown characters are gone. For CMD, the color works fine.

https://superuser.com/questions/1202003/some-git-colors-dont-work-in-powershell-why