### PR TITLE
Update gofmt and goimports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - &base-test
       stage: test
       go_import_path: github.com/redhat-developer/odo
-      go: "1.11"
+      go: "1.11.2"
       install:
         - make goget-tools
       script:

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/util"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sync"
 	"time"
+
+	"github.com/redhat-developer/odo/pkg/util"
 
 	"github.com/redhat-developer/odo/pkg/occlient"
 

--- a/pkg/component/watch_test.go
+++ b/pkg/component/watch_test.go
@@ -174,55 +174,55 @@ func TestWatchAndPush(t *testing.T) {
 			delayInterval:   1,
 			wantErr:         false,
 			requiredFilePaths: []testingutil.FileProperties{
-				testingutil.FileProperties{
+				{
 					FilePath:         "src",
 					FileParent:       "",
 					FileType:         testingutil.Directory,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "tests",
 					FileParent:       "",
 					FileType:         testingutil.Directory,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         ".git",
 					FileParent:       "",
 					FileType:         testingutil.Directory,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "LICENSE",
 					FileParent:       "",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "main.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "tests",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "test1.py",
 					FileParent:       "tests",
 					FileType:         testingutil.RegularFile,
@@ -230,31 +230,31 @@ func TestWatchAndPush(t *testing.T) {
 				},
 			},
 			fileModifications: []testingutil.FileProperties{
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.APPEND,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "read_licenses.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "read_licenses.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.APPEND,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "test_read_licenses.py",
 					FileParent:       "tests",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "tests",
 					FileParent:       "",
 					FileType:         testingutil.Directory,

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -58,7 +58,7 @@ func fakeDeploymentConfig(name string, image string, envVars []corev1.EnvVar, re
 		Name:      name,
 		Tag:       "latest",
 		Namespace: "openshift",
-		Ports:     []corev1.ContainerPort{corev1.ContainerPort{Name: "foo", HostPort: 80, ContainerPort: 80}},
+		Ports:     []corev1.ContainerPort{{Name: "foo", HostPort: 80, ContainerPort: 80}},
 	}
 
 	// Generate the DeploymentConfig that will be used.
@@ -3402,7 +3402,7 @@ func TestPatchCurrentDC(t *testing.T) {
 				name:     "foo",
 				dcBefore: *fakeDeploymentConfig("foo", "foo", []corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}}, fakeResourceConsumption()),
 				dcPatch: generateGitDeploymentConfig(metav1.ObjectMeta{Name: "foo2"}, "bar",
-					[]corev1.ContainerPort{corev1.ContainerPort{Name: "foo", HostPort: 80, ContainerPort: 80}},
+					[]corev1.ContainerPort{{Name: "foo", HostPort: 80, ContainerPort: 80}},
 					[]corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}},
 					nil),
 			},
@@ -3586,31 +3586,31 @@ func TestUniqueAppendOrOverwriteEnvVars(t *testing.T) {
 		{
 			name: "Case: Overlapping env vars appends",
 			existingEnvVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value1",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value2",
 				},
 			},
 			envVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value4",
 				},
 			},
 			want: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value4",
 				},
@@ -3619,39 +3619,39 @@ func TestUniqueAppendOrOverwriteEnvVars(t *testing.T) {
 		{
 			name: "New env vars append",
 			existingEnvVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value1",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value2",
 				},
 			},
 			envVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key3",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key4",
 					Value: "value4",
 				},
 			},
 			want: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value1",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value2",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key3",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key4",
 					Value: "value4",
 				},

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -2,12 +2,13 @@ package application
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
-	"os"
-	"strings"
 
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 

--- a/pkg/odo/cli/catalog/catalog.go
+++ b/pkg/odo/cli/catalog/catalog.go
@@ -2,12 +2,13 @@ package catalog
 
 import (
 	"fmt"
-	"github.com/olekukonko/tablewriter"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/redhat-developer/odo/pkg/catalog"
 	svc "github.com/redhat-developer/odo/pkg/service"

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/odo/cli/application"

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 
 	"github.com/golang/glog"

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -2,9 +2,10 @@ package component
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/component"

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -2,12 +2,13 @@ package component
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/secret"
-	"os"
 
 	svc "github.com/redhat-developer/odo/pkg/service"
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -2,10 +2,11 @@ package component
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"os"
 	"text/tabwriter"
+
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -1,9 +1,10 @@
 package component
 
 import (
+	"os"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
-	"os"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -2,11 +2,12 @@ package component
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"net/url"
 	"os"
 	"runtime"
+
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/fatih/color"
 	"github.com/redhat-developer/odo/pkg/component"

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -1,10 +1,11 @@
 package logout
 
 import (
+	"os"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var logoutCmd = &cobra.Command{

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -2,11 +2,12 @@ package project
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
-	"os"
-	"strings"
 
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/service/service.go
+++ b/pkg/odo/cli/service/service.go
@@ -2,12 +2,13 @@ package service
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/odo/util"
-	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util"
+	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 
 	"github.com/golang/glog"
 	svc "github.com/redhat-developer/odo/pkg/service"

--- a/pkg/odo/cli/service/service_test.go
+++ b/pkg/odo/cli/service/service_test.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"sort"
+	"testing"
+
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/posener/complete"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
@@ -11,8 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
-	"sort"
-	"testing"
 )
 
 func TestCompletions(t *testing.T) {

--- a/pkg/odo/cli/storage/storage.go
+++ b/pkg/odo/cli/storage/storage.go
@@ -2,15 +2,16 @@ package storage
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
-	"os"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/redhat-developer/odo/pkg/storage"
 	"github.com/redhat-developer/odo/pkg/util"

--- a/pkg/odo/cli/url/url.go
+++ b/pkg/odo/cli/url/url.go
@@ -2,10 +2,11 @@ package url
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
 	"strings"
+
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/util"

--- a/pkg/odo/cli/utils/terminal.go
+++ b/pkg/odo/cli/utils/terminal.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"io"
 	"os"
+
+	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/spf13/cobra"
 )

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -2,11 +2,12 @@ package version
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/redhat-developer/odo/pkg/notify"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
-	"os"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -2,6 +2,8 @@ package genericclioptions
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
@@ -9,7 +11,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -2,10 +2,11 @@ package util
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/storage"
-	"os"
 )
 
 // CheckError prints the cause of the given error and exits the code with an

--- a/pkg/odo/util/validation.go
+++ b/pkg/odo/util/validation.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"strings"
 )
 
 // ValidateName will do validation of application & component names

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -2,9 +2,10 @@ package secret
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/redhat-developer/odo/pkg/occlient"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 import (
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -1,6 +1,8 @@
 package secret
 
 import (
+	"testing"
+
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
@@ -8,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
-	"testing"
 )
 
 func TestGetServiceInstanceList(t *testing.T) {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -3,8 +3,9 @@ package service
 import (
 	"encoding/json"
 	"fmt"
-	appsv1 "github.com/openshift/api/apps/v1"
 	"strings"
+
+	appsv1 "github.com/openshift/api/apps/v1"
 
 	"sort"
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -3,6 +3,10 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
@@ -13,9 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
-	"reflect"
-	"sort"
-	"testing"
 )
 
 // M is an alias for map[string]interface{}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,11 +1,12 @@
 package storage
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/redhat-developer/odo/pkg/storage/labels"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 func Test_getStorageFromPVC(t *testing.T) {

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fmt"
+
 	routev1 "github.com/openshift/api/route/v1"
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"


### PR DESCRIPTION
Updates imports as well as `gofmt`.

This is needed in order to reduce the amount of rebasing in new PR's
that use the auto-package-importer `goimports` as well as `gofmt`.