### PR TITLE
Add info to turn off update notification

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,9 @@ func getLatestReleaseInfo(info chan<- string) {
 			"Update using your package manager, or run\n" +
 			"curl " + notify.InstallScriptURL + " | sh\n" +
 			"to update manually, or visit https://github.com/redhat-developer/odo/releases\n" +
-			"---\n"
+			"---\n" +
+			"If you wish to disable the update notifications, you can disable it by running\n" +
+			"'odo utils config set UpdateNotification false'\n"
 	}
 }
 


### PR DESCRIPTION
example of how the latest notification looks like
```sh
$./odo catalog list components
NAME        PROJECT       TAGS
dotnet      openshift     2.0,latest        
httpd       openshift     2.4,latest  
nginx       openshift     1.10,1.12,1.8,latest
nodejs      openshift     0.10,4,6,8,latest       
perl        openshift     5.16,5.20,5.24,latest
php         openshift     5.5,5.6,7.0,7.1,latest
python      openshift     2.7,3.3,3.4,3.5,3.6,latest
ruby        openshift     2.0,2.2,2.3,2.4,2.5,latest
wildfly     openshift     10.0,10.1,11.0,12.0,8.1,9.0,latest
---                                   
A newer version of odo (version: 0.0.12) is available.
Update using your package manager, or run
curl https://raw.githubusercontent.com/redhat-developer/odo/master/scripts/install.sh | sh
to update manually, or visit https://github.com/redhat-developer/odo/releases
---                                                  
If you wish to disable the update notifications, you can disable it by running
'odo utils config set UpdateNotification false'
   ```