### PR TITLE
Fix watch support check

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -51,7 +51,7 @@ var watchCmd = &cobra.Command{
 		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName, projectName)
 		checkError(err, "Unable to get source for %s component.", componentName)
 
-		if sourceType != "binary" && sourcePath != "local" {
+		if sourceType != "binary" && sourceType != "local" {
 			fmt.Printf("Watch is supported by binary and local components only and source type of component %s is %s\n", componentName, sourceType)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Fix watch support check

This PR fixes a regression which wrongly validated sourcepath against the sourcetype(local)
The PR now checks if sourceType is local or binary and allows watch to be created
 
fixes #746
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>