### PR TITLE
Add go completion for odo url delete

### DIFF
--- a/cmd/url.go
+++ b/cmd/url.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
 	"strings"
 
@@ -200,4 +201,6 @@ func init() {
 	addComponentFlag(urlCreateCmd)
 
 	rootCmd.AddCommand(urlCmd)
+
+	completion.RegisterCommandHandler(urlDeleteCmd, completion.URLCompletionHandler)
 }

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/redhat-developer/odo/pkg/service"
+	"github.com/redhat-developer/odo/pkg/url"
 	"github.com/spf13/cobra"
 )
 
@@ -78,4 +79,24 @@ var ProjectNameCompletionHandler = func(cmd *cobra.Command, args parsedArgs, con
 		completions = append(completions, project.Name)
 	}
 	return completions
+}
+
+// URLCompletionHandler provides completion for the url commands
+var URLCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
+	completions = make([]string, 0)
+
+	urls, err := url.List(context.Client, context.Component(), context.Application)
+	if err != nil {
+		return completions
+	}
+
+	for _, url := range urls {
+		// we found the url in the list which means
+		// that the url name has been already selected by the user so no need to suggest more
+		if val, ok := args.commands[url.Name]; ok && val {
+			return nil
+		}
+		completions = append(completions, url.Name)
+	}
+	return
 }


### PR DESCRIPTION
**What is the purpose of this change? What does it change?**

Add go completion for odo url delete

**Was the change discussed in an issue?**

#938 

How to test changes?

```
make install
odo create ....
odo url create ...
odo url delete <tab>
````

the last command should auto-complete the url that was created from the previous step

Fixes: #938 