### PR TITLE
Factor out creation of contextual information (project, application, component) to make it easier to manage and facilitate refactoring of commands

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -83,7 +83,7 @@ If no app name is passed, a default app name will be auto-generated.
 		util.CheckError(err, "")
 		err = application.SetCurrent(client, appName)
 
-		// todo: updating the app name should be done via SetCurrent and passing the Context
+		// TODO: updating the app name should be done via SetCurrent and passing the Context
 		// not strictly needed here but Context should stay in sync
 		context.Application = appName
 
@@ -232,7 +232,7 @@ var applicationSetCmd = &cobra.Command{
 		util.CheckError(err, "")
 		fmt.Printf("Switched to application: %v in project: %v\n", args[0], projectName)
 
-		// todo: updating the app name should be done via SetCurrent and passing the Context
+		// TODO: updating the app name should be done via SetCurrent and passing the Context
 		// not strictly needed here but Context should stay in sync
 		context.Application = appName
 	},

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/olekukonko/tablewriter"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
@@ -46,7 +47,7 @@ var catalogListComponentCmd = &cobra.Command{
   odo catalog search component nodejs
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		catalogList, err := catalog.List(client)
 		util.CheckError(err, "unable to list components")
 		switch len(catalogList) {
@@ -90,7 +91,7 @@ var catalogListServiceCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		catalogList, err := svc.ListCatalog(client)
 		util.CheckError(err, "unable to list services because Service Catalog is not enabled in your cluster")
 		switch len(catalogList) {
@@ -137,7 +138,7 @@ components.
   odo catalog search component python
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		searchTerm := args[0]
 		components, err := catalog.Search(client, searchTerm)
 		util.CheckError(err, "unable to search for components")
@@ -167,7 +168,7 @@ services from service catalog.
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		searchTerm := args[0]
 		components, err := svc.Search(client, searchTerm)
 		util.CheckError(err, "unable to search for services")
@@ -209,7 +210,7 @@ This describes the service and the associated plans.
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		serviceName := args[0]
 		service, plans, err := svc.GetServiceClassAndPlans(client, serviceName)
 		util.CheckError(err, "")

--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -150,13 +150,13 @@ func printUnmountedStorage(client *occlient.Client, applicationName string) {
 }
 
 func addProjectFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&util.ProjectFlag, "project", "", "Project, defaults to active project")
+	cmd.Flags().StringVar(&util.ProjectFlag, util.ProjectFlagName, "", "Project, defaults to active project")
 }
 
 func addComponentFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&util.ComponentFlag, "component", "", "Component, defaults to active component.")
+	cmd.Flags().StringVar(&util.ComponentFlag, util.ComponentFlagName, "", "Component, defaults to active component.")
 }
 
 func addApplicationFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&util.ApplicationFlag, "app", "", "Application, defaults to active application")
+	cmd.Flags().StringVar(&util.ApplicationFlag, util.ApplicationFlagName, "", "Application, defaults to active application")
 }

--- a/cmd/cmdutils.go
+++ b/cmd/cmdutils.go
@@ -150,13 +150,13 @@ func printUnmountedStorage(client *occlient.Client, applicationName string) {
 }
 
 func addProjectFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&util.ProjectFlag, util.ProjectFlagName, "", "Project, defaults to active project")
+	cmd.Flags().String(util.ProjectFlagName, "", "Project, defaults to active project")
 }
 
 func addComponentFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&util.ComponentFlag, util.ComponentFlagName, "", "Component, defaults to active component.")
+	cmd.Flags().String(util.ComponentFlagName, "", "Component, defaults to active component.")
 }
 
 func addApplicationFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&util.ApplicationFlag, util.ApplicationFlagName, "", "Application, defaults to active application")
+	cmd.Flags().String(util.ApplicationFlagName, "", "Application, defaults to active application")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
@@ -69,17 +70,10 @@ A full list of component types that can be deployed is available using: 'odo cat
 		stdout := color.Output
 		glog.V(4).Infof("Component create called with args: %#v, flags: binary=%s, git=%s, local=%s", strings.Join(args, " "), componentBinary, componentGit, componentLocal)
 
-		client := odoutil.GetOcClient()
-
-		projectName := odoutil.GetAndSetNamespace(client)
-		var applicationName string
-		var err error
-		if odoutil.ApplicationFlag != "" && odoutil.ProjectFlag != "" {
-			applicationName = odoutil.GetAppName(client)
-		} else {
-			applicationName, err = application.GetCurrentOrGetCreateSetDefault(client)
-			odoutil.CheckError(err, "")
-		}
+		context := genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+		client := context.Client
+		projectName := context.Project
+		applicationName := context.Application
 
 		checkFlag := 0
 		componentPath := ""

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -88,19 +88,16 @@ A full list of component types that can be deployed is available using: 'odo cat
 		if len(componentBinary) != 0 {
 			componentPath = componentBinary
 			componentPathType = component.BINARY
-			odoutil.CheckError(err, "")
 			checkFlag++
 		}
 		if len(componentGit) != 0 {
 			componentPath = componentGit
 			componentPathType = component.GIT
-			odoutil.CheckError(err, "")
 			checkFlag++
 		}
 		if len(componentLocal) != 0 {
 			componentPath = componentLocal
 			componentPathType = component.SOURCE
-			odoutil.CheckError(err, "")
 			checkFlag++
 		}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
-	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -27,29 +27,19 @@ var componentDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		glog.V(4).Infof("component delete called")
 		glog.V(4).Infof("args: %#v", strings.Join(args, " "))
-		client := util.GetOcClient()
 
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
-		// Get the current component if no arguments have been passed
-		var componentName string
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		projectName := context.Project
+		applicationName := context.Application
 
 		// If no arguments have been passed, get the current component
 		// else, use the first argument and check to see if it exists
+		var componentName string
 		if len(args) == 0 {
-			componentName = util.GetComponent(client, "", applicationName)
+			componentName = context.Component()
 		} else {
-
-			componentName = args[0]
-
-			// Checks to see if the component actually exists
-			exists, err := component.Exists(client, componentName, applicationName)
-			util.CheckError(err, "")
-			if !exists {
-				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
-				os.Exit(1)
-			}
+			componentName = context.Component(args[0])
 		}
 
 		var confirmDeletion string

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/util"
-	"os"
-
 	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 )
 
@@ -18,25 +16,17 @@ var describeCmd = &cobra.Command{
 	`,
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
-		util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
+		// If no arguments have been passed, get the current component
+		// else, use the first argument and check to see if it exists
 		var componentName string
 		if len(args) == 0 {
-			componentName = util.GetComponent(client, "", applicationName)
+			componentName = context.Component()
 		} else {
-
-			componentName = args[0]
-
-			// Checks to see if the component actually exists
-			exists, err := component.Exists(client, componentName, applicationName)
-			util.CheckError(err, "")
-			if !exists {
-				fmt.Printf("Component with the name %s does not exist in the current application\n", componentName)
-				os.Exit(1)
-			}
+			componentName = context.Component(args[0])
 		}
 		componentType, path, componentURL, appStore, err := component.GetComponentDesc(client, componentName, applicationName)
 		util.CheckError(err, "")

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"fmt"
 	"github.com/golang/glog"
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/secret"
 	"os"
 
-	"github.com/redhat-developer/odo/pkg/component"
 	svc "github.com/redhat-developer/odo/pkg/service"
 	"github.com/spf13/cobra"
 )
@@ -66,17 +67,11 @@ DB_PASSWORD=secret
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-		sourceComponentName := util.GetComponent(client, util.ComponentFlag, applicationName)
-
-		exists, err := component.Exists(client, sourceComponentName, applicationName)
-		util.CheckError(err, "")
-		if !exists {
-			fmt.Printf("Component %v does not exist\n", sourceComponentName)
-			os.Exit(1)
-		}
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		projectName := context.Project
+		applicationName := context.Application
+		sourceComponentName := context.Component()
 
 		suppliedName := args[0]
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"text/tabwriter"
@@ -19,16 +20,12 @@ var componentListCmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
-
-		currentComponent, err := component.GetCurrent(applicationName, projectName)
-		util.CheckError(err, "")
 		components, err := component.List(client, applicationName)
 		util.CheckError(err, "")
-
 		if len(components) == 0 {
 			fmt.Println("There are no components deployed.")
 			return
@@ -37,6 +34,7 @@ var componentListCmd = &cobra.Command{
 		activeMark := " "
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE")
+		currentComponent := context.ComponentAllowingEmpty(true)
 		for _, comp := range components {
 			if comp.Name == currentComponent {
 				activeMark = "*"

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 
@@ -25,23 +26,18 @@ var logCmd = &cobra.Command{
 		// Retrieve stdout / io.Writer
 		stdout := os.Stdout
 
-		// Retrieve the client
-		client := util.GetOcClient()
-
-		util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
 		var argComponent string
-
 		if len(args) == 1 {
 			argComponent = args[0]
 		}
-
-		// Retrieve and set the currentComponent
-		currentComponent := util.GetComponent(client, argComponent, applicationName)
+		componentName := context.Component(argComponent)
 
 		// Retrieve the log
-		err := component.GetLogs(client, currentComponent, applicationName, logFollow, stdout)
+		err := component.GetLogs(client, componentName, applicationName, logFollow, stdout)
 		util.CheckError(err, "Unable to retrieve logs, does your component exist?")
 	},
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
@@ -46,8 +47,9 @@ var projectSetCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
-		client := util.GetOcClient()
-		current := project.GetCurrent(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		current := context.Project
 
 		exists, err := project.Exists(client, projectName)
 		util.CheckError(err, "")
@@ -79,8 +81,8 @@ var projectGetCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-		project := project.GetCurrent(client)
+		context := genericclioptions.NewContext(cmd)
+		project := context.Project
 
 		if projectShortFlag {
 			fmt.Print(project)
@@ -100,7 +102,7 @@ var projectCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		err := project.Create(client, projectName)
 		util.CheckError(err, "")
 		err = project.SetCurrent(client, projectName)
@@ -119,7 +121,7 @@ var projectDeleteCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 
 		// Validate existence of the project to be deleted
 		isValidProject, err := project.Exists(client, projectName)
@@ -175,7 +177,7 @@ var projectListCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
+		client := genericclioptions.Client(cmd)
 		projects, err := project.List(client)
 		util.CheckError(err, "")
 		if len(projects) == 0 {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"net/url"
 	"os"
@@ -33,18 +34,17 @@ var pushCmd = &cobra.Command{
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		stdout := color.Output
-		client := odoutil.GetOcClient()
 
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
-		var inputName string
-		if len(args) == 0 {
-			inputName = ""
-		} else {
-			inputName = args[0]
+		var argComponent string
+		if len(args) == 1 {
+			argComponent = args[0]
 		}
-		componentName := odoutil.GetComponent(client, inputName, applicationName)
+		componentName := context.Component(argComponent)
+
 		fmt.Printf("Pushing changes to component: %v\n", componentName)
 
 		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,7 +124,7 @@ func init() {
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
-	rootCmd.PersistentFlags().BoolVar(&util.GlobalSkipConnectionCheck, "skip-connection-check", false, "Skip cluster check")
+	rootCmd.PersistentFlags().BoolVar(&util.GlobalSkipConnectionCheck, util.SkipConnectionCheckFlagName, false, "Skip cluster check")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.Set("logtostderr", "true")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,7 +124,7 @@ func init() {
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
-	rootCmd.PersistentFlags().BoolVar(&util.GlobalSkipConnectionCheck, util.SkipConnectionCheckFlagName, false, "Skip cluster check")
+	rootCmd.PersistentFlags().Bool(util.SkipConnectionCheckFlagName, false, "Skip cluster check")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.Set("logtostderr", "true")
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
@@ -123,13 +124,11 @@ var serviceDeleteCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-
 		glog.V(4).Infof("service delete called\n args: %#v", strings.Join(args, " "))
 
-		client := util.GetOcClient()
-
-		util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
 		serviceName := args[0]
 
@@ -169,10 +168,9 @@ var serviceListCmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-
-		util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
 		services, err := svc.List(client, applicationName)
 		util.CheckError(err, "Service Catalog is not enabled in your cluster")

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -10,7 +10,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/glog"
-	"github.com/redhat-developer/odo/pkg/application"
 	svc "github.com/redhat-developer/odo/pkg/service"
 	"github.com/spf13/cobra"
 )
@@ -48,17 +47,9 @@ A full list of service types that can be deployed are available using: 'odo cata
 	`,
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-		util.GetAndSetNamespace(client)
-		var applicationName string
-		var err error
-		if util.ApplicationFlag != "" && util.ProjectFlag != "" {
-			applicationName = util.GetAppName(client)
-		} else {
-
-			applicationName, err = application.GetCurrentOrGetCreateSetDefault(client)
-			util.CheckError(err, "")
-		}
+		context := genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+		client := context.Client
+		applicationName := context.Application
 
 		// make sure the service type exists
 		serviceType := args[0]

--- a/cmd/service_test.go
+++ b/cmd/service_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/posener/complete"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,10 +63,11 @@ func TestCompletions(t *testing.T) {
 			},
 		}, nil
 	})
+	context := genericclioptions.NewFakeContext("", "", "", client)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := complete.Args{Last: tt.last}
-			got := tt.handler(a, client)
+			got := tt.handler(nil, a, context)
 			if !equal(got, tt.want) {
 				t.Errorf("Failed %s: got: %q, want: %q", t.Name(), got, tt.want)
 			}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
@@ -38,11 +39,10 @@ var storageCreateCmd = &cobra.Command{
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-		componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
+		componentName := context.Component()
 
 		var storageName string
 		if len(args) != 0 {
@@ -81,11 +81,10 @@ var storageUnmountCmd = &cobra.Command{
 	Aliases: []string{"umount"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-		componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
+		componentName := context.Component()
 
 		var storageName string
 		var err error
@@ -126,12 +125,11 @@ var storageDeleteCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
 		storageName := args[0]
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
 
 		exists, err := storage.Exists(client, storageName, applicationName)
 		odoutil.CheckError(err, "")
@@ -182,10 +180,9 @@ var storageListCmd = &cobra.Command{
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
 
 		if storageAllListflag {
 			if odoutil.ComponentFlag != "" {
@@ -195,7 +192,7 @@ var storageListCmd = &cobra.Command{
 			printMountedStorageInAllComponent(client, applicationName)
 		} else {
 			// storageComponent is the input component name
-			componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
+			componentName := context.Component()
 			printMountedStorageInComponent(client, componentName, applicationName)
 		}
 		printUnmountedStorage(client, applicationName)
@@ -212,13 +209,12 @@ var storageMountCmd = &cobra.Command{
   odo storage mount database --component mongodb --path /data`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
+		componentName := context.Component()
 
 		storageName := args[0]
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-		componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
 
 		exists, err := storage.Exists(client, storageName, applicationName)
 		odoutil.CheckError(err, "unable to check if the storage exists in the current application")

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -185,7 +185,7 @@ var storageListCmd = &cobra.Command{
 		applicationName := context.Application
 
 		if storageAllListflag {
-			if cmd.Flag(odoutil.ComponentFlagName) != nil {
+			if len(genericclioptions.FlagValueIfSet(cmd, odoutil.ComponentFlagName)) > 0 {
 				fmt.Println("Invalid arguments. Component name is not needed")
 				os.Exit(1)
 			}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -185,7 +185,7 @@ var storageListCmd = &cobra.Command{
 		applicationName := context.Application
 
 		if storageAllListflag {
-			if odoutil.ComponentFlag != "" {
+			if cmd.Flag(odoutil.ComponentFlagName) != nil {
 				fmt.Println("Invalid arguments. Component name is not needed")
 				os.Exit(1)
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -58,7 +58,7 @@ var updateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// todo: check if we can use context.Component() here
+		// TODO: check if we can use context.Component() here
 		var componentName string
 		if len(args) == 0 {
 			componentName, err := component.GetCurrent(applicationName, projectName)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"path/filepath"
@@ -33,10 +34,10 @@ var updateCmd = &cobra.Command{
   odo update wildfly --binary ./downloads/sample.war
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := util.GetOcClient()
-
-		projectName := util.GetAndSetNamespace(client)
-		applicationName := util.GetAppName(client)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		projectName := context.Project
+		applicationName := context.Application
 
 		stdout := color.Output
 
@@ -57,8 +58,8 @@ var updateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// todo: check if we can use context.Component() here
 		var componentName string
-
 		if len(args) == 0 {
 			componentName, err := component.GetCurrent(applicationName, projectName)
 			util.CheckError(err, "unable to get current component")

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"os"
 	"strings"
 
@@ -53,11 +54,10 @@ The created URL can be used to access the specified component from outside the O
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-		componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
+		componentName := context.Component()
 
 		var urlName string
 		switch len(args) {
@@ -101,13 +101,10 @@ var urlDeleteCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-
-		// Initialization
-		client := odoutil.GetOcClient()
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-		componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
+		componentName := context.Component()
 
 		urlName := args[0]
 
@@ -147,11 +144,10 @@ var urlListCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := odoutil.GetOcClient()
-
-		odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-		componentName := odoutil.GetComponent(client, odoutil.ComponentFlag, applicationName)
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		applicationName := context.Application
+		componentName := context.Component()
 
 		urls, err := url.List(client, componentName, applicationName)
 		odoutil.CheckError(err, "")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
-
-	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -44,10 +44,8 @@ var versionCmd = &cobra.Command{
 		fmt.Println("odo " + VERSION + " (" + GITCOMMIT + ")")
 
 		if !clientFlag {
-			// turning off the flag which checks for login status
-			util.GlobalSkipConnectionCheck = true
 			// Lets fetch the info about the server
-			serverInfo, err := util.GetOcClient().GetServerVersion()
+		serverInfo, err := genericclioptions.ClientWithConnectionCheck(cmd, true).GetServerVersion()
 			util.CheckError(err, "")
 			// make sure we only include Openshift info if we actually have it
 			openshiftStr := ""

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -45,7 +45,7 @@ var versionCmd = &cobra.Command{
 
 		if !clientFlag {
 			// Lets fetch the info about the server
-		serverInfo, err := genericclioptions.ClientWithConnectionCheck(cmd, true).GetServerVersion()
+			serverInfo, err := genericclioptions.ClientWithConnectionCheck(cmd, true).GetServerVersion()
 			util.CheckError(err, "")
 			// make sure we only include Openshift info if we actually have it
 			openshiftStr := ""

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -39,7 +39,7 @@ var watchCmd = &cobra.Command{
 		projectName := context.Project
 		applicationName := context.Application
 
-		// todo: check if we can use context.Component() here
+		// TODO: check if we can use context.Component() here
 		var componentName string
 		if len(args) == 0 {
 			var err error

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"net/url"
 	"os"
 	"runtime"
@@ -33,11 +34,12 @@ var watchCmd = &cobra.Command{
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		stdout := os.Stdout
-		client := odoutil.GetOcClient()
+		context := genericclioptions.NewContext(cmd)
+		client := context.Client
+		projectName := context.Project
+		applicationName := context.Application
 
-		projectName := odoutil.GetAndSetNamespace(client)
-		applicationName := odoutil.GetAppName(client)
-
+		// todo: check if we can use context.Component() here
 		var componentName string
 		if len(args) == 0 {
 			var err error

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -1,0 +1,118 @@
+package genericclioptions
+
+import (
+	"fmt"
+	"github.com/redhat-developer/odo/pkg/application"
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/odo/util"
+	"github.com/redhat-developer/odo/pkg/project"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
+func NewContext(command *cobra.Command) *Context {
+	flags := command.Flags()
+	skipConnectionCheck, err := flags.GetBool(util.SkipConnectionCheckFlagName)
+	util.CheckError(err, "")
+
+	client, err := occlient.New(skipConnectionCheck)
+	util.CheckError(err, "")
+
+	// project
+	var ns string
+	projectFlag, err := flags.GetString(util.ProjectFlagName)
+	util.CheckError(err, "")
+	if len(projectFlag) > 0 {
+		_, err := project.Exists(client, projectFlag)
+		util.CheckError(err, "")
+		ns = projectFlag
+	} else {
+		ns = project.GetCurrent(client)
+	}
+	client.Namespace = ns
+
+	// application
+	var app string
+	appFlag, err := flags.GetString(util.ApplicationFlagName)
+	util.CheckError(err, "")
+	if len(appFlag) > 0 {
+		_, err := application.Exists(client, appFlag)
+		util.CheckError(err, "")
+		app = appFlag
+	} else {
+		appName, err := application.GetCurrent(ns)
+		util.CheckError(err, "unable to get current application")
+		app = appName
+	}
+
+	context := &Context{
+		Client:      client,
+		Project:     ns,
+		Application: app,
+	}
+
+	// component
+	var cmp string
+	cmpFlag, err := flags.GetString(util.ComponentFlagName)
+	util.CheckError(err, "")
+	if len(cmpFlag) == 0 {
+		cmp, err = component.GetCurrent(app, ns)
+		util.CheckError(err, "could not get current component")
+	} else {
+		context.existsOrExit(cmpFlag)
+		cmp = cmpFlag
+	}
+
+	context.cmp = cmp
+
+	return context
+}
+
+// Context holds contextual information useful to commands such as correctly configured client, target project and application
+// (based on specified flag values) and provides for a way to retrieve a given component given this context
+type Context struct {
+	Client      *occlient.Client
+	Project     string
+	Application string
+	cmp         string
+}
+
+// Component retrieves the optionally specified component or the current one if it is set
+func (o *Context) Component(optionalComponent ...string) string {
+	if len(o.cmp) > 0 {
+		return o.cmp
+	}
+
+	switch len(optionalComponent) {
+	case 0:
+		if len(o.cmp) == 0 {
+			fmt.Println("No component is set")
+			os.Exit(-1)
+		}
+		break
+	case 1:
+		cmp := optionalComponent[0]
+		// only check the component if we passed a non-empty string, otherwise return the current component set in NewContext
+		if len(cmp) > 0 {
+			o.existsOrExit(cmp)
+			o.cmp = cmp // update context
+		}
+		break
+	default:
+		fmt.Printf("Component function only accepts one optional argument, was given: %v", optionalComponent)
+		os.Exit(-1)
+	}
+
+	return o.cmp
+}
+
+func (o *Context) existsOrExit(cmp string) {
+	exists, err := component.Exists(o.Client, cmp, o.Application)
+	util.CheckError(err, "")
+	if !exists {
+		fmt.Printf("Component %v does not exist in application %s\n", cmp, o.Application)
+		os.Exit(-1)
+	}
+}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -49,7 +49,7 @@ func client(command *cobra.Command, shouldSkipConnectionCheck ...bool) *occlient
 	default:
 		// safeguard: fail if more than one optional bool is passed because it would be a programming error
 		fmt.Printf("client function only accepts one optional argument, was given: %v", shouldSkipConnectionCheck)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	client, err := occlient.New(skipConnectionCheck)
@@ -168,7 +168,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 		// so nothing to do here unless the calling context doesn't allow no component to be set in which case we exit with error
 		if !allowEmpty && len(o.cmp) == 0 {
 			fmt.Println("No component is set")
-			os.Exit(-1)
+			os.Exit(1)
 		}
 	case 1:
 		cmp := optionalComponent[0]
@@ -180,7 +180,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 	default:
 		// safeguard: fail if more than one optional string is passed because it would be a programming error
 		fmt.Printf("ComponentAllowingEmpty function only accepts one optional argument, was given: %v", optionalComponent)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	return o.cmp
@@ -192,7 +192,7 @@ func (o *Context) checkComponentExistsOrFail(cmp string) {
 	util.CheckError(err, "")
 	if !exists {
 		fmt.Printf("Component %v does not exist in application %s\n", cmp, o.Application)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -91,7 +91,6 @@ func (o *Context) Component(optionalComponent ...string) string {
 			fmt.Println("No component is set")
 			os.Exit(-1)
 		}
-		break
 	case 1:
 		cmp := optionalComponent[0]
 		// only check the component if we passed a non-empty string, otherwise return the current component set in NewContext
@@ -99,7 +98,6 @@ func (o *Context) Component(optionalComponent ...string) string {
 			o.existsOrExit(cmp)
 			o.cmp = cmp // update context
 		}
-		break
 	default:
 		fmt.Printf("Component function only accepts one optional argument, was given: %v", optionalComponent)
 		os.Exit(-1)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -82,10 +82,6 @@ type Context struct {
 
 // Component retrieves the optionally specified component or the current one if it is set
 func (o *Context) Component(optionalComponent ...string) string {
-	if len(o.cmp) > 0 {
-		return o.cmp
-	}
-
 	switch len(optionalComponent) {
 	case 0:
 		if len(o.cmp) == 0 {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -118,7 +118,7 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 		util.CheckError(err, "could not get current component")
 	} else {
 		// if flag is set, check that the specified component exists
-		context.existsOrExit(cmpFlag)
+		context.checkComponentExistsOrFail(cmpFlag)
 		cmp = cmpFlag
 	}
 
@@ -174,7 +174,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 		cmp := optionalComponent[0]
 		// only check the component if we passed a non-empty string, otherwise return the current component set in NewContext
 		if len(cmp) > 0 {
-			o.existsOrExit(cmp)
+			o.checkComponentExistsOrFail(cmp)
 			o.cmp = cmp // update context
 		}
 	default:
@@ -187,7 +187,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 }
 
 // existsOrExit checks if the specified component exists with the given context and exits the app if not.
-func (o *Context) existsOrExit(cmp string) {
+func (o *Context) checkComponentExistsOrFail(cmp string) {
 	exists, err := component.Exists(o.Client, cmp, o.Application)
 	util.CheckError(err, "")
 	if !exists {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -124,18 +124,6 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 	return o.cmp
 }
 
-// GetOrCreateAppName retrieves the current application name from the context or creates a new default application
-func (context *Context) GetOrCreateAppName() (applicationName string) {
-	if len(ApplicationFlag) > 0 && len(ProjectFlag) > 0 {
-		applicationName = context.Application
-	} else {
-		var err error
-		applicationName, err = application.GetCurrentOrGetCreateSetDefault(context.Client)
-		util.CheckError(err, "")
-	}
-	return
-}
-
 func (o *Context) existsOrExit(cmp string) {
 	exists, err := component.Exists(o.Client, cmp, o.Application)
 	util.CheckError(err, "")

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -2,6 +2,7 @@ package genericclioptions
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/occlient"
@@ -23,7 +24,7 @@ func NewContext(command *cobra.Command) *Context {
 	// project
 	var ns string
 	projectFlag, err := flags.GetString(util.ProjectFlagName)
-	util.CheckError(err, "")
+	ignoreButLog(err)
 	if len(projectFlag) > 0 {
 		_, err := project.Exists(client, projectFlag)
 		util.CheckError(err, "")
@@ -36,7 +37,7 @@ func NewContext(command *cobra.Command) *Context {
 	// application
 	var app string
 	appFlag, err := flags.GetString(util.ApplicationFlagName)
-	util.CheckError(err, "")
+	ignoreButLog(err)
 	if len(appFlag) > 0 {
 		_, err := application.Exists(client, appFlag)
 		util.CheckError(err, "")
@@ -56,7 +57,7 @@ func NewContext(command *cobra.Command) *Context {
 	// component
 	var cmp string
 	cmpFlag, err := flags.GetString(util.ComponentFlagName)
-	util.CheckError(err, "")
+	ignoreButLog(err)
 	if len(cmpFlag) == 0 {
 		cmp, err = component.GetCurrent(app, ns)
 		util.CheckError(err, "could not get current component")
@@ -113,4 +114,8 @@ func (o *Context) existsOrExit(cmp string) {
 		fmt.Printf("Component %v does not exist in application %s\n", cmp, o.Application)
 		os.Exit(-1)
 	}
+}
+
+func ignoreButLog(err error) {
+	glog.V(4).Infof("Ignoring error as it usually means flag wasn't set: %v", err)
 }

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -62,10 +62,14 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 		util.CheckError(err, "unable to get current application")
 	}
 
-	context := &Context{
+	internalCxt := internalCxt{
 		Client:      client,
 		Project:     ns,
 		Application: app,
+	}
+
+	context := &Context{
+		internalCxt: internalCxt,
 	}
 
 	// component
@@ -88,6 +92,10 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 // Context holds contextual information useful to commands such as correctly configured client, target project and application
 // (based on specified flag values) and provides for a way to retrieve a given component given this context
 type Context struct {
+	internalCxt
+}
+
+type internalCxt struct {
 	Client      *occlient.Client
 	Project     string
 	Application string

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -80,11 +80,18 @@ type Context struct {
 	cmp         string
 }
 
-// Component retrieves the optionally specified component or the current one if it is set
+// Component retrieves the optionally specified component or the current one if it is set. If no component is set, exit with
+// an error
 func (o *Context) Component(optionalComponent ...string) string {
+	return o.ComponentAllowingEmpty(false, optionalComponent...)
+}
+
+// ComponentAllowingEmpty retrieves the optionally specified component or the current one if it is set, allowing empty
+// components (instead of exiting with an error) if so specified
+func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...string) string {
 	switch len(optionalComponent) {
 	case 0:
-		if len(o.cmp) == 0 {
+		if !allowEmpty && len(o.cmp) == 0 {
 			fmt.Println("No component is set")
 			os.Exit(-1)
 		}

--- a/pkg/odo/genericclioptions/fakecontext.go
+++ b/pkg/odo/genericclioptions/fakecontext.go
@@ -1,0 +1,14 @@
+package genericclioptions
+
+import "github.com/redhat-developer/odo/pkg/occlient"
+
+func NewFakeContext(project, application, component string, client *occlient.Client) *Context {
+	return &Context{
+		internalCxt{
+			Client:      client,
+			Project:     project,
+			Application: application,
+			cmp:         component,
+		},
+	}
+}

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -56,6 +56,7 @@ func CheckError(err error, context string, a ...interface{}) {
 }
 
 // GetAppName returns application name from the provided flag or if flag is not provided, it will return current application name
+// Deprecated: should be replaced by accessing the application information from genericclioptions.Context
 func GetAppName(client *occlient.Client) string {
 	// applicationFlag is `--application` flag
 	if ApplicationFlag != "" {

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/occlient"
 	"os"
 )
 
@@ -20,21 +19,6 @@ const (
 	// ComponentFlagName is the name of the flag allowing a user to specify which component to operate on
 	ComponentFlagName = "component"
 )
-
-// Global variables
-var (
-	GlobalSkipConnectionCheck bool
-	ProjectFlag               string
-	ApplicationFlag           string
-	ComponentFlag             string
-)
-
-// GetOcClient creates a client to connect to OpenShift cluster
-func GetOcClient() *occlient.Client {
-	client, err := occlient.New(GlobalSkipConnectionCheck)
-	CheckError(err, "")
-	return client
-}
 
 // CheckError prints the cause of the given error and exits the code with an
 // exit code of 1.

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -11,8 +11,18 @@ import (
 	"os"
 )
 
-// RootCommandName is the name of the root command
-const RootCommandName = "odo"
+const (
+	// RootCommandName is the name of the root command
+	RootCommandName = "odo"
+	// SkipConnectionCheckFlagName is the name of the global flag used to skip connection check in the client
+	SkipConnectionCheckFlagName = "skip-connection-check"
+	// ProjectFlagName is the name of the flag allowing a user to specify which project to operate on
+	ProjectFlagName = "project"
+	// ApplicationFlagName is the name of the flag allowing a user to specify which application to operate on
+	ApplicationFlagName = "app"
+	// ComponentFlagName is the name of the flag allowing a user to specify which component to operate on
+	ComponentFlagName = "component"
+)
 
 // Global variables
 var (

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -74,6 +74,7 @@ func GetAppName(client *occlient.Client) string {
 // if provided, it validates the name and sets it as namespace for further operations
 // if not provided, it fetches current namespace and sets it as namespace for further operations
 // getAndSetNamespace also return the project name
+// Deprecated: should be replaced by accessing the project information from genericclioptions.Context
 func GetAndSetNamespace(client *occlient.Client) string {
 	// projectFlag is `--project` flag
 	if ProjectFlag != "" {

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/occlient"
-	"github.com/redhat-developer/odo/pkg/project"
 	"os"
 )
 
@@ -53,36 +51,4 @@ func CheckError(err error, context string, a ...interface{}) {
 
 		os.Exit(1)
 	}
-}
-
-// GetAppName returns application name from the provided flag or if flag is not provided, it will return current application name
-// Deprecated: should be replaced by accessing the application information from genericclioptions.Context
-func GetAppName(client *occlient.Client) string {
-	// applicationFlag is `--application` flag
-	if ApplicationFlag != "" {
-		_, err := application.Exists(client, ApplicationFlag)
-		CheckError(err, "")
-		return ApplicationFlag
-	}
-	applicationName, err := application.GetCurrent(client.Namespace)
-	CheckError(err, "unable to get current application")
-
-	return applicationName
-}
-
-// GetAndSetNamespace checks whether project flag is provided,
-// if provided, it validates the name and sets it as namespace for further operations
-// if not provided, it fetches current namespace and sets it as namespace for further operations
-// getAndSetNamespace also return the project name
-// Deprecated: should be replaced by accessing the project information from genericclioptions.Context
-func GetAndSetNamespace(client *occlient.Client) string {
-	// projectFlag is `--project` flag
-	if ProjectFlag != "" {
-		_, err := project.Exists(client, ProjectFlag)
-		CheckError(err, "")
-		client.Namespace = ProjectFlag
-		return ProjectFlag
-	}
-	client.Namespace = project.GetCurrent(client)
-	return client.Namespace
 }

--- a/pkg/odo/util/client.go
+++ b/pkg/odo/util/client.go
@@ -5,7 +5,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/application"
-	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/project"
 	"os"
@@ -84,26 +83,4 @@ func GetAndSetNamespace(client *occlient.Client) string {
 	}
 	client.Namespace = project.GetCurrent(client)
 	return client.Namespace
-}
-
-// GetComponent returns the component to be used for the operation. If an input
-// component is specified, then it is returned if it exists, if not,
-// the current component is fetched and returned. If no component set, throws error
-func GetComponent(client *occlient.Client, inputComponent string, applicationName string) string {
-	if len(inputComponent) == 0 {
-		c, err := component.GetCurrent(applicationName, client.Namespace)
-		CheckError(err, "Could not get current component")
-		if c == "" {
-			fmt.Println("There is no component set")
-			os.Exit(1)
-		}
-		return c
-	}
-	exists, err := component.Exists(client, inputComponent, applicationName)
-	CheckError(err, "")
-	if !exists {
-		fmt.Printf("Component %v does not exist\n", inputComponent)
-		os.Exit(1)
-	}
-	return inputComponent
 }

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -3,18 +3,16 @@ package completion
 import (
 	"github.com/posener/complete"
 	"github.com/redhat-developer/odo/pkg/application"
-	"github.com/redhat-developer/odo/pkg/occlient"
-	"github.com/redhat-developer/odo/pkg/odo/util"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/service"
+	"github.com/spf13/cobra"
 )
 
 // ServiceCompletionHandler provides service name completion for the current project and application
-var ServiceCompletionHandler = func(args complete.Args, client *occlient.Client) (completions []string) {
+var ServiceCompletionHandler = func(cmd *cobra.Command, args complete.Args, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	util.GetAndSetNamespace(client)
-	applicationName := util.GetAppName(client)
 
-	services, err := service.List(client, applicationName)
+	services, err := service.List(context.Client, context.Application)
 	if err != nil {
 		return completions
 	}
@@ -27,9 +25,9 @@ var ServiceCompletionHandler = func(args complete.Args, client *occlient.Client)
 }
 
 // ServiceClassCompletionHandler provides catalog service class name completion
-var ServiceClassCompletionHandler = func(args complete.Args, client *occlient.Client) (completions []string) {
+var ServiceClassCompletionHandler = func(cmd *cobra.Command, args complete.Args, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	services, err := client.GetClusterServiceClasses()
+	services, err := context.Client.GetClusterServiceClasses()
 	if err != nil {
 		return completions
 	}

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -56,7 +56,7 @@ var AppCompletionHandler = func(args complete.Args, client *occlient.Client) (co
 }
 
 // FileCompletionHandler provides suggestions for files and directories
-var FileCompletionHandler = func(args complete.Args, client *occlient.Client) (completions []string) {
+var FileCompletionHandler = func(cmd *cobra.Command, args complete.Args, context *genericclioptions.Context) (completions []string) {
 	completions = append(completions, complete.PredictFiles("*").Predict(args)...)
 	return completions
 }

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -21,7 +21,7 @@ var ServiceCompletionHandler = func(cmd *cobra.Command, args complete.Args, cont
 		completions = append(completions, class.Name)
 	}
 
-	return completions
+	return
 }
 
 // ServiceClassCompletionHandler provides catalog service class name completion
@@ -36,15 +36,14 @@ var ServiceClassCompletionHandler = func(cmd *cobra.Command, args complete.Args,
 		completions = append(completions, class.Spec.ExternalName)
 	}
 
-	return completions
+	return
 }
 
 // AppCompletionHandler provides completion for the app commands
-var AppCompletionHandler = func(args complete.Args, client *occlient.Client) (completions []string) {
+var AppCompletionHandler = func(cmd *cobra.Command, args complete.Args, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	util.GetAndSetNamespace(client)
 
-	applications, err := application.List(client)
+	applications, err := application.List(context.Client)
 	if err != nil {
 		return completions
 	}
@@ -52,11 +51,11 @@ var AppCompletionHandler = func(args complete.Args, client *occlient.Client) (co
 	for _, app := range applications {
 		completions = append(completions, app.Name)
 	}
-	return completions
+	return
 }
 
 // FileCompletionHandler provides suggestions for files and directories
 var FileCompletionHandler = func(cmd *cobra.Command, args complete.Args, context *genericclioptions.Context) (completions []string) {
 	completions = append(completions, complete.PredictFiles("*").Predict(args)...)
-	return completions
+	return
 }


### PR DESCRIPTION
== What is the purpose of this change? What does it change?
Introduces a new `Context` struct to hold project, application and component information based on specified flags. This should simplify the commands a bit and ultimately, this structure should be passed as an argument to lots of functions which currently take a client, project, application or component name as arguments. This work also targets #871 

== Was the change discussed in an issue?
No

== How to test changes?
External behavior shouldn't change.