### PR TITLE
Add completion for odo link

### DIFF
--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
 
 	"github.com/golang/glog"
@@ -149,6 +150,8 @@ func NewCmdLink() *cobra.Command {
 	genericclioptions.AddApplicationFlag(linkCmd)
 	//Adding `--component` flag
 	genericclioptions.AddComponentFlag(linkCmd)
+
+	completion.RegisterCommandHandler(linkCmd, completion.LinkCompletionHandler)
 
 	return linkCmd
 }

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -1,0 +1,155 @@
+package completion
+
+import (
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"reflect"
+	"sort"
+	"testing"
+
+	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestLinkCompletionHandler(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		component   string
+		dcList      appsv1.DeploymentConfigList
+		serviceList scv1beta1.ServiceInstanceList
+		output      []string
+	}{
+		{
+			name:      "Case 1: both components and services are present",
+			component: "frontend",
+			serviceList: scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mysql-persistent",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "mysql-persistent",
+								componentlabels.ComponentTypeLabel: "mysql-persistent",
+							},
+						},
+						Spec: scv1beta1.ServiceInstanceSpec{
+							PlanReference: scv1beta1.PlanReference{
+								ClusterServiceClassExternalName: "mysql-persistent",
+								ClusterServicePlanExternalName:  "default",
+							},
+						},
+						Status: scv1beta1.ServiceInstanceStatus{
+							Conditions: []scv1beta1.ServiceInstanceCondition{
+								{
+									Reason: "ProvisionedSuccessfully",
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "postgresql-ephemeral",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "postgresql-ephemeral",
+								componentlabels.ComponentTypeLabel: "postgresql-ephemeral",
+							},
+						},
+						Spec: scv1beta1.ServiceInstanceSpec{
+							PlanReference: scv1beta1.PlanReference{
+								ClusterServiceClassExternalName: "postgresql-ephemeral",
+								ClusterServicePlanExternalName:  "default",
+							},
+						},
+						Status: scv1beta1.ServiceInstanceStatus{
+							Conditions: []scv1beta1.ServiceInstanceCondition{
+								{
+									Reason: "Provisioning",
+								},
+							},
+						},
+					},
+				},
+			},
+			dcList: appsv1.DeploymentConfigList{
+				Items: []appsv1.DeploymentConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "backend",
+								componentlabels.ComponentTypeLabel: "java",
+							},
+						},
+						Spec: appsv1.DeploymentConfigSpec{
+							Template: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name: "dummyContainer",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "frontend",
+								componentlabels.ComponentTypeLabel: "nodejs",
+							},
+						},
+						Spec: appsv1.DeploymentConfigSpec{
+							Template: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name: "dummyContainer",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			// make sure that the 'component' is not part of the suggestions
+			output: []string{"backend", "mysql-persistent", "postgresql-ephemeral"},
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := occlient.FakeNew()
+		parsedArgs := parsedArgs{
+			commands: make(map[string]bool),
+		}
+		context := genericclioptions.NewFakeContext("project", "app", tt.component, client)
+
+		//fake the services
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.serviceList, nil
+		})
+
+		//fake the dcs
+		fakeClientSet.AppsClientset.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &tt.dcList, nil
+		})
+
+		completions := LinkCompletionHandler(nil, parsedArgs, context)
+		sort.Strings(completions)
+
+		if !reflect.DeepEqual(tt.output, completions) {
+			t.Errorf("expected output: %#v,got: %#v", tt.output, completions)
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
This PR adds support for providing completion suggestions for `odo link`.
It also refactors `components.List` to make a single API server call and adds a unit test for it (I also spotted plenty more improvement of such nature that can be made to `component` but didn't attempt them in this PR since I didn't want to change irrelevant code)

## Was the change discussed in an issue?
Fixes: #1064

## How to test changes?
Assuming that the completion scripts have already been setup and that the binary from this PR is on $PATH, a good test would be the following:

```
odo create nodejs frontend
odo create python backend
odo service create mysql-ephemeral
```

Now `odo link` + [TAB] should yield `fronend` and `mysql-ephemeral` while
`odo link --component frontend` + [TAB] should yield `backend` and `mysql-ephemeral` while
