### PR TITLE
Add CHECKSUM file to the release page

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -39,7 +39,9 @@ for arch in `ls -1 $BIN_DIR/`;do
 done
 
 function release_sha() {
-  find $RELEASE_DIR -maxdepth 1 -type f | xargs sha256sum > $RELEASE_DIR/CHECKSUM
+    for filename in $(find $RELEASE_DIR -maxdepth 1 ! -name SHA256_SUM -type f -printf '%f\n'); do
+        sha_sum=`sha256sum $RELEASE_DIR${filename}|awk '{ print $1 }'`; echo $sha_sum  $filename;
+    done > ${RELEASE_DIR}SHA256_SUM
 }
 
 release_sha

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -37,3 +37,9 @@ for arch in `ls -1 $BIN_DIR/`;do
     echo "copying binary $source_file to release directory"
     cp $source_file $target_file
 done
+
+function release_sha() {
+  find $RELEASE_DIR -maxdepth 1 -type f | xargs sha256sum > $RELEASE_DIR/CHECKSUM
+}
+
+release_sha

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -39,7 +39,8 @@ for arch in `ls -1 $BIN_DIR/`;do
 done
 
 function release_sha() {
-    for filename in $(find $RELEASE_DIR -maxdepth 1 ! -name SHA256_SUM -type f -printf '%f\n'); do
+    release_dir_files=`find $RELEASE_DIR -maxdepth 1 ! -name SHA256_SUM -type f -printf "%f\n"`
+    for filename in $release_dir_files; do
         sha_sum=`sha256sum $RELEASE_DIR${filename}|awk '{ print $1 }'`; echo $sha_sum  $filename;
     done > ${RELEASE_DIR}SHA256_SUM
 }

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -44,7 +44,7 @@ function release_sha() {
     for filename in $release_dir_files; do
         sha_sum=`sha256sum $RELEASE_DIR${filename}|awk '{ print $1 }'`; echo $sha_sum  $filename;
     done > ${RELEASE_DIR}SHA256_SUM
-    echo "the SHA256_SUM for release packages are:"
+    echo "The SHA256 SUM for the release packages are:"
     cat ${RELEASE_DIR}SHA256_SUM
 }
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -39,10 +39,13 @@ for arch in `ls -1 $BIN_DIR/`;do
 done
 
 function release_sha() {
+    echo "generating SHA256_SUM for release packages"
     release_dir_files=`find $RELEASE_DIR -maxdepth 1 ! -name SHA256_SUM -type f -printf "%f\n"`
     for filename in $release_dir_files; do
         sha_sum=`sha256sum $RELEASE_DIR${filename}|awk '{ print $1 }'`; echo $sha_sum  $filename;
     done > ${RELEASE_DIR}SHA256_SUM
+    echo "the SHA256_SUM for release packages are:"
+    cat ${RELEASE_DIR}SHA256_SUM
 }
 
 release_sha


### PR DESCRIPTION
This PR adds CHECKSUM file to the release page.
Currently, everything in dist/release/ on the build machine(travis) is
pushed to release page as in the `deploy` job config in travis configuration
So, this PR just loops around contents of dist/release and generates sha256
for each file in the folder and puts them in a file by name CHECKSUM in the
same path(dist/release/) expecting it to be uploaded to the release page.

fixes #736
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>