### PR TITLE
Factor out context (project, app, component) handling from commands into NewContextOptions func

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -38,21 +38,12 @@ var componentGetCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		glog.V(4).Infof("component get called")
-		client := util.GetOcClient()
+		context := util.NewContextOptions()
 
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
-		component, err := component.GetCurrent(applicationName, projectName)
-		util.CheckError(err, "unable to get current component")
 		if componentShortFlag {
-			fmt.Print(component)
+			fmt.Print(context.Component)
 		} else {
-			if component == "" {
-				fmt.Printf("No component is set as current\n")
-				return
-			}
-			fmt.Printf("The current component is: %v\n", component)
+			fmt.Printf("The current component is: %v\n", context.Component)
 		}
 	},
 }
@@ -66,19 +57,16 @@ var componentSetCmd = &cobra.Command{
   `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		context := util.NewContextOptions()
 
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
-		exists, err := component.Exists(client, args[0], applicationName)
+		exists, err := component.Exists(context.Client, args[0], context.Application)
 		util.CheckError(err, "")
 		if !exists {
 			fmt.Printf("Component %s does not exist in the current application\n", args[0])
 			os.Exit(1)
 		}
 
-		err = component.SetCurrent(args[0], applicationName, projectName)
+		err = component.SetCurrent(args[0], context.Application, context.Project)
 		util.CheckError(err, "")
 		fmt.Printf("Switched to component: %v\n", args[0])
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,10 +27,8 @@ var componentDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		glog.V(4).Infof("component delete called")
 		glog.V(4).Infof("args: %#v", strings.Join(args, " "))
-		client := util.GetOcClient()
 
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
+		context := util.NewContextOptions()
 
 		// Get the current component if no arguments have been passed
 		var componentName string
@@ -38,13 +36,13 @@ var componentDeleteCmd = &cobra.Command{
 		// If no arguments have been passed, get the current component
 		// else, use the first argument and check to see if it exists
 		if len(args) == 0 {
-			componentName = util.GetComponent(client, "", applicationName)
+			componentName = context.Application
 		} else {
 
 			componentName = args[0]
 
 			// Checks to see if the component actually exists
-			exists, err := component.Exists(client, componentName, applicationName)
+			exists, err := component.Exists(context.Client, componentName, context.Application)
 			util.CheckError(err, "")
 			if !exists {
 				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
@@ -56,16 +54,16 @@ var componentDeleteCmd = &cobra.Command{
 		if componentForceDeleteFlag {
 			confirmDeletion = "y"
 		} else {
-			fmt.Printf("Are you sure you want to delete %v from %v? [y/N] ", componentName, applicationName)
+			fmt.Printf("Are you sure you want to delete %v from %v? [y/N] ", componentName, context.Application)
 			fmt.Scanln(&confirmDeletion)
 		}
 
 		if strings.ToLower(confirmDeletion) == "y" {
-			err := component.Delete(client, componentName, applicationName)
+			err := component.Delete(context.Client, componentName, context.Application)
 			util.CheckError(err, "")
-			fmt.Printf("Component %s from application %s has been deleted\n", componentName, applicationName)
+			fmt.Printf("Component %s from application %s has been deleted\n", componentName, context.Application)
 
-			currentComponent, err := component.GetCurrent(applicationName, projectName)
+			currentComponent, err := component.GetCurrent(context.Application, context.Project)
 			util.CheckError(err, "Unable to get current component")
 
 			if currentComponent == "" {

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -18,27 +18,24 @@ var describeCmd = &cobra.Command{
 	`,
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-
-		util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
+		context := util.NewContextOptions()
 
 		var componentName string
 		if len(args) == 0 {
-			componentName = util.GetComponent(client, "", applicationName)
+			componentName = context.Component
 		} else {
 
 			componentName = args[0]
 
 			// Checks to see if the component actually exists
-			exists, err := component.Exists(client, componentName, applicationName)
+			exists, err := component.Exists(context.Client, componentName, context.Application)
 			util.CheckError(err, "")
 			if !exists {
 				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
 				os.Exit(1)
 			}
 		}
-		componentType, path, componentURL, appStore, err := component.GetComponentDesc(client, componentName, applicationName)
+		componentType, path, componentURL, appStore, err := component.GetComponentDesc(context.Client, componentName, context.Application)
 		util.CheckError(err, "")
 		printComponentInfo(componentName, componentType, path, componentURL, appStore)
 	},

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -29,20 +29,17 @@ is injected into the component.
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-		componentName := util.GetComponent(client, util.ComponentFlag, applicationName)
+		context := util.NewContextOptions()
 		serviceName := args[0]
 
-		exists, err := component.Exists(client, componentName, applicationName)
+		exists, err := component.Exists(context.Client, context.Component, context.Application)
 		util.CheckError(err, "")
 		if !exists {
-			fmt.Printf("Component %v does not exist\n", componentName)
+			fmt.Printf("Component %v does not exist\n", context.Component)
 			os.Exit(1)
 		}
 
-		exists, err = svc.SvcExists(client, serviceName, applicationName)
+		exists, err = svc.SvcExists(context.Client, serviceName, context.Application)
 		util.CheckError(err, "Unable to determine if service %s exists within the current namespace", serviceName)
 		if !exists {
 			fmt.Printf(`Service %s does not exist within the current namespace.
@@ -52,7 +49,7 @@ Please perform 'odo service create %s ...' before attempting to link the service
 
 		// we also need to check whether there is a secret with the same name as the service
 		// the secret should have been created along with the secret
-		_, err = client.GetSecret(serviceName, projectName)
+		_, err = context.Client.GetSecret(serviceName, context.Project)
 		if err != nil {
 			fmt.Printf(`Secret %s should have been created along with the service
 If you previously created the service with 'odo service create', then you may have to wait a few seconds until OpenShift provisions it.
@@ -60,10 +57,10 @@ If not, then please delete the service and recreate it using 'odo service create
 			os.Exit(1)
 		}
 
-		err = client.LinkSecret(serviceName, componentName, applicationName, projectName)
+		err = context.Client.LinkSecret(serviceName, context.Component, context.Application, context.Project)
 		util.CheckError(err, "")
 
-		fmt.Printf("Service %s has been successfully linked to the component %s.\n", serviceName, applicationName)
+		fmt.Printf("Service %s has been successfully linked to the component %s.\n", serviceName, context.Application)
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,14 +19,8 @@ var componentListCmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
-		currentComponent, err := component.GetCurrent(applicationName, projectName)
-		util.CheckError(err, "")
-		components, err := component.List(client, applicationName)
+		context := util.NewContextOptions()
+		components, err := component.List(context.Client, context.Application)
 		util.CheckError(err, "")
 
 		if len(components) == 0 {
@@ -38,7 +32,7 @@ var componentListCmd = &cobra.Command{
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE")
 		for _, comp := range components {
-			if comp.Name == currentComponent {
+			if comp.Name == context.Component {
 				activeMark = "*"
 			}
 			fmt.Fprintln(w, activeMark, "\t", comp.Name, "\t", comp.Type)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -25,23 +25,16 @@ var logCmd = &cobra.Command{
 		// Retrieve stdout / io.Writer
 		stdout := os.Stdout
 
-		// Retrieve the client
-		client := util.GetOcClient()
+		context := util.NewContextOptions()
 
-		util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
-		var argComponent string
-
+		currentComponent := context.Component
 		if len(args) == 1 {
-			argComponent = args[0]
+			// Retrieve and set the currentComponent
+			currentComponent = util.GetComponent(context.Client, args[0], context.Application)
 		}
 
-		// Retrieve and set the currentComponent
-		currentComponent := util.GetComponent(client, argComponent, applicationName)
-
 		// Retrieve the log
-		err := component.GetLogs(client, currentComponent, applicationName, logFollow, stdout)
+		err := component.GetLogs(context.Client, currentComponent, context.Application, logFollow, stdout)
 		util.CheckError(err, "Unable to retrieve logs, does your component exist?")
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   util.RootCommandName,
+	Use:   "odo",
 	Short: "Odo (Openshift Do)",
 	Long: `Odo (OpenShift Do) is a CLI tool for running OpenShift applications in a fast and automated matter. Odo reduces the complexity of deployment by adding iterative development without the worry of deploying your source code.
 

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -67,7 +67,7 @@ The created URL can be used to access the specified component from outside the O
 		}
 
 		exists, err := url.Exists(context.Client, urlName, "", context.Application)
-
+		odoutil.CheckError(err, "")
 		if exists {
 			fmt.Printf("The url %s already exists in the application: %s\n", urlName, context.Application)
 			os.Exit(1)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -33,16 +33,14 @@ var watchCmd = &cobra.Command{
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		stdout := os.Stdout
-		client := odoutil.GetOcClient()
 
-		projectName := odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
+		context := odoutil.NewContextOptions()
 
 		var componentName string
 		if len(args) == 0 {
 			var err error
 			glog.V(4).Info("No component name passed, assuming current component")
-			componentName, err = component.GetCurrent(applicationName, projectName)
+			componentName, err = component.GetCurrent(context.Application, context.Project)
 			odoutil.CheckError(err, "")
 			if componentName == "" {
 				fmt.Println("No component is set as active.")
@@ -53,7 +51,7 @@ var watchCmd = &cobra.Command{
 			componentName = args[0]
 		}
 
-		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName)
+		sourceType, sourcePath, err := component.GetComponentSource(context.Client, componentName, context.Application)
 		odoutil.CheckError(err, "Unable to get source for %s component.", componentName)
 
 		if sourceType != "binary" && sourceType != "local" {
@@ -70,7 +68,7 @@ var watchCmd = &cobra.Command{
 		}
 		watchPath := util.ReadFilePath(u, runtime.GOOS)
 
-		err = component.WatchAndPush(client, componentName, applicationName, watchPath, stdout, ignores, delay, make(chan string), component.PushLocal)
+		err = component.WatchAndPush(context.Client, componentName, context.Application, watchPath, stdout, ignores, delay, make(chan string), component.PushLocal)
 		odoutil.CheckError(err, "Error while trying to watch %s", watchPath)
 	},
 }

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -19,6 +19,7 @@ var (
 	ComponentFlag             string
 )
 
+// ContextOptions gathers common contextual information for commands such as current project, application or component
 type ContextOptions struct {
 	Client      *occlient.Client
 	Project     string
@@ -26,6 +27,7 @@ type ContextOptions struct {
 	Component   string
 }
 
+// NewContextOptions creates a new ContextOptions instance based on the current state of the cluster and provided flags
 func NewContextOptions() ContextOptions {
 	client := GetOcClient()
 	project := GetAndSetNamespace(client)

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -11,9 +11,6 @@ import (
 	"os"
 )
 
-// RootCommandName is the name of the root command
-const RootCommandName = "odo"
-
 // Global variables
 var (
 	GlobalSkipConnectionCheck bool


### PR DESCRIPTION
What is the purpose of this change? What does it change?
This work starts the process of creating common options which will be needed for #871 

Was the change discussed in an issue?
No

How to test changes?
`make && make test`. External behavior shouldn't change.