### PR TITLE
Split env vars only by the first `=` to allow for base64-encoded values

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2411,8 +2411,8 @@ func getInputEnvVarsFromStrings(envVars []string) ([]corev1.EnvVar, error) {
 	var inputEnvVars []corev1.EnvVar
 	var keys = make(map[string]int)
 	for _, env := range envVars {
-		splits := strings.Split(env, "=")
-		if len(splits) < 2 || len(splits) > 2 {
+		splits := strings.SplitN(env, "=", 2)
+		if len(splits) < 2 {
 			return nil, errors.New("invalid syntax for env, please specify a VariableName=Value pair")
 		}
 		_, ok := keys[splits[0]]

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -3506,12 +3506,37 @@ func Test_getInputEnvVarsFromStrings(t *testing.T) {
 		{
 			name:    "Test case 4: one env var with multiple values",
 			envVars: []string{"key=value", "key1=value1=value2"},
-			wantErr: true,
+			wantedEnvVars: []corev1.EnvVar{
+				{
+					Name:  "key",
+					Value: "value",
+				},
+				{
+					Name:  "key1",
+					Value: "value1=value2",
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name:    "Test case 5: two env var with same key",
 			envVars: []string{"key=value", "key=value1"},
 			wantErr: true,
+		},
+		{
+			name:    "Test case 6: one env var with base64 encoded value",
+			envVars: []string{"key=value", "key1=SSd2ZSBnb3QgYSBsb3ZlbHkgYnVuY2ggb2YgY29jb251dHMhCg=="},
+			wantedEnvVars: []corev1.EnvVar{
+				{
+					Name:  "key",
+					Value: "value",
+				},
+				{
+					Name:  "key1",
+					Value: "SSd2ZSBnb3QgYSBsb3ZlbHkgYnVuY2ggb2YgY29jb251dHMhCg==",
+				},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?

In order to allow base64 encoded environment variables, only the first encountered `=` is used for the string split. This has the side-effect of reading in `key1=value1=value2` as `{"key1": "value1=value2"}`, but does allow, for example, ssh keys to be passed in as env vars.

Was the change discussed in an issue?
No

How to test changes?
make test