### PR TITLE
Fix broken odo version for Openshift 3.11

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2210,7 +2210,7 @@ func (c *Client) GetServerVersion() (*serverInfo, error) {
 	}
 
 	// This will fetch the information about OpenShift Version
-	rawOpenShiftVersion, err := c.kubeClient.CoreV1().RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
+	rawOpenShiftVersion, err := c.kubeClient.CoreV1().RESTClient().Get().AbsPath("/version").Do().Raw()
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get OpenShift Version")
 	}


### PR DESCRIPTION
What is the purpose of this change? What does it change?

This PR addresses the broken `odo version` command for Openshift 3.11

Was the change discussed in an issue?

Fixes: #872

How to test changes?

Simply execute `odo version` against both an Openshift `3.9`, `3.10` and an `3.11` cluster.
The versions information should be displayed for both 
