### PR TITLE
e2e test: Ugly and temporary fix for timeout issue during odo push.

### DIFF
--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -87,6 +87,9 @@ var _ = Describe("odoCmpE2e", func() {
 			runCmd("odo create wildfly wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
 			runCmd("find " + tmpDir)
 
+			// TODO: remove this once https://github.com/redhat-developer/odo/issues/943 is implemented
+			time.Sleep(90 * time.Second)
+
 			// Run push
 			runCmd("odo push -v 4")
 


### PR DESCRIPTION
This is just quick ugly fix to make test passing again.
It should be removed once we make `waitForPodTimeOut` timeout configurable.

Check https://github.com/redhat-developer/odo/pull/943 for more details.