### PR TITLE
Fix intermittent bug of `odo update` failing

### DIFF
--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -88,7 +88,7 @@ var _ = Describe("odoCmpE2e", func() {
 			runCmd("find " + tmpDir)
 
 			// Run push
-			runCmd("odo push")
+			runCmd("odo push -v 4")
 
 			cmpList := runCmd("odo list")
 			Expect(cmpList).To(ContainSubstring("wildfly"))


### PR DESCRIPTION
This fixes an intermittent bug of `odo update` failing due to Odo being
"too fast" on CI / local machines and not waiting for OpenShift to
update the correct annotation labels.

Closes: https://github.com/redhat-developer/odo/issues/835