### PR TITLE
Configurable watch

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -78,8 +78,8 @@ var watchCmd = &cobra.Command{
 func init() {
 	// ignore git as it can change even if no source file changed
 	// for example some plugins providing git info in PS1 doing that
-	watchCmd.Flags().StringSliceVar(&ignores, "ignores", []string{".*\\.git.*"}, "Files and/or folders to be recursively ignored for watch")
-	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection in code push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
+	watchCmd.Flags().StringSliceVar(&ignores, "ignores", []string{".*\\.git.*"}, "Files and/or folders to be recursively ignored for watch can be specified as regular expressions with this flag.")
+	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(cmdUsageTemplate)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -15,6 +15,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	ignores []string
+	delay   int
+)
+
 var watchCmd = &cobra.Command{
 	Use:   "watch [component name]",
 	Short: "Watch for changes, update component on change",
@@ -65,12 +70,16 @@ var watchCmd = &cobra.Command{
 		}
 		watchPath := util.ReadFilePath(u, runtime.GOOS)
 
-		err = component.WatchAndPush(client, componentName, applicationName, watchPath, stdout)
+		err = component.WatchAndPush(client, componentName, applicationName, watchPath, stdout, ignores, delay)
 		checkError(err, "Error while trying to watch %s", watchPath)
 	},
 }
 
 func init() {
+	// ignore git as it can change even if no source file changed
+	// for example some plugins providing git info in PS1 doing that
+	watchCmd.Flags().StringSliceVar(&ignores, "ignores", []string{".*\\.git.*"}, "Files and/or folders to be recursively ignored for watch")
+	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection of a diff in component source to the push of diff. delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(cmdUsageTemplate)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -79,7 +79,7 @@ func init() {
 	// ignore git as it can change even if no source file changed
 	// for example some plugins providing git info in PS1 doing that
 	watchCmd.Flags().StringSliceVar(&ignores, "ignores", []string{".*\\.git.*"}, "Files and/or folders to be recursively ignored for watch")
-	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection of a diff in component source to the push of diff. delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
+	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection in code push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(cmdUsageTemplate)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -78,7 +78,7 @@ var watchCmd = &cobra.Command{
 func init() {
 	// ignore git as it can change even if no source file changed
 	// for example some plugins providing git info in PS1 doing that
-	watchCmd.Flags().StringSliceVar(&ignores, "ignores", []string{".*\\.git.*"}, "Files and/or folders to be recursively ignored for watch can be specified as regular expressions with this flag.")
+	watchCmd.Flags().StringSliceVar(&ignores, "ignore", []string{".*\\.git.*"}, "Files or folders to be ignored via regular expressions.")
 	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -133,7 +133,8 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 
 				stat, err := os.Lstat(event.Name)
 				if err != nil {
-					glog.V(4).Infof("Failed getting details of the changed file %s", event.Name)
+					glog.Errorf("Failed getting details of the changed file %s", event.Name)
+					watchError = errors.Wrap(err, "unable to watch changes")
 				}
 
 				// add file name to changedFiles only once

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -143,6 +143,12 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 						glog.Errorf("Failed getting details of the changed file %s", event.Name)
 						watchError = errors.Wrap(err, "unable to watch changes")
 					}
+					// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
+					// Avoid pushing such buffer files
+					if stat == nil {
+						break
+					}
+
 					// In windows, every new file created under a sub-directory of the watched directory, raises 2 events:
 					// 1. Write event for the directory under which the file was created
 					// 2. Create event for the file that was created

--- a/pkg/component/watch_test.go
+++ b/pkg/component/watch_test.go
@@ -1,0 +1,49 @@
+package component
+
+import (
+	"testing"
+)
+
+func TestIsRegExpMatch(t *testing.T) {
+
+	tests := []struct {
+		testName   string
+		strToMatch string
+		regExps    []string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			testName:   "Test regexp matches ",
+			strToMatch: "/home/redhat/git-srcs/src/github.com/redhat-developer/nodejs-ex/.git/",
+			regExps:    []string{".*\\.git.*", "tests"},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			testName:   "Test regexp does not match ",
+			strToMatch: "/home/redhat/git-srcs/src/github.com/redhat-developer/nodejs-ex/git.git/",
+			regExps:    []string{".*\\.git.*", "tests"},
+			want:       true,
+			wantErr:    false,
+		},
+	}
+
+	// Test that it "joins"
+
+	for _, tt := range tests {
+		t.Log("Running test: ", tt.testName)
+		t.Run(tt.testName, func(t *testing.T) {
+			matched, err := isRegExpMatch(tt.strToMatch, tt.regExps)
+
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.want != matched {
+				t.Errorf("Expected %v, got %v", tt.want, matched)
+			}
+		})
+	}
+
+}

--- a/pkg/component/watch_test.go
+++ b/pkg/component/watch_test.go
@@ -14,18 +14,25 @@ func TestIsRegExpMatch(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			testName:   "Test regexp matches ",
+			testName:   "Test regexp matches",
 			strToMatch: "/home/redhat/git-srcs/src/github.com/redhat-developer/nodejs-ex/.git/",
 			regExps:    []string{".*\\.git.*", "tests"},
 			want:       true,
 			wantErr:    false,
 		},
 		{
-			testName:   "Test regexp does not match ",
-			strToMatch: "/home/redhat/git-srcs/src/github.com/redhat-developer/nodejs-ex/git.git/",
+			testName:   "Test regexp does not match",
+			strToMatch: "/home/redhat/git-srcs/src/github.com/redhat-developer/nodejs-ex/gimmt.gimmt/",
 			regExps:    []string{".*\\.git.*", "tests"},
-			want:       true,
+			want:       false,
 			wantErr:    false,
+		},
+		{
+			testName:   "Test incorrect regexp",
+			strToMatch: "a(b",
+			regExps:    []string{"a(b"},
+			want:       false,
+			wantErr:    true,
 		},
 	}
 
@@ -38,6 +45,7 @@ func TestIsRegExpMatch(t *testing.T) {
 
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 
 			if tt.want != matched {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1816,10 +1816,8 @@ func makeTar(srcPath, destPath string, writer io.Writer, files []string) error {
 		//watchTar
 		for _, fileName := range files {
 			if checkFileExist(fileName) {
-				err := tar(tarWriter, fileName, path.Base(destPath))
-				if err != nil {
-					return err
-				}
+				// The file could be a regular file or even a folder, so use recursiveTar which handles symlinks, regular files and folders
+				return recursiveTar(path.Dir(srcPath), path.Base(srcPath), path.Dir(destPath), path.Base(destPath), tarWriter)
 
 			}
 		}


### PR DESCRIPTION
Make odo watch command configurable

This PR makes the list of filepath patterns to be ignored
and also the watch-push delay configurable which can now be
passed as arguements to the command. It also performs the
following fixes to the watch command:

1. Ignore watch on directories and files matching the ignore paths
2. Avoid pushing changes in files and folders that match ignore paths

2 above is required in-spite of 1, because, 1 can only ignore paths
that match the ignores along with their children but not their parents.
So, the watch on parent dir still can potentially catch a change in its
immediate child which can only be ignored at the time of push.

fixes #639 #640
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>