### PR TITLE
e2e: add travis_wait for test-cmp-e2e

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - make test-cmp-e2e
+        - travis_wait make test-cmp-e2e
 
     # Run java e2e tests
     - <<: *base-test


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Increase timout to 20 minutes

Travis-ci kills jobs that don't output something for more than 10 mins.


## Was the change discussed in an issue?


## How to test changes?
<!-- Please describe the steps to test the PR -->
