### PR TITLE
Move getOcClient and checkError to pkg/odo/util.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ odo
 dist
 bin
 
+# Un-ignore odo directories
+!odo/
+
 # Ignore coverage report
 coverage.txt
 

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/olekukonko/tablewriter"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -45,9 +46,9 @@ var catalogListComponentCmd = &cobra.Command{
   odo catalog search component nodejs
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		catalogList, err := catalog.List(client)
-		checkError(err, "unable to list components")
+		util.CheckError(err, "unable to list components")
 		switch len(catalogList) {
 		case 0:
 			fmt.Printf("No deployable components found\n")
@@ -89,9 +90,9 @@ var catalogListServiceCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		catalogList, err := svc.ListCatalog(client)
-		checkError(err, "unable to list services because Service Catalog is not enabled in your cluster")
+		util.CheckError(err, "unable to list services because Service Catalog is not enabled in your cluster")
 		switch len(catalogList) {
 		case 0:
 			fmt.Printf("No deployable services found\n")
@@ -136,10 +137,10 @@ components.
   odo catalog search component python
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		searchTerm := args[0]
 		components, err := catalog.Search(client, searchTerm)
-		checkError(err, "unable to search for components")
+		util.CheckError(err, "unable to search for components")
 
 		switch len(components) {
 		case 0:
@@ -166,10 +167,10 @@ services from service catalog.
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		searchTerm := args[0]
 		components, err := svc.Search(client, searchTerm)
-		checkError(err, "unable to search for services")
+		util.CheckError(err, "unable to search for services")
 
 		switch len(components) {
 		case 0:
@@ -208,10 +209,10 @@ This describes the service and the associated plans.
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		serviceName := args[0]
 		service, plans, err := svc.GetServiceClassAndPlans(client, serviceName)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)

--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/posener/complete"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	"os"
 	"strings"
@@ -79,7 +80,7 @@ func printDeleteAppInfo(client *occlient.Client, appName string, currentProject 
 func getComponent(client *occlient.Client, inputComponent string, applicationName string, projectName string) string {
 	if len(inputComponent) == 0 {
 		c, err := component.GetCurrent(client, applicationName, projectName)
-		checkError(err, "Could not get current component")
+		util.CheckError(err, "Could not get current component")
 		if c == "" {
 			fmt.Println("There is no component set")
 			os.Exit(1)
@@ -87,7 +88,7 @@ func getComponent(client *occlient.Client, inputComponent string, applicationNam
 		return c
 	}
 	exists, err := component.Exists(client, inputComponent, applicationName, projectName)
-	checkError(err, "")
+	util.CheckError(err, "")
 	if !exists {
 		fmt.Printf("Component %v does not exist\n", inputComponent)
 		os.Exit(1)
@@ -149,7 +150,7 @@ func printMountedStorageInComponent(client *occlient.Client, componentName strin
 	fmt.Fprintln(tabWriterMounted, "NAME", "\t", "SIZE", "\t", "PATH")
 
 	storageListMounted, err := storage.ListMounted(client, componentName, applicationName)
-	checkError(err, "could not get mounted storage list")
+	util.CheckError(err, "could not get mounted storage list")
 
 	// iterating over all mounted storage and put in the mount storage table
 	if len(storageListMounted) > 0 {
@@ -169,7 +170,7 @@ func printMountedStorageInComponent(client *occlient.Client, componentName strin
 // printMountedStorageInAllComponent prints all the mounted storage in all the components of the application and project
 func printMountedStorageInAllComponent(client *occlient.Client, applicationName string, projectName string) {
 	componentList, err := component.List(client, applicationName, projectName)
-	checkError(err, "could not get component list")
+	util.CheckError(err, "could not get component list")
 
 	// iterating over all the components in the given aplication and project
 	for _, component := range componentList {
@@ -187,7 +188,7 @@ func printUnmountedStorage(client *occlient.Client, applicationName string) {
 	fmt.Fprintln(tabWriterUnmounted, "NAME", "\t", "SIZE")
 
 	storageListUnmounted, err := storage.ListUnmounted(client, applicationName)
-	checkError(err, "could not get unmounted storage list")
+	util.CheckError(err, "could not get unmounted storage list")
 
 	// iterating over all unmounted storage and put in the unmount storage table
 	if len(storageListUnmounted) > 0 {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"io"
 	"os"
 
@@ -140,7 +141,7 @@ Auto completion supports both bash and zsh. Output is to STDOUT.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		err := Generate(cmd, args)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		return nil
 	},

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 
 	"github.com/golang/glog"
@@ -39,13 +40,13 @@ var componentGetCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		glog.V(4).Infof("component get called")
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		component, err := component.GetCurrent(client, applicationName, projectName)
-		checkError(err, "unable to get current component")
+		util.CheckError(err, "unable to get current component")
 		if componentShortFlag {
 			fmt.Print(component)
 		} else {
@@ -67,20 +68,20 @@ var componentSetCmd = &cobra.Command{
   `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		exists, err := component.Exists(client, args[0], applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if !exists {
 			fmt.Printf("Component %s does not exist in the current application\n", args[0])
 			os.Exit(1)
 		}
 
 		err = component.SetCurrent(client, args[0], applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		fmt.Printf("Switched to component: %v\n", args[0])
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 
@@ -28,11 +29,11 @@ var componentDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		glog.V(4).Infof("component delete called")
 		glog.V(4).Infof("args: %#v", strings.Join(args, " "))
-		client := getOcClient()
+		client := util.GetOcClient()
 
 		// Get all necessary names (current application + project)
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		// Get the current component if no arguments have been passed
@@ -48,7 +49,7 @@ var componentDeleteCmd = &cobra.Command{
 
 			// Checks to see if the component actually exists
 			exists, err := component.Exists(client, componentName, applicationName, projectName)
-			checkError(err, "")
+			util.CheckError(err, "")
 			if !exists {
 				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
 				os.Exit(1)
@@ -65,11 +66,11 @@ var componentDeleteCmd = &cobra.Command{
 
 		if strings.ToLower(confirmDeletion) == "y" {
 			err := component.Delete(client, componentName, applicationName, projectName)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fmt.Printf("Component %s from application %s has been deleted\n", componentName, applicationName)
 
 			currentComponent, err := component.GetCurrent(client, applicationName, projectName)
-			checkError(err, "Unable to get current component")
+			util.CheckError(err, "Unable to get current component")
 
 			if currentComponent == "" {
 				fmt.Println("No default component has been set")

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 
 	"github.com/redhat-developer/odo/pkg/application"
@@ -19,22 +20,22 @@ var describeCmd = &cobra.Command{
 	`,
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		// Application
 		currentApplication, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		// Project
 		currentProject := project.GetCurrent(client)
 		var currentComponent string
 		if len(args) == 0 {
 			var err error
 			currentComponent, err = component.GetCurrent(client, currentApplication, currentProject)
-			checkError(err, "")
+			util.CheckError(err, "")
 		} else {
 			currentComponent = args[0]
 			//Check whether component exist or not
 			exists, err := component.Exists(client, currentComponent, currentApplication, currentProject)
-			checkError(err, "")
+			util.CheckError(err, "")
 			if !exists {
 				fmt.Printf("component with the name %s does not exist\n", currentComponent)
 				os.Exit(1)
@@ -42,7 +43,7 @@ var describeCmd = &cobra.Command{
 		}
 
 		componentType, path, componentURL, appStore, err := component.GetComponentDesc(client, currentComponent, currentApplication, currentProject)
-		checkError(err, "")
+		util.CheckError(err, "")
 		printComponentInfo(currentComponent, componentType, path, componentURL, appStore)
 	},
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 
 	"github.com/redhat-developer/odo/pkg/application"
@@ -34,23 +35,23 @@ is injected into the component.
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		componentName := getComponent(client, linkComponent, applicationName, projectName)
 		serviceName := args[0]
 
 		exists, err := component.Exists(client, componentName, applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if !exists {
 			fmt.Printf("Component %v does not exist\n", componentName)
 			os.Exit(1)
 		}
 
 		exists, err = svc.SvcExists(client, serviceName, applicationName, projectName)
-		checkError(err, "Unable to determine if service %s exists within the current namespace", serviceName)
+		util.CheckError(err, "Unable to determine if service %s exists within the current namespace", serviceName)
 		if !exists {
 			fmt.Printf(`Service %s does not exist within the current namespace.
 Please perform 'odo service create %s ...' before attempting to link the service.`, serviceName, serviceName)
@@ -68,7 +69,7 @@ If not, then please delete the service and recreate it using 'odo service create
 		}
 
 		err = client.LinkSecret(serviceName, componentName, applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		fmt.Printf("Service %s has been successfully linked to the component %s.\n", serviceName, applicationName)
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"text/tabwriter"
 
@@ -20,14 +21,14 @@ var componentListCmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		currentComponent, err := component.GetCurrent(client, applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		components, err := component.List(client, applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		if len(components) == 0 {
 			fmt.Println("There are no components deployed.")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 
 	"github.com/redhat-developer/odo/pkg/application"
@@ -27,11 +28,11 @@ var logCmd = &cobra.Command{
 		stdout := os.Stdout
 
 		// Retrieve the client
-		client := getOcClient()
+		client := util.GetOcClient()
 
 		// Application
 		currentApplication, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		// Project
 		currentProject := project.GetCurrent(client)
@@ -47,7 +48,7 @@ var logCmd = &cobra.Command{
 
 		// Retrieve the log
 		err = component.GetLogs(client, currentComponent, currentApplication, logFollow, stdout)
-		checkError(err, "Unable to retrieve logs, does your component exist?")
+		util.CheckError(err, "Unable to retrieve logs, does your component exist?")
 	},
 }
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 
@@ -45,18 +46,18 @@ var projectSetCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
-		client := getOcClient()
+		client := util.GetOcClient()
 		current := project.GetCurrent(client)
 
 		exists, err := project.Exists(client, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if !exists {
 			fmt.Printf("The project %s does not exist\n", projectName)
 			os.Exit(1)
 		}
 
 		err = project.SetCurrent(client, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if projectShortFlag {
 			fmt.Print(projectName)
 		} else {
@@ -78,7 +79,7 @@ var projectGetCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		project := project.GetCurrent(client)
 
 		if projectShortFlag {
@@ -99,11 +100,11 @@ var projectCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
-		client := getOcClient()
+		client := util.GetOcClient()
 		err := project.Create(client, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		err = project.SetCurrent(client, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		fmt.Printf("New project created and now using project : %v\n", projectName)
 	},
 }
@@ -118,11 +119,11 @@ var projectDeleteCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
-		client := getOcClient()
+		client := util.GetOcClient()
 
 		// Validate existence of the project to be deleted
 		isValidProject, err := project.Exists(client, projectName)
-		checkError(err, "Failed to delete project %s", projectName)
+		util.CheckError(err, "Failed to delete project %s", projectName)
 		if !isValidProject {
 			fmt.Printf("The project %s does not exist. Please check the list of projects using `odo project list`\n", projectName)
 			os.Exit(1)
@@ -144,7 +145,7 @@ var projectDeleteCmd = &cobra.Command{
 		fmt.Printf("Deleting project %s...\n(this operation may take some time)\n", projectName)
 		err = project.Delete(client, projectName)
 		if err != nil {
-			checkError(err, "")
+			util.CheckError(err, "")
 		}
 		fmt.Printf("Deleted project : %v\n", projectName)
 
@@ -154,7 +155,7 @@ var projectDeleteCmd = &cobra.Command{
 		// Check if List returns empty, if so, the currProject is showing old currentProject
 		// In openshift, when the project is deleted, it does not reset the current project in kube config file which is used by odo for current project
 		projects, err := project.List(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if len(projects) != 0 {
 			fmt.Printf("%s has been set as the active project\n", currProject)
 		} else {
@@ -174,9 +175,9 @@ var projectListCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		projects, err := project.List(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if len(projects) == 0 {
 			fmt.Println("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command")
 			return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,20 +3,12 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
-
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/notify"
-	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-)
-
-// Global variables
-var (
-	GlobalSkipConnectionCheck bool
 )
 
 // Templates
@@ -108,13 +100,13 @@ func Execute() {
 	// before proceeding with fetching the latest version
 	cfg, err := config.New()
 	if err != nil {
-		checkError(err, "")
+		util.CheckError(err, "")
 	}
 	if cfg.GetUpdateNotification() == true {
 		updateInfo := make(chan string)
 		go getLatestReleaseInfo(updateInfo)
 
-		checkError(rootCmd.Execute(), "")
+		util.CheckError(rootCmd.Execute(), "")
 		select {
 		case message := <-updateInfo:
 			fmt.Println(message)
@@ -122,7 +114,7 @@ func Execute() {
 			glog.V(4).Info("Could not get the latest release information in time. Never mind, exiting gracefully :)")
 		}
 	} else {
-		checkError(rootCmd.Execute(), "")
+		util.CheckError(rootCmd.Execute(), "")
 	}
 
 }
@@ -133,7 +125,7 @@ func init() {
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
-	rootCmd.PersistentFlags().BoolVar(&GlobalSkipConnectionCheck, "skip-connection-check", false, "Skip cluster check")
+	rootCmd.PersistentFlags().BoolVar(&util.GlobalSkipConnectionCheck, "skip-connection-check", false, "Skip cluster check")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.Set("logtostderr", "true")
 
@@ -161,28 +153,5 @@ func getLatestReleaseInfo(info chan<- string) {
 			"---\n" +
 			"If you wish to disable the update notifications, you can disable it by running\n" +
 			"'odo utils config set UpdateNotification false'\n"
-	}
-}
-
-func getOcClient() *occlient.Client {
-	client, err := occlient.New(GlobalSkipConnectionCheck)
-	checkError(err, "")
-	return client
-}
-
-// checkError prints the cause of the given error and exits the code with an
-// exit code of 1.
-// If the context is provided, then that is printed, if not, then the cause is
-// detected using errors.Cause(err)
-func checkError(err error, context string, a ...interface{}) {
-	if err != nil {
-		glog.V(4).Infof("Error:\n%v", err)
-		if context == "" {
-			fmt.Println(errors.Cause(err))
-		} else {
-			fmt.Printf(fmt.Sprintf("%s\n", context), a...)
-		}
-
-		os.Exit(1)
 	}
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/posener/complete"
 	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -48,15 +49,15 @@ A full list of service types that can be deployed are available using: 'odo cata
 	`,
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrentOrGetCreateSetDefault(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		// make sure the service type exists
 		serviceType := args[0]
 		matchingService, err := svc.GetSvcByType(client, serviceType)
-		checkError(err, "unable to create service because Service Catalog is not enabled in your cluster")
+		util.CheckError(err, "unable to create service because Service Catalog is not enabled in your cluster")
 		if matchingService == nil {
 			fmt.Printf("Service %v doesn't exist\nRun 'odo service catalog' to see a list of supported services.\n", serviceType)
 			os.Exit(1)
@@ -94,15 +95,15 @@ A full list of service types that can be deployed are available using: 'odo cata
 		}
 		//validate service name
 		err = validateName(serviceName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		exists, err := svc.SvcExists(client, serviceName, applicationName, projectName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		if exists {
 			fmt.Printf("%s service already exists in the current application.\n", serviceName)
 			os.Exit(1)
 		}
 		err = svc.CreateService(client, serviceName, serviceType, plan, parameters, applicationName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		fmt.Printf("Service '%s' was created.\n", serviceName)
 	},
 }
@@ -119,17 +120,17 @@ var serviceDeleteCmd = &cobra.Command{
 
 		glog.V(4).Infof("service delete called\n args: %#v", strings.Join(args, " "))
 
-		client := getOcClient()
+		client := util.GetOcClient()
 
 		// Get all necessary names (current application + project)
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		serviceName := args[0]
 
 		// Checks to see if the service actually exists
 		exists, err := svc.SvcExists(client, serviceName, applicationName, projectName)
-		checkError(err, "unable to delete service because Service Catalog is not enabled in your cluster")
+		util.CheckError(err, "unable to delete service because Service Catalog is not enabled in your cluster")
 		if !exists {
 			fmt.Printf("Service with the name %s does not exist in the current application\n", serviceName)
 			os.Exit(1)
@@ -145,7 +146,7 @@ var serviceDeleteCmd = &cobra.Command{
 
 		if strings.ToLower(confirmDeletion) == "y" {
 			err := svc.DeleteService(client, serviceName, applicationName)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fmt.Printf("Service %s from application %s has been deleted\n", serviceName, applicationName)
 
 		} else {
@@ -163,12 +164,12 @@ var serviceListCmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		services, err := svc.List(client, applicationName, projectName)
-		checkError(err, "Service Catalog is not enabled in your cluster")
+		util.CheckError(err, "Service Catalog is not enabled in your cluster")
 
 		if len(services) == 0 {
 			fmt.Println("There are no services deployed for this application")
@@ -191,7 +192,7 @@ func init() {
 
 	Suggesters[GetCommandSuggesterName(serviceCreateCmd)] = completionHandler{
 		client: func() *occlient.Client {
-			return getOcClient()
+			return util.GetOcClient()
 		},
 		predictor: func(args complete.Args, client *occlient.Client) (completions []string) {
 			completions = make([]string, 0)
@@ -210,7 +211,7 @@ func init() {
 
 	Suggesters[GetCommandSuggesterName(serviceDeleteCmd)] = completionHandler{
 		client: func() *occlient.Client {
-			return getOcClient()
+			return util.GetOcClient()
 		},
 		predictor: func(args complete.Args, client *occlient.Client) (completions []string) {
 			completions = make([]string, 0)

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	util2 "github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 
@@ -40,9 +41,9 @@ var storageCreateCmd = &cobra.Command{
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util2.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		componentName := getComponent(client, storageComponent, applicationName, projectName)
 		var storageName string
@@ -53,10 +54,10 @@ var storageCreateCmd = &cobra.Command{
 		}
 		// validate storage path
 		err = validateStoragePath(client, storagePath, componentName, applicationName)
-		checkError(err, "")
+		util2.CheckError(err, "")
 
 		_, err = storage.Create(client, storageName, storageSize, storagePath, componentName, applicationName)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		fmt.Printf("Added storage %v to %v\n", storageName, componentName)
 	},
 }
@@ -82,9 +83,9 @@ var storageUnmountCmd = &cobra.Command{
 	Aliases: []string{"umount"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util2.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		componentName := getComponent(client, storageComponent, applicationName, projectName)
 
@@ -93,7 +94,7 @@ var storageUnmountCmd = &cobra.Command{
 		if string(args[0][0]) == "/" {
 			path := args[0]
 			storageName, err = storage.GetStorageNameFromMountPath(client, path, componentName, applicationName)
-			checkError(err, "Unable to get storage name from mount path")
+			util2.CheckError(err, "Unable to get storage name from mount path")
 			if storageName == "" {
 				fmt.Printf("No storage is mounted to %s in the component %s\n", path, componentName)
 				os.Exit(1)
@@ -101,7 +102,7 @@ var storageUnmountCmd = &cobra.Command{
 		} else {
 			storageName = args[0]
 			exists, err := storage.IsMounted(client, storageName, componentName, applicationName)
-			checkError(err, "Unable to check if storage is mounted or not")
+			util2.CheckError(err, "Unable to check if storage is mounted or not")
 			if !exists {
 				fmt.Printf("Storage %v does not exist in component %v\n", storageName, componentName)
 				os.Exit(1)
@@ -109,7 +110,7 @@ var storageUnmountCmd = &cobra.Command{
 		}
 
 		err = storage.Unmount(client, storageName, componentName, applicationName, true)
-		checkError(err, "Unable to unmount storage %v from component %v", storageName, componentName)
+		util2.CheckError(err, "Unable to unmount storage %v from component %v", storageName, componentName)
 
 		fmt.Printf("Unmounted storage %v from %v\n", storageName, componentName)
 	},
@@ -126,13 +127,13 @@ var storageDeleteCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util2.GetOcClient()
 
 		storageName := args[0]
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		exists, err := storage.Exists(client, storageName, applicationName)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		if !exists {
 
 			fmt.Printf("The storage %v does not exists in the application %v\n", storageName, applicationName)
@@ -141,7 +142,7 @@ var storageDeleteCmd = &cobra.Command{
 
 		componentName, err := storage.GetComponentNameFromStorageName(client, storageName)
 		if err != nil {
-			checkError(err, "Unable to get component associated with %s storage.", storageName)
+			util2.CheckError(err, "Unable to get component associated with %s storage.", storageName)
 		}
 
 		var confirmDeletion string
@@ -158,7 +159,7 @@ var storageDeleteCmd = &cobra.Command{
 		}
 		if strings.ToLower(confirmDeletion) == "y" {
 			componentName, err = storage.Delete(client, storageName, applicationName)
-			checkError(err, "failed to delete storage")
+			util2.CheckError(err, "failed to delete storage")
 			if componentName != "" {
 				fmt.Printf("Deleted storage %v from %v\n", storageName, componentName)
 			} else {
@@ -180,9 +181,9 @@ var storageListCmd = &cobra.Command{
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util2.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		if storageAllListflag {
 			if storageComponent != "" {
@@ -209,28 +210,28 @@ var storageMountCmd = &cobra.Command{
   odo storage mount database --component mongodb --path /data`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util2.GetOcClient()
 
 		storageName := args[0]
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 		componentName := getComponent(client, storageComponent, applicationName, projectName)
 
 		exists, err := storage.Exists(client, storageName, applicationName)
-		checkError(err, "unable to check if the storage exists in the current application")
+		util2.CheckError(err, "unable to check if the storage exists in the current application")
 		if !exists {
 			fmt.Printf("The storage %v does not exists in the current application '%v'", storageName, applicationName)
 			os.Exit(1)
 		}
 		isMounted, err := storage.IsMounted(client, storageName, componentName, applicationName)
-		checkError(err, "unable to check if the component is already mounted or not")
+		util2.CheckError(err, "unable to check if the component is already mounted or not")
 		if isMounted {
 			fmt.Printf("The storage %v is already mounted on the current component '%v'\n", storageName, componentName)
 			os.Exit(1)
 		}
 		err = storage.Mount(client, storagePath, storageName, componentName, applicationName)
-		checkError(err, "")
+		util2.CheckError(err, "")
 		fmt.Printf("The storage %v is successfully mounted to the current component '%v'\n", storageName, componentName)
 	},
 }

--- a/cmd/terminal.go
+++ b/cmd/terminal.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"io"
 	"os"
 
@@ -24,7 +25,7 @@ This will append your PS1 environment variable with Odo component and applicatio
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		err := TerminalGenerate(os.Stdout, cmd, args)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		return nil
 	},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"path/filepath"
 
@@ -33,9 +34,9 @@ var updateCmd = &cobra.Command{
   odo update wildfly --binary ./downloads/sample.war
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		stdout := color.Output
@@ -62,10 +63,10 @@ var updateCmd = &cobra.Command{
 		)
 		if len(args) == 0 {
 			componentName, err = component.GetCurrent(client, applicationName, projectName)
-			checkError(err, "unable to get current component")
+			util.CheckError(err, "unable to get current component")
 			if len(componentName) == 0 {
 				appList, err := application.List(client)
-				checkError(err, "")
+				util.CheckError(err, "")
 				if len(appList) == 0 {
 					fmt.Println("Cannot update as no application exists in the current project")
 					os.Exit(1)
@@ -74,7 +75,7 @@ var updateCmd = &cobra.Command{
 		} else {
 			componentName = args[0]
 			exists, err := component.Exists(client, componentName, applicationName, projectName)
-			checkError(err, "")
+			util.CheckError(err, "")
 			if !exists {
 				fmt.Printf("Component with name %s does not exist in the current application\n", componentName)
 				os.Exit(1)
@@ -88,26 +89,26 @@ var updateCmd = &cobra.Command{
 
 		if len(componentGit) != 0 {
 			err := component.Update(client, componentName, applicationName, "git", componentGit, stdout)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs(componentLocal)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fileInfo, err := os.Stat(dir)
-			checkError(err, "")
+			util.CheckError(err, "")
 			if !fileInfo.IsDir() {
 				fmt.Println("Please provide a path to the directory")
 				os.Exit(1)
 			}
 			err = component.Update(client, componentName, applicationName, "local", dir, stdout)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fmt.Printf("The component %s was updated successfully, please use 'odo push' to push your local changes\n", componentName)
 		} else if len(componentBinary) != 0 {
 			path, err := filepath.Abs(componentBinary)
-			checkError(err, "")
+			util.CheckError(err, "")
 			err = component.Update(client, componentName, applicationName, "binary", path, stdout)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fmt.Printf("The component %s was updated successfully, please use 'odo push' to push your local changes\n", componentName)
 		}
 	},

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 
@@ -52,9 +53,9 @@ The created URL can be used to access the specified component from outside the O
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 		projectName := project.GetCurrent(client)
 
 		var app string
@@ -62,10 +63,10 @@ The created URL can be used to access the specified component from outside the O
 
 		if urlApplication == "" {
 			app, err = application.GetCurrent(client)
-			checkError(err, "")
+			util.CheckError(err, "")
 		} else {
 			exists, err := application.Exists(client, urlApplication)
-			checkError(err, "unable to check if the application exists or not")
+			util.CheckError(err, "unable to check if the application exists or not")
 			if !exists {
 				fmt.Printf("The application %s does not exists in the project %s\n", urlApplication, projectName)
 				os.Exit(1)
@@ -94,7 +95,7 @@ The created URL can be used to access the specified component from outside the O
 
 		fmt.Printf("Adding URL to component: %v\n", componentName)
 		urlRoute, err := url.Create(client, urlName, urlPort, componentName, applicationName)
-		checkError(err, "")
+		util.CheckError(err, "")
 		fmt.Printf("URL created for component: %v\n\n"+
 			"%v - %v\n", componentName, urlRoute.Name, url.GetUrlString(*urlRoute))
 	},
@@ -111,17 +112,17 @@ var urlDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// Initialization
-		client := getOcClient()
+		client := util.GetOcClient()
 		projectName := project.GetCurrent(client)
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		componentName := getComponent(client, urlComponent, applicationName, projectName)
 
 		urlName := args[0]
 
 		exists, err := url.Exists(client, urlName, componentName, applicationName)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		if !exists {
 			fmt.Printf("The URL %s does not exist within the component %s\n", urlName, componentName)
@@ -139,7 +140,7 @@ var urlDeleteCmd = &cobra.Command{
 		if strings.ToLower(confirmDeletion) == "y" {
 
 			err = url.Delete(client, urlName, applicationName)
-			checkError(err, "")
+			util.CheckError(err, "")
 			fmt.Printf("Deleted URL: %v\n", urlName)
 		} else {
 			fmt.Printf("Aborting deletion of url: %v\n", urlName)
@@ -156,7 +157,7 @@ var urlListCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
+		client := util.GetOcClient()
 		projectName := project.GetCurrent(client)
 
 		var app string
@@ -164,10 +165,10 @@ var urlListCmd = &cobra.Command{
 
 		if urlApplication == "" {
 			app, err = application.GetCurrent(client)
-			checkError(err, "")
+			util.CheckError(err, "")
 		} else {
 			exists, err := application.Exists(client, urlApplication)
-			checkError(err, "unable to check if the application exists or not")
+			util.CheckError(err, "unable to check if the application exists or not")
 			if !exists {
 				fmt.Printf("The application %s does not exists in the project %s\n", urlApplication, projectName)
 				os.Exit(1)
@@ -178,7 +179,7 @@ var urlListCmd = &cobra.Command{
 		componentName := getComponent(client, urlComponent, app, projectName)
 
 		urls, err := url.List(client, componentName, app)
-		checkError(err, "")
+		util.CheckError(err, "")
 
 		if len(urls) == 0 {
 			fmt.Printf("No URLs found for component %v in application %v\n", componentName, app)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 
@@ -40,10 +41,10 @@ var versionCmd = &cobra.Command{
 		fmt.Println("odo " + VERSION + " (" + GITCOMMIT + ")")
 
 		// turning off the flag which checks for login status
-		GlobalSkipConnectionCheck = true
+		util.GlobalSkipConnectionCheck = true
 		// Lets fetch the info about the server
-		serverInfo, err := getOcClient().GetServerVersion()
-		checkError(err, "")
+		serverInfo, err := util.GetOcClient().GetServerVersion()
+		util.CheckError(err, "")
 		fmt.Printf("\n"+
 			"Server: %v\n"+
 			"OpenShift: %v\n"+

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	util2 "github.com/redhat-developer/odo/pkg/odo/util"
 	"net/url"
 	"os"
 	"runtime"
@@ -33,17 +34,17 @@ var watchCmd = &cobra.Command{
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		stdout := os.Stdout
-		client := getOcClient()
+		client := util2.GetOcClient()
 		projectName := project.GetCurrent(client)
 		applicationName, err := application.GetCurrent(client)
-		checkError(err, "Unable to get current application.")
+		util2.CheckError(err, "Unable to get current application.")
 
 		var componentName string
 		if len(args) == 0 {
 			var err error
 			glog.V(4).Info("No component name passed, assuming current component")
 			componentName, err = component.GetCurrent(client, applicationName, projectName)
-			checkError(err, "")
+			util2.CheckError(err, "")
 			if componentName == "" {
 				fmt.Println("No component is set as active.")
 				fmt.Println("Use 'odo component set <component name> to set and existing component as active or call this command with component name as and argument.")
@@ -54,7 +55,7 @@ var watchCmd = &cobra.Command{
 		}
 
 		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName, projectName)
-		checkError(err, "Unable to get source for %s component.", componentName)
+		util2.CheckError(err, "Unable to get source for %s component.", componentName)
 
 		if sourceType != "binary" && sourceType != "local" {
 			fmt.Printf("Watch is supported by binary and local components only and source type of component %s is %s\n", componentName, sourceType)
@@ -62,7 +63,7 @@ var watchCmd = &cobra.Command{
 		}
 
 		u, err := url.Parse(sourcePath)
-		checkError(err, "Unable to parse source %s from component %s.", sourcePath, componentName)
+		util2.CheckError(err, "Unable to parse source %s from component %s.", sourcePath, componentName)
 
 		if u.Scheme != "" && u.Scheme != "file" {
 			fmt.Printf("Component %s has invalid source path %s.", componentName, u.Scheme)
@@ -71,7 +72,7 @@ var watchCmd = &cobra.Command{
 		watchPath := util.ReadFilePath(u, runtime.GOOS)
 
 		err = component.WatchAndPush(client, componentName, applicationName, watchPath, stdout, ignores, delay)
-		checkError(err, "Error while trying to watch %s", watchPath)
+		util2.CheckError(err, "Error while trying to watch %s", watchPath)
 	},
 }
 

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"os"
+)
+
+// GetOcClient creates a client to connect to OpenShift cluster
+func GetOcClient() *occlient.Client {
+	client, err := occlient.New(GlobalSkipConnectionCheck)
+	CheckError(err, "")
+	return client
+}
+
+// CheckError prints the cause of the given error and exits the code with an
+// exit code of 1.
+// If the context is provided, then that is printed, if not, then the cause is
+// detected using errors.Cause(err)
+func CheckError(err error, context string, a ...interface{}) {
+	if err != nil {
+		glog.V(4).Infof("Error:\n%v", err)
+		if context == "" {
+			fmt.Println(errors.Cause(err))
+		} else {
+			fmt.Printf(fmt.Sprintf("%s\n", context), a...)
+		}
+
+		os.Exit(1)
+	}
+}
+
+// Global variables
+var (
+	GlobalSkipConnectionCheck bool
+)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
Incremental change to make it easier to keep work done for #871 in sync with `master` by moving some utility functions to `pkg/odo/util` where they should be according to `oc` conventions.

Was the change discussed in an issue?
Mentioned in #871.

How to test changes?
`make test`