### PR TITLE
Missing Deploying an Application using Odo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [What is Odo?](#odo)
 - [Features](#features)
 - [Setup and Installation](#setup-and-installation)
-- [Deploying an Application using Odo](#deploying-a-nodejs-application-using-odo)
+- [Deploying an Application using Odo](#deploying-an-application-using-odo)
 - [Additional Documentation](#additional-documentation)
 - [Community, Discussion, Contribution and Support](#community-discussion-contribution-and-support)
 - [Glossary](#glossary)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Fixing the missing link. ```Deploying an Application using Odo``` should redirect to the proper place

## Was the change discussed in an issue?
Actually it is a minor change, not really need any discussion i guess. The problem is with the link ```Deploying an Application using Odo``` in [README.md](https://github.com/redhat-developer/odo/blob/master/README.md) and is not redirected to the place where should actually go. 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->

