### PR TITLE
resolved bug in the way componentCmd was added FlagSet

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
@@ -77,7 +78,7 @@ func init() {
 	componentGetCmd.Flags().BoolVarP(&componentShortFlag, "short", "q", false, "If true, display only the component name")
 
 	// add flags from 'get' to component command
-	componentCmd.Flags().AddFlagSet(applicationGetCmd.Flags())
+	componentCmd.Flags().AddFlagSet(componentGetCmd.Flags())
 
 	componentCmd.AddCommand(componentGetCmd)
 	componentCmd.AddCommand(componentSetCmd)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
- Changes the use of applicationGetCmd to componentGetCmd in component code

Was the change discussed in an issue?
- Issue #550 

How to test changes?
- `odo component -q` should output nothing incase of no current component being set