### PR TITLE
made runFailCmd wait till cmd gets completed

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -33,6 +33,7 @@ func runFailCmd(cmdS string) string {
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 
 	// wait for the command execution to complete
+	<-session.Exited
 	Expect(session.ExitCode()).To(Equal(1))
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
The `runFailCmd` wasn't waiting for the command to complete due to which the exit code of the Cmd always returned as `-1`. This occurs due to premature stopping.

## Was the change discussed in an issue?
No Issue

## How to test changes?
try using `runFailCmd` for a failing odo cli combination  eg. `odo create test --local test --git test`
