### PR TITLE
Update the release documentation for Odo.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -177,31 +177,53 @@ glide --version
 ## Making a release
 
 Making artifacts for new release is automated. 
+
 When new git tag is created, Travis-ci deploy job automatically builds binaries and uploads it to GitHub release page.
 
 1. Create PR with updated version in following files:
+
     - [cmd/version.go](/cmd/version.go)
     - [scripts/install.sh](/scripts/install.sh)
     - [README.md](/README.md)
-    - [odo.rb](https://github.com/kadel/homebrew-odo/blob/master/Formula/odo.rb) in [kadel/homebrew-odo](https://github.com/kadel/homebrew-odo)
 
     There is a helper script [scripts/bump-version.sh](/scripts/bump-version.sh) that should change version number in all files listed above (expect odo.rb).
 
     To update the CLI Structure in README.md, run `make generate-cli-structure` and update the section in [README.md](/README.md#cli-structure)
 
     To update the CLI reference documentation in docs/cli-reference.md, run `make generate-cli-structure > docs/cli-reference.md`.
-2. When PR is merged create and push new git tag for version.
+
+2. Merge the above PR
+
+3. Once the PR is merged create and push new git tag for version.
     ```
     git tag v0.0.1
     git push upstream v0.0.1
     ```
-    Or create new release using GitHub site (this has to be a proper release, not just draft). 
+    **Or** create the new release using GitHub site (this has to be a proper release, not just draft). 
+
     Do not upload any binaries for release
+
     When new tag is created Travis-CI starts a special deploy job.
+
     This job builds binaries automatically (via `make prepare-release`) and then uploads it to GitHub release page (done using odo-bot user).
-3. When a job finishes you should see binaries on the GitHub release page. Release is now marked as a draft. Update descriptions and publish release.
-4. Verify that packages have been uploaded to rpm and deb repositories.
-5. Confirm the binaries are available in GitHub release page and update the file `build/VERSION` with latest version number.
+
+4. When a job finishes you should see binaries on the GitHub release page. Release is now marked as a draft. Update descriptions and publish release.
+
+5. Verify that packages have been uploaded to rpm and deb repositories.
+
+6. We must now update the Homebrew package. Download the current release `.tar.gz` file and retrieve the sha256 value.
+
+    ```sh
+    RELEASE=X.X.X
+    wget https://github.com/redhat-developer/odo/archive/v$RELEASE.tar.gz
+    sha256 v$RELEASE.tar.gz
+    ```
+
+    Then open a PR to update: [odo.rb](https://github.com/kadel/homebrew-odo/blob/master/Formula/odo.rb) in [kadel/homebrew-odo](https://github.com/kadel/homebrew-odo)
+
+7. Confirm the binaries are available in GitHub release page.
+
+8. Create a PR and update the file `build/VERSION` with latest version number.
 
 ## odo-bot
 This is GitHub user that does all the automation.


### PR DESCRIPTION
We had some troubles following the current instructions and thus these
new instructions go into more detail (as well as what order to go in for
the Homebrew package).