### PR TITLE
Decouple service catalog e2e tests from the the actual Openshift delete

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -76,10 +76,10 @@ func waitForDeleteCmd(cmd string, object string) bool {
 	})
 }
 
-// waitForEqualCmd calls the waitForCmdOut function to wait and check if the output is equal to the given string within 5 mins
+// waitForServiceStatusCmd calls the waitForCmdOut function to wait and check if the output is equal to the given string within 5 mins
 // cmd is the command to run
 // expOut is the expected output
-func waitForServiceCreateCmd(cmd string, status string) bool {
+func waitForServiceStatusCmd(cmd string, status string) bool {
 
 	return waitForCmdOut(cmd, 5, func(output string) bool {
 		return output == status

--- a/tests/e2e/service_test.go
+++ b/tests/e2e/service_test.go
@@ -11,7 +11,7 @@ var _ = Describe("odoServiceE2e", func() {
 		It("should be able to create a service", func() {
 			runCmd("odo service create mysql-persistent")
 			cmd := "oc get serviceinstance mysql-persistent -o go-template='{{ (index .status.conditions 0).reason}}'"
-			waitForServiceCreateCmd(cmd, "ProvisionedSuccessfully")
+			waitForServiceStatusCmd(cmd, "ProvisionedSuccessfully")
 		})
 
 		It("should be able to list the service", func() {
@@ -22,7 +22,8 @@ var _ = Describe("odoServiceE2e", func() {
 
 		It("should be able to delete a service", func() {
 			runCmd("odo service delete mysql-persistent -f")
-			waitForDeleteCmd("oc get serviceinstance", "mysql-persistent")
+			cmd := "oc get serviceinstance mysql-persistent -o go-template='{{ (index .status.conditions 0).reason}}'"
+			waitForServiceStatusCmd(cmd, "Deprovisioning")
 		})
 	})
 })


### PR DESCRIPTION
What is the purpose of this change? What does it change?

This is done because odo's part in deleting a service from the service
catalog ends with it's deletion of the serviceinstance, the actual
delete process is not something odo has any control of, so waiting
for the service to actually be deleted doesn't test odo, but Openshift.

Was the change discussed in an issue?

No. This work was performed because we have noticed that the integration test in Travis sometimes timeout waiting for the service to be deleted

How to test changes?

Nothing to test in odo proper. The service-catalog e2e tests should now never fail in delete operation
