### PR TITLE
Avoid watching the main src directory

### DIFF
--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -55,8 +55,8 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, path string, ignores []string)
 		ignore := false
 		for _, pattern := range ignores {
 			// Don't watch:
-			// 	1. The main src directory as its files and sub-directories will already be watched
-			//	2. Anything in ignores
+			// 	1. The main src directory, as its files and sub-directories will already be watched
+			//	2. Anything it ignores
 			if matched, _ := regexp.MatchString(pattern, v); matched || v == path {
 				ignore = true
 				break


### PR DESCRIPTION
Currently the watch has a provision to allow as exceptions certain
directories and not watch them for changes ex: .git. Now, if we watch
the main directory, it will include the watch for its nested dirs automatically.
So, this PR avoids watching the main source directory.

fixes #639
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>