### PR TITLE
Remove release / notify test temporarily

### DIFF
--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -1,5 +1,6 @@
 package notify
 
+/*
 import (
 	"context"
 	"fmt"
@@ -40,3 +41,4 @@ func Test_getLatestReleaseTag(t *testing.T) {
 		})
 	}
 }
+*/


### PR DESCRIPTION
We're hitting the API limit and tests are failing.

Disabling this for now.