### PR TITLE
Open created url with --open

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -225,4 +227,25 @@ func SliceDifference(s1 []string, s2 []string) []string {
 		}
 	}
 	return difference
+}
+
+// OpenBrowser opens the URL within the users default browser
+func OpenBrowser(url string) error {
+	var err error
+
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This function adds the --open parameter to `odo url create`.

This will open the created link on the user's default browser.

To test:

```sh
odo create nodejs
odo url create --open
```

Closes https://github.com/redhat-developer/odo/issues/905