### PR TITLE
Add --show-log parameter

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -53,7 +53,7 @@ func Search(client *occlient.Client, name string) ([]string, error) {
 // Exists returns true if the given component type is valid, false if not
 func Exists(client *occlient.Client, componentType string) (bool, error) {
 
-	s := log.Spinner("Checking component")
+	s := log.Spinner(true, "Checking component")
 	defer s.End(false)
 	catalogList, err := List(client)
 	if err != nil {
@@ -73,7 +73,7 @@ func Exists(client *occlient.Client, componentType string) (bool, error) {
 func VersionExists(client *occlient.Client, componentType string, componentVersion string) (bool, error) {
 
 	// Loading status
-	s := log.Spinner("Checking component version")
+	s := log.Spinner(true, "Checking component version")
 	defer s.End(false)
 
 	// Retrieve the catalogList

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -31,11 +31,13 @@ type WatchParameters struct {
 	// List/Slice of files/folders in component source, the updates to which need not be pushed to component deployed pod
 	FileIgnores []string
 	// Custom function that can be used to push detected changes to remote pod. For more info about what each of the parameters to this function, please refer, pkg/component/component.go#PushLocal
-	WatchHandler func(*occlient.Client, string, string, string, io.Writer, []string, []string, bool) error
+	WatchHandler func(*occlient.Client, string, string, string, io.Writer, []string, []string, bool, bool) error
 	// This is a channel added to signal readiness of the watch command to the external channel listeners
 	StartChan chan bool
 	// This is a channel added to terminate the watch command gracefully without passing SIGINT. "Stop" message on this channel terminates WatchAndPush function
 	ExtChan chan bool
+	// Parameter whether or not to show the logs
+	Show bool
 	// Interval of time before pushing changes to remote(component) pod
 	PushDiffDelay int
 }
@@ -321,11 +323,11 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 				}
 				if fileInfo.IsDir() {
 					glog.V(4).Infof("Copying files %s to pod", changedFiles)
-					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, parameters.Path, out, changedFiles, deletedPaths, false)
+					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, parameters.Path, out, changedFiles, deletedPaths, false, false)
 				} else {
 					pathDir := filepath.Dir(parameters.Path)
 					glog.V(4).Infof("Copying file %s to pod", parameters.Path)
-					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, pathDir, out, []string{parameters.Path}, deletedPaths, false)
+					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, pathDir, out, []string{parameters.Path}, deletedPaths, false, false)
 				}
 				if err != nil {
 					// Intentionally not exiting on error here.

--- a/pkg/component/watch_test.go
+++ b/pkg/component/watch_test.go
@@ -163,7 +163,7 @@ var ExtChan = make(chan bool)
 var StartChan = make(chan bool)
 
 // Mock PushLocal to collect changed files and compare against expected changed files
-func mockPushLocal(client *occlient.Client, componentName string, applicationName string, path string, out io.Writer, files []string, delFiles []string, isPushForce bool) error {
+func mockPushLocal(client *occlient.Client, componentName string, applicationName string, path string, out io.Writer, files []string, delFiles []string, isPushForce bool, show bool) error {
 	for _, gotChangedFile := range files {
 		found := false
 		// Verify every file in expected file changes to be actually observed to be changed
@@ -369,6 +369,7 @@ func TestWatchAndPush(t *testing.T) {
 					PushDiffDelay:   tt.delayInterval,
 					StartChan:       StartChan,
 					ExtChan:         ExtChan,
+					Show:            false,
 					WatchHandler:    mockPushLocal,
 				},
 			)

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -196,18 +196,22 @@ func Askf(format string, a ...interface{}) {
 // Status creates a spinner, sets the prefix then returns it.
 // Remember to use .End(bool) to stop the spin / when you're done.
 // For example: defer s.End(false)
-func Spinner(status string) *Status {
+// Spin parameter is used to start the initial spin. This helpful
+// for situations where spinning isn't viable (debug)
+func Spinner(spin bool, status string) *Status {
 	s := NewStatus(os.Stdout)
-	s.Start(status, IsDebug())
+	s.Start(status, IsDebug() || !spin)
 	return s
 }
 
 // Statusf creates a spinner, sets the prefix then returns it.
 // Remember to use .End(bool) to stop the spin / when you're done.
 // For example: defer s.End(false)
-func Spinnerf(format string, a ...interface{}) *Status {
+// Spin parameter is used to start the initial spin. This helpful
+// for situations where spinning isn't viable (debug)
+func Spinnerf(spin bool, format string, a ...interface{}) *Status {
 	s := NewStatus(os.Stdout)
-	s.Start(fmt.Sprintf(format, a...), IsDebug())
+	s.Start(fmt.Sprintf(format, a...), IsDebug() || !spin)
 	return s
 }
 

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1658,7 +1658,7 @@ func (c *Client) WaitAndGetDC(name string, field string, value string, timeout t
 // WaitAndGetPod block and waits until pod matching selector is in in Running state
 func (c *Client) WaitAndGetPod(selector string) (*corev1.Pod, error) {
 	glog.V(4).Infof("Waiting for %s pod", selector)
-	s := log.Spinner("Waiting for pod to start")
+	s := log.Spinner(true, "Waiting for pod to start")
 	defer s.End(false)
 
 	w, err := c.kubeClient.CoreV1().Pods(c.Namespace).Watch(metav1.ListOptions{

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -38,6 +38,7 @@ var (
 	cpuMin           string
 	cpu              string
 	wait             bool
+	show             bool
 )
 
 var componentCreateCmd = &cobra.Command{
@@ -228,7 +229,9 @@ A full list of component types that can be deployed is available using: 'odo cat
 			odoutil.LogErrorAndExit(err, "")
 
 			// Git is the only one using BuildConfig since we need to retrieve the git
-			err = component.Build(client, componentName, applicationName, wait, stdout)
+			// Show has been set as "false" due to "git" building when using create.
+			// TODO: Building with git initially will be removed in the future..  for now, we hide the output (despite building..)
+			err = component.Build(client, componentName, applicationName, wait, false, stdout)
 			odoutil.LogErrorAndExit(err, "")
 
 		} else if len(componentLocal) != 0 {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -89,11 +89,11 @@ var pushCmd = &cobra.Command{
 
 			if sourceType == "local" {
 				glog.V(4).Infof("Copying directory %s to pod", localLocation)
-				err = component.PushLocal(client, componentName, applicationName, localLocation, os.Stdout, []string{}, []string{}, true)
+				err = component.PushLocal(client, componentName, applicationName, localLocation, os.Stdout, []string{}, []string{}, true, show)
 			} else {
 				dir := filepath.Dir(localLocation)
 				glog.V(4).Infof("Copying file %s to pod", localLocation)
-				err = component.PushLocal(client, componentName, applicationName, dir, os.Stdout, []string{localLocation}, []string{}, true)
+				err = component.PushLocal(client, componentName, applicationName, dir, os.Stdout, []string{localLocation}, []string{}, true, show)
 			}
 			odoutil.LogErrorAndExit(err, fmt.Sprintf("Failed to push component: %v", componentName))
 
@@ -104,7 +104,7 @@ var pushCmd = &cobra.Command{
 				log.Errorf("Unable to push local directory:%s to component %s that uses Git repository:%s.", componentLocal, componentName, sourcePath)
 				os.Exit(1)
 			}
-			err := component.Build(client, componentName, applicationName, true, stdout)
+			err := component.Build(client, componentName, applicationName, true, show, stdout)
 			odoutil.LogErrorAndExit(err, fmt.Sprintf("failed to push component: %v", componentName))
 		}
 
@@ -114,6 +114,7 @@ var pushCmd = &cobra.Command{
 
 // NewCmdPush implements the push odo command
 func NewCmdPush() *cobra.Command {
+	pushCmd.Flags().BoolVar(&show, "show-log", false, "If enabled, logs will be shown when built")
 	pushCmd.Flags().StringVarP(&componentLocal, "local", "l", "", "Use given local directory as a source for component. (It must be a local component)")
 
 	// Add a defined annotation in order to appear in the help menu

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -84,7 +84,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if len(componentGit) != 0 {
-			err := component.Update(client, componentName, applicationName, "git", componentGit, componentGitRef, stdout)
+			err := component.Update(client, componentName, applicationName, "git", componentGit, componentGitRef, false, stdout)
 			odoutil.LogErrorAndExit(err, "")
 			log.Successf("The component %s was updated successfully", componentName)
 		} else if len(componentLocal) != 0 {
@@ -97,13 +97,13 @@ var updateCmd = &cobra.Command{
 				log.Error("Please provide a path to the directory")
 				os.Exit(1)
 			}
-			err = component.Update(client, componentName, applicationName, "local", dir, "", stdout)
+			err = component.Update(client, componentName, applicationName, "local", dir, "", false, stdout)
 			odoutil.LogErrorAndExit(err, "")
 			log.Successf("The component %s was updated successfully, please use 'odo push' to push your local changes", componentName)
 		} else if len(componentBinary) != 0 {
 			path, err := pkgUtil.GetAbsPath(componentBinary)
-			util.LogErrorAndExit(err, "")
-			err = component.Update(client, componentName, applicationName, "binary", path, "", stdout)
+			odoutil.LogErrorAndExit(err, "")
+			err = component.Update(client, componentName, applicationName, "binary", path, "", false, stdout)
 			odoutil.LogErrorAndExit(err, "")
 			log.Successf("The component %s was updated successfully, please use 'odo push' to push your local changes", componentName)
 		}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -106,6 +106,7 @@ func NewCmdWatch() *cobra.Command {
 	// for example some plugins providing git info in PS1 doing that
 	watchCmd.Flags().StringSliceVar(&ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
 	watchCmd.Flags().IntVar(&delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
+
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -58,7 +58,7 @@ func Create(client *occlient.Client, projectName string) error {
 // and returns the current project or "" if no current project is set and errors if any
 func Delete(client *occlient.Client, projectName string) (string, error) {
 	// Loading spinner
-	s := log.Spinnerf("Deleting project %s", projectName)
+	s := log.Spinnerf(true, "Deleting project %s", projectName)
 	defer s.End(false)
 
 	currentProject := GetCurrent(client)


### PR DESCRIPTION
Adds a --show-log paramater to create, update and push.

This will show the build progress.

If --show-log is passed in, it will also disable the "spinner" as it may
conflict / get caught within the build output.

Closes https://github.com/redhat-developer/odo/issues/1058