### PR TITLE
fix #690 : odo version shows server version without logging in

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ import (
 
 // Global variables
 var (
-	GlobalConnectionCheck bool
+	GlobalSkipConnectionCheck bool
 )
 
 // Templates
@@ -130,7 +130,7 @@ func init() {
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
-	rootCmd.PersistentFlags().BoolVar(&GlobalConnectionCheck, "skip-connection-check", false, "Skip cluster check")
+	rootCmd.PersistentFlags().BoolVar(&GlobalSkipConnectionCheck, "skip-connection-check", false, "Skip cluster check")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.Set("logtostderr", "true")
 
@@ -162,7 +162,7 @@ func getLatestReleaseInfo(info chan<- string) {
 }
 
 func getOcClient() *occlient.Client {
-	client, err := occlient.New(GlobalConnectionCheck)
+	client, err := occlient.New(GlobalSkipConnectionCheck)
 	checkError(err, "")
 	return client
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -40,7 +40,7 @@ var versionCmd = &cobra.Command{
 		fmt.Println("odo " + VERSION + " (" + GITCOMMIT + ")")
 
 		// turning off the flag which checks for login status
-		GlobalConnectionCheck = true
+		GlobalSkipConnectionCheck = true
 		// Lets fetch the info about the server
 		serverInfo, err := getOcClient().GetServerVersion()
 		checkError(err, "")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -39,6 +39,8 @@ var versionCmd = &cobra.Command{
 
 		fmt.Println("odo " + VERSION + " (" + GITCOMMIT + ")")
 
+		// turning off the flag which checks for login status
+		GlobalConnectionCheck = true
 		// Lets fetch the info about the server
 		serverInfo, err := getOcClient().GetServerVersion()
 		checkError(err, "")

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2013,6 +2013,11 @@ func (c *Client) GetServerVersion() (*serverInfo, error) {
 	}
 	info.Address = config.Host
 
+	// checking if the server is reachable
+	if !isServerUp(config.Host) {
+		return nil, errors.New("Unable to connect to OpenShift cluster, is it down?")
+	}
+
 	// This will fetch the information about OpenShift Version
 	rawOpenShiftVersion, err := c.kubeClient.CoreV1().RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
 	if err != nil {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -515,4 +515,22 @@ var _ = Describe("odoe2e", func() {
 			waitForDeleteCmd("odo project list", projName)
 		})
 	})
+	Context("validate odo version cmd with oc version", func() {
+		// test for odo version
+		It("should show the version of OpenShift server", func() {
+			odoVersion := runCmd("odo version")
+
+			ocServer := runCmd("oc version|grep Server|cut -d ' ' -f 2")
+			ocVersion := runCmd("oc version|grep openshift|cut -d ' ' -f 2")
+			k8sVersion := runCmd("oc version|grep kubernetes|tail -1|cut -d ' ' -f 2")
+
+			Expect(odoVersion).To(ContainSubstring("Server"))
+			Expect(odoVersion).To(ContainSubstring(ocServer))
+			Expect(odoVersion).To(ContainSubstring("OpenShift"))
+			Expect(odoVersion).To(ContainSubstring(ocVersion))
+			Expect(odoVersion).To(ContainSubstring("Kubernetes"))
+			Expect(odoVersion).To(ContainSubstring(k8sVersion))
+		})
+	})
+
 })


### PR DESCRIPTION
odo version shows the server version without logging in.
fixes #690

# How to test this?
First login and logout from a cluster, then 
run `odo version` - verify it shows the server version.

disconnect from the network and make the server not reachable from the machine where you are running odo
run `odo version` - verify it shows `Unable to connect to OpenShift cluster, is it down`

