### PR TITLE
Updated gofmt and goimports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - &base-test
       stage: test
       go_import_path: github.com/redhat-developer/odo
-      go: "1.11"
+      go: "1.11.2"
       install:
         - make goget-tools
       script:
@@ -106,7 +106,7 @@ jobs:
       # run this stage only on master branch and on tags
       if: branch = master || tag IS present
       go_import_path:  github.com/redhat-developer/odo
-      go: "1.11"
+      go: "1.11.2"
       env: BUILD_DOCS=yes
       install:
         - make goget-tools

--- a/pkg/component/watch_test.go
+++ b/pkg/component/watch_test.go
@@ -174,55 +174,55 @@ func TestWatchAndPush(t *testing.T) {
 			delayInterval:   1,
 			wantErr:         false,
 			requiredFilePaths: []testingutil.FileProperties{
-				testingutil.FileProperties{
+				{
 					FilePath:         "src",
 					FileParent:       "",
 					FileType:         testingutil.Directory,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "tests",
 					FileParent:       "",
 					FileType:         testingutil.Directory,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         ".git",
 					FileParent:       "",
 					FileType:         testingutil.Directory,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "LICENSE",
 					FileParent:       "",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "main.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "tests",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "test1.py",
 					FileParent:       "tests",
 					FileType:         testingutil.RegularFile,
@@ -230,31 +230,31 @@ func TestWatchAndPush(t *testing.T) {
 				},
 			},
 			fileModifications: []testingutil.FileProperties{
-				testingutil.FileProperties{
+				{
 					FilePath:         "__init__.py",
 					FileParent:       "",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.APPEND,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "read_licenses.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "read_licenses.py",
 					FileParent:       "src",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.APPEND,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "test_read_licenses.py",
 					FileParent:       "tests",
 					FileType:         testingutil.RegularFile,
 					ModificationType: testingutil.CREATE,
 				},
-				testingutil.FileProperties{
+				{
 					FilePath:         "tests",
 					FileParent:       "",
 					FileType:         testingutil.Directory,

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -58,7 +58,7 @@ func fakeDeploymentConfig(name string, image string, envVars []corev1.EnvVar, re
 		Name:      name,
 		Tag:       "latest",
 		Namespace: "openshift",
-		Ports:     []corev1.ContainerPort{corev1.ContainerPort{Name: "foo", HostPort: 80, ContainerPort: 80}},
+		Ports:     []corev1.ContainerPort{{Name: "foo", HostPort: 80, ContainerPort: 80}},
 	}
 
 	// Generate the DeploymentConfig that will be used.
@@ -3402,7 +3402,7 @@ func TestPatchCurrentDC(t *testing.T) {
 				name:     "foo",
 				dcBefore: *fakeDeploymentConfig("foo", "foo", []corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}}, fakeResourceConsumption()),
 				dcPatch: generateGitDeploymentConfig(metav1.ObjectMeta{Name: "foo2"}, "bar",
-					[]corev1.ContainerPort{corev1.ContainerPort{Name: "foo", HostPort: 80, ContainerPort: 80}},
+					[]corev1.ContainerPort{{Name: "foo", HostPort: 80, ContainerPort: 80}},
 					[]corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}},
 					nil),
 			},
@@ -3586,31 +3586,31 @@ func TestUniqueAppendOrOverwriteEnvVars(t *testing.T) {
 		{
 			name: "Case: Overlapping env vars appends",
 			existingEnvVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value1",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value2",
 				},
 			},
 			envVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value4",
 				},
 			},
 			want: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value4",
 				},
@@ -3619,39 +3619,39 @@ func TestUniqueAppendOrOverwriteEnvVars(t *testing.T) {
 		{
 			name: "New env vars append",
 			existingEnvVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value1",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value2",
 				},
 			},
 			envVars: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key3",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key4",
 					Value: "value4",
 				},
 			},
 			want: []corev1.EnvVar{
-				corev1.EnvVar{
+				{
 					Name:  "key1",
 					Value: "value1",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key2",
 					Value: "value2",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key3",
 					Value: "value3",
 				},
-				corev1.EnvVar{
+				{
 					Name:  "key4",
 					Value: "value4",
 				},

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -2,9 +2,10 @@ package application
 
 import (
 	"fmt"
-	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 	"os"
 	"strings"
+
+	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/log"

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/odo/cli/application"
 	"github.com/redhat-developer/odo/pkg/odo/cli/catalog"
 	"github.com/redhat-developer/odo/pkg/odo/cli/component"

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/odo/cli/application"
 	"github.com/redhat-developer/odo/pkg/odo/cli/project"
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -2,10 +2,11 @@ package component
 
 import (
 	"fmt"
-	appCmd "github.com/redhat-developer/odo/pkg/odo/cli/application"
-	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 	"os"
 	"strings"
+
+	appCmd "github.com/redhat-developer/odo/pkg/odo/cli/application"
+	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -1,8 +1,9 @@
 package component
 
 import (
-	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"os"
+
+	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 
 	appCmd "github.com/redhat-developer/odo/pkg/odo/cli/application"
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	appCmd "github.com/redhat-developer/odo/pkg/odo/cli/application"
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
@@ -9,7 +11,6 @@ import (
 	svc "github.com/redhat-developer/odo/pkg/service"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-	"strings"
 )
 
 const deleteRecommendedCommandName = "delete"

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -2,13 +2,14 @@ package service
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	svc "github.com/redhat-developer/odo/pkg/service"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-	"os"
-	"text/tabwriter"
 )
 
 const listRecommendedCommandName = "list"

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -3,6 +3,8 @@ package genericclioptions
 import (
 	"fmt"
 
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/component"
@@ -10,7 +12,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -1,11 +1,12 @@
 package completion
 
 import (
-	"github.com/redhat-developer/odo/pkg/occlient"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	appsv1 "github.com/openshift/api/apps/v1"

--- a/pkg/odo/util/validation.go
+++ b/pkg/odo/util/validation.go
@@ -3,9 +3,10 @@ package util
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"strings"
 )
 
 // ValidateName will do validation of application & component names

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -3,9 +3,10 @@ package secret
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/redhat-developer/odo/pkg/occlient"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 import (
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -1,6 +1,8 @@
 package secret
 
 import (
+	"testing"
+
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/occlient"
@@ -8,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
-	"testing"
 )
 
 func TestGetServiceInstanceList(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"reflect"
+	"sort"
+	"testing"
+
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
@@ -14,9 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
-	"reflect"
-	"sort"
-	"testing"
 )
 
 // M is an alias for map[string]interface{}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,11 +1,12 @@
 package storage
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/redhat-developer/odo/pkg/storage/labels"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 func Test_getStorageFromPVC(t *testing.T) {


### PR DESCRIPTION
This reduces conflicts / errors for people who are running the latest
version of go (1.11.2).

The following commands have been ran:

```sh
gofmt -s -w pkg
goimports -w pkg
```