### PR TITLE
Added the odo catalog describe service command

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 	"github.com/olekukonko/tablewriter"
-	"github.com/redhat-developer/odo/pkg/application"
-	"github.com/redhat-developer/odo/pkg/project"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -211,18 +209,9 @@ This describes the service and the associated plans.
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
-		projectName := project.GetCurrent(client)
 		serviceName := args[0]
-		exists, err := svc.SvcExists(client, serviceName, applicationName, projectName)
-		checkError(err, "Failed to get the service")
-		if !exists {
-			fmt.Printf("The service %s does not exist.\n", serviceName)
-			os.Exit(1)
-		}
 		service, plans, err := svc.GetServiceClassAndPlans(client, serviceName)
-		checkError(err, "Failed to get the service")
+		checkError(err, "")
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"github.com/olekukonko/tablewriter"
+	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/project"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -16,9 +18,10 @@ var catalogCmd = &cobra.Command{
 	Use:   "catalog [options]",
 	Short: "Catalog related operations",
 	Long:  "Catalog related operations",
-	Example: fmt.Sprintf("%s\n%s",
+	Example: fmt.Sprintf("%s\n%s\n%s",
 		catalogListCmd.Example,
-		catalogSearchCmd.Example),
+		catalogSearchCmd.Example,
+		catalogDescribeCmd.Example),
 }
 
 var catalogListCmd = &cobra.Command{
@@ -187,31 +190,32 @@ services from service catalog.
 
 var catalogDescribeCmd = &cobra.Command{
 	Use:   "describe",
-	Short: "describe given component or service types.",
-	Long:  "Describe given component or service types from OpenShift",
-	Example: `  # Get the supported components
-  odo catalog describe component
-
-  # Get the supported services from service catalog
-  odo catalog describe service
+	Short: "describe given service.",
+	Long:  "Describe given service from OpenShift",
+	Args:  cobra.ExactArgs(1),
+	Example: `  # Describe the given service
+  odo catalog describe service mysql-persistent
 `,
 }
 
 var catalogDescribeServiceCmd = &cobra.Command{
 	Use:   "service",
-	Short: "Search service type in catalog",
+	Short: "Describe service in catalog",
 	Long: `Describe a service type.
 
 This describes the service and the associated plans.
 `,
 	Example: `  # Describe a service
-  odo catalog describe service mysql
+  odo catalog describe service mysql-persistent
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
+		applicationName, err := application.GetCurrent(client)
+		checkError(err, "")
+		projectName := project.GetCurrent(client)
 		serviceName := args[0]
-		exists, err := svc.SvcTypeExists(client, serviceName)
+		exists, err := svc.SvcExists(client, serviceName, applicationName, projectName)
 		checkError(err, "Failed to get the service")
 		if !exists {
 			fmt.Printf("The service %s does not exist.\n", serviceName)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -241,6 +241,7 @@ This describes the service and the associated plans.
 					{"Display Name", plan.DisplayName},
 					{"Short Description", plan.Description},
 					{"Required", strings.Join(plan.Required, ", ")},
+					{"Optional", strings.Join(plan.Optional, ", ")},
 				}
 				table.AppendBulk(planData)
 			}

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -188,17 +188,17 @@ services from service catalog.
 
 var catalogDescribeCmd = &cobra.Command{
 	Use:   "describe",
-	Short: "describe catalog item.",
+	Short: "Describe catalog item",
 	Long:  "Describe the given catalog item from OpenShift",
 	Args:  cobra.ExactArgs(1),
 	Example: `  # Describe the given service
   odo catalog describe service mysql-persistent
-`,
+	`,
 }
 
 var catalogDescribeServiceCmd = &cobra.Command{
 	Use:   "service",
-	Short: "Describe service in catalog",
+	Short: "Describe a service",
 	Long: `Describe a service type.
 
 This describes the service and the associated plans.

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -188,8 +188,8 @@ services from service catalog.
 
 var catalogDescribeCmd = &cobra.Command{
 	Use:   "describe",
-	Short: "describe given service.",
-	Long:  "Describe given service from OpenShift",
+	Short: "describe catalog item.",
+	Long:  "Describe the given catalog item from OpenShift",
 	Args:  cobra.ExactArgs(1),
 	Example: `  # Describe the given service
   odo catalog describe service mysql-persistent
@@ -240,8 +240,8 @@ This describes the service and the associated plans.
 					{"Name", plan.Name},
 					{"Display Name", plan.DisplayName},
 					{"Short Description", plan.Description},
-					{"Required", strings.Join(plan.Required, ", ")},
-					{"Optional", strings.Join(plan.Optional, ", ")},
+					{"Required Parameters", strings.Join(plan.Required, ", ")},
+					{"Optional Parameters", strings.Join(plan.Optional, ", ")},
 				}
 				table.AppendBulk(planData)
 			}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -36,6 +36,7 @@ type ServicePlans struct {
 	DisplayName string
 	Description string
 	Required    []string
+	Optional    []string
 }
 
 // ListCatalog lists all the available service types
@@ -228,6 +229,19 @@ func GetServiceClassAndPlans(client *occlient.Client, serviceName string) (Servi
 			required = strings.Replace(required, "[", "", -1)
 			required = strings.Replace(required, "]", "", -1)
 			plan.Required = strings.Split(required, " ")
+		}
+
+		// set the optional properties by inspecting additionalProperties
+		// and if it's true, then
+		if val, ok := createParameter["properties"]; ok {
+			propertiesMap, ok := val.(map[string]interface{})
+			if ok {
+				allPropertyNames := make([]string, 0, len(propertiesMap))
+				for k := range propertiesMap {
+					allPropertyNames = append(allPropertyNames, k)
+				}
+				plan.Optional = util.SliceDifference(plan.Required, allPropertyNames)
+			}
 		}
 
 		plans = append(plans, plan)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1,0 +1,263 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/pkg/errors"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"reflect"
+	"testing"
+)
+
+func fakePlanExternalMetaDataRaw() ([][]byte, error) {
+	planExternalMetaData1 := make(map[string]string)
+	planExternalMetaData1["displayName"] = "plan-name-1"
+
+	planExternalMetaData2 := make(map[string]string)
+	planExternalMetaData2["displayName"] = "plan-name-2"
+
+	planExternalMetaDataRaw1, err := json.Marshal(planExternalMetaData1)
+	if err != nil {
+		return nil, errors.Wrap(err, "")
+	}
+
+	planExternalMetaDataRaw2, err := json.Marshal(planExternalMetaData2)
+	if err != nil {
+		return nil, errors.Wrap(err, "")
+	}
+
+	var data [][]byte
+	data = append(data, planExternalMetaDataRaw1)
+	data = append(data, planExternalMetaDataRaw2)
+
+	return data, nil
+}
+
+func fakePlanServiceInstanceCreateParameterSchemasRaw() ([][]byte, error) {
+	planServiceInstanceCreateParameterSchema1 := make(map[string][]string)
+	planServiceInstanceCreateParameterSchema1["required"] = []string{"PLAN_DATABASE_URI", "PLAN_DATABASE_USERNAME", "PLAN_DATABASE_PASSWORD"}
+
+	planServiceInstanceCreateParameterSchema2 := make(map[string][]string)
+	planServiceInstanceCreateParameterSchema2["required"] = []string{"PLAN_DATABASE_USERNAME_2", "PLAN_DATABASE_PASSWORD"}
+
+	planServiceInstanceCreateParameterSchemaRaw1, err := json.Marshal(planServiceInstanceCreateParameterSchema1)
+	if err != nil {
+		if err != nil {
+			return nil, errors.Wrap(err, "")
+		}
+	}
+
+	planServiceInstanceCreateParameterSchemaRaw2, err := json.Marshal(planServiceInstanceCreateParameterSchema2)
+	if err != nil {
+		if err != nil {
+			return nil, errors.Wrap(err, "")
+		}
+	}
+
+	var data [][]byte
+	data = append(data, planServiceInstanceCreateParameterSchemaRaw1)
+	data = append(data, planServiceInstanceCreateParameterSchemaRaw2)
+
+	return data, nil
+}
+
+func TestGetServiceClassAndPlans(t *testing.T) {
+
+	classExternalMetaData := make(map[string]interface{})
+	classExternalMetaData["longDescription"] = "example long description"
+	classExternalMetaData["dependencies"] = []string{"docker.io/centos/7", "docker.io/centos/8"}
+
+	classExternalMetaDataRaw, err := json.Marshal(classExternalMetaData)
+	if err != nil {
+		fmt.Printf("error occured %v during marshalling", err)
+		return
+	}
+
+	planExternalMetaDataRaw, err := fakePlanExternalMetaDataRaw()
+	if err != nil {
+		fmt.Printf("error occured %v during marshalling", err)
+		return
+	}
+
+	planServiceInstanceCreateParameterSchemasRaw, err := fakePlanServiceInstanceCreateParameterSchemasRaw()
+	if err != nil {
+		fmt.Printf("error occured %v during marshalling", err)
+		return
+	}
+
+	type args struct {
+		ServiceName string
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		returnedClassID      string
+		returnedServiceClass *scv1beta1.ClusterServiceClassList
+		returnedServicePlan  []scv1beta1.ClusterServicePlan
+		wantedServiceClass   ServiceClass
+		wantedServicePlans   []ServicePlans
+		wantErr              bool
+	}{
+		{
+			name: "test 1 : with correct values",
+			args: args{
+				ServiceName: "class name",
+			},
+			returnedClassID: "1dda1477cace09730bd8ed7a6505607e",
+			returnedServiceClass: &scv1beta1.ClusterServiceClassList{
+				Items: []scv1beta1.ClusterServiceClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "1dda1477cace09730bd8ed7a6505607e"},
+						Spec: scv1beta1.ClusterServiceClassSpec{
+							CommonServiceClassSpec: scv1beta1.CommonServiceClassSpec{
+								ExternalName:     "class name",
+								Bindable:         false,
+								Description:      "example description",
+								Tags:             []string{"php", "java"},
+								ExternalMetadata: &runtime.RawExtension{Raw: classExternalMetaDataRaw},
+							},
+							ClusterServiceBrokerName: "broker name",
+						},
+					},
+				},
+			},
+			returnedServicePlan: []scv1beta1.ClusterServicePlan{
+				{
+					Spec: scv1beta1.ClusterServicePlanSpec{
+						ClusterServiceClassRef: scv1beta1.ClusterObjectReference{
+							Name: "1dda1477cace09730bd8ed7a6505607e",
+						},
+						CommonServicePlanSpec: scv1beta1.CommonServicePlanSpec{
+							ExternalName:                         "dev",
+							Description:                          "this is a example description 1",
+							ExternalMetadata:                     &runtime.RawExtension{Raw: planExternalMetaDataRaw[0]},
+							ServiceInstanceCreateParameterSchema: &runtime.RawExtension{Raw: planServiceInstanceCreateParameterSchemasRaw[0]},
+						},
+					},
+				},
+				{
+					Spec: scv1beta1.ClusterServicePlanSpec{
+						ClusterServiceClassRef: scv1beta1.ClusterObjectReference{
+							Name: "1dda1477cace09730bd8ed7a6505607e",
+						},
+						CommonServicePlanSpec: scv1beta1.CommonServicePlanSpec{
+							ExternalName:                         "prod",
+							Description:                          "this is a example description 2",
+							ExternalMetadata:                     &runtime.RawExtension{Raw: planExternalMetaDataRaw[1]},
+							ServiceInstanceCreateParameterSchema: &runtime.RawExtension{Raw: planServiceInstanceCreateParameterSchemasRaw[1]},
+						},
+					},
+				},
+			},
+			wantedServiceClass: ServiceClass{
+				Name:              "class name",
+				ShortDescription:  "example description",
+				LongDescription:   "example long description",
+				Tags:              []string{"php", "java"},
+				Bindable:          false,
+				ServiceBrokerName: "broker name",
+				VersionsAvailable: []string{"docker.io/centos/7", "docker.io/centos/8"},
+			},
+			wantedServicePlans: []ServicePlans{
+				{
+					Name:        "dev",
+					Description: "this is a example description 1",
+					DisplayName: "plan-name-1",
+					Required:    []string{"PLAN_DATABASE_URI", "PLAN_DATABASE_USERNAME", "PLAN_DATABASE_PASSWORD"},
+				},
+				{
+					Name:        "prod",
+					Description: "this is a example description 2",
+					DisplayName: "plan-name-2",
+					Required:    []string{"PLAN_DATABASE_USERNAME_2", "PLAN_DATABASE_PASSWORD"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := occlient.FakeNew()
+
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			if action.(ktesting.ListAction).GetListRestrictions().Fields.String() != fmt.Sprintf("spec.externalName=%v", tt.args.ServiceName) {
+				t.Errorf("got a different service name got: %v , expected: %v", action.(ktesting.ListAction).GetListRestrictions().Fields.String(), fmt.Sprintf("spec.externalName=%v", tt.args.ServiceName))
+			}
+			return true, tt.returnedServiceClass, nil
+		})
+
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			if action.(ktesting.ListAction).GetListRestrictions().Fields.String() != fmt.Sprintf("spec.clusterServiceClassRef.name=%v", tt.returnedClassID) {
+				t.Errorf("got a different service name got: %v , expected: %v", action.(ktesting.ListAction).GetListRestrictions().Fields.String(), fmt.Sprintf("spec.clusterServiceClassRef.name=%v", tt.returnedClassID))
+			}
+			return true, &scv1beta1.ClusterServicePlanList{Items: tt.returnedServicePlan}, nil
+		})
+
+		serviceClass, servicePlans, err := GetServiceClassAndPlans(client, tt.args.ServiceName)
+
+		if err == nil && !tt.wantErr {
+			if len(fakeClientSet.ServiceCatalogClientSet.Actions()) != 2 {
+				t.Errorf("expected 2 actions in GetServiceClassAndPlans got: %v", fakeClientSet.ServiceCatalogClientSet.Actions())
+			}
+
+			if !reflect.DeepEqual(tt.wantedServiceClass.Name, serviceClass.Name) {
+				t.Errorf("different service class name expected got: %v , expected: %v", serviceClass.Name, tt.wantedServiceClass.Name)
+			}
+
+			if !reflect.DeepEqual(tt.wantedServiceClass.Bindable, serviceClass.Bindable) {
+				t.Errorf("different service class bindable value expected got: %v , expected: %v", serviceClass.Bindable, tt.wantedServiceClass.Bindable)
+			}
+
+			if !reflect.DeepEqual(tt.wantedServiceClass.ShortDescription, serviceClass.ShortDescription) {
+				t.Errorf("different short description value expected got: %v , expected: %v", serviceClass.ShortDescription, tt.wantedServiceClass.ShortDescription)
+			}
+
+			if !reflect.DeepEqual(tt.wantedServiceClass.LongDescription, serviceClass.LongDescription) {
+				t.Errorf("different long description value expected got: %v , expected: %v", serviceClass.LongDescription, tt.wantedServiceClass.LongDescription)
+			}
+
+			if !reflect.DeepEqual(tt.wantedServiceClass.ServiceBrokerName, serviceClass.ServiceBrokerName) {
+				t.Errorf("different service broker name value expected got: %v , expected: %v", serviceClass.ServiceBrokerName, tt.wantedServiceClass.ServiceBrokerName)
+			}
+
+			if !reflect.DeepEqual(tt.wantedServiceClass.Tags, serviceClass.Tags) {
+				t.Errorf("different service class tags value expected got: %v , expected: %v", serviceClass.Tags, tt.wantedServiceClass.Tags)
+			}
+
+			for _, wantedServicePlan := range tt.wantedServicePlans {
+				found := false
+				for _, gotServicePlan := range servicePlans {
+					if reflect.DeepEqual(wantedServicePlan.Name, gotServicePlan.Name) {
+						found = true
+					} else {
+						continue
+					}
+
+					if !reflect.DeepEqual(wantedServicePlan.Required, gotServicePlan.Required) {
+						t.Errorf("different plan required value expected got: %v , expected: %v", wantedServicePlan.Required, gotServicePlan.Required)
+					}
+
+					if !reflect.DeepEqual(wantedServicePlan.DisplayName, gotServicePlan.DisplayName) {
+						t.Errorf("different plan display name value expected got: %v , expected: %v", wantedServicePlan.DisplayName, gotServicePlan.DisplayName)
+					}
+
+					if !reflect.DeepEqual(wantedServicePlan.Description, gotServicePlan.Description) {
+						t.Errorf("different plan description value expected got: %v , expected: %v", wantedServicePlan.Description, gotServicePlan.Description)
+					}
+				}
+
+				if !found {
+					t.Errorf("service plan %v not found", wantedServicePlan.Name)
+				}
+			}
+		} else if err == nil && tt.wantErr {
+			t.Error("test failed, expected: false, got true")
+		} else if err != nil && !tt.wantErr {
+			t.Errorf("test failed, expected: no error, got error: %s", err.Error())
+		}
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -211,3 +211,18 @@ func GetDNS1123Name(str string) string {
 	)
 	return strings.TrimSpace(replacer.Replace(strings.ToLower(str)))
 }
+
+// SliceDifference returns the values of s2 that do not exist in s1
+func SliceDifference(s1 []string, s2 []string) []string {
+	mb := map[string]bool{}
+	for _, x := range s1 {
+		mb[x] = true
+	}
+	difference := []string{}
+	for _, x := range s2 {
+		if _, ok := mb[x]; !ok {
+			difference = append(difference, x)
+		}
+	}
+	return difference
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -408,3 +408,46 @@ func TestGenerateRandomString(t *testing.T) {
 		})
 	}
 }
+
+func TestSliceDifference(t *testing.T) {
+	tests := []struct {
+		testName       string
+		slice1         []string
+		slice2         []string
+		expectedResult []string
+	}{
+		{
+			testName:       "Empty slices",
+			slice1:         []string{},
+			slice2:         []string{},
+			expectedResult: []string{},
+		},
+		{
+			testName:       "Single different slices",
+			slice1:         []string{"a"},
+			slice2:         []string{"b"},
+			expectedResult: []string{"b"},
+		},
+		{
+			testName:       "Single same slices",
+			slice1:         []string{"a"},
+			slice2:         []string{"a"},
+			expectedResult: []string{},
+		},
+		{
+			testName:       "Large slices with matching and non matching items",
+			slice1:         []string{"a", "b", "c", "d", "e"},
+			slice2:         []string{"e", "a", "u", "1", "d"},
+			expectedResult: []string{"u", "1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Log("Running test: ", tt.testName)
+		t.Run(tt.testName, func(t *testing.T) {
+			result := SliceDifference(tt.slice1, tt.slice2)
+			if !reflect.DeepEqual(tt.expectedResult, result) {
+				t.Errorf("Expected %v, got %v", tt.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #689 
Signed-off-by: mik-dass mrinald7@gmail.com

Added the odo catalog describe service command e.g `odo catalog describe service <service-name>`

Functions GetClusterServiceClass() and GetClusterPlansFromServiceName() are added to occlient to get the service class and the plans associated with the class.

How to test : 
1. odo catalog list services      //select a plan name
2. odo catalog describe service <service-name>