### PR TITLE
Removes a new line from the project get short flag

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -82,7 +82,7 @@ var projectGetCmd = &cobra.Command{
 		project := project.GetCurrent(client)
 
 		if projectShortFlag {
-			fmt.Println(project)
+			fmt.Print(project)
 		} else {
 			fmt.Printf("The current project is: %v\n", project)
 		}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -54,7 +54,7 @@ var _ = Describe("odoe2e", func() {
 
 		It("should get the project", func() {
 			getProj := runCmd("odo project get --short")
-			Expect(strings.TrimSpace(getProj)).To(Equal(projName))
+			Expect(getProj).To(Equal(projName))
 		})
 
 		// Issue #630
@@ -105,7 +105,7 @@ var _ = Describe("odoe2e", func() {
 
 			It("should be created within the project", func() {
 				projName := runCmd("odo project get --short")
-				Expect(projName).To(ContainSubstring(projName))
+				Expect(projName).To(Equal(projName))
 			})
 
 			It("should be able to create another application", func() {


### PR DESCRIPTION
fixes : #758
Signed-off-by: mik-dass mrinald7@gmail.com

It removes the new line from the short flags for `project get`