### PR TITLE
Attempt to fix cmp e2e test flakiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test-cmp-e2e:
 ifdef TIMEOUT
 	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.v -timeout $(TIMEOUT)
 else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.v
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.v -timeout 15m
 endif
 
 # Run java e2e tests

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -82,10 +82,9 @@ var _ = Describe("odoCmpE2e", func() {
 
 	Context("updating the component", func() {
 		It("should be able to create binary component", func() {
-			runCmd("curl -v -o " + tmpDir + "/sample-binary-testing-1.war " +
+			runCmd("curl -L -o " + tmpDir + "/sample-binary-testing-1.war " +
 				"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
 			runCmd("odo create wildfly wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
-			runCmd("ls -l " + tmpDir)
 
 			// TODO: remove this once https://github.com/redhat-developer/odo/issues/943 is implemented
 			time.Sleep(90 * time.Second)
@@ -100,7 +99,7 @@ var _ = Describe("odoCmpE2e", func() {
 		})
 
 		It("should update component from binary to binary", func() {
-			runCmd("curl -o " + tmpDir + "/sample-binary-testing-2.war " +
+			runCmd("curl -L -o " + tmpDir + "/sample-binary-testing-2.war " +
 				"'https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/85354d9ee8583a9c1e64a331425eede235b07a9e/sample%2520(1).war'")
 
 			waitForDCOfComponentToRollout("wildfly")

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -647,6 +647,8 @@ var _ = Describe("updateE2e", func() {
 		It("should update component from binary to binary", func() {
 			runCmd("curl -o " + tmpDir + "/sample-binary-testing-2.war " +
 				"'https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/85354d9ee8583a9c1e64a331425eede235b07a9e/sample%2520(1).war'")
+
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-2.war")
 
 			// checking bc for updates
@@ -679,6 +681,7 @@ var _ = Describe("updateE2e", func() {
 			runCmd("git clone " + wildflyUri1 + " " +
 				tmpDir + "/katacoda-odo-backend-1")
 
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-1")
 
 			// checking bc for updates
@@ -711,6 +714,7 @@ var _ = Describe("updateE2e", func() {
 			runCmd("git clone " + wildflyUri2 + " " +
 				tmpDir + "/katacoda-odo-backend-2")
 
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-2")
 
 			// checking bc for updates
@@ -740,6 +744,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from local to git", func() {
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --git " + wildflyUri1)
 
 			// checking bc for updates
@@ -769,6 +774,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from git to git", func() {
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --git " + wildflyUri2)
 
 			// checking bc for updates
@@ -798,6 +804,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from git to binary", func() {
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
 
 			// checking bc for updates
@@ -827,6 +834,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from binary to git", func() {
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --git " + wildflyUri1)
 
 			// checking bc for updates
@@ -856,6 +864,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from git to local", func() {
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-1")
 
 			// checking bc for updates
@@ -885,6 +894,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from local to binary", func() {
+			waitForDCOfComponentToRollout("wildfly")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
 
 			// checking bc for updates

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -634,7 +634,7 @@ var _ = Describe("updateE2e", func() {
 
 	Context("updating the component", func() {
 		It("should be able to create binary component", func() {
-			runCmd("curl -o " + tmpDir + "/sample-binary-testing-1.war " +
+			runCmd("curl -L -o " + tmpDir + "/sample-binary-testing-1.war " +
 				"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
 			runCmd("odo create wildfly --binary " + tmpDir + "/sample-binary-testing-1.war  --env key=value,key1=value1")
 			cmpList := runCmd("odo list")
@@ -645,7 +645,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from binary to binary", func() {
-			runCmd("curl -o " + tmpDir + "/sample-binary-testing-2.war " +
+			runCmd("curl -L -o " + tmpDir + "/sample-binary-testing-2.war " +
 				"'https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/85354d9ee8583a9c1e64a331425eede235b07a9e/sample%2520(1).war'")
 
 			waitForDCOfComponentToRollout("wildfly")


### PR DESCRIPTION
**What is the purpose of this change? What does it change?**

This PR attempts to reduce the flakiness of the component end-to-end tests.
The source of flakiness that was identified and fixed with this PR was a race condition that was being incurred when updating a component a quick succession.


**Was the change discussed in an issue?**

No, but the team has been experiencing lots of flakiness the past few weeks

**How to test changes?**

This PR does not touch odo proper. All tests should now pass without flakiness
