### PR TITLE
Display odo version when installing via brew.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,7 +114,7 @@ Aborting now!
         echo "# Enabling kadel/odo... "
         brew tap kadel/odo
 
-        echo "Installing odo..."
+        echo "Installing odo ${ODO_VERSION}"
         case "$ODO_VERSION" in
         master)
             brew install kadel/odo/odo -- HEAD


### PR DESCRIPTION
What is the purpose of this change? What does it change?
See subject ;)

Was the change discussed in an issue?
No.

How to test changes?
Nothing to do, should just improve diagnosing test errors when building from brew.