### PR TITLE
Remove test execution from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,6 @@ install:
 - set PATH=%PATH%;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%GOPATH%\bin
 - make goget-tools
 
-test_script:
-- make test
-
 build_script:
 - make cross
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?

We remove the test execution phase from appveyor
This is done because all we want appveyor to do is produce artifacts
Tests are covered already by Travis.
Furthermore tests can sometimes timeout thus failing appveyor execution, which we can't then seem to restart from the Appveyor UI

Was the change discussed in an issue?
No

How to test changes?
Not odo code related, so nothing to test :)
