### PR TITLE
Added support for exact one  argument in service delete

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -79,7 +79,7 @@ var serviceDeleteCmd = &cobra.Command{
 	Example: `  # Delete the service named 'mysql-persistent'
   odo service delete mysql-persistent
 	`,
-	Args: cobra.MaximumNArgs(1),
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 
 		glog.V(4).Infof("service delete called\n args: %#v", strings.Join(args, " "))


### PR DESCRIPTION
fixes #810 
Signed-off-by: mik-dass mrinald7@gmail.com

This PR makes `odo service delete` accept exactly one argument to stop it from crashing when no argument is passed.