### PR TITLE
fix v0.0.17 version

### DIFF
--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v0.0.16"
+	VERSION = "v0.0.17"
 
 	// GITCOMMIT is hash of the commit that wil be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/redhat-developer/odo/cmd.GITCOMMIT=$(GITCOMMIT)"


### PR DESCRIPTION
fix version number in version.go that wasn't updated due to broken bump-version.sh script (fix in #1074)