### PR TITLE
Wrap filepath#Abs to also resolve shell symbol ~ to user home

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -208,8 +208,6 @@ A full list of component types that can be deployed is available using: 'odo cat
 			odoutil.CheckError(err, "")
 
 		} else if len(componentLocal) != 0 {
-
-			// Use the absolute path for the component
 			fileInfo, err := os.Stat(componentPath)
 			odoutil.CheckError(err, "")
 			if !fileInfo.IsDir() {

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -2,11 +2,12 @@ package component
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
-	"os"
-	"path/filepath"
+	pkgUtil "github.com/redhat-developer/odo/pkg/util"
 
 	"github.com/fatih/color"
 	"github.com/redhat-developer/odo/pkg/component"
@@ -75,7 +76,7 @@ var updateCmd = &cobra.Command{
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
-			dir, err := filepath.Abs(componentLocal)
+			dir, err := pkgUtil.GetAbsPath(componentLocal)
 			util.CheckError(err, "")
 			fileInfo, err := os.Stat(dir)
 			util.CheckError(err, "")
@@ -87,7 +88,7 @@ var updateCmd = &cobra.Command{
 			util.CheckError(err, "")
 			fmt.Printf("The component %s was updated successfully, please use 'odo push' to push your local changes\n", componentName)
 		} else if len(componentBinary) != 0 {
-			path, err := filepath.Abs(componentBinary)
+			path, err := pkgUtil.GetAbsPath(componentBinary)
 			util.CheckError(err, "")
 			err = component.Update(client, componentName, applicationName, "binary", path, stdout)
 			util.CheckError(err, "")

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"fmt"
 	"net/url"
+	"os"
+	"os/user"
 	"reflect"
 	"regexp"
 	"testing"
@@ -447,6 +449,54 @@ func TestSliceDifference(t *testing.T) {
 			result := SliceDifference(tt.slice1, tt.slice2)
 			if !reflect.DeepEqual(tt.expectedResult, result) {
 				t.Errorf("Expected %v, got %v", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestGetAbsPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		absPath string
+		wantErr bool
+	}{
+		{
+			name:    "Case 1: Valid abs path resolution of `~`",
+			path:    "~",
+			wantErr: false,
+		},
+		{
+			name:    "Case 2: Valid abs path resolution of `.`",
+			path:    ".",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Log("Running test: ", tt.name)
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.path {
+			case "~":
+				usr, err := user.Current()
+				if err != nil {
+					t.Errorf("Failed to get absolute path corresponding to `~`. Error %v", err)
+					return
+				}
+				tt.absPath = usr.HomeDir
+			case ".":
+				absPath, err := os.Getwd()
+				if err != nil {
+					t.Errorf("Failed to get absolute path corresponding to `.`. Error %v", err)
+					return
+				}
+				tt.absPath = absPath
+			}
+			result, err := GetAbsPath(tt.path)
+			if result != tt.absPath {
+				t.Errorf("Expected %v, got %v", tt.absPath, result)
+			}
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("Expected error: %v got error %v", tt.wantErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a wrapper around filepath#Abs to apart from resolving
relative paths to absolute paths also resolves ~ to user home.
This PR also resolves all references to filepath#Abs to the new wrapper
util.

This is in attempt to resolve bugs like #916

fixes #916
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>