### PR TITLE
Improve odo link support

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -110,7 +110,9 @@ A full list of service types that can be deployed are available using: 'odo cata
 		}
 		err = svc.CreateService(client, serviceName, serviceType, plan, parameters, applicationName)
 		util.CheckError(err, "")
-		fmt.Printf("Service '%s' was created.\n", serviceName)
+		fmt.Printf(`Service '%s' was created.
+Progress of the provisioning will not be reported and might take a long time.
+You can see the current status by executing 'odo service list'`, serviceName)
 	},
 }
 
@@ -174,7 +176,7 @@ var serviceListCmd = &cobra.Command{
 		util.GetAndSetNamespace(client)
 		applicationName := util.GetAppName(client)
 
-		services, err := svc.List(client, applicationName)
+		services, err := svc.ListWithDetailedStatus(client, applicationName)
 		util.CheckError(err, "Service Catalog is not enabled in your cluster")
 
 		if len(services) == 0 {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1289,6 +1289,30 @@ func (c *Client) WaitAndGetPod(selector string) (*corev1.Pod, error) {
 	}
 }
 
+// WaitAndGetSecret blocks and waits until the secret is available
+func (c *Client) WaitAndGetSecret(name string, namespace string) (*corev1.Secret, error) {
+	glog.V(4).Infof("Waiting for secret %s to become available", name)
+
+	w, err := c.kubeClient.CoreV1().Secrets(namespace).Watch(metav1.ListOptions{
+		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to watch secret")
+	}
+	defer w.Stop()
+	for {
+		val, ok := <-w.ResultChan()
+		if !ok {
+			break
+		}
+		if e, ok := val.Object.(*corev1.Secret); ok {
+			glog.V(4).Infof("Secret %s now exists", e.Name)
+			return e, nil
+		}
+	}
+	return nil, errors.Errorf("unknown error while waiting for secret '%s'", name)
+}
+
 // FollowBuildLog stream build log to stdout
 func (c *Client) FollowBuildLog(buildName string, stdout io.Writer) error {
 	buildLogOptions := buildv1.BuildLogOptions{
@@ -1691,6 +1715,11 @@ func (c *Client) CreateServiceBinding(componentName string, namespace string) er
 	return nil
 }
 
+// GetServiceBinding returns the ServiceBinding named serviceName in the namespace namespace
+func (c *Client) GetServiceBinding(serviceName string, namespace string) (*scv1beta1.ServiceBinding, error) {
+	return c.serviceCatalogClient.ServiceBindings(namespace).Get(serviceName, metav1.GetOptions{})
+}
+
 // serviceInstanceParameters converts a map of variable assignments to a byte encoded json document,
 // which is what the ServiceCatalog API consumes.
 func serviceInstanceParameters(params map[string]string) (*runtime.RawExtension, error) {
@@ -1889,9 +1918,14 @@ func (c *Client) ListRouteNames(labelSelector string) ([]string, error) {
 
 // ListSecrets lists all the secrets based on the given label selector
 func (c *Client) ListSecrets(labelSelector string) ([]corev1.Secret, error) {
-	secretList, err := c.kubeClient.CoreV1().Secrets(c.Namespace).List(metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
+	listOptions := metav1.ListOptions{}
+	if len(labelSelector) > 0 {
+		listOptions = metav1.ListOptions{
+			LabelSelector: labelSelector,
+		}
+	}
+
+	secretList, err := c.kubeClient.CoreV1().Secrets(c.Namespace).List(listOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get secret list")
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2406,7 +2406,7 @@ func TestListSecrets(t *testing.T) {
 		}
 
 		if err == nil && !tt.wantErr {
-			if (len(fakeClientSet.Kubernetes.Actions()) != 1) && (tt.wantErr != true) {
+			if len(fakeClientSet.Kubernetes.Actions()) != 1 {
 				t.Errorf("expected 1 action in ListSecrets got: %v", fakeClientSet.Kubernetes.Actions())
 			}
 		} else if err == nil && tt.wantErr {

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2222,6 +2222,63 @@ func TestCreateServiceBinding(t *testing.T) {
 	}
 }
 
+func TestGetServiceBinding(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		serviceName string
+		wantErr     bool
+		want        *scv1beta1.ServiceBinding
+	}{
+		{
+			name:        "Case: Valid request for retrieving a service binding",
+			namespace:   "",
+			serviceName: "foo",
+			want: &scv1beta1.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "Case: Invalid request for retrieving a service binding",
+			namespace:   "",
+			serviceName: "foo2",
+			want: &scv1beta1.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, fakeClientSet := FakeNew()
+
+			// Fake getting Secret
+			fakeClientSet.ServiceCatalogClientSet.PrependReactor("get", "servicebindings", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if tt.want.Name != tt.serviceName {
+					return true, nil, fmt.Errorf("'get' called with a different serviebinding name")
+				}
+				return true, tt.want, nil
+			})
+
+			returnValue, err := fakeClient.GetServiceBinding(tt.serviceName, tt.namespace)
+
+			// Check for validating return value
+			if err == nil && returnValue != tt.want {
+				t.Errorf("error in return value got: %v, expected %v", returnValue, tt.want)
+			}
+
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("\nclient.GetServiceBinding(serviceName, namespace) unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLinkSecret(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -2291,6 +2348,72 @@ func TestLinkSecret(t *testing.T) {
 				//TODO enhance test if the Instantiate issue can be overcome
 			}
 		})
+	}
+}
+
+func TestListSecrets(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		secretList corev1.SecretList
+		output     []corev1.Secret
+		wantErr    bool
+	}{
+		{
+			name: "Case 1: Ensure secrets are properly listed",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "secret1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "secret2",
+						},
+					},
+				},
+			},
+			output: []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "secret1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "secret2",
+					},
+				},
+			},
+
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := FakeNew()
+
+		fakeClientSet.Kubernetes.PrependReactor("list", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.secretList, nil
+		})
+
+		secretsList, err := client.ListSecrets("")
+
+		if !reflect.DeepEqual(tt.output, secretsList) {
+			t.Errorf("expected output: %#v,got: %#v", tt.secretList, secretsList)
+		}
+
+		if err == nil && !tt.wantErr {
+			if (len(fakeClientSet.Kubernetes.Actions()) != 1) && (tt.wantErr != true) {
+				t.Errorf("expected 1 action in ListSecrets got: %v", fakeClientSet.Kubernetes.Actions())
+			}
+		} else if err == nil && tt.wantErr {
+			t.Error("test failed, expected: false, got true")
+		} else if err != nil && !tt.wantErr {
+			t.Errorf("test failed, expected: no error, got error: %s", err.Error())
+		}
 	}
 }
 
@@ -2671,6 +2794,71 @@ func TestWaitAndGetPod(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestWaitAndGetSecret(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		secretName string
+		namespace  string
+		wantErr    bool
+	}{
+		{
+			name:       "Case 1: no error expected",
+			secretName: "ruby",
+			namespace:  "dummy",
+			wantErr:    false,
+		},
+
+		{
+			name:       "Case 2: error expected",
+			secretName: "",
+			namespace:  "dummy",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			fkclient, fkclientset := FakeNew()
+			fkWatch := watch.NewFake()
+
+			// Change the status
+			go func() {
+				fkWatch.Modify(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tt.secretName,
+					},
+				})
+			}()
+
+			fkclientset.Kubernetes.PrependWatchReactor("secrets", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				if len(tt.secretName) == 0 {
+					return true, nil, fmt.Errorf("error watching secret")
+				}
+				return true, fkWatch, nil
+			})
+
+			pod, err := fkclient.WaitAndGetSecret(tt.secretName, tt.namespace)
+
+			if !tt.wantErr == (err != nil) {
+				t.Errorf(" client.WaitAndGetSecret(string, string) unexpected error %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if len(fkclientset.Kubernetes.Actions()) != 1 {
+				t.Errorf("expected 1 action in WaitAndGetSecret got: %v", fkclientset.Kubernetes.Actions())
+			}
+
+			if err == nil {
+				if pod.Name != tt.secretName {
+					t.Errorf("secret name is not matching to expected name, expected: %s, got %s", tt.secretName, pod.Name)
+				}
+			}
 		})
 	}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -162,6 +162,9 @@ func ListWithDetailedStatus(client *occlient.Client, applicationName string) ([]
 	}
 	applicationSelector := util.ConvertLabelsToSelector(labels)
 	deploymentConfigs, err := client.GetDeploymentConfigsFromSelector(applicationSelector)
+	if err != nil {
+		return nil, err
+	}
 
 	// go through each service and see if there is a secret that has been created
 	// if so, update the status of the service

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	appsv1 "github.com/openshift/api/apps/v1"
 	"strings"
 
 	"sort"
@@ -13,6 +14,9 @@ import (
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/util"
 )
+
+const provisionedAndBoundStatus = "ProvisionedAndBound"
+const provisionedAndLinkedStatus = "ProvisionedAndLinked"
 
 // ServiceInfo holds all important information about one service
 type ServiceInfo struct {
@@ -130,6 +134,72 @@ func List(client *occlient.Client, applicationName string) ([]ServiceInfo, error
 	}
 
 	return services, nil
+}
+
+// ListWithDetailedStatus lists all the deployed services and additionally provides a "smart" status for each one of them
+// The smart status takes into account how Services are used in odo.
+// So when a secret has been created as a result of the created ServiceBinding, we set the appropriate status
+// Same for when the secret has been "linked" into the deploymentconfig
+func ListWithDetailedStatus(client *occlient.Client, applicationName string) ([]ServiceInfo, error) {
+
+	services, err := List(client, applicationName)
+	if err != nil {
+		return nil, err
+	}
+
+	// retrieve secrets in order to set status
+	secrets, err := client.ListSecrets("")
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to list secrets as part of the bindings check")
+	}
+
+	// use the standard selector to retrieve DeploymentConfigs
+	// these are used in order to update the status of a service
+	// because if a DeploymentConfig contains a secret with the service name
+	// then it has been successfully linked
+	labels := map[string]string{
+		applabels.ApplicationLabel: applicationName,
+	}
+	applicationSelector := util.ConvertLabelsToSelector(labels)
+	deploymentConfigs, err := client.GetDeploymentConfigsFromSelector(applicationSelector)
+
+	// go through each service and see if there is a secret that has been created
+	// if so, update the status of the service
+	for i, service := range services {
+		for _, secret := range secrets {
+			if secret.Name == service.Name {
+				// this is the default status when the secret exists
+				services[i].Status = provisionedAndBoundStatus
+
+				// if we find that the dc contains a link to the secret
+				// we update the status to be even more specific
+				updateStatusIfMatchingDeploymentExists(deploymentConfigs, secret.Name, services, i)
+
+				break
+			}
+		}
+	}
+
+	return services, nil
+}
+
+func updateStatusIfMatchingDeploymentExists(dcs []appsv1.DeploymentConfig, secretName string,
+	services []ServiceInfo, index int) {
+
+	for _, dc := range dcs {
+		foundMatchingSecret := false
+		for _, env := range dc.Spec.Template.Spec.Containers[0].EnvFrom {
+			if env.SecretRef.Name == secretName {
+				services[index].Status = provisionedAndLinkedStatus
+			}
+			foundMatchingSecret = true
+			break
+		}
+
+		if foundMatchingSecret {
+			break
+		}
+	}
 }
 
 // GetSvcByType returns the matching (by type) service or nil of there are no matches

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -349,7 +349,7 @@ func TestGetServiceClassAndPlans(t *testing.T) {
 	}
 }
 
-func TestListWithSmartStatus(t *testing.T) {
+func TestListWithDetailedStatus(t *testing.T) {
 
 	type args struct {
 		Project  string
@@ -363,7 +363,6 @@ func TestListWithSmartStatus(t *testing.T) {
 		secretList  corev1.SecretList
 		dcList      appsv1.DeploymentConfigList
 		output      []ServiceInfo
-		wantErr     bool
 	}{
 		{
 			name: "Case 1: services with various statuses, some bound and some linked",

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
@@ -341,6 +345,246 @@ func TestGetServiceClassAndPlans(t *testing.T) {
 			t.Error("test failed, expected: false, got true")
 		} else if err != nil && !tt.wantErr {
 			t.Errorf("test failed, expected: no error, got error: %s", err.Error())
+		}
+	}
+}
+
+func TestListWithSmartStatus(t *testing.T) {
+
+	type args struct {
+		Project  string
+		Selector string
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		serviceList scv1beta1.ServiceInstanceList
+		secretList  corev1.SecretList
+		dcList      appsv1.DeploymentConfigList
+		output      []ServiceInfo
+		wantErr     bool
+	}{
+		{
+			name: "Case 1: services with various statuses, some bound and some linked",
+			args: args{
+				Project:  "myproject",
+				Selector: "app.kubernetes.io/component-name=mysql-persistent,app.kubernetes.io/name=app",
+			},
+			serviceList: scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mysql-persistent",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "mysql-persistent",
+								componentlabels.ComponentTypeLabel: "mysql-persistent",
+							},
+							Namespace: "myproject",
+						},
+						Spec: scv1beta1.ServiceInstanceSpec{
+							PlanReference: scv1beta1.PlanReference{
+								ClusterServiceClassExternalName: "mysql-persistent",
+								ClusterServicePlanExternalName:  "default",
+							},
+						},
+						Status: scv1beta1.ServiceInstanceStatus{
+							Conditions: []scv1beta1.ServiceInstanceCondition{
+								{
+									Reason: "ProvisionedSuccessfully",
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "postgresql-ephemeral",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "postgresql-ephemeral",
+								componentlabels.ComponentTypeLabel: "postgresql-ephemeral",
+							},
+							Namespace: "myproject",
+						},
+						Spec: scv1beta1.ServiceInstanceSpec{
+							PlanReference: scv1beta1.PlanReference{
+								ClusterServiceClassExternalName: "postgresql-ephemeral",
+								ClusterServicePlanExternalName:  "default",
+							},
+						},
+						Status: scv1beta1.ServiceInstanceStatus{
+							Conditions: []scv1beta1.ServiceInstanceCondition{
+								{
+									Reason: "ProvisionedSuccessfully",
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mongodb",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "mongodb",
+								componentlabels.ComponentTypeLabel: "mongodb",
+							},
+							Namespace: "myproject",
+						},
+						Spec: scv1beta1.ServiceInstanceSpec{
+							PlanReference: scv1beta1.PlanReference{
+								ClusterServiceClassExternalName: "mongodb",
+								ClusterServicePlanExternalName:  "default",
+							},
+						},
+						Status: scv1beta1.ServiceInstanceStatus{
+							Conditions: []scv1beta1.ServiceInstanceCondition{
+								{
+									Reason: "ProvisionedSuccessfully",
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "jenkins-persistent",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "jenkins-persistent",
+								componentlabels.ComponentTypeLabel: "jenkins-persistent",
+							},
+							Namespace: "myproject",
+						},
+						Spec: scv1beta1.ServiceInstanceSpec{
+							PlanReference: scv1beta1.PlanReference{
+								ClusterServiceClassExternalName: "jenkins-persistent",
+								ClusterServicePlanExternalName:  "default",
+							},
+						},
+						Status: scv1beta1.ServiceInstanceStatus{
+							Conditions: []scv1beta1.ServiceInstanceCondition{
+								{
+									Reason: "Provisioning",
+								},
+							},
+						},
+					},
+				},
+			},
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "dummySecret",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "postgresql-ephemeral",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mysql-persistent",
+						},
+					},
+				},
+			},
+			dcList: appsv1.DeploymentConfigList{
+				Items: []appsv1.DeploymentConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								applabels.ApplicationLabel: "app",
+							},
+						},
+						Spec: appsv1.DeploymentConfigSpec{
+							Template: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name: "dummyContainer",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								applabels.ApplicationLabel: "app",
+							},
+						},
+						Spec: appsv1.DeploymentConfigSpec{
+							Template: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											EnvFrom: []corev1.EnvFromSource{
+												{
+													SecretRef: &corev1.SecretEnvSource{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "mysql-persistent",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			output: []ServiceInfo{
+				{
+					Name:   "mysql-persistent",
+					Status: "ProvisionedAndLinked",
+					Type:   "mysql-persistent",
+				},
+				{
+					Name:   "postgresql-ephemeral",
+					Status: "ProvisionedAndBound",
+					Type:   "postgresql-ephemeral",
+				},
+				{
+					Name:   "mongodb",
+					Status: "ProvisionedSuccessfully",
+					Type:   "mongodb",
+				},
+				{
+					Name:   "jenkins-persistent",
+					Status: "Provisioning",
+					Type:   "jenkins-persistent",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := occlient.FakeNew()
+
+		//fake the services
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.serviceList, nil
+		})
+
+		//fake the secrets
+		fakeClientSet.Kubernetes.PrependReactor("list", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.secretList, nil
+		})
+
+		//fake the dcs
+		fakeClientSet.AppsClientset.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.dcList, nil
+		})
+
+		svcInstanceList, _ := ListWithDetailedStatus(client, "app")
+
+		if !reflect.DeepEqual(tt.output, svcInstanceList) {
+			t.Errorf("expected output: %#v,got: %#v", tt.serviceList, svcInstanceList)
 		}
 	}
 }

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -40,7 +40,7 @@ func waitForCmdOut(cmd string, timeout int, check func(output string) bool) bool
 	for {
 		select {
 		case <-pingTimeout:
-			Fail("Timeout out after " + string(timeout) + " minutes")
+			Fail(fmt.Sprintf("Timeout out after %v minutes", timeout))
 
 		case <-tick:
 			out, err := exec.Command("/bin/sh", "-c", cmd).Output()

--- a/tests/e2e/service_test.go
+++ b/tests/e2e/service_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("odoServiceE2e", func() {
 
-	Context("odo component creation", func() {
+	Context("odo service creation", func() {
 		It("should be able to create a service", func() {
 			runCmd("odo service create mysql-persistent")
 			cmd := "oc get serviceinstance mysql-persistent -o go-template='{{ (index .status.conditions 0).reason}}'"


### PR DESCRIPTION
This PR makes the handling of `odo link` better for the user.
This is done by doing the following:

* Provide a `wait` flag that when enabled wait for the service to be provisioned and the secret to be created, before updating the DeploymentConfig. If the flag is not enabled, the command fails with the appropriate message
* Slightly improve the error messages to give even more information about what is going on
* Provide some "smart" statuses (as part of `odo service list`) for the Services that have been linked and / or bound. This makes it easier for the user to determine the status of the service provisioning

Fixes: #846
