### PR TITLE
update supervisord image to use v0.2.0

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -63,7 +63,7 @@ const (
 	nameLength = 5
 
 	// Image that will be used containing the supervisord binary and assembly scripts
-	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.1.0"
+	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.2.0"
 
 	// Create a custom name and (hope) that users don't use the *exact* same name in their deployment
 	supervisordVolumeName = "odo-supervisord-shared-data"


### PR DESCRIPTION
What is the purpose of this change? What does it change?

this pr will update supervisord image to use v0.2.0
which will fix issue #840 

Was the change discussed in an issue?
#840 
How to test changes?
build this pr or download binary from the  AppVeyor build artifacts [here](https://ci.appveyor.com/project/kadel/odo/builds/19935811/artifacts) and try deploying the example code mentioned in issue #840 
and validate if the stderr logs are being shown on `./odo logs`