### PR TITLE
Corrected the import command in readme

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -237,7 +237,7 @@ Below is an example of how to successfully import and use the [redhat-openjdk-18
 
 ```sh
 # Import the image into OpenShift
-oc import openjdk18 --from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift --confirm
+oc import-image openjdk18 --from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift --confirm
 
 # Tag the image so it is accessible by Odo
 oc annotate istag/openjdk18:latest tags=builder


### PR DESCRIPTION
What is the purpose of this change? What does it change?
Corrected the incorrectly mentioned `oc import` to `oc import-image` in the custom builder readme section

Was the change discussed in an issue?
No

How to test changes?
No need to test the changes
