### PR TITLE
Update the service catalog test to take into account the detailed status and improve robustness

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -90,7 +90,7 @@ func waitForDeleteCmd(cmd string, object string) bool {
 	})
 }
 
-// waitForServiceStatusCmd calls the waitForCmdOut function to wait and check if the output is equal to the given string within 5 mins
+// waitForServiceStatusCmd calls the waitForCmdOut function to wait and check if the output is equal to the given string within 10 mins
 // cmd is the command to run
 // expOut is the expected output
 func waitForServiceStatusCmd(cmd string, status string) bool {

--- a/tests/e2e/service_test.go
+++ b/tests/e2e/service_test.go
@@ -1,8 +1,9 @@
 package e2e
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"strings"
 )
 
 var _ = Describe("odoServiceE2e", func() {
@@ -10,20 +11,28 @@ var _ = Describe("odoServiceE2e", func() {
 	Context("odo service creation", func() {
 		It("should be able to create a service", func() {
 			runCmd("odo service create mysql-persistent")
-			cmd := "oc get serviceinstance mysql-persistent -o go-template='{{ (index .status.conditions 0).reason}}'"
+			waitForCmdOut("oc get serviceinstance -o name", 1, func(output string) bool {
+				return strings.Contains(output, "mysql-persistent")
+			})
+			cmd := serviceInstanceStatusCmd("mysql-persistent")
 			waitForServiceStatusCmd(cmd, "ProvisionedSuccessfully")
 		})
 
-		It("should be able to list the service", func() {
-			out := runCmd("odo service list | sed 1d")
-			Expect(out).To(ContainSubstring("mysql-persistent"))
-			Expect(out).To(ContainSubstring("ProvisionedSuccessfully"))
+		It("should be able to list the service with correct status", func() {
+			waitForCmdOut("odo service list | sed 1d", 1, func(output string) bool {
+				return strings.Contains(output, "mysql-persistent") &&
+					strings.Contains(output, "ProvisionedAndBound")
+			})
 		})
 
 		It("should be able to delete a service", func() {
 			runCmd("odo service delete mysql-persistent -f")
-			cmd := "oc get serviceinstance mysql-persistent -o go-template='{{ (index .status.conditions 0).reason}}'"
+			cmd := serviceInstanceStatusCmd("mysql-persistent")
 			waitForServiceStatusCmd(cmd, "Deprovisioning")
 		})
 	})
 })
+
+func serviceInstanceStatusCmd(serviceInstanceName string) string {
+	return fmt.Sprintf("oc get serviceinstance %s -o go-template='{{ (index .status.conditions 0).reason}}'", serviceInstanceName)
+}


### PR DESCRIPTION
**What is the purpose of this change? What does it change?**

Robustness is improved by introducing an extra wait step for the
ServiceInstance.
Completeness is improved by updating the list test to take into account
the detailed status. This is needed because of #847 was merged

**Was the change discussed in an issue?**

No

**How to test changes?**

Not part of odo proper, this only affects the e2e tests 
