### PR TITLE
Fix panic when no args supplied to cli-doc

### DIFF
--- a/cmd/cli-doc/cli-doc.go
+++ b/cmd/cli-doc/cli-doc.go
@@ -143,13 +143,17 @@ func main() {
 		ValidArgs: []string{"help", "reference", "structure"},
 
 		Run: func(command *cobra.Command, args []string) {
-			switch args[0] {
-			case "reference":
-				fmt.Print(referencePrinter(cli.RootCmd(), 0))
-			case "structure":
-				fmt.Print(commandPrinter(cli.RootCmd(), 0))
-			default:
+			if len(args) == 0 {
 				fmt.Print(command.Usage())
+			} else {
+				switch args[0] {
+				case "reference":
+					fmt.Print(referencePrinter(cli.RootCmd(), 0))
+				case "structure":
+					fmt.Print(commandPrinter(cli.RootCmd(), 0))
+				default:
+					fmt.Print(command.Usage())
+				}
 			}
 		},
 	}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Fixes the bug reported in #1047

## Was the change discussed in an issue?
fixes #???
#1047

## How to test changes?
`go run cmd/cli-doc/cli-doc.go` should now work instead of resulting in a panic.
Also: `go run cmd/cli-doc/cli-doc.go structure` and `go run cmd/cli-doc/cli-doc.go reference` should continue to work as previously
