### PR TITLE
Fix #1132: Add debug target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 PROJECT := github.com/redhat-developer/odo
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor)
-BUILD_FLAGS := -ldflags="-w -X $(PROJECT)/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)"
-DEBUG_BUILD_FLAGS := -ldflags="-X $(PROJECT)/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)"
+COMMON_FLAGS := -X $(PROJECT)/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)
+BUILD_FLAGS := -ldflags="-w $(COMMON_FLAGS)"
+DEBUG_BUILD_FLAGS := -ldflags="$(COMMON_FLAGS)"
 FILES := odo dist
 
 default: bin

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@ PROJECT := github.com/redhat-developer/odo
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor)
 BUILD_FLAGS := -ldflags="-w -X $(PROJECT)/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)"
+DEBUG_BUILD_FLAGS := -ldflags="-X $(PROJECT)/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)"
 FILES := odo dist
 
 default: bin
+
+.PHONY: debug
+debug:
+	go build ${DEBUG_BUILD_FLAGS} -o odo cmd/odo/odo.go
 
 .PHONY: bin
 bin:


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Adds a `debug` target to Makefile.

## Was the change discussed in an issue?
fixes #1132 

## How to test changes?
`make debug` then try to attach a debugger to the running `odo` instance. Without this fix, you'd get an error similar to: `could not attach to pid 90236: decoding dwarf section info at offset 0x0: too short`
