### PR TITLE
Fix #903: rewrite completion handler key generation to avoid collisions.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "odo",
+	Use:   util.RootCommandName,
 	Short: "Odo (Openshift Do)",
 	Long: `Odo (OpenShift Do) is a CLI tool for running OpenShift applications in a fast and automated matter. Odo reduces the complexity of deployment by adding iterative development without the worry of deploying your source code.
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -196,9 +196,6 @@ func init() {
 	serviceCreateCmd.Flags().StringVar(&plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringSliceVarP(&parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")
 
-	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
-	completion.RegisterCommandHandler(serviceDeleteCmd, completion.ServiceCompletionHandler)
-
 	// Add a defined annotation in order to appear in the help menu
 	serviceCmd.Annotations = map[string]string{"command": "other"}
 	serviceCmd.SetUsageTemplate(cmdUsageTemplate)
@@ -217,4 +214,8 @@ func init() {
 	addApplicationFlag(serviceListCmd)
 
 	rootCmd.AddCommand(serviceCmd)
+
+	// completions need to be registered after the command is inserted in the command hierarchy
+	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
+	completion.RegisterCommandHandler(serviceDeleteCmd, completion.ServiceCompletionHandler)
 }

--- a/docs/completion-architecture.md
+++ b/docs/completion-architecture.md
@@ -49,6 +49,10 @@ argument completion handler or using
 a flag completion handler. Registering the completion handler will make it available for `main.createCompletion` which will 
 then automatically create the completion information from it.
 
+*NOTE*: completion handlers *MUST* be registered after the command (and its parents) is inserted in the command hierarchy 
+(i.e. we can walk from the command back to the root command) for the registration to happen properly. Failure to do so will 
+result in the app exiting during the registration process (as a failsafe to avoid collisions during the registration process).
+
 ## Enabling / disabling completion
 
 While the completion code is written in go, we still need some integration at the shell level so that the executing shell knows

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 )
 
+// RootCommandName is the name of the root command
 const RootCommandName = "odo"
 
 // Global variables

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -11,6 +11,8 @@ import (
 	"os"
 )
 
+const RootCommandName = "odo"
+
 // Global variables
 var (
 	GlobalSkipConnectionCheck bool

--- a/pkg/odo/util/completion/completion.go
+++ b/pkg/odo/util/completion/completion.go
@@ -1,10 +1,12 @@
 package completion
 
 import (
+	"fmt"
 	"github.com/posener/complete"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 type completionHandler struct {
@@ -25,20 +27,31 @@ func (ch completionHandler) Predict(args complete.Args) []string {
 // completionHandlers records available completion handlers for commands and flags
 var completionHandlers = make(map[string]completionHandler)
 
-// getCommandSuggesterName retrieves the completion handler identifier associated with the specified command. The associated
+// getCommandCompletionHandlerKey retrieves the completion handler identifier associated with the specified command. The associated
 // handler should provide completions for valid values for the specified command's arguments.
-func getCommandSuggesterName(command *cobra.Command) string {
-	return getCommandSuggesterNameFrom(command.Name())
+func getCommandCompletionHandlerKey(command *cobra.Command) (name string) {
+	current := command
+
+	// check if the command was properly registered after being inserted in the hierarchy
+	if current.Root().Name() != util.RootCommandName {
+		// if we're walking back this command hierarchy back to its root but the root doesn't match our defined root this means
+		// the command hierarchy hasn't been set yet
+		fmt.Printf("'%p' has not been inserted in the command hiearchy before registering a completion handler", command)
+		os.Exit(-1)
+	}
+
+	name = current.Name()
+	for current.HasParent() {
+		name = current.Parent().Name() + "_" + name
+		current = current.Parent()
+	}
+	return
 }
 
-func getCommandSuggesterNameFrom(commandName string) string {
-	return commandName
-}
-
-// getFlagSuggesterName retrieves the completion handler identifier associated with the specified command and flag name. The
+// getCommandFlagCompletionHandlerKey retrieves the completion handler identifier associated with the specified command and flag name. The
 // associated handler should provide completion for valid values for the specified command's flag.
-func getFlagSuggesterName(command *cobra.Command, flag string) string {
-	return getCommandSuggesterNameFrom(command.Name()) + "_" + flag
+func getCommandFlagCompletionHandlerKey(command *cobra.Command, flag string) string {
+	return getCommandCompletionHandlerKey(command) + "_" + flag
 }
 
 func newHandler(predictor ContextualizedPredictor) completionHandler {
@@ -50,23 +63,23 @@ func newHandler(predictor ContextualizedPredictor) completionHandler {
 
 // RegisterCommandHandler registers the provided ContextualizedPredictor as a completion handler for the specified command
 func RegisterCommandHandler(command *cobra.Command, predictor ContextualizedPredictor) {
-	completionHandlers[getCommandSuggesterName(command)] = newHandler(predictor)
+	completionHandlers[getCommandCompletionHandlerKey(command)] = newHandler(predictor)
 }
 
 // RegisterCommandFlagHandler registers the provided ContextualizedPredictor as a completion handler for the specified flag
 // of the specified command
 func RegisterCommandFlagHandler(command *cobra.Command, flag string, predictor ContextualizedPredictor) {
-	completionHandlers[getFlagSuggesterName(command, flag)] = newHandler(predictor)
+	completionHandlers[getCommandFlagCompletionHandlerKey(command, flag)] = newHandler(predictor)
 }
 
 // GetCommandHandler retrieves the command handler associated with the specified command or nil otherwise
 func GetCommandHandler(command *cobra.Command) (predictor complete.Predictor, ok bool) {
-	predictor, ok = completionHandlers[getCommandSuggesterName(command)]
+	predictor, ok = completionHandlers[getCommandCompletionHandlerKey(command)]
 	return
 }
 
 // GetCommandFlagHandler retrieves the command handler associated with the specified flag of the specified command or nil otherwise
 func GetCommandFlagHandler(command *cobra.Command, flag string) (predictor complete.Predictor, ok bool) {
-	predictor, ok = completionHandlers[getFlagSuggesterName(command, flag)]
+	predictor, ok = completionHandlers[getCommandFlagCompletionHandlerKey(command, flag)]
 	return
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?

The previous implementation only used the command's name as key which
wasn't enough. This implementation requires the command hierarchy to be
resolved before the registration process as the key is generated by
walking back to the root command. The implementation will exit with an
error message if registration happens before the hierarchy is set.

Was the change discussed in an issue?
#903 

How to test changes?
Before the change: `odo create <tab>` would result in showing service class names as completions. 
After the change: `odo create <tab>` properly doesn't show any completions while `odo service create <tab>` still shows the service class names as completions.