### PR TITLE
Adds a new line in odo app describe when there is no active applicati…

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -244,7 +244,7 @@ var applicationDescribeCmd = &cobra.Command{
 			appName, err = application.GetCurrent(projectName)
 			util.CheckError(err, "")
 			if appName == "" {
-				fmt.Printf("There's no active application in project: %v", projectName)
+				fmt.Printf("There's no active application in project: %v\n", projectName)
 				os.Exit(1)
 			}
 		} else {


### PR DESCRIPTION
fixes #955 

Adds a new line in `odo app describe` when there is no active application