### PR TITLE
Remove the code in tests/e2e from test coverage report

### DIFF
--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -6,7 +6,7 @@
 set -e
 echo "" > coverage.txt
 go test -i -race ./cmd/odo
-for d in $(go list ./... | grep -v vendor); do
+for d in $(go list ./... | grep -v vendor | grep -v tests/e2e); do
     # For watch related tests, race check causes issue so disabling them here as race is already tested in other tests when used with `-coverprofile=profile.out`
     if [ "$d" = "github.com/redhat-developer/odo/pkg/component" ]; then
         go test -coverprofile=profile.out -covermode=atomic $d


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Currently the code coverage tool also looks into the e2e tests code which means that our test coverage is reported as lower than the actual test coverage

## Was the change discussed in an issue?
No

## How to test changes?
Nothing to test. The test coverage should increase and the dashboard should no longer show the `e2e/tests` directory
