### PR TITLE
Fix #1086: exit with 0 code on help

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"os"
 )
 
 func main() {
@@ -32,8 +33,14 @@ func main() {
 		_ = root.Help()
 	}
 
-	// parse the flags - both the program's flags and the completion flags
-	flag.Parse()
+	// parse the flags but hack around to avoid exiting with error code 2 on help
+	flag.CommandLine.Init(os.Args[0], flag.ContinueOnError)
+	args := os.Args[1:]
+	if err := flag.CommandLine.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			os.Exit(0)
+		}
+	}
 
 	// run the completion, in case that the completion was invoked
 	// and ran as a completion script or handled a flag that passed


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Make CommandLine not exit on error and intercept flag.ErrHelp to return
0 instead of default behavior of flag.Parse which is to exit with code 2
on error (flag.ErrHelp is raised when help is asked).

## Was the change discussed in an issue?
fixes #1086 

## How to test changes?
`odo -h` returns `2` prior to this change
`odo -h` returns `0` after
Nothing else should change.
