### PR TITLE
use dumb-init as PID1 process for containers

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -92,7 +92,7 @@ const (
 	nameLength = 5
 
 	// Image that will be used containing the supervisord binary and assembly scripts
-	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.4.0"
+	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.5.0"
 
 	// Create a custom name and (hope) that users don't use the *exact* same name in their deployment
 	supervisordVolumeName = "odo-supervisord-shared-data"

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -47,11 +47,13 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, bui
 							Ports: commonImageMeta.Ports,
 							// Run the actual supervisord binary that has been mounted into the container
 							Command: []string{
-								"/var/lib/supervisord/bin/supervisord",
+								"/var/lib/supervisord/bin/dumb-init",
+								"--",
 							},
 							// Using the appropriate configuration file that contains the "run" script for the component.
 							// either from: /usr/libexec/s2i/assemble or /opt/app-root/src/.s2i/bin/assemble
 							Args: []string{
+								"/var/lib/supervisord/bin/supervisord",
 								"-c",
 								"/var/lib/supervisord/conf/supervisor.conf",
 							},


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
adds dumb-init to fix the issue with orphaned processes, because there was no init process in a container to clean it

more at https://github.com/redhat-developer/odo/issues/1076#issuecomment-444642582


## Was the change discussed in an issue?
fixes #1076

## How to test changes?
it requires a new version of initContainer image with this PR https://github.com/redhat-developer/odo-supervisord-image/pull/8


build new odo-supervisord-image inside minishift instance
```
eval $(minishift docker-env)
docker build -t quay.io/openshiftdo/supervisord:0.5.0 .
```
now you can build odo with this patch and run it as usual

**Tests will be failing until `quay.io/openshiftdo/supervisord:0.5.0`(with https://github.com/redhat-developer/odo-supervisord-image/pull/8)  is released**




