### PR TITLE
add config parameter to modify server connection check timeout

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,10 +53,8 @@ Timeout - Timeout (in seconds) for OpenShift server connection check`,
 	Example: `
    # Set a configuration value
    odo utils config set UpdateNotification false
-   odo utils config set NamePrefix ""
    odo utils config set NamePrefix "app"
    odo utils config set timeout 20
-   odo utils config set timeout 0
 	`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -46,6 +46,7 @@ var configurationSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set a value in odo config file",
 	Long: `Set an individual value in the Odo configuration file
+
 Available Parameters:
 UpdateNotification - Controls if an update notification is shown or not (true or false)
 NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,15 +19,16 @@ var configurationCmd = &cobra.Command{
 
 Available Parameters:
 UpdateNotification - Controls if an update notification is shown or not (true or false)
-NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix`,
-	Example: fmt.Sprintf("%s\n%s",
+NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix
+Timeout - Timeout (in seconds) for OpenShift server connection check`,
+	Example: fmt.Sprintf("%s\n%s\n",
 		configurationViewCmd.Example,
 		configurationSetCmd.Example),
 	Aliases: []string{"configuration"},
 	// 'odo utils config' is the same as 'odo utils config --help'
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) >= 1 && args[0] != "view" && args[0] != "set" {
-			return fmt.Errorf("Unknown command, use set or view")
+			return fmt.Errorf(`Unknown command, use "set" or "view"`)
 		}
 		return nil
 	}, Run: func(cmd *cobra.Command, args []string) {
@@ -47,12 +48,16 @@ var configurationSetCmd = &cobra.Command{
 	Long: `Set an individual value in the Odo configuration file
 Available Parameters:
 UpdateNotification - Controls if an update notification is shown or not (true or false)
-NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix.`,
-	Example: `  # Set a configuration value
+NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix.
+Timeout - Timeout (in seconds) for OpenShift server connection check`,
+	Example: `
+   # Set a configuration value
    odo utils config set UpdateNotification false
    odo utils config set NamePrefix ""
    odo utils config set NamePrefix "app"
-  `,
+   odo utils config set timeout 20
+   odo utils config set timeout 0
+	`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return fmt.Errorf("Please provide a parameter name and value")
@@ -61,6 +66,7 @@ NamePrefix - Default prefix is the current directory name. Use this value to set
 		} else {
 			return nil
 		}
+
 	}, RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.New()
 		if err != nil {
@@ -87,6 +93,7 @@ var configurationViewCmd = &cobra.Command{
 		fmt.Fprintln(w, "PARAMETER", "\t", "CURRENT_VALUE")
 		fmt.Fprintln(w, "UpdateNotification", "\t", cfg.GetUpdateNotification())
 		fmt.Fprintln(w, "NamePrefix", "\t", cfg.GetNamePrefix())
+		fmt.Fprintln(w, "Timeout", "\t", cfg.GetTimeout())
 		w.Flush()
 	},
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,7 +138,7 @@ func (c *ConfigInfo) writeToFile() error {
 }
 
 // SetConfiguration modifies Odo configurations in the config file
-// as of now being used for timeout, updatenotification
+// as of now being used for nameprefix, timeout, updatenotification
 func (c *ConfigInfo) SetConfiguration(parameter string, value string) error {
 	// processing values according to the parameter names
 	switch parameter {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,6 +140,7 @@ func (c *ConfigInfo) writeToFile() error {
 // SetConfiguration modifies Odo configurations in the config file
 // as of now being used for timeout, updatenotification
 func (c *ConfigInfo) SetConfiguration(parameter string, value string) error {
+	// processing values according to the parameter names
 	switch parameter {
 
 	case "timeout":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -935,13 +935,13 @@ func TestGetTimeout(t *testing.T) {
 		want           int
 	}{
 		{
-			name:           "validating value 1 from config in default case",
+			name:           "Case 1: validating value 1 from config in default case",
 			existingConfig: Config{},
 			want:           1,
 		},
 
 		{
-			name: "validating value 0 from config",
+			name: "Case 2: validating value 0 from config",
 			existingConfig: Config{
 				OdoSettings: OdoSettings{
 					Timeout: &zeroValue,
@@ -951,7 +951,7 @@ func TestGetTimeout(t *testing.T) {
 		},
 
 		{
-			name: "validating value 5 from config",
+			name: "Case 3: validating value 5 from config",
 			existingConfig: Config{
 				OdoSettings: OdoSettings{
 					Timeout: &nonzeroValue,
@@ -998,7 +998,7 @@ func TestSetConfiguration(t *testing.T) {
 	}{
 		// updatenotification
 		{
-			name:           "updatenotification set nil to true",
+			name:           "Case 1: updatenotification set nil to true",
 			parameter:      "updatenotification",
 			value:          "true",
 			existingConfig: Config{},
@@ -1006,7 +1006,7 @@ func TestSetConfiguration(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:      "updatenotification set true to false",
+			name:      "Case 2: updatenotification set true to false",
 			parameter: "updatenotification",
 			value:     "false",
 			existingConfig: Config{
@@ -1018,7 +1018,7 @@ func TestSetConfiguration(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "updatenotification set false to true",
+			name:      "Case 3: updatenotification set false to true",
 			parameter: "updatenotification",
 			value:     "true",
 			existingConfig: Config{
@@ -1031,7 +1031,7 @@ func TestSetConfiguration(t *testing.T) {
 		},
 
 		{
-			name:           "updatenotification invalid value",
+			name:           "Case 4: updatenotification invalid value",
 			parameter:      "updatenotification",
 			value:          "invalid_value",
 			existingConfig: Config{},
@@ -1040,7 +1040,7 @@ func TestSetConfiguration(t *testing.T) {
 
 		// timeout
 		{
-			name:      "Timeout set to 5 from 0",
+			name:      "Case 5: Timeout set to 5 from 0",
 			parameter: "timeout",
 			value:     "5",
 			existingConfig: Config{
@@ -1052,7 +1052,7 @@ func TestSetConfiguration(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "Timeout set to 300",
+			name:           "Case 6: Timeout set to 300",
 			parameter:      "timeout",
 			value:          "300",
 			existingConfig: Config{},
@@ -1060,7 +1060,7 @@ func TestSetConfiguration(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "Timeout set to 0",
+			name:           "Case 7: Timeout set to 0",
 			parameter:      "timeout",
 			value:          "0",
 			existingConfig: Config{},
@@ -1068,14 +1068,14 @@ func TestSetConfiguration(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "Timeout set to -1",
+			name:           "Case 8: Timeout set to -1",
 			parameter:      "timeout",
 			value:          "-1",
 			existingConfig: Config{},
 			wantErr:        true,
 		},
 		{
-			name:           "Timeout invalid value",
+			name:           "Case 9: Timeout invalid value",
 			parameter:      "timeout",
 			value:          "this",
 			existingConfig: Config{},
@@ -1083,7 +1083,7 @@ func TestSetConfiguration(t *testing.T) {
 		},
 		// invalid parameter
 		{
-			name:           "invalid parameter",
+			name:           "Case 10: invalid parameter",
 			parameter:      "invalid_parameter",
 			existingConfig: Config{},
 			wantErr:        true,
@@ -1148,12 +1148,12 @@ func TestGetupdateNotification(t *testing.T) {
 		want           bool
 	}{
 		{
-			name:           "updatenotification nil",
+			name:           "Case 1: updatenotification nil",
 			existingConfig: Config{},
 			want:           true,
 		},
 		{
-			name: "updatenotification true",
+			name: "Case 2: updatenotification true",
 			existingConfig: Config{
 				OdoSettings: OdoSettings{
 					UpdateNotification: &trueValue,
@@ -1162,7 +1162,7 @@ func TestGetupdateNotification(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "updatenotification false",
+			name: "Case 3: updatenotification false",
 			existingConfig: Config{
 				OdoSettings: OdoSettings{
 					UpdateNotification: &falseValue,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1186,20 +1186,3 @@ func TestGetupdateNotification(t *testing.T) {
 		})
 	}
 }
-
-//
-//func TestGet(t *testing.T) {
-//
-//}
-//
-//func TestSet(t *testing.T) {
-//
-//}
-//
-//func TestApplicationExists(t *testing.T) {
-//
-//}
-//
-//func TestAddApplication(t *testing.T) {
-//
-//}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -19,12 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 
-	"github.com/redhat-developer/odo/pkg/util"
-
 	"github.com/fatih/color"
 	"github.com/golang/glog"
 	dockerapiv10 "github.com/openshift/api/image/docker10"
 	"github.com/pkg/errors"
+	"github.com/redhat-developer/odo/pkg/config"
+	"github.com/redhat-developer/odo/pkg/util"
 
 	servicecatalogclienset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
 	appsschema "github.com/openshift/client-go/apps/clientset/versioned/scheme"
@@ -57,7 +57,6 @@ import (
 )
 
 const (
-	ocRequestTimeout   = 1 * time.Second
 	OpenShiftNameSpace = "openshift"
 
 	// The length of the string to be generated for names of resources
@@ -262,6 +261,15 @@ func isServerUp(server string) bool {
 		return false
 	}
 
+	ocRequestTimeout := config.DefaultTimeout * time.Second
+	// checking the value of timeout in config
+	// before proceeding with default timeout
+	cfg, configReadErr := config.New()
+	if configReadErr != nil {
+		glog.V(4).Info(errors.Wrap(configReadErr, "unable to read config file"))
+	} else {
+		ocRequestTimeout = time.Duration(cfg.GetTimeout()) * time.Second
+	}
 	glog.V(4).Infof("Trying to connect to server %v", u.Host)
 	_, connectionError := net.DialTimeout("tcp", u.Host, time.Duration(ocRequestTimeout))
 	if connectionError != nil {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -261,6 +261,8 @@ func isServerUp(server string) bool {
 		return false
 	}
 
+	// initialising the default timeout, this will be used
+	// when the value is not readable from config
 	ocRequestTimeout := config.DefaultTimeout * time.Second
 	// checking the value of timeout in config
 	// before proceeding with default timeout

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/config"
 	"io/ioutil"
 	"log"
 	"strings"
@@ -81,10 +82,23 @@ var _ = Describe("odoe2e", func() {
 	})
 
 	Context("odo utils config", func() {
-		It("should get true for updatenotification by defult", func() {
-			config := runCmd("odo utils config view")
-			Expect(config).To(ContainSubstring("true"))
-			Expect(config).To(ContainSubstring("UpdateNotification"))
+		It("should get true for updatenotification by default", func() {
+			config_output := runCmd("odo utils config view")
+			Expect(config_output).To(ContainSubstring("true"))
+			Expect(config_output).To(ContainSubstring("UpdateNotification"))
+		})
+		It("should be checking to see if timeout is the same as the constant", func() {
+			config_output := runCmd("odo utils config view|grep Timeout")
+			Expect(config_output).To(ContainSubstring(fmt.Sprintf("%d", config.DefaultTimeout)))
+		})
+		It("should be checking to see if config values are the same as the configured ones", func() {
+			runCmd("odo utils config set updatenotification false")
+			runCmd("odo utils config set timeout 5")
+			config_output := runCmd("odo utils config view|grep UpdateNotification")
+			Expect(config_output).To(ContainSubstring("false"))
+			Expect(config_output).To(ContainSubstring("UpdateNotification"))
+			config_output = runCmd("odo utils config view|grep Timeout")
+			Expect(config_output).To(ContainSubstring("5"))
 		})
 	})
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -83,22 +83,22 @@ var _ = Describe("odoe2e", func() {
 
 	Context("odo utils config", func() {
 		It("should get true for updatenotification by default", func() {
-			config_output := runCmd("odo utils config view")
-			Expect(config_output).To(ContainSubstring("true"))
-			Expect(config_output).To(ContainSubstring("UpdateNotification"))
+			configOutput := runCmd("odo utils config view")
+			Expect(configOutput).To(ContainSubstring("true"))
+			Expect(configOutput).To(ContainSubstring("UpdateNotification"))
 		})
 		It("should be checking to see if timeout is the same as the constant", func() {
-			config_output := runCmd("odo utils config view|grep Timeout")
-			Expect(config_output).To(ContainSubstring(fmt.Sprintf("%d", config.DefaultTimeout)))
+			configOutput := runCmd("odo utils config view|grep Timeout")
+			Expect(configOutput).To(ContainSubstring(fmt.Sprintf("%d", config.DefaultTimeout)))
 		})
 		It("should be checking to see if config values are the same as the configured ones", func() {
 			runCmd("odo utils config set updatenotification false")
 			runCmd("odo utils config set timeout 5")
-			config_output := runCmd("odo utils config view|grep UpdateNotification")
-			Expect(config_output).To(ContainSubstring("false"))
-			Expect(config_output).To(ContainSubstring("UpdateNotification"))
-			config_output = runCmd("odo utils config view|grep Timeout")
-			Expect(config_output).To(ContainSubstring("5"))
+			configOutput := runCmd("odo utils config view|grep UpdateNotification")
+			Expect(configOutput).To(ContainSubstring("false"))
+			Expect(configOutput).To(ContainSubstring("UpdateNotification"))
+			configOutput = runCmd("odo utils config view|grep Timeout")
+			Expect(configOutput).To(ContainSubstring("5"))
 		})
 	})
 


### PR DESCRIPTION
add a parameter for modifying default connect check timeout 

```sh
# Example:
# for setting timeout to 9seconds
$ odo utils config set timeout 9
# for setting timeout to minimum
$ odo utils config set timeout 0
Cannot set timeout to 0 setting it to the minimum value(1sec)
$ odo utils config view 
PARAMETER             CURRENT_VALUE
UpdateNotification    false
Timeout               1


```