### PR TITLE
Detect correct port when testing OpenShift connection

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -377,13 +377,8 @@ func (c *Client) RunLogout(stdout io.Writer) error {
 }
 
 // isServerUp returns true if server is up and running
+// server parameter has to be a valid url
 func isServerUp(server string) bool {
-	u, err := url.Parse(server)
-	if err != nil {
-		glog.V(4).Info(errors.Wrap(err, "unable to parse url"))
-		return false
-	}
-
 	// initialising the default timeout, this will be used
 	// when the value is not readable from config
 	ocRequestTimeout := config.DefaultTimeout * time.Second
@@ -395,9 +390,12 @@ func isServerUp(server string) bool {
 	} else {
 		ocRequestTimeout = time.Duration(cfg.GetTimeout()) * time.Second
 	}
-	glog.V(4).Infof("Trying to connect to server %v", u.Host)
-
-	_, connectionError := net.DialTimeout("tcp", u.Host, time.Duration(ocRequestTimeout))
+	address, err := util.GetHostWithPort(server)
+	if err != nil {
+		glog.V(4).Infof("Unable to parse url %s (%s)", server, err)
+	}
+	glog.V(4).Infof("Trying to connect to server %s", address)
+	_, connectionError := net.DialTimeout("tcp", address, time.Duration(ocRequestTimeout))
 	if connectionError != nil {
 		glog.V(4).Info(errors.Wrap(connectionError, "unable to connect to server"))
 		return false

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/types"
 	"net"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -17,17 +16,15 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
-
 	"github.com/fatih/color"
 	"github.com/golang/glog"
-	dockerapiv10 "github.com/openshift/api/image/docker10"
 	"github.com/pkg/errors"
+
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/util"
 
+	// api clientsets
 	servicecatalogclienset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
 	appsschema "github.com/openshift/client-go/apps/clientset/versioned/scheme"
 	appsclientset "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
@@ -38,20 +35,26 @@ import (
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	userclientset "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 
+	// api resource types
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
+	dockerapiv10 "github.com/openshift/api/image/docker10"
 	imagev1 "github.com/openshift/api/image/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	oauthv1client "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	// utilities
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apimachinery/pkg/watch"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -10,27 +10,29 @@ import (
 
 	"github.com/pkg/errors"
 
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	"github.com/redhat-developer/odo/pkg/util"
+
+	// api resources
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	dockerapi "github.com/openshift/api/image/docker10"
+	dockerapiv10 "github.com/openshift/api/image/docker10"
 	imagev1 "github.com/openshift/api/image/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	routev1 "github.com/openshift/api/route/v1"
-
-	dockerapiv10 "github.com/openshift/api/image/docker10"
-	applabels "github.com/redhat-developer/odo/pkg/application/labels"
-	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
-	"github.com/redhat-developer/odo/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
-	ktesting "k8s.io/client-go/testing"
-
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/watch"
+
+	ktesting "k8s.io/client-go/testing"
 )
 
 // fakeDeploymentConfig creates a fake DC.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -344,4 +346,29 @@ func CheckPathExists(path string) bool {
 		return true
 	}
 	return false
+}
+
+// GetHostWithPort parses provided url and returns string formated as
+// host:port even if port was not specifically specified in the origin url.
+// If port is not specified, standart port corresponding to url schema is provided.
+// example: for url https://example.com function will return "example.com:443"
+//          for url https://example.com:8443 function will return "example:8443"
+func GetHostWithPort(inputURL string) (string, error) {
+	u, err := url.Parse(inputURL)
+	if err != nil {
+		return "", errors.Wrapf(err, "error while getting port for url %s ", inputURL)
+	}
+
+	port := u.Port()
+	address := u.Host
+	// if port is not specified try to detect it based on provided scheme
+	if port == "" {
+		portInt, err := net.LookupPort("tcp", u.Scheme)
+		if err != nil {
+			return "", errors.Wrapf(err, "error while getting port for url %s ", inputURL)
+		}
+		port = strconv.Itoa(portInt)
+		address = fmt.Sprintf("%s:%s", u.Host, port)
+	}
+	return address, nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -560,3 +560,54 @@ func TestCheckPathExists(t *testing.T) {
 		}
 	}
 }
+func TestGetHostWithPort(t *testing.T) {
+
+	tests := []struct {
+		inputURL string
+		want     string
+		wantErr  bool
+	}{
+		{
+			inputURL: "https://example.com",
+			want:     "example.com:443",
+			wantErr:  false,
+		},
+		{
+			inputURL: "https://example.com:8443",
+			want:     "example.com:8443",
+			wantErr:  false,
+		},
+		{
+			inputURL: "http://example.com",
+			want:     "example.com:80",
+			wantErr:  false,
+		},
+		{
+			inputURL: "notexisting://example.com",
+			want:     "",
+			wantErr:  true,
+		},
+		{
+			inputURL: "http://127.0.0.1",
+			want:     "127.0.0.1:80",
+			wantErr:  false,
+		},
+		{
+			inputURL: "example.com:1234",
+			want:     "",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Testing inputURL: %s", tt.inputURL), func(t *testing.T) {
+			got, err := GetHostWithPort(tt.inputURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHostWithPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getHostWithPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## What is the purpose of this change? What does it change?
Connect to correct port when testing openShift connection
It uses `net.LookupPort` to correctly resolve url schema part to port if not explicitly specified.

## Was the change discussed in an issue?
fixes #1028
<!-- Please do Link issues here. -->

## How to test changes?
modify part of the kubeconfig that points to the server and remove port from it
```
clusters:
- cluster:
    server: https://youurhost:443
```

```
clusters:
- cluster:
    server: https://youurhost
```

NOTE: your cluster has to be using standart https port (443) or http (80)



