### PR TITLE
Enhance project delete + Add UTs

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -140,6 +140,7 @@ var projectDeleteCmd = &cobra.Command{
 			fmt.Printf("Aborting deletion of project: %v\n", projectName)
 		}
 
+		fmt.Printf("Deleting project %s...\n(this operation may take some time)\n", projectName)
 		err = project.Delete(client, projectName)
 		if err != nil {
 			checkError(err, "")

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
@@ -147,9 +146,6 @@ var projectDeleteCmd = &cobra.Command{
 		}
 		fmt.Printf("Deleted project : %v\n", projectName)
 
-		// Wait for the delete operation to reflect in the projects list
-		time.Sleep(9 * time.Second)
-
 		// Get Current Project
 		currProject := project.GetCurrent(client)
 
@@ -159,6 +155,9 @@ var projectDeleteCmd = &cobra.Command{
 		checkError(err, "")
 		if len(projects) != 0 {
 			fmt.Printf("%s has been set as active project\n", currProject)
+		} else {
+			// oc errors out as "error: you do not have rights to view project "$deleted_project"."
+			fmt.Printf("You are not a member of any projects. You can request a project to be created with the `odo project create <project_name>` command\n")
 		}
 
 	},

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -154,10 +154,10 @@ var projectDeleteCmd = &cobra.Command{
 		projects, err := project.List(client)
 		checkError(err, "")
 		if len(projects) != 0 {
-			fmt.Printf("%s has been set as active project\n", currProject)
+			fmt.Printf("%s has been set as the active project\n", currProject)
 		} else {
 			// oc errors out as "error: you do not have rights to view project "$deleted_project"."
-			fmt.Printf("You are not a member of any projects. You can request a project to be created with the `odo project create <project_name>` command\n")
+			fmt.Printf("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command\n")
 		}
 
 	},
@@ -176,7 +176,7 @@ var projectListCmd = &cobra.Command{
 		projects, err := project.List(client)
 		checkError(err, "")
 		if len(projects) == 0 {
-			fmt.Println("You are not a member of any projects. You can request a project to be created with the `odo project create <project_name>` command")
+			fmt.Println("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command")
 			return
 		}
 		fmt.Printf("ACTIVE   NAME\n")

--- a/pkg/occlient/fakeclient.go
+++ b/pkg/occlient/fakeclient.go
@@ -53,5 +53,7 @@ func FakeNew() (*Client, *FakeClientset) {
 	fkclientset.ServiceCatalogClientSet = fakeServiceCatalogClientSet.NewSimpleClientset()
 	client.serviceCatalogClient = fkclientset.ServiceCatalogClientSet.Servicecatalog()
 
+	client.namespace = "testing"
+
 	return &client, &fkclientset
 }

--- a/pkg/occlient/fakeclient.go
+++ b/pkg/occlient/fakeclient.go
@@ -53,7 +53,5 @@ func FakeNew() (*Client, *FakeClientset) {
 	fkclientset.ServiceCatalogClientSet = fakeServiceCatalogClientSet.NewSimpleClientset()
 	client.serviceCatalogClient = fkclientset.ServiceCatalogClientSet.Servicecatalog()
 
-	client.namespace = "testing"
-
 	return &client, &fkclientset
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -301,6 +301,11 @@ func (c *Client) CreateNewProject(name string) error {
 	return nil
 }
 
+// SetCurrentProject sets the passed project as active in kube config file
+// Parameters:
+//	1. project to set as active
+//	2. the instance of client to be used to set the project as active
+// Returns: error. non nil error in case of errors, nil otherwise
 var SetCurrentProject = func(project string, c *Client) error {
 	rawConfig, err := c.kubeConfig.RawConfig()
 	if err != nil {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/redhat-developer/odo/pkg/util"
 

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1364,7 +1364,7 @@ func (c *Client) DeleteProject(name string) error {
 			}
 		*/
 		if !ok {
-			return fmt.Errorf("Received unexpected signal %+v on project watch channel", val)
+			return fmt.Errorf("received unexpected signal %+v on project watch channel", val)
 		}
 		// So we depend on val.Type as val.Object.Status.Phase is just empty string and not a mapped value constant
 		if prj, ok := val.Object.(*projectv1.Project); ok {
@@ -1376,7 +1376,7 @@ func (c *Client) DeleteProject(name string) error {
 					return nil
 				}
 				if val.Type == watch.Error {
-					return fmt.Errorf("Failed watching the deletion of project %s", name)
+					return fmt.Errorf("failed watching the deletion of project %s", name)
 				}
 			}
 		}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -301,7 +301,7 @@ func (c *Client) CreateNewProject(name string) error {
 	return nil
 }
 
-func (c *Client) SetCurrentProject(project string) error {
+var SetCurrentProject = func(project string, c *Client) error {
 	rawConfig, err := c.kubeConfig.RawConfig()
 	if err != nil {
 		return errors.Wrapf(err, "unable to switch to %s project", project)

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -18,6 +18,7 @@ import (
 	dockerapiv10 "github.com/openshift/api/image/docker10"
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	"github.com/redhat-developer/odo/pkg/testingutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -671,7 +672,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "mailserver",
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
-				"SLA":                              "High",
+				"SLA": "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "python",
 			},
@@ -684,7 +685,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "blog",
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
-				"SLA":                              "High",
+				"SLA": "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "golang",
 			},
@@ -996,7 +997,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1030,7 +1031,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1059,7 +1060,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1094,7 +1095,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1123,7 +1124,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1158,7 +1159,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1186,7 +1187,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app": "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1758,7 +1759,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1784,7 +1785,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1811,7 +1812,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1838,7 +1839,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app": "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -2796,7 +2797,7 @@ func TestCreateService(t *testing.T) {
 			commonObjectMeta: metav1.ObjectMeta{
 				Name: "nodejs",
 				Labels: map[string]string{
-					"app":                              "apptmp",
+					"app": "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -3770,6 +3771,49 @@ func Test_updateEnvVar(t *testing.T) {
 				t.Error("error was expected, but no error was returned")
 			} else if err != nil && !tt.wantErr {
 				t.Errorf("test failed, no error was expected, but got unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestDeleteProject(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		wantErr     bool
+	}{
+		{
+			name:        "phase: deleted",
+			projectName: "testing",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			fkclient, fkclientset := FakeNew()
+			fkWatch := watch.NewFake()
+
+			fkclientset.ProjClientset.PrependReactor("delete", "projects", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+			go func() {
+				fkWatch.Delete(testingutil.FakeProjectStatus(corev1.NamespacePhase(""), tt.projectName))
+			}()
+			fkclientset.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				return true, fkWatch, nil
+			})
+
+			err := fkclient.DeleteProject(tt.projectName)
+
+			if !tt.wantErr == (err != nil) {
+				t.Errorf(" client.projectName(string) unexpected error %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if len(fkclientset.ProjClientset.Actions()) != 2 {
+				t.Errorf("expected 1 action in DeleteProject got: %v", fkclientset.ProjClientset.Actions())
 			}
 		})
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -671,7 +671,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "mailserver",
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "python",
 			},
@@ -684,7 +684,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "blog",
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "golang",
 			},
@@ -996,7 +996,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1030,7 +1030,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1059,7 +1059,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1094,7 +1094,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1123,7 +1123,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1158,7 +1158,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1186,7 +1186,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1758,7 +1758,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1784,7 +1784,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1811,7 +1811,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1838,7 +1838,7 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "ruby",
 						"app.kubernetes.io/component-type": "ruby",
 						"app.kubernetes.io/name":           "apptmp",
@@ -2796,7 +2796,7 @@ func TestCreateService(t *testing.T) {
 			commonObjectMeta: metav1.ObjectMeta{
 				Name: "nodejs",
 				Labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -82,7 +82,6 @@ func Delete(client *occlient.Client, projectName string) error {
 		return errors.Wrap(err, "unable to delete project")
 	}
 
-	SetCurrent(client, "")
 	// If there will be any projects post the current deletion,
 	// Choose the first project from remainder of the project list to set as current
 	if len(projects) > 0 {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -36,7 +36,7 @@ func SetCurrent(client *occlient.Client, project string) error {
 		return errors.Wrap(err, "unable to unset active component of current project "+project)
 	}
 
-	err = occlient.SetCurrentProject(project, client)
+	err = client.SetCurrentProject(project)
 	if err != nil {
 		return errors.Wrap(err, "unable to set current project to"+project)
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -36,7 +36,7 @@ func SetCurrent(client *occlient.Client, project string) error {
 		return errors.Wrap(err, "unable to unset active component of current project "+project)
 	}
 
-	err = client.SetCurrentProject(project)
+	err = occlient.SetCurrentProject(project, client)
 	if err != nil {
 		return errors.Wrap(err, "unable to set current project to"+project)
 	}
@@ -67,15 +67,6 @@ func Delete(client *occlient.Client, projectName string) error {
 		}
 	}
 
-	// If there will be any projects post the current deletion,
-	// Choose the first project from remainder of the project list to set as current
-	if len(projects) > 0 {
-		currentProject = projects[0].Name
-	} else {
-		// Set the current project to empty string
-		currentProject = ""
-	}
-
 	// If current project is not same as the project to be deleted, set it as current
 	if currentProject != projectName {
 		// Set the project to be deleted as current inorder to be able to delete it
@@ -89,6 +80,16 @@ func Delete(client *occlient.Client, projectName string) error {
 	err = client.DeleteProject(projectName)
 	if err != nil {
 		return errors.Wrap(err, "unable to delete project")
+	}
+
+	SetCurrent(client, "")
+	// If there will be any projects post the current deletion,
+	// Choose the first project from remainder of the project list to set as current
+	if len(projects) > 0 {
+		currentProject = projects[0].Name
+	} else {
+		// Set the current project to empty string
+		currentProject = ""
 	}
 
 	// If current project is not empty string, set currentProject as current project

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,9 +1,8 @@
 package project
 
 // ToDo(@anmolbabu) uncomment tests when we have a nicer and cleaner way to stub occlient.go#ModifyConfig
-/*
+
 import (
-	"reflect"
 	"testing"
 
 	"github.com/redhat-developer/odo/pkg/occlient"
@@ -11,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
 )
-
 
 func TestDelete(t *testing.T) {
 	tests := []struct {
@@ -25,9 +23,9 @@ func TestDelete(t *testing.T) {
 			projectName: "prj2",
 		},
 		{
-			name:        "Test only project delete",
+			name:        "Test delete the only remaining project",
 			wantErr:     false,
-			projectName: "prj1",
+			projectName: "testing",
 		},
 	}
 
@@ -36,8 +34,14 @@ func TestDelete(t *testing.T) {
 
 			// Fake the client with the appropriate arguments
 			client, fakeClientSet := occlient.FakeNew()
+			occlient.SetCurrentProject = func(project string, c *occlient.Client) error {
+				return nil
+			}
 
 			fakeClientSet.ProjClientset.PrependReactor("list", "projects", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if tt.name == "Test delete the only remaining project" {
+					return true, testingutil.FakeOnlyOneExistingProjects(), nil
+				}
 				return true, testingutil.FakeProjects(), nil
 			})
 
@@ -55,4 +59,3 @@ func TestDelete(t *testing.T) {
 		})
 	}
 }
-*/

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -44,7 +44,7 @@ func TestDelete(t *testing.T) {
 	)
 	defer testingutil.CleanupEnv([]*os.File{odoConfigFile, kubeConfigFile}, t)
 	if err != nil {
-		t.Errorf("Failed to create mock odo and kube config files. Error %v", err)
+		t.Errorf("failed to create mock odo and kube config files. Error %v", err)
 	}
 
 	for _, tt := range tests {

--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -14,6 +14,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// ConfigDetails struct holds configuration details(odo and/or kube config)
 type ConfigDetails struct {
 	FileName      string
 	Config        interface{}

--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -1,0 +1,168 @@
+package testingutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/pkg/errors"
+	"github.com/redhat-developer/odo/pkg/config"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type ConfigDetails struct {
+	FileName      string
+	Config        interface{}
+	ConfigPathEnv string
+}
+
+// getConfFolder generates a mock config folder for the unit testing
+func getConfFolder() (string, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	dir, err := ioutil.TempDir(currentUser.HomeDir, ".kube")
+	if err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// setupTempConfigFile takes config file name - confFile and creates it for unit testing
+// The invocation of setupTempConfigFile puts the onus of invoking the configCleanUp as well
+func setupTempConfigFile(confFile string) (*os.File, error) {
+	confFolder, err := getConfFolder()
+	if err != nil {
+		return nil, err
+	}
+	tmpfile, err := ioutil.TempFile(confFolder, confFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to create test config file")
+	}
+	return tmpfile, nil
+}
+
+// setupEnv takes odoConfigFile name and sets env var ODOCONFIG to odoConfigFile
+// The config logic relies on this env var(if present) to read and/or write config
+func setupEnv(envName string, odoconfigfile string) error {
+	err := os.Setenv(envName, odoconfigfile)
+	if err != nil {
+		return errors.Wrap(err, "unable to set ODOCONFIG to odo-test-config")
+	}
+	return nil
+}
+
+// SetUp sets up the odo and kube config files and returns respective conf file pointers and error
+func SetUp(odoConfigDetails ConfigDetails, kubeConfigDetails ConfigDetails) (*os.File, *os.File, error) {
+	odoConfigFile, err := setUpConfig(odoConfigDetails.FileName, odoConfigDetails.Config, odoConfigDetails.ConfigPathEnv)
+	if err != nil {
+		return odoConfigFile, nil, err
+	}
+	kubeConfigFile, err := setUpConfig(kubeConfigDetails.FileName, kubeConfigDetails.Config, kubeConfigDetails.ConfigPathEnv)
+	return odoConfigFile, kubeConfigFile, err
+}
+
+// setUpConfig sets up mock config
+// Parameters:
+//	conf: the config object to write to the mock config file
+//	testFile: the name of the mock config file
+//  configEnvName: Name of env variable that corresponds to config file
+// Returns:
+//	file handler for the mock config file
+//	error if any
+func setUpConfig(testFile string, conf interface{}, configEnvName string) (*os.File, error) {
+	foundConfigType := false
+	var err error
+	var data []byte
+	if conf, ok := conf.(config.ConfigInfo); ok {
+		data, err = yaml.Marshal(conf.Config)
+		foundConfigType = true
+	}
+	if conf, ok := conf.(clientcmdapi.Config); ok {
+		data, err = yaml.Marshal(conf)
+		foundConfigType = true
+	}
+	if conf, ok := conf.(string); ok {
+		data = []byte(conf)
+		foundConfigType = true
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create mock config file")
+	}
+	if !foundConfigType {
+		return nil, fmt.Errorf("Config %+v not of recognisable type", conf)
+	}
+	configFile, err := setupTempConfigFile(testFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create mock config file")
+	}
+	if conf != nil {
+		if _, err := configFile.Write(data); err != nil {
+			return nil, errors.Wrapf(err, "unable to write config %+v to mock config file %s", conf, configFile.Name())
+		}
+	}
+	return configFile, setupEnv(configEnvName, configFile.Name())
+}
+
+// CleanupEnv cleans up the mock config file and anything that SetupEnv generated
+// Parameters:
+//	configFile: the mock config file handler
+//	t: testing pointer to log errors if any
+func CleanupEnv(confFiles []*os.File, t *testing.T) {
+	for _, confFile := range confFiles {
+		if confFile == nil {
+			continue
+		}
+		if err := confFile.Close(); err != nil {
+			t.Errorf("Failed to cleanup the test env. Error: %v", err)
+		}
+		os.Remove(confFile.Name())
+	}
+}
+
+// FakeOdoConfig returns mock odo config
+// It takes a confPath which is the path to the config
+func FakeOdoConfig(confPath string) config.ConfigInfo {
+	odoConfig := config.ConfigInfo{
+		Filename: confPath,
+		Config: config.Config{
+			ActiveApplications: []config.ApplicationInfo{
+				{
+					Name:            "app-india",
+					Active:          true,
+					Project:         "prj1",
+					ActiveComponent: "comp1",
+				},
+			},
+		},
+	}
+	return odoConfig
+}
+
+// FakeKubeClientConfig returns mock kube client config
+func FakeKubeClientConfig() string {
+	return `apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://192.168.42.237:8443
+  name: 192-168-42-237:8443
+contexts:
+- context:
+    cluster: 192-168-42-237:8443
+    namespace: testing
+    user: developer/192-168-42-237:8443
+  name: myproject/192-168-42-237:8443/developer
+current-context: myproject/192-168-42-237:8443/developer
+kind: Config
+preferences: {}
+users:
+- name: developer/192-168-42-237:8443
+  user:
+    token: C0E6Gkmi3n_Se2QKx6Unw3Y3Zu4mJHgzdrMVK0DsDwc`
+}

--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -120,7 +120,7 @@ func CleanupEnv(confFiles []*os.File, t *testing.T) {
 			continue
 		}
 		if err := confFile.Close(); err != nil {
-			t.Errorf("Failed to cleanup the test env. Error: %v", err)
+			t.Errorf("failed to cleanup the test env. Error: %v", err)
 		}
 		os.Remove(confFile.Name())
 	}

--- a/pkg/testingutil/projects.go
+++ b/pkg/testingutil/projects.go
@@ -24,7 +24,7 @@ func FakeProjects() *v1.ProjectList {
 	}
 }
 
-// FakeProjects returns fake projectlist for use by API mock functions for Unit tests
+// FakeOnlyOneExistingProjects returns fake projectlist with single project for use by API mock functions for Unit tests testing delete of the only available project
 func FakeOnlyOneExistingProjects() *v1.ProjectList {
 	return &v1.ProjectList{
 		Items: []v1.Project{

--- a/pkg/testingutil/projects.go
+++ b/pkg/testingutil/projects.go
@@ -23,3 +23,22 @@ func FakeProjects() *v1.ProjectList {
 		},
 	}
 }
+
+// FakeProjects returns fake projectlist for use by API mock functions for Unit tests
+func FakeOnlyOneExistingProjects() *v1.ProjectList {
+	return &v1.ProjectList{
+		Items: []v1.Project{
+			getFakeProject("testing"),
+		},
+	}
+}
+
+// FakeRemoveProject removes the delete requested project from the list of projects passed
+func FakeRemoveProject(project string, projects *v1.ProjectList) *v1.ProjectList {
+	for index, proj := range projects.Items {
+		if proj.Name == project {
+			projects.Items = append(projects.Items[:index], projects.Items[index+1:]...)
+		}
+	}
+	return projects
+}

--- a/pkg/testingutil/projects.go
+++ b/pkg/testingutil/projects.go
@@ -1,7 +1,9 @@
 package testingutil
 
 import (
+	projectv1 "github.com/openshift/api/project/v1"
 	v1 "github.com/openshift/api/project/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -21,6 +23,16 @@ func FakeProjects() *v1.ProjectList {
 			getFakeProject("prj1"),
 			getFakeProject("prj2"),
 		},
+	}
+}
+
+// FakeProjectStatus returns fake project status for use by mock watch on project
+func FakeProjectStatus(prjStatus corev1.NamespacePhase, prjName string) *projectv1.Project {
+	return &projectv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: prjName,
+		},
+		Status: projectv1.ProjectStatus{Phase: prjStatus},
 	}
 }
 

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -332,7 +332,7 @@ var _ = Describe("odoCmpE2e", func() {
 		It("should delete the application", func() {
 			runCmd("odo app delete " + appTestName + " -f")
 
-			runCmd("odo project delete " + projName)
+			runCmd("odo project delete " + projName + " -f")
 			waitForDeleteCmd("odo project list", projName)
 		})
 	})

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -548,7 +548,7 @@ var _ = Describe("odoe2e", func() {
 			cmpList := runCmd("odo list")
 			Expect(cmpList).NotTo(ContainSubstring("nodejs"))
 
-			runCmd("odo project delete " + projName)
+			runCmd("odo project delete " + projName + " -f")
 			waitForDeleteCmd("odo project list", projName)
 		})
 	})


### PR DESCRIPTION
Delete project enhancements + Unit tests and e2e tests

This PR adds the following:
1. When a project is deleted, the delete project now displays also the
   active project post deletion if there are more projects left post deletion
2. Adds UTs and e2e tests for project delete
3. Handles the case of project list with no projects with a proper message
   indicating that there are no currently available projects and suggests the
   command to create a project instead of displaying an empty table.

fixes #726 #750
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>
