### PR TITLE
Added component flag to `odo link`

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
+
+	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	svc "github.com/redhat-developer/odo/pkg/service"
@@ -76,6 +77,8 @@ func init() {
 	addProjectFlag(linkCmd)
 	//Adding `--application` flag
 	addApplicationFlag(linkCmd)
+	// Adding `--component` flag
+	addComponentFlag(linkCmd)
 
 	rootCmd.AddCommand(linkCmd)
 }


### PR DESCRIPTION

What is the purpose of this change? What does it change?

This PR adds `--component` flag to `odo link` command


Was the change discussed in an issue?

#928 

How to test changes?


`odo link nationalparks-db --component nationalparks`