### PR TITLE
Add cpu flags to component create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ bin:
 
 .PHONY: install
 install:
-	go install ${BUILD_FLAGS}
+	go install ${BUILD_FLAGS} ./cmd/odo/
 
 # run all validation tests
 .PHONY: validate

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -279,7 +279,7 @@ func FetchResourceQuantity(resourceType corev1.ResourceName, min string, max str
 		maxResource = resource.MustParse(request)
 	}
 	return &ResourceRequirementInfo{
-		ResourceType: corev1.ResourceMemory,
+		ResourceType: resourceType,
 		MinQty:       minResource,
 		MaxQty:       maxResource,
 	}

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -55,7 +55,7 @@ var _ = Describe("odoCmpE2e", func() {
 		})
 
 		It("should be able to create a component with git source", func() {
-			runCmd("odo create nodejs cmp-git --git https://github.com/openshift/nodejs-ex --min-memory 100Mi --max-memory 300Mi")
+			runCmd("odo create nodejs cmp-git --git https://github.com/openshift/nodejs-ex --min-memory 100Mi --max-memory 300Mi --min-cpu 0.1 --max-cpu 2")
 			getMemoryLimit := runCmd("oc get dc cmp-git-" +
 				appTestName +
 				" -o go-template='{{range .spec.template.spec.containers}}{{.resources.limits.memory}}{{end}}'",
@@ -66,6 +66,17 @@ var _ = Describe("odoCmpE2e", func() {
 				" -o go-template='{{range .spec.template.spec.containers}}{{.resources.requests.memory}}{{end}}'",
 			)
 			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+
+			getCpuLimit := runCmd("oc get dc cmp-git-" +
+				appTestName +
+				" -o go-template='{{range .spec.template.spec.containers}}{{.resources.limits.cpu}}{{end}}'",
+			)
+			Expect(getCpuLimit).To(ContainSubstring("2"))
+			getCpuRequest := runCmd("oc get dc cmp-git-" +
+				appTestName +
+				" -o go-template='{{range .spec.template.spec.containers}}{{.resources.requests.cpu}}{{end}}'",
+			)
+			Expect(getCpuRequest).To(ContainSubstring("100m"))
 		})
 
 		It("should list the component", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
In the spirit of what was done for #907, we introduce flags to control the cpu requests and limits.
This work was made super easy by the great implementation that was done by @anmolbabu for #907 - you'll notice that the code changes are very minimal  

## Was the change discussed in an issue?
Fixes: #908
Fixes: #1037

## How to test changes?
Test the creation of the DC using of `--cpu` or `--min-cpu` / `--max-cpu`.
Also try testing with `--memory` to make sure that both resources are applied properly
