### PR TITLE
Removed unused parameter from DeleteService()

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -109,7 +109,7 @@ var serviceDeleteCmd = &cobra.Command{
 		}
 
 		if strings.ToLower(confirmDeletion) == "y" {
-			err := svc.DeleteService(client, serviceName, applicationName, projectName)
+			err := svc.DeleteService(client, serviceName, applicationName)
 			checkError(err, "")
 			fmt.Printf("Service %s from application %s has been deleted\n", serviceName, applicationName)
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -68,7 +68,7 @@ func CreateService(client *occlient.Client, serviceName string, serviceType stri
 }
 
 // DeleteService will delete the service with the provided `name`
-func DeleteService(client *occlient.Client, name string, applicationName string, projectName string) error {
+func DeleteService(client *occlient.Client, name string, applicationName string) error {
 
 	labels := componentlabels.GetLabels(name, applicationName, false)
 	err := client.DeleteServiceInstance(labels)


### PR DESCRIPTION
fixes #811 

Signed-off-by: mik-dass mrinald7@gmail.com

Removed the unused parameter from service/service.go and cmd/service.go