### PR TITLE
Using curl instead of wget

### DIFF
--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -82,7 +82,7 @@ var _ = Describe("odoCmpE2e", func() {
 
 	Context("updating the component", func() {
 		It("should be able to create binary component", func() {
-			runCmd("wget -O " + tmpDir + "/sample-binary-testing-1.war " +
+			runCmd("curl -o " + tmpDir + "/sample-binary-testing-1.war " +
 				"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
 			runCmd("odo create wildfly wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
 			runCmd("find " + tmpDir)
@@ -100,7 +100,7 @@ var _ = Describe("odoCmpE2e", func() {
 		})
 
 		It("should update component from binary to binary", func() {
-			runCmd("wget -O " + tmpDir + "/sample-binary-testing-2.war " +
+			runCmd("curl -o " + tmpDir + "/sample-binary-testing-2.war " +
 				"'https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/85354d9ee8583a9c1e64a331425eede235b07a9e/sample%2520(1).war'")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-2.war")
 


### PR DESCRIPTION


What is the purpose of this change? What does it change?

 replacing  wget with curl in e2e tests, because wget is not present in macOS

Was the change discussed in an issue?

Resolves #933 
