### PR TITLE
Add an even more strict policy of waiting for dc updates

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -645,7 +645,7 @@ var _ = Describe("updateE2e", func() {
 			runCmd("curl -L -o " + tmpDir + "/sample-binary-testing-2.war " +
 				"'https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/85354d9ee8583a9c1e64a331425eede235b07a9e/sample%2520(1).war'")
 
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-2.war")
 
 			// checking bc for updates
@@ -678,7 +678,7 @@ var _ = Describe("updateE2e", func() {
 			runCmd("git clone " + wildflyUri1 + " " +
 				tmpDir + "/katacoda-odo-backend-1")
 
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-1")
 
 			// checking bc for updates
@@ -711,7 +711,7 @@ var _ = Describe("updateE2e", func() {
 			runCmd("git clone " + wildflyUri2 + " " +
 				tmpDir + "/katacoda-odo-backend-2")
 
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-2")
 
 			// checking bc for updates
@@ -741,7 +741,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from local to git", func() {
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --git " + wildflyUri1)
 
 			// checking bc for updates
@@ -771,7 +771,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from git to git", func() {
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --git " + wildflyUri2)
 
 			// checking bc for updates
@@ -801,7 +801,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from git to binary", func() {
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
 
 			// checking bc for updates
@@ -831,7 +831,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from binary to git", func() {
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --git " + wildflyUri1)
 
 			// checking bc for updates
@@ -861,7 +861,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from git to local", func() {
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --local " + tmpDir + "/katacoda-odo-backend-1")
 
 			// checking bc for updates
@@ -891,7 +891,7 @@ var _ = Describe("updateE2e", func() {
 		})
 
 		It("should update component from local to binary", func() {
-			waitForDCOfComponentToRollout("wildfly")
+			waitForDCOfComponentToRolloutCompletely("wildfly")
 			runCmd("odo update wildfly --binary " + tmpDir + "/sample-binary-testing-1.war")
 
 			// checking bc for updates


### PR DESCRIPTION
**What is the purpose of this change? What does it change?**

Now we wait until there are no pods of the old replication controller
running before updating a DC

**Was the change discussed in an issue?**

No. But we are all feeling the pain of flaky tests

**How to test changes?**

Nothing to test in `odo` proper