### PR TITLE
Fix #1028: odo version does not exit with error code when server is not reachable

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2764,6 +2764,12 @@ func (c *Client) GetServerVersion() (*ServerInfo, error) {
 		return nil, errors.New("Unable to connect to OpenShift cluster, is it down?")
 	}
 
+	// fail fast if user is not connected (same logic as `oc whoami`)
+	_, err = c.userClient.Users().Get("~", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	// This will fetch the information about OpenShift Version
 	rawOpenShiftVersion, err := c.kubeClient.CoreV1().RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
 	if err != nil {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -163,6 +163,7 @@ type Client struct {
 	Namespace            string
 }
 
+// New creates a new client
 func New(skipConnectionCheck bool) (*Client, error) {
 	var client Client
 

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -163,7 +163,7 @@ type Client struct {
 	Namespace            string
 }
 
-func New(connectionCheck bool) (*Client, error) {
+func New(skipConnectionCheck bool) (*Client, error) {
 	var client Client
 
 	// initialize client-go clients
@@ -231,8 +231,8 @@ func New(connectionCheck bool) (*Client, error) {
 	}
 	client.Namespace = namespace
 
-	// Skip this if connectionCheck is false
-	if !connectionCheck {
+	// if we're not skipping the connection check, check the connection :)
+	if !skipConnectionCheck {
 		if !isServerUp(config.Host) {
 			return nil, errors.New("Unable to connect to OpenShift cluster, is it down?")
 		}

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -9,8 +9,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 
-	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
-
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
@@ -48,21 +46,22 @@ var versionCmd = &cobra.Command{
 		fmt.Println("odo " + VERSION + " (" + GITCOMMIT + ")")
 
 		if !clientFlag {
-			// Lets fetch the info about the server
+			// Let's fetch the info about the server
 			serverInfo, err := genericclioptions.ClientWithConnectionCheck(cmd, true).GetServerVersion()
-			odoutil.CheckError(err, "")
-			// make sure we only include Openshift info if we actually have it
-			openshiftStr := ""
-			if len(serverInfo.OpenShiftVersion) > 0 {
-				openshiftStr = fmt.Sprintf("OpenShift: %v\n", serverInfo.OpenShiftVersion)
+			if err == nil {
+				// make sure we only include Openshift info if we actually have it
+				openshiftStr := ""
+				if len(serverInfo.OpenShiftVersion) > 0 {
+					openshiftStr = fmt.Sprintf("OpenShift: %v\n", serverInfo.OpenShiftVersion)
+				}
+				fmt.Printf("\n"+
+					"Server: %v\n"+
+					"%v"+
+					"Kubernetes: %v\n",
+					serverInfo.Address,
+					openshiftStr,
+					serverInfo.KubernetesVersion)
 			}
-			fmt.Printf("\n"+
-				"Server: %v\n"+
-				"%v"+
-				"Kubernetes: %v\n",
-				serverInfo.Address,
-				openshiftStr,
-				serverInfo.KubernetesVersion)
 		}
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
`odo version` should not end with an error code if the server is not reachable.

## Was the change discussed in an issue?
fixes #1028 

## How to test changes?
`odo version` when not logged in will result in an error before the change.
`odo  version` will complete successfully after the change.
