### PR TITLE
Fixed the problem of displaying wrong project as active after project delete

### DIFF
--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -146,21 +146,15 @@ var projectDeleteCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Deleting project %s...\n(this operation may take some time)\n", projectName)
-		err = project.Delete(client, projectName)
+		currentProject, err := project.Delete(client, projectName)
 		if err != nil {
 			util.CheckError(err, "")
 		}
+
 		fmt.Printf("Deleted project : %v\n", projectName)
 
-		// Get Current Project
-		currProject := project.GetCurrent(client)
-
-		// Check if List returns empty, if so, the currProject is showing old currentProject
-		// In openshift, when the project is deleted, it does not reset the current project in kube config file which is used by odo for current project
-		projects, err := project.List(client)
-		util.CheckError(err, "")
-		if len(projects) != 0 {
-			fmt.Printf("%s has been set as the active project\n", currProject)
+		if currentProject != "" {
+			fmt.Printf("%s has been set as the active project\n", currentProject)
 		} else {
 			// oc errors out as "error: you do not have rights to view project "$deleted_project"."
 			fmt.Printf("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command\n")

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -53,8 +53,8 @@ func Create(client *occlient.Client, projectName string) error {
 	return nil
 }
 
-// Delete deletes the project with name projectName and sets the project with name currentProject as current project
-// and returns the current project or ("" if no current project is set) and errors if any
+// Delete deletes the project with name projectName and sets any other remaining project as the current project
+// and returns the current project or "" if no current project is set and errors if any
 func Delete(client *occlient.Client, projectName string) (string, error) {
 	currentProject := GetCurrent(client)
 

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -79,7 +79,17 @@ func TestDelete(t *testing.T) {
 			})
 
 			// The function we are testing
-			err = Delete(client, tt.projectName)
+			newSetProject, err := Delete(client, tt.projectName)
+
+			if err == nil && !tt.wantErr {
+				if len(fakeClientSet.ProjClientset.Actions()) != 3 {
+					t.Errorf("expected 1 ProjClientSet.Actions() in Project Delete, got: %v", len(fakeClientSet.ProjClientset.Actions()))
+				}
+
+				if newSetProject == tt.projectName {
+					t.Errorf("the deleted project was returned as active, expected : the project name not to be equal to %v", tt.projectName)
+				}
+			}
 
 			// Checks for error in positive cases
 			if !tt.wantErr == (err != nil) {


### PR DESCRIPTION
fixes #887 

The project delete function in pkg folder now returns the current set project along with the error if any. If no project is left to be set active, "" is returned.

To test :
1. Create a new project
2. Delete the project and check the name of the project which is set as active.
