### PR TITLE
Add flag.Parse call to avoid logging errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,6 +138,7 @@ func init() {
 	verbosity.Usage += ". Level varies from 0 to 9 (default 0)."
 
 	rootCmd.SetUsageTemplate(rootUsageTemplate)
+	flag.Parse()
 }
 
 func getLatestReleaseInfo(info chan<- string) {


### PR DESCRIPTION
Without flag.Parse, glog complains "ERROR: logging before flag.Parse".
To avoid it, this PR adds flag.Parse() call

fixes #752
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>