### PR TITLE
Unlink service that was deleted

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1791,20 +1791,20 @@ func (c *Client) DeleteServiceInstance(labels map[string]string) error {
 	glog.V(4).Infof("Selectors used for deletion: %s", selector)
 
 	// Listing out serviceInstance because `DeleteCollection` method don't work on serviceInstance
-	svcCatList, err := c.GetServiceInstanceList(selector)
+	serviceInstances, err := c.GetServiceInstanceList(selector)
 	if err != nil {
 		return errors.Wrap(err, "unable to list service instance")
 	}
 
 	// Iterating over serviceInstance List and deleting one by one
-	for _, svc := range svcCatList {
+	for _, serviceInstance := range serviceInstances {
 		// we need to delete the ServiceBinding before deleting the ServiceInstance
-		err = c.serviceCatalogClient.ServiceBindings(c.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+		err = c.serviceCatalogClient.ServiceBindings(c.Namespace).Delete(serviceInstance.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			return errors.Wrap(err, "unable to delete serviceBinding")
 		}
 		// now we perform the actual deletion
-		err = c.serviceCatalogClient.ServiceInstances(c.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+		err = c.serviceCatalogClient.ServiceInstances(c.Namespace).Delete(serviceInstance.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			return errors.Wrap(err, "unable to delete serviceInstance")
 		}
@@ -2003,19 +2003,19 @@ func (c *Client) CreateServiceInstance(serviceName string, serviceType string, s
 
 // CreateServiceBinding creates a ServiceBinding (essentially a secret) within the namespace of the
 // service instance created using the service's parameters.
-func (c *Client) CreateServiceBinding(componentName string, namespace string) error {
+func (c *Client) CreateServiceBinding(bindingName string, namespace string) error {
 	_, err := c.serviceCatalogClient.ServiceBindings(namespace).Create(
 		&scv1beta1.ServiceBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      componentName,
+				Name:      bindingName,
 				Namespace: namespace,
 			},
 			Spec: scv1beta1.ServiceBindingSpec{
 				//ExternalID: UUID,
 				ServiceInstanceRef: scv1beta1.LocalObjectReference{
-					Name: componentName,
+					Name: bindingName,
 				},
-				SecretName: componentName,
+				SecretName: bindingName,
 			},
 		})
 

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -3530,6 +3530,89 @@ func TestGetServiceInstanceList(t *testing.T) {
 	}
 }
 
+func TestDeleteServiceInstance(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		serviceName string
+		labels      map[string]string
+		serviceList scv1beta1.ServiceInstanceList
+		wantErr     bool
+	}{
+		{
+			name:        "Delete service instance",
+			serviceName: "mongodb",
+			labels: map[string]string{
+				applabels.ApplicationLabel:     "app",
+				componentlabels.ComponentLabel: "mongodb",
+			},
+			serviceList: scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mongodb",
+							Labels: map[string]string{
+								applabels.ApplicationLabel:         "app",
+								componentlabels.ComponentLabel:     "mongodb",
+								componentlabels.ComponentTypeLabel: "mongodb-persistent",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fkclient, fkclientset := FakeNew()
+
+			//fake the services listing
+			fkclientset.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, &tt.serviceList, nil
+			})
+
+			// Fake the servicebinding delete
+			fkclientset.ServiceCatalogClientSet.PrependReactor("delete", "servicebindings", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+			// Fake the serviceinstance delete
+			fkclientset.ServiceCatalogClientSet.PrependReactor("delete", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+			err := fkclient.DeleteServiceInstance(tt.labels)
+			// Checks for error in positive cases
+			if !tt.wantErr && (err != nil) {
+				t.Errorf(" client.DeleteServiceInstance(labels) unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Check for validating actions performed
+			// deleting based on the labels means listing the services and then delete the instance and binding for each
+			// thus we have 1 list action that always takes place, plus another 2 (delete instance, delete binding)
+			// for each service
+			expectedNumberOfServiceCatalogActions := 1 + (2 * len(tt.serviceList.Items))
+			if len(fkclientset.ServiceCatalogClientSet.Actions()) != expectedNumberOfServiceCatalogActions && !tt.wantErr {
+				t.Errorf("expected %d action in CreateServiceInstace got: %v",
+					expectedNumberOfServiceCatalogActions, fkclientset.ServiceCatalogClientSet.Actions())
+			}
+
+			// Check that the correct service binding was deleted
+			DeletedServiceBinding := fkclientset.ServiceCatalogClientSet.Actions()[1].(ktesting.DeleteAction).GetName()
+			if DeletedServiceBinding != tt.serviceName {
+				t.Errorf("Delete action is performed with wrong ServiceBinding, expected: %s, got %s", tt.serviceName, DeletedServiceBinding)
+			}
+
+			// Check that the correct service instance was deleted
+			DeletedServiceInstance := fkclientset.ServiceCatalogClientSet.Actions()[2].(ktesting.DeleteAction).GetName()
+			if DeletedServiceInstance != tt.serviceName {
+				t.Errorf("Delete action is performed with wrong ServiceInstance, expected: %s, got %s", tt.serviceName, DeletedServiceInstance)
+			}
+		})
+	}
+}
+
 func TestPatchCurrentDC(t *testing.T) {
 	type args struct {
 		name              string

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -66,7 +66,7 @@ func (o *ServiceDeleteOptions) Run() (err error) {
 		_, _ = fmt.Scanln(&confirmDeletion)
 	}
 	if strings.ToLower(confirmDeletion) == "y" {
-		err = svc.DeleteService(o.Client, o.serviceName, o.Application)
+		err = svc.DeleteServiceAndUnlinkComponents(o.Client, o.serviceName, o.Application)
 		if err != nil {
 			return fmt.Errorf("unable to delete service %s:\n%v", o.serviceName, err)
 		}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
When a service is deleted (`odo service delete ...`) then we need to "links" that have been created in the DeploymentConfig of components that were linked to the service (via `odo link ...`)

## Was the change discussed in an issue?
Fixes: #1094

## How to test changes?
The following scenario should cover everything: 

Create the components
```
odo create nodejs frontend
odo create python backend
```

Create the service

```
odo service create postgresql-persistent
```

Create a link from the frontend to the backend

```
odo link backend --component frontend
```

Create a link from backend to the database

```
odo link postgresql-persistent -w
```

Both components should now have a single `envFrom` value in their DC.

We now delete the service

```
odo service delete postgresql-persistent -f
```

Now the frontend service should not have been touched while the backend service should no longer have an `envFrom` value in it's DC