### PR TITLE
Make link handling common across both components and services

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/odo/util"
+	"github.com/redhat-developer/odo/pkg/secret"
 	"os"
 
 	"github.com/redhat-developer/odo/pkg/component"
@@ -10,64 +12,118 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	port string
+)
+
 var linkCmd = &cobra.Command{
-	Use:   "link <service> --component [component]",
-	Short: "Link component to a service",
-	Long: `Link component to a service
+	Use:   "link <service> --component [component] OR link <component> --component [component]",
+	Short: "Link component to a service or component",
+	Long: `Link component to a service or component
 
-If source component is not provided, the link is created to the current active
-component.
+If the source component is not provided, the current active component is assumed.
 
-During the linking process, the secret that is created during the service creation (odo service create),
-is injected into the component.
+In both use cases, link adds the appropriate secret to the environment of the source component. 
+The source component can then consume the entries of the secret as environment variables.
+
+For example:
+
+We have created a backend application called 'backend' with port 8080 exposed:
+odo create backend nodejs --port 8080
+
+We've also created a frontend application called 'frontend':
+odo create frontend nodejs
+
+You can now link the two applications:
+odo link backend --component frontend
+
+Now the frontend has 2 ENV variables it can use:
+COMPONENT_BACKEND_HOST=backend-app
+COMPONENT_BACKEND_PORT=8080
+
+If you wish to use a database, we can use the Service Catalog and link it to our backend:
+odo service create dh-postgresql-apb --plan dev -p postgresql_user=luke -p postgresql_password=secret
+odo link dh-postgresql-apb
+
+Now backend has 2 ENV variables it can use:
+DB_USER=luke
+DB_PASSWORD=secret
 `,
 	Example: `  # Link the current component to the 'my-postgresql' service
   odo link my-postgresql
 
   # Link component 'nodejs' to the 'my-postgresql' service
   odo link my-postgresql --component nodejs
+
+  # Link current component to the 'backend' component (backend must have a single exposed port)
+  odo link backend
+
+  # Link component 'nodejs' to the 'backend' component
+  odo link backend --component nodejs
+
+  # Link current component to port 8080 of the 'backend' component (backend must have port 8080 exposed) 
+  odo link backend --port 8080
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := util.GetOcClient()
 		projectName := util.GetAndSetNamespace(client)
 		applicationName := util.GetAppName(client)
-		componentName := util.GetComponent(client, util.ComponentFlag, applicationName)
-		serviceName := args[0]
+		sourceComponentName := util.GetComponent(client, util.ComponentFlag, applicationName)
 
-		exists, err := component.Exists(client, componentName, applicationName)
+		exists, err := component.Exists(client, sourceComponentName, applicationName)
 		util.CheckError(err, "")
 		if !exists {
-			fmt.Printf("Component %v does not exist\n", componentName)
+			fmt.Printf("Component %v does not exist\n", sourceComponentName)
 			os.Exit(1)
 		}
 
-		exists, err = svc.SvcExists(client, serviceName, applicationName)
-		util.CheckError(err, "Unable to determine if service %s exists within the current namespace", serviceName)
-		if !exists {
-			fmt.Printf(`Service %s does not exist within the current namespace.
-Please perform 'odo service create %s ...' before attempting to link the service.`, serviceName, serviceName)
-			os.Exit(1)
-		}
+		suppliedName := args[0]
 
-		// we also need to check whether there is a secret with the same name as the service
-		// the secret should have been created along with the secret
-		_, err = client.GetSecret(serviceName, projectName)
-		if err != nil {
-			fmt.Printf(`Secret %s should have been created along with the service
+		svcSxists, err := svc.SvcExists(client, suppliedName, applicationName)
+		util.CheckError(err, "Unable to determine if service %s exists", suppliedName)
+
+		cmpExists, err := component.Exists(client, suppliedName, applicationName)
+		util.CheckError(err, "Unable to determine if component %s exists", suppliedName)
+
+		if svcSxists {
+			if cmpExists {
+				glog.V(4).Infof("Both a service and component with name %s - assuming a link to the service is required", suppliedName)
+			}
+
+			serviceName := suppliedName
+
+			// we also need to check whether there is a secret with the same name as the service
+			// the secret should have been created along with the secret
+			_, err = client.GetSecret(serviceName, projectName)
+			if err != nil {
+				fmt.Printf(`Secret %s should have been created along with the service
 If you previously created the service with 'odo service create', then you may have to wait a few seconds until OpenShift provisions it.
 If not, then please delete the service and recreate it using 'odo service create %s`, serviceName, serviceName)
+				os.Exit(1)
+			}
+			err = client.LinkSecret(serviceName, sourceComponentName, applicationName, projectName)
+			util.CheckError(err, "")
+			fmt.Printf("Service %s has been successfully linked to the component %s.\n", serviceName, sourceComponentName)
+		} else if cmpExists {
+			targetComponent := args[0]
+
+			secretName, err := secret.DetermineSecretName(client, targetComponent, applicationName, port)
+			util.CheckError(err, "")
+
+			err = client.LinkSecret(secretName, sourceComponentName, applicationName, projectName)
+			util.CheckError(err, "")
+			fmt.Printf("Component %s has been successfully linked to component %s.\n", targetComponent, sourceComponentName)
+		} else {
+			fmt.Printf(`Neither a service nor a component named %s could be located
+Please create one of the two before attempting to use odo link`, suppliedName)
 			os.Exit(1)
 		}
-
-		err = client.LinkSecret(serviceName, componentName, applicationName, projectName)
-		util.CheckError(err, "")
-
-		fmt.Printf("Service %s has been successfully linked to the component %s.\n", serviceName, applicationName)
 	},
 }
 
 func init() {
+	linkCmd.PersistentFlags().StringVar(&port, "port", "", "Port of the backend to which to link")
 
 	// Add a defined annotation in order to appear in the help menu
 	linkCmd.Annotations = map[string]string{"command": "component"}
@@ -76,6 +132,8 @@ func init() {
 	addProjectFlag(linkCmd)
 	//Adding `--application` flag
 	addApplicationFlag(linkCmd)
+	//Adding `--component` flag
+	addComponentFlag(linkCmd)
 
 	rootCmd.AddCommand(linkCmd)
 }

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -1,0 +1,55 @@
+package secret
+
+import (
+	"fmt"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+)
+import (
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+)
+
+// DetermineSecretName resolves the name of the secret that corresponds to the supplied component name and port
+func DetermineSecretName(client *occlient.Client, componentName, applicationName, port string) (string, error) {
+	labelSelector := fmt.Sprintf("%v=%v", applabels.ApplicationLabel, applicationName) +
+		fmt.Sprintf(",%v=%v", componentlabels.ComponentLabel, componentName)
+	secrets, err := client.ListSecrets(labelSelector)
+	if err != nil {
+		return "", err
+	}
+
+	if len(secrets) == 0 {
+		return "", fmt.Errorf(`A secret should have been created for component %s. 
+Please delete the component and recreate it using 'odo create'`, componentName)
+	}
+
+	// when the port is not supplied, then we either select the only one exposed is so is the case,
+	// or when there multiple ports exposed, we fail
+	if len(port) == 0 {
+		if len(secrets) == 1 {
+			return secrets[0].Name, nil
+		}
+		return "", fmt.Errorf(`Multiple secrets exist for component %s. 
+Please select one of the following ports: '%s'`, componentName, strings.Join(availablePorts(secrets), ","))
+	}
+
+	// search each secret to see which port is corresponds to
+	for _, secret := range secrets {
+		if secret.Annotations[occlient.ComponentPortAnnotationName] == port {
+			return secret.Name, nil
+		}
+	}
+	return "", fmt.Errorf(`None of the secrets that exist for component %s match port %s. 
+Please select one of the following ports: '%s'`, componentName, port, strings.Join(availablePorts(secrets), ","))
+
+}
+
+func availablePorts(secrets []corev1.Secret) []string {
+	ports := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		ports = append(ports, secret.Annotations[occlient.ComponentPortAnnotationName])
+	}
+	return ports
+}

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -1,0 +1,247 @@
+package secret
+
+import (
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+func TestGetServiceInstanceList(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		componentName   string
+		applicationName string
+		port            string
+		secretList      corev1.SecretList
+		want            string
+		wantErr         bool
+	}{
+		{
+			name:            "Case 1: No secrets returned",
+			componentName:   "backend",
+			applicationName: "app",
+			port:            "",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:            "Case 2: No (matching) secrets returned",
+			componentName:   "backend",
+			applicationName: "app",
+			port:            "",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "other-8080",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "other",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8080",
+							},
+						},
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:            "Case 3: Single (matching) secret returned and no port is specified",
+			componentName:   "backend",
+			applicationName: "app",
+			port:            "",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "other-8080",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "other",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8080",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8080",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8080",
+							},
+						},
+					},
+				},
+			},
+			want:    "backend-8080",
+			wantErr: false,
+		},
+		{
+			name:            "Case 4: Multiple secrets returned and no port is specified",
+			componentName:   "backend",
+			applicationName: "app",
+			port:            "",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8080",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8080",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8443",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8443",
+							},
+						},
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:            "Case 5: Multiple secrets returned and non-matching port is specified",
+			componentName:   "backend",
+			applicationName: "app",
+			port:            "9090",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8080",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8080",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8443",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8443",
+							},
+						},
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:            "Case 6: Multiple secrets returned and matching port is specified",
+			componentName:   "backend",
+			applicationName: "app",
+			port:            "8080",
+			secretList: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8443",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8443",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8080",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8080",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backend-8779",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+							Annotations: map[string]string{
+								occlient.ComponentPortAnnotationName: "8779",
+							},
+						},
+					},
+				},
+			},
+			want:    "backend-8080",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := occlient.FakeNew()
+
+		//fake the secrets
+		fakeClientSet.Kubernetes.PrependReactor("list", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.secretList, nil
+		})
+
+		secretName, err := DetermineSecretName(client, tt.componentName, tt.applicationName, tt.port)
+
+		if !tt.wantErr == (err != nil) {
+			t.Errorf("client.GetExposedPorts(imagestream imageTag) unexpected error %v, wantErr %v", err, tt.wantErr)
+		}
+		if secretName != tt.want {
+			t.Errorf("Expected service name '%s', got '%s'", tt.want, secretName)
+		}
+	}
+}


### PR DESCRIPTION
This is done by making `link` always "inject" a secret into the
DeploymentConfig of the source component.
In the case of services, the secret is created indirectly via the
ServiceBinding (this was implemented in #723).
In the case of components, the secret is created when when we create
the component. In such cases on secret is created per exposed port.

Fixes: #652 (see [this](https://github.com/redhat-developer/odo/issues/652#issuecomment-431317769) and [this](https://github.com/redhat-developer/odo/issues/652#issuecomment-431452720))

To test the changes:

For component to component linking:
1. Create a backend application
2. Create a frontend application
3. `odo link --to-component backend`
4. Exec into the frontend pod and make sure `COMPONENT_BACKEND_HOST=backend-app`

For component to service linking:
Follow the same instructions that were used to test the existing component-to-service linking functionality. The only thing that changes in this case is that now `--to-service` needs to be supplied to `odo link`

The changes here are orthogonal to the ones in #847. There will probably need to be a PR rebase for whichever one is merged second :)
