### PR TITLE
Adds PodTimeout to odo utils config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,8 +16,12 @@ import (
 const (
 	configEnvName  = "ODOCONFIG"
 	configFileName = "odo"
+
 	//DefaultTimeout for openshift server connection check
 	DefaultTimeout = 1
+
+	// Default PodTimeout for OpenShift
+	DefaultPodTimeout = 120
 )
 
 // OdoSettings holds all odo specific configurations
@@ -28,6 +32,8 @@ type OdoSettings struct {
 	NamePrefix *string `json:"nameprefix,omitempty"`
 	// Timeout for openshift server connection check
 	Timeout *int `json:"timeout,omitempty"`
+	// PodTimeout for OpenShift Pods
+	PodTimeout *int `json:"podtimeout,omitempty"`
 }
 
 // ApplicationInfo holds all important information about one application
@@ -154,6 +160,16 @@ func (c *ConfigInfo) SetConfiguration(parameter string, value string) error {
 		}
 		c.OdoSettings.Timeout = &typedval
 
+	case "podtimeout":
+		typedval, err := strconv.Atoi(value)
+		if err != nil {
+			return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
+		}
+		if typedval < 0 {
+			return errors.Errorf("cannot set podtimeout to less than 0")
+		}
+		c.OdoSettings.PodTimeout = &typedval
+
 	case "updatenotification":
 		val, err := strconv.ParseBool(strings.ToLower(value))
 		if err != nil {
@@ -181,6 +197,14 @@ func (c *ConfigInfo) GetTimeout() int {
 		return DefaultTimeout
 	}
 	return *c.OdoSettings.Timeout
+}
+
+// GetPodTimeout returns the value of PodTimeout from config
+func (c *ConfigInfo) GetPodTimeout() int {
+	if c.OdoSettings.PodTimeout == nil {
+		return DefaultPodTimeout
+	}
+	return *c.OdoSettings.PodTimeout
 }
 
 // GetUpdateNotification returns the value of UpdateNotification from config

--- a/pkg/odo/cli/utils/config.go
+++ b/pkg/odo/cli/utils/config.go
@@ -13,16 +13,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const availableParameters = `
+Available Parameters:
+UpdateNotification - Controls if an update notification is shown or not (true or false)
+NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix
+Timeout - Timeout (in seconds) for OpenShift server connection check
+PodTimeout - Pod Timeout (in seconds) to wait for an OpenShift Pod to start when deploying a component
+`
+
 // configurationCmd represents the app command
 var configurationCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Modifies configuration settings",
 	Long: `Modifies Odo specific configuration settings within the config file.
-
-Available Parameters:
-UpdateNotification - Controls if an update notification is shown or not (true or false)
-NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix
-Timeout - Timeout (in seconds) for OpenShift server connection check`,
+	` + availableParameters,
 	Example: fmt.Sprintf("%s\n%s",
 		configurationViewCmd.Example,
 		configurationSetCmd.Example),
@@ -49,16 +53,13 @@ var configurationSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set a value in odo config file",
 	Long: `Set an individual value in the Odo configuration file
-
-Available Parameters:
-UpdateNotification - Controls if an update notification is shown or not (true or false)
-NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix.
-Timeout - Timeout (in seconds) for OpenShift server connection check`,
+	` + availableParameters,
 	Example: `
    # Set a configuration value
    odo utils config set UpdateNotification false
    odo utils config set NamePrefix "app"
    odo utils config set Timeout 20
+   odo utils config set PodTimeout 20
 	`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
@@ -96,6 +97,7 @@ var configurationViewCmd = &cobra.Command{
 		fmt.Fprintln(w, "UpdateNotification", "\t", cfg.GetUpdateNotification())
 		fmt.Fprintln(w, "NamePrefix", "\t", cfg.GetNamePrefix())
 		fmt.Fprintln(w, "Timeout", "\t", cfg.GetTimeout())
+		fmt.Fprintln(w, "PodTimeout", "\t", cfg.GetPodTimeout())
 		w.Flush()
 	},
 }

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -49,6 +49,11 @@ var _ = Describe("odoCmpE2e", func() {
 
 	Context("odo component creation", func() {
 
+		// This is required as some CI's (such as TravisCI) requires a little bit more time
+		It("should set an appropriate test-configured PodTimeout", func() {
+			runCmd("odo utils config set PodTimeout 121")
+		})
+
 		It("should create the project and application", func() {
 			runCmd("odo project create " + projName)
 			runCmd("odo app create " + appTestName)
@@ -119,9 +124,6 @@ var _ = Describe("odoCmpE2e", func() {
 			runCmd("curl -L -o " + tmpDir + "/sample-binary-testing-1.war " +
 				"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
 			runCmd("odo create wildfly wildfly --binary " + tmpDir + "/sample-binary-testing-1.war --memory 500Mi")
-
-			// TODO: remove this once https://github.com/redhat-developer/odo/issues/943 is implemented
-			time.Sleep(90 * time.Second)
 
 			// Run push
 			runCmd("odo push -v 4")

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -78,6 +78,7 @@ var _ = Describe("odoe2e", func() {
 		})
 	})
 
+	// NOTE: This will permanently set the config for the rest of the tests..
 	Context("odo utils config", func() {
 		It("should get true for updatenotification by default", func() {
 			configOutput := runCmd("odo utils config view")
@@ -90,12 +91,15 @@ var _ = Describe("odoe2e", func() {
 		})
 		It("should be checking to see if config values are the same as the configured ones", func() {
 			runCmd("odo utils config set updatenotification false")
-			runCmd("odo utils config set timeout 5")
+			runCmd("odo utils config set timeout 31")
+			runCmd("odo utils config set podtimeout 121")
 			configOutput := runCmd("odo utils config view|grep UpdateNotification")
 			Expect(configOutput).To(ContainSubstring("false"))
 			Expect(configOutput).To(ContainSubstring("UpdateNotification"))
 			configOutput = runCmd("odo utils config view|grep Timeout")
-			Expect(configOutput).To(ContainSubstring("5"))
+			Expect(configOutput).To(ContainSubstring("31"))
+			configOutput = runCmd("odo utils config view|grep PodTimeout")
+			Expect(configOutput).To(ContainSubstring("121"))
 		})
 	})
 


### PR DESCRIPTION
Adds PodTimeout to odo utils in order to set the length of time to wait
for a Pod to timeout when deploying to OpenShift.

This can be tested with `odo utils config set PodTimeout 30`

Closes https://github.com/redhat-developer/odo/issues/943