### PR TITLE
better travis.yaml: run deploy stage only for tags and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,8 @@ jobs:
     #     ./scripts/install.sh
 
     - stage: deploy
+      # run this stage only on master branch and on tags
+      if: branch = master || tag IS present
       go_import_path:  github.com/redhat-developer/odo
       go: "1.11"
       env: BUILD_DOCS=yes


### PR DESCRIPTION
-  skip deploy stage for PRs
- reduced number of jobs (by 1) ;-) 
   We used to run unit tests twice (one for computing coverage, and run regular run). Now there is only one job (the one that computes coverage)