### PR TITLE
Change version command to tolerate missing possible /version/openshift

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -45,12 +45,18 @@ var versionCmd = &cobra.Command{
 		// Lets fetch the info about the server
 		serverInfo, err := util.GetOcClient().GetServerVersion()
 		util.CheckError(err, "")
+
+		// make sure we only include Openshift info if we actually have it
+		openshiftStr := ""
+		if len(serverInfo.OpenShiftVersion) > 0 {
+			openshiftStr = fmt.Sprintf("OpenShift: %v\n", serverInfo.OpenShiftVersion)
+		}
 		fmt.Printf("\n"+
 			"Server: %v\n"+
-			"OpenShift: %v\n"+
+			"%v"+
 			"Kubernetes: %v\n",
 			serverInfo.Address,
-			serverInfo.OpenShiftVersion,
+			openshiftStr,
 			serverInfo.KubernetesVersion)
 	},
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?

Change version command to tolerate missing possible /version/openshift

This is done because a cluster created with "oc cluster up" can in some
cases (as is the case for OKD 3.11) the endpoint is missing completely
and we don't want the tool to fail in such cases (following the example
set by oc)

Was the change discussed in an issue?
#872

How to test changes?

Launch Minishift using OKD 3.11.
Doing `odo version` should now yield all the expected output, except the `Openshift:....` line (which is the same behavior you'll see with `oc version` as well).
When applying `odo version` against a proper Openshift cluster, or even one launched by Minishift that uses OKD 3.10, the `Openshift: ....` should be present