### PR TITLE
gitUrl variable to gitURL

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -525,9 +525,9 @@ func getAppRootVolumeName(dcName string) string {
 }
 
 // NewAppS2I create new application using S2I
-// gitUrl is the url of the git repo
+// gitURL is the url of the git repo
 // inputPorts is the array containing the string port values
-func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labels map[string]string, annotations map[string]string, inputPorts []string) error {
+func (c *Client) NewAppS2I(name string, builderImage string, gitURL string, labels map[string]string, annotations map[string]string, inputPorts []string) error {
 
 	imageNS, imageName, imageTag, _, err := ParseImageName(builderImage)
 	if err != nil {
@@ -576,14 +576,14 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 		return errors.Wrapf(err, "unable to create ImageStream for %s", name)
 	}
 
-	// if gitUrl is not set, error out
-	if gitUrl == "" {
-		return errors.New("unable to create buildSource with empty gitUrl")
+	// if gitURL is not set, error out
+	if gitURL == "" {
+		return errors.New("unable to create buildSource with empty gitURL")
 	}
 
 	buildSource := buildv1.BuildSource{
 		Git: &buildv1.GitBuildSource{
-			URI: gitUrl,
+			URI: gitURL,
 		},
 		Type: buildv1.BuildSourceGit,
 	}
@@ -914,17 +914,17 @@ func addBootstrapVolumeMount(dc *appsv1.DeploymentConfig, dcName string) {
 // UpdateBuildConfig updates the BuildConfig file
 // buildConfigName is the name of the BuildConfig file to be updated
 // projectName is the name of the project
-// gitUrl equals to the git URL of the source and is equals to "" if the source is of type dir or binary
+// gitURL equals to the git URL of the source and is equals to "" if the source is of type dir or binary
 // annotations contains the annotations for the BuildConfig file
-func (c *Client) UpdateBuildConfig(buildConfigName string, projectName string, gitUrl string, annotations map[string]string) error {
+func (c *Client) UpdateBuildConfig(buildConfigName string, projectName string, gitURL string, annotations map[string]string) error {
 	// generate BuildConfig
 	buildSource := buildv1.BuildSource{}
 
-	// if gitUrl set change buildSource to git and use given repo
-	if gitUrl != "" {
+	// if gitURL set change buildSource to git and use given repo
+	if gitURL != "" {
 		buildSource = buildv1.BuildSource{
 			Git: &buildv1.GitBuildSource{
-				URI: gitUrl,
+				URI: gitURL,
 			},
 			Type: buildv1.BuildSourceGit,
 		}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -1605,7 +1605,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 		name                string
 		buildConfigName     string
 		projectName         string
-		gitUrl              string
+		gitURL              string
 		annotations         map[string]string
 		existingBuildConfig buildv1.BuildConfig
 		updatedBuildConfig  buildv1.BuildConfig
@@ -1615,7 +1615,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 			name:            "git to local with proper parameters",
 			buildConfigName: "nodejs",
 			projectName:     "app",
-			gitUrl:          "",
+			gitURL:          "",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
@@ -1661,7 +1661,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 			name:            "local to git with proper parameters",
 			buildConfigName: "nodejs",
 			projectName:     "app",
-			gitUrl:          "https://github.com/sclorg/nodejs-ex",
+			gitURL:          "https://github.com/sclorg/nodejs-ex",
 			annotations: map[string]string{
 				"app.kubernetes.io/url":                   "https://github.com/sclorg/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "git",
@@ -1723,7 +1723,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 				return true, &tt.updatedBuildConfig, nil
 			})
 
-			err := fkclient.UpdateBuildConfig(tt.buildConfigName, tt.projectName, tt.gitUrl, tt.annotations)
+			err := fkclient.UpdateBuildConfig(tt.buildConfigName, tt.projectName, tt.gitURL, tt.annotations)
 			if err == nil && !tt.wantErr {
 				// Check for validating actions performed
 				if (len(fkclientset.BuildClientset.Actions()) != 2) && (tt.wantErr != true) {
@@ -1752,7 +1752,7 @@ func TestNewAppS2I(t *testing.T) {
 		name         string
 		namespace    string
 		builderImage string
-		gitUrl       string
+		gitURL       string
 		labels       map[string]string
 		annotations  map[string]string
 		inputPorts   []string
@@ -1765,12 +1765,12 @@ func TestNewAppS2I(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name: "case 1: with valid gitUrl",
+			name: "case 1: with valid gitURL",
 			args: args{
 				name:         "ruby",
 				builderImage: "ruby:latest",
 				namespace:    "testing",
-				gitUrl:       "https://github.com/openshift/ruby",
+				gitURL:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
 					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
@@ -1788,12 +1788,12 @@ func TestNewAppS2I(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "case 2 : binary buildSource with gitUrl empty",
+			name: "case 2 : binary buildSource with gitURL empty",
 			args: args{
 				name:         "ruby",
 				builderImage: "ruby:latest",
 				namespace:    "testing",
-				gitUrl:       "",
+				gitURL:       "",
 				labels: map[string]string{
 					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
@@ -1818,7 +1818,7 @@ func TestNewAppS2I(t *testing.T) {
 				name:         "ruby",
 				builderImage: "ruby:latest",
 				namespace:    "testing",
-				gitUrl:       "https://github.com/openshift/ruby",
+				gitURL:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
 					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
@@ -1843,7 +1843,7 @@ func TestNewAppS2I(t *testing.T) {
 				name:         "ruby",
 				builderImage: "ruby:latest",
 				namespace:    "testing",
-				gitUrl:       "https://github.com/openshift/ruby",
+				gitURL:       "https://github.com/openshift/ruby",
 				labels: map[string]string{
 					"app":                              "apptmp",
 					"app.kubernetes.io/component-name": "ruby",
@@ -1869,7 +1869,7 @@ func TestNewAppS2I(t *testing.T) {
 		// 	args: args{
 		// 		name:         "ruby",
 		// 		builderImage: "",
-		// 		gitUrl:       "https://github.com/openshift/ruby",
+		// 		gitURL:       "https://github.com/openshift/ruby",
 		// 		labels: map[string]string{
 		// 			"app": "apptmp",
 		// 			"app.kubernetes.io/component-name": "ruby",
@@ -1903,7 +1903,7 @@ func TestNewAppS2I(t *testing.T) {
 
 			err := fkclient.NewAppS2I(tt.args.name,
 				tt.args.builderImage,
-				tt.args.gitUrl,
+				tt.args.gitURL,
 				tt.args.labels,
 				tt.args.annotations,
 				tt.args.inputPorts)
@@ -1959,9 +1959,9 @@ func TestNewAppS2I(t *testing.T) {
 				// Check buildconfig objects
 				createdBC := fkclientset.BuildClientset.Actions()[0].(ktesting.CreateAction).GetObject().(*buildv1.BuildConfig)
 
-				if tt.args.gitUrl != "" {
-					if createdBC.Spec.CommonSpec.Source.Git.URI != tt.args.gitUrl {
-						t.Errorf("git url is not matching with expected value, expected: %s, got %s", tt.args.gitUrl, createdBC.Spec.CommonSpec.Source.Git.URI)
+				if tt.args.gitURL != "" {
+					if createdBC.Spec.CommonSpec.Source.Git.URI != tt.args.gitURL {
+						t.Errorf("git url is not matching with expected value, expected: %s, got %s", tt.args.gitURL, createdBC.Spec.CommonSpec.Source.Git.URI)
 					}
 
 					if createdBC.Spec.CommonSpec.Source.Type != "Git" {

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -15,7 +15,7 @@ import (
 // SourceTest checks the component-source-type and the source url in the annotation of the bc and dc
 // appTestName is the name of the app
 // sourceType is the type of the source of the component i.e git/binary/local
-// source is the source of the component i.e gitUrl or path to the directory or binary file
+// source is the source of the component i.e gitURL or path to the directory or binary file
 func SourceTest(appTestName string, sourceType string, source string) {
 	// checking for source-type in dc
 	getDc := runCmd("oc get dc wildfly-" + appTestName + " -o go-template='{{index .metadata.annotations \"app.kubernetes.io/component-source-type\"}}'")


### PR DESCRIPTION
Fixes codeclimate complaining about acronyms, specifically: gitUrl.

This replaces gitUrl with gitURL.