### PR TITLE
Fix potential race condition on odo link/unlink

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -201,6 +201,23 @@ make test-service-e2e
 Running a subset of tests is possible with ginkgo by using focused specs mechanism
 https://onsi.github.io/ginkgo/#focused-specs
 
+### Race conditions
+
+It is not uncommon that during the execution of the integration tests, test failures occur.
+Although it's possible that this is due to the tests themselves, more often than not this occurs due to the the actual odo code is written.
+For example, the following error has been encountered multiple times:
+
+```
+Operation cannot be fulfilled on deploymentconfigs.apps.openshift.io "component-app": the object has been modified; please apply your changes to the latest version and try again
+```
+
+The reason this happens is because the `read DeploymentCondif` / `update DC in memory` / `call Update` can potentially fail to due 
+the DC being updated concurrently by some other component (usually by Kubernetes/Openshift itself)
+
+For such case it's recommended to avoid the read/update-in-memory-/push-update as much as possible.
+One remedy is to use the Patch operation (see `Resource Operations` section from [this](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/) docs page)
+Another remedy would be to retry the operation when the optimistic concurrency error is encountered  
+
 ## Dependency Management
 
 odo uses `glide` to manage dependencies.

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2013,8 +2013,8 @@ func TestLinkSecret(t *testing.T) {
 			secretName:      "secret",
 			componentName:   "component",
 			applicationName: "app",
-			existingDC:      *fakeDeploymentConfig("foo", "", nil, nil, nil),
-			expectedUpdatedDC: *fakeDeploymentConfig("foo", "", nil,
+			existingDC:      *fakeDeploymentConfig("component-app", "", nil, nil, nil),
+			expectedUpdatedDC: *fakeDeploymentConfig("component-app", "", nil,
 				[]corev1.EnvFromSource{
 					{
 						SecretRef: &corev1.SecretEnvSource{
@@ -2030,7 +2030,7 @@ func TestLinkSecret(t *testing.T) {
 			secretName:      "secret",
 			componentName:   "component",
 			applicationName: "app",
-			existingDC: *fakeDeploymentConfig("foo", "", nil,
+			existingDC: *fakeDeploymentConfig("component-app", "", nil,
 				[]corev1.EnvFromSource{
 					{
 						SecretRef: &corev1.SecretEnvSource{
@@ -2039,7 +2039,7 @@ func TestLinkSecret(t *testing.T) {
 					},
 				},
 				nil),
-			expectedUpdatedDC: *fakeDeploymentConfig("foo", "", nil,
+			expectedUpdatedDC: *fakeDeploymentConfig("component-app", "", nil,
 				[]corev1.EnvFromSource{
 					{
 						SecretRef: &corev1.SecretEnvSource{
@@ -2070,9 +2070,9 @@ func TestLinkSecret(t *testing.T) {
 			})
 
 			// Fake updating DC
-			fakeClientSet.AppsClientset.PrependReactor("update", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+			fakeClientSet.AppsClientset.PrependReactor("patch", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if len(tt.componentName) == 0 {
-					return true, nil, fmt.Errorf("could not update dc")
+					return true, nil, fmt.Errorf("could not patch dc")
 				}
 				return true, &tt.expectedUpdatedDC, nil
 			})
@@ -2087,9 +2087,9 @@ func TestLinkSecret(t *testing.T) {
 					t.Errorf("expected 1 AppsClientset.Actions() in LinkSecret, got: %v", fakeClientSet.AppsClientset.Actions())
 				}
 
-				updatedDc := fakeClientSet.AppsClientset.Actions()[1].(ktesting.UpdateAction).GetObject().(*appsv1.DeploymentConfig)
-				if !reflect.DeepEqual(updatedDc.Spec, tt.expectedUpdatedDC.Spec) {
-					t.Errorf("deployment Config Spec not matching with expected values, expected: %v, got %v", tt.expectedUpdatedDC.Spec, updatedDc.Spec)
+				dcPatched := fakeClientSet.AppsClientset.Actions()[1].(ktesting.PatchAction).GetName()
+				if dcPatched != tt.existingDC.Name {
+					t.Errorf("Expected patch to be performed on dc named: %s but instead got: %s", tt.expectedUpdatedDC.Name, dcPatched)
 				}
 			}
 		})
@@ -2135,7 +2135,7 @@ func TestUnlinkSecret(t *testing.T) {
 			secretName:      "secret",
 			componentName:   "component",
 			applicationName: "app",
-			existingDC: *fakeDeploymentConfig("foo", "", nil,
+			existingDC: *fakeDeploymentConfig("component-app", "", nil,
 				[]corev1.EnvFromSource{
 					{
 						SecretRef: &corev1.SecretEnvSource{
@@ -2144,7 +2144,7 @@ func TestUnlinkSecret(t *testing.T) {
 					},
 				},
 				nil),
-			expectedUpdatedDC: *fakeDeploymentConfig("foo", "", nil, []corev1.EnvFromSource{}, nil),
+			expectedUpdatedDC: *fakeDeploymentConfig("component-app", "", nil, []corev1.EnvFromSource{}, nil),
 			wantErr:           false,
 		},
 		{
@@ -2152,7 +2152,7 @@ func TestUnlinkSecret(t *testing.T) {
 			secretName:      "secret",
 			componentName:   "component",
 			applicationName: "app",
-			existingDC: *fakeDeploymentConfig("foo", "", nil,
+			existingDC: *fakeDeploymentConfig("component-app", "", nil,
 				[]corev1.EnvFromSource{
 					{
 						SecretRef: &corev1.SecretEnvSource{
@@ -2171,7 +2171,7 @@ func TestUnlinkSecret(t *testing.T) {
 					},
 				},
 				nil),
-			expectedUpdatedDC: *fakeDeploymentConfig("foo", "", nil,
+			expectedUpdatedDC: *fakeDeploymentConfig("component-app", "", nil,
 				[]corev1.EnvFromSource{
 					{
 						SecretRef: &corev1.SecretEnvSource{
@@ -2202,9 +2202,9 @@ func TestUnlinkSecret(t *testing.T) {
 			})
 
 			// Fake updating DC
-			fakeClientSet.AppsClientset.PrependReactor("update", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+			fakeClientSet.AppsClientset.PrependReactor("patch", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if len(tt.componentName) == 0 {
-					return true, nil, fmt.Errorf("could not update dc")
+					return true, nil, fmt.Errorf("could not patch dc")
 				}
 				return true, &tt.expectedUpdatedDC, nil
 			})
@@ -2219,9 +2219,9 @@ func TestUnlinkSecret(t *testing.T) {
 					t.Errorf("expected 1 AppsClientset.Actions() in LinkSecret, got: %v", fakeClientSet.AppsClientset.Actions())
 				}
 
-				updatedDc := fakeClientSet.AppsClientset.Actions()[1].(ktesting.UpdateAction).GetObject().(*appsv1.DeploymentConfig)
-				if !reflect.DeepEqual(updatedDc.Spec, tt.expectedUpdatedDC.Spec) {
-					t.Errorf("deployment Config Spec not matching with expected values, expected: %v, got %v", tt.expectedUpdatedDC.Spec, updatedDc.Spec)
+				dcPatched := fakeClientSet.AppsClientset.Actions()[1].(ktesting.PatchAction).GetName()
+				if dcPatched != tt.existingDC.Name {
+					t.Errorf("Expected patch to be performed on dc named: %s but instead got: %s", tt.expectedUpdatedDC.Name, dcPatched)
 				}
 			}
 		})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Fixes a subtle race condition that can occur during `odo link` or `odo unlink`.
The race condition could (and sometimes does in our e2e tests) occur if we were adding a link while the
deployment was still being rolled out.
With this change, we now use Patch instead of Update ensuring that
no write conflicts occur.

## Was the change discussed in an issue?
No, but I have seen the problem occur a few times in the integration tests

## How to test changes? 
`odo link` and `odo unlink` should continue to work as before.
Furthermore, the `link` integration tests should now not exhibit flaky behavior (unless Travis fails to launch Openshift)
