### PR TITLE
fix path to GITCOMMIT variable to display correct value in 'odo version'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT := github.com/redhat-developer/odo
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor)
-BUILD_FLAGS := -ldflags="-w -X $(PROJECT)/cmd.GITCOMMIT=$(GITCOMMIT)"
+BUILD_FLAGS := -ldflags="-w -X $(PROJECT)/odo/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)"
 FILES := odo dist
 
 default: bin


### PR DESCRIPTION
`odo version` was always reporting just HEAD because this was not properly updated after the file moved