### PR TITLE
Add implementation of bash completion for a few commands

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -15,7 +15,7 @@ const (
 		__custom_func is called automatically when none of the auto-created (via cobra)
 		functions handle the given input
 
-		Currently the only case handled is 'odo create'
+		Currently the only cases handled are the following
 
 		'odo create':
 		Handled by simply providing a list of name of the available components
@@ -24,6 +24,11 @@ const (
 		trailing lines that might exist after the data.
 		- Then 'awk' is used again to use select only the name.
 		- Finally 'paste' is used turn the multiple lines into a single line of names separated by spaces
+
+		'odo service create':
+		Handled by providing of available services
+		- 'cut' is used in order to remove the leading characters from the service names
+		- 'paste' is then used turn the multiple lines into a single line of names separated by spaces
 
 		More information about writing bash completion functions can be found at
 		https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2 for
@@ -35,15 +40,23 @@ __custom_func() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	prevPrev="${COMP_WORDS[COMP_CWORD-2]}"
 	
 	case "${prev}" in
 		create)
-			local components=$(odo catalog list components | awk  '/NAME/{flag=1;next}/---/{flag=0}flag' | awk '{ print $1; }' | paste -sd " " -)
-			COMPREPLY=( $(compgen -W "${components}" -- ${cur}) )
-            return 0
-            ;;
-        *)
-        ;;
+			case "${prevPrev}" in
+				odo)
+					local components=$(odo catalog list components | awk  '/NAME/{flag=1;next}/---/{flag=0}flag' | awk '{ print $1; }' | paste -sd " " -)
+					COMPREPLY=( $(compgen -W "${components}" -- ${cur}) )
+					return 0
+					;;
+				service)
+					local services=$(odo catalog list services | cut -c 3- | paste -sd " " -)
+					COMPREPLY=( $(compgen -W "${services}" -- ${cur}) )
+					return 0
+					;;
+			esac
+			;;
     esac
 
 	return 0;

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -9,6 +9,48 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+
+	/*
+		__custom_func is called automatically when none of the auto-created (via cobra)
+		functions handle the given input
+
+		Currently the only case handled is 'odo create'
+
+		'odo create':
+		Handled by simply providing a list of name of the available components
+		(meaning no namespaces or versions are shown).
+		- 'awk' is first used in order to filter out the first line containing the "header" and any
+		trailing lines that might exist after the data.
+		- Then 'awk' is used again to use select only the name.
+		- Finally 'paste' is used turn the multiple lines into a single line of names separated by spaces
+
+		More information about writing bash completion functions can be found at
+		https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2 for
+	*/
+
+	bashCompletionFunc = `
+__custom_func() {
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	
+	case "${prev}" in
+		create)
+			local components=$(odo catalog list components | awk  '/NAME/{flag=1;next}/---/{flag=0}flag' | awk '{ print $1; }' | paste -sd " " -)
+			COMPREPLY=( $(compgen -W "${components}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+	return 0;
+}
+`
+)
+
 var completionCmd = &cobra.Command{
 	Use:   "completion SHELL",
 	Short: "Output shell completion code",

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -12,10 +12,14 @@ import (
 const (
 
 	/*
-		__custom_func is called automatically when none of the auto-created (via cobra)
+
+		Completion support for bash only
+		TODO: Add proper support zsh as well
+
+		__custom_func is called when none of the auto-created (via cobra)
 		functions handle the given input
 
-		Currently the only cases handled are the following
+		Currently the cases handled are the following
 
 		'odo create':
 		Handled by simply providing a list of name of the available components

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -46,6 +46,13 @@ const (
 		- Then 'awk' is used again to use select only the name.
 		- Finally 'paste' is used turn the multiple lines into a single line of names separated by spaces
 
+		'odo url delete':
+		Handled by providing the available urls
+		- 'awk' is first used in order to filter out the first line containing the "header".
+		We use the marker 'dummy' to make awk work until the end of the file
+		- Then 'awk' is used again to use select only the name.
+		- Finally 'paste' is used turn the multiple lines into a single line of names separated by spaces
+
 		More information about writing bash completion functions can be found at
 		https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2 for
 	*/
@@ -92,6 +99,15 @@ __custom_func() {
             delete|mount|unmount)
               local storages=$(odo storage list | awk  '/NAME/{flag=1;next}/NAME/{flag=0}flag' | sed '/No/d' | sed '/^\s*$/d' | awk '{ print $1; }' | paste -sd " " -)
               COMPREPLY=( $(compgen -W "${storages}" -- ${cur}) )
+              return 0
+              ;;
+          esac
+          ;;
+        url)
+          case "${verb}" in
+            delete)
+              local urls=$(odo url list | awk  '/NAME/{flag=1;next}/dummy/{flag=0}flag' | sed '/No/d' | sed '/^\s*$/d' | awk '{ print $1; }' | paste -sd " " -)
+              COMPREPLY=( $(compgen -W "${urls}" -- ${cur}) )
               return 0
               ;;
           esac

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ Find more information at https://github.com/redhat-developer/odo`,
   odo url create`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 	},
+	BashCompletionFunction: bashCompletionFunc,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
This PR implements the requirement in #77 but also goes on step further.
It provides bash completion support to:

* `odo create`
  - By providing the available components (essentially using `odo catalog list components`)
* `odo service create`
  - By providing the available services (essentially using `odo catalog list service`)
* `odo project delete|set`
  - By providing the available projects (essentially using `odo project list`)
* `odo storage delete|mount|unmount`
  - By providing the available storage objects (essentially using `odo storage list`)
* `odo url delete`
  - By providing the available url (essentially using `odo url list`)