### PR TITLE
Fix watch command

### DIFF
--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -141,13 +141,16 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 				if !(event.Op&fsnotify.Remove == fsnotify.Remove || event.Op&fsnotify.Rename == fsnotify.Rename) {
 					stat, err := os.Lstat(event.Name)
 					if err != nil {
-						glog.Errorf("Failed getting details of the changed file %s", event.Name)
-						//watchError = errors.Wrap(err, "unable to watch changes")
+						// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
+						// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
+						// which will terminate the watch
+						glog.Errorf("Failed getting details of the changed file %s. So, ignoring te event", event.Name)
 					}
 					// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
-					// Avoid pushing such buffer files
+					// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
+					// which will terminate the watch
 					if stat == nil {
-						glog.V(4).Infof("Ignoring event for temp file %s", event.Name)
+						glog.Errorf("Ignoring event for file %s as details about the file couldn't be fetched", event.Name)
 						isIgnoreEvent = true
 					}
 

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -144,7 +144,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 						// Some of the editors like vim and gedit, generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 						// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
 						// which will terminate the watch
-						glog.Errorf("Failed getting details of the changed file %s. So, ignoring te event", event.Name)
+						glog.Errorf("Failed getting details of the changed file %s. Ignoring the change", event.Name)
 					}
 					// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 					// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -134,6 +134,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 		for {
 			select {
 			case event := <-watcher.Events:
+				isIgnoreEvent := false
 				changeLock.Lock()
 				glog.V(4).Infof("filesystem watch event: %s", event)
 
@@ -141,20 +142,21 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 					stat, err := os.Lstat(event.Name)
 					if err != nil {
 						glog.Errorf("Failed getting details of the changed file %s", event.Name)
-						watchError = errors.Wrap(err, "unable to watch changes")
+						//watchError = errors.Wrap(err, "unable to watch changes")
 					}
 					// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 					// Avoid pushing such buffer files
 					if stat == nil {
-						break
+						glog.V(4).Infof("Ignoring event for temp file %s", event.Name)
+						isIgnoreEvent = true
 					}
 
 					// In windows, every new file created under a sub-directory of the watched directory, raises 2 events:
 					// 1. Write event for the directory under which the file was created
 					// 2. Create event for the file that was created
 					// Ignore 1 to avoid duplicate events.
-					if stat.IsDir() && event.Op&fsnotify.Write == fsnotify.Write {
-						break
+					if isIgnoreEvent || (stat.IsDir() && event.Op&fsnotify.Write == fsnotify.Write) {
+						isIgnoreEvent = true
 					}
 				}
 
@@ -177,7 +179,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 				if err != nil {
 					watchError = errors.Wrap(err, "unable to watch changes")
 				}
-				if !alreadyInChangedFiles && !matched {
+				if !alreadyInChangedFiles && !matched && !isIgnoreEvent {
 					changedFiles = append(changedFiles, event.Name)
 				}
 

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -141,7 +141,7 @@ func WatchAndPush(client *occlient.Client, componentName string, applicationName
 				if !(event.Op&fsnotify.Remove == fsnotify.Remove || event.Op&fsnotify.Rename == fsnotify.Rename) {
 					stat, err := os.Lstat(event.Name)
 					if err != nil {
-						// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
+						// Some of the editors like vim and gedit, generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 						// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
 						// which will terminate the watch
 						glog.Errorf("Failed getting details of the changed file %s. So, ignoring te event", event.Name)


### PR DESCRIPTION
A break from select case with signal handling causes complete
exit from receiving that particular signal. So avoid break from
select case with signal handling.

fixes #796
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>