### PR TITLE
Bump Supervisord image version

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -91,7 +91,7 @@ const (
 	nameLength = 5
 
 	// Image that will be used containing the supervisord binary and assembly scripts
-	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.3.0"
+	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.4.0"
 
 	// Create a custom name and (hope) that users don't use the *exact* same name in their deployment
 	supervisordVolumeName = "odo-supervisord-shared-data"


### PR DESCRIPTION

## What is the purpose of this change? What does it change?
Update supervisord container image version to `0.4.0`

## Was the change discussed in an issue?
fixes https://github.com/redhat-developer/odo/issues/445

