### PR TITLE
Fixed `odo login` message

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -120,7 +120,7 @@ var S2IDeploymentsDir = []string{
 const errorMsg = `
 Please login to your server: 
 
-oc login https://mycluster.mydomain.com
+odo login https://mycluster.mydomain.com
 `
 
 type Client struct {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

`odo version` error message shows `oc login` if kubeconfig is not present.

## Was the change discussed in an issue?

Fixes #1003


## How to test changes?

remove `kubeconfig` and do `odo version`
