### PR TITLE
Temporary disable installation script test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,12 +95,12 @@ jobs:
     #   script:
     #     ./scripts/test-install.sh
     # test installation script on macOS
-    - state: test
-      os: osx
-      install:
-        - true
-      script:
-        ./scripts/install.sh
+    # - state: test
+    #   os: osx
+    #   install:
+    #     - true
+    #   script:
+    #     ./scripts/install.sh
 
     - stage: deploy
       go_import_path:  github.com/redhat-developer/odo


### PR DESCRIPTION
This test at its current form it is just wasting resources without
adding any benefit. It tests latest released version over and over
again.
