### PR TITLE
Fix #913: fix completion handler key generation.

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -215,7 +215,6 @@ func init() {
 
 	rootCmd.AddCommand(serviceCmd)
 
-	// completions need to be registered after the command is inserted in the command hierarchy
 	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
 	completion.RegisterCommandHandler(serviceDeleteCmd, completion.ServiceCompletionHandler)
 }

--- a/docs/completion-architecture.md
+++ b/docs/completion-architecture.md
@@ -49,10 +49,6 @@ argument completion handler or using
 a flag completion handler. Registering the completion handler will make it available for `main.createCompletion` which will 
 then automatically create the completion information from it.
 
-*NOTE*: completion handlers *MUST* be registered after the command (and its parents) is inserted in the command hierarchy 
-(i.e. we can walk from the command back to the root command) for the registration to happen properly. Failure to do so will 
-result in the app exiting during the registration process (as a failsafe to avoid collisions during the registration process).
-
 ## Enabling / disabling completion
 
 While the completion code is written in go, we still need some integration at the shell level so that the executing shell knows


### PR DESCRIPTION
It should now work even the command hierarchy is not complete and the
code is also simpler. Win! :)

What is the purpose of this change? What does it change?
Fix #913 

Was the change discussed in an issue?
#913 

How to test changes?
Completion should still work as before with the added bonus that completion handlers can now be registered as soon as the target command is created.