### PR TITLE
Update go version to 1.11 in .travis.yaml and fix current go fmt errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - &base-test
       stage: test
       go_import_path: github.com/redhat-developer/odo
-      go: "1.10"
+      go: "1.11"
       install:
         - make goget-tools
       script:
@@ -68,7 +68,7 @@ jobs:
 
     - stage: deploy
       go_import_path:  github.com/redhat-developer/odo
-      go: "1.10"
+      go: "1.11"
       install:
         - make goget-tools
         - gem install fpm

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -92,7 +92,7 @@ func List(client *occlient.Client) ([]config.ApplicationInfo, error) {
 
 // Delete deletes the given application
 func Delete(client *occlient.Client, name string) error {
-	glog.V(4).Info("Deleting application %s", name)
+	glog.V(4).Infof("Deleting application %s", name)
 
 	labels := applabels.GetLabels(name, false)
 

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -186,7 +186,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 			if err != nil {
 				// Intentionally not exiting on error here.
 				// We don't want to break watch when push failed, it might be fixed with the next change.
-				glog.V(4).Info("Error from PushLocal: %v", err)
+				glog.V(4).Infof("Error from PushLocal: %v", err)
 			}
 			dirty = false
 			showWaitingMessage = true

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -256,7 +256,7 @@ func isServerUp(server string) bool {
 		return false
 	}
 
-	glog.V(4).Infof("Trying to connect to server %v - %v", u.Host)
+	glog.V(4).Infof("Trying to connect to server %v", u.Host)
 	_, connectionError := net.DialTimeout("tcp", u.Host, time.Duration(ocRequestTimeout))
 	if connectionError != nil {
 		glog.V(4).Info(errors.Wrap(connectionError, "unable to connect to server"))

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -631,7 +631,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "mailserver",
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "python",
 			},
@@ -644,7 +644,7 @@ func TestCreateRoute(t *testing.T) {
 			service:    "blog",
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
-				"SLA": "High",
+				"SLA":                              "High",
 				"app.kubernetes.io/component-name": "backend",
 				"app.kubernetes.io/component-type": "golang",
 			},
@@ -956,7 +956,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -990,7 +990,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1019,7 +1019,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1054,7 +1054,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1083,7 +1083,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1118,7 +1118,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app": "apptmp",
+						"app":                              "apptmp",
 						"app.kubernetes.io/component-name": "wildfly",
 						"app.kubernetes.io/component-type": "wildfly",
 						"app.kubernetes.io/name":           "apptmp",
@@ -1146,7 +1146,7 @@ func TestSetupForSupervisor(t *testing.T) {
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app": "apptmp",
+				"app":                              "apptmp",
 				"app.kubernetes.io/component-name": "ruby",
 				"app.kubernetes.io/component-type": "ruby",
 				"app.kubernetes.io/name":           "apptmp",
@@ -1772,7 +1772,7 @@ func TestNewAppS2I(t *testing.T) {
 				namespace:    "testing",
 				gitUrl:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -1795,7 +1795,7 @@ func TestNewAppS2I(t *testing.T) {
 				namespace:    "testing",
 				gitUrl:       "",
 				labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -1820,7 +1820,7 @@ func TestNewAppS2I(t *testing.T) {
 				namespace:    "testing",
 				gitUrl:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -1845,7 +1845,7 @@ func TestNewAppS2I(t *testing.T) {
 				namespace:    "testing",
 				gitUrl:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",
@@ -2628,7 +2628,7 @@ func TestCreateService(t *testing.T) {
 			commonObjectMeta: metav1.ObjectMeta{
 				Name: "nodejs",
 				Labels: map[string]string{
-					"app": "apptmp",
+					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
 					"app.kubernetes.io/component-type": "ruby",
 					"app.kubernetes.io/name":           "apptmp",

--- a/pkg/testingutil/deploymentconfigs.go
+++ b/pkg/testingutil/deploymentconfigs.go
@@ -34,7 +34,7 @@ func getDeploymentConfig(namespace string, componentName string, componentType s
 			Name:      fmt.Sprintf("%v-%v", componentName, applicationName),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app": "app",
+				"app":                              "app",
 				"app.kubernetes.io/component-name": componentName,
 				"app.kubernetes.io/component-type": componentType,
 				"app.kubernetes.io/name":           applicationName,


### PR DESCRIPTION
fixes #767

Updates the go version to 1.11 in travis.yml as go fmt is not detecting many errors. This PR also fixes the current go fmt errors.