### PR TITLE
added check for componentName before pushing

### DIFF
--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -51,6 +51,13 @@ var pushCmd = &cobra.Command{
 		}
 		componentName := context.Component(argComponent)
 
+		// if the componentName is blank then there is not active component set
+		if len(componentName) == 0 {
+			log.Error(`No component is set as active.
+Use 'odo component set' to set and existing component as active or call this command with component name as and argument.`)
+			os.Exit(1)
+		}
+
 		log.Namef("Pushing changes to component: %v", componentName)
 
 		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -53,8 +53,9 @@ var pushCmd = &cobra.Command{
 
 		// if the componentName is blank then there is no active component set
 		if len(componentName) == 0 {
-			log.Error(`No component is set as active.
-Use 'odo component set' to set and existing component as active or call this command with component name as an argument.`)
+			log.Error("No component is set as active.\n" +
+				"Use 'odo component set' to set and existing component as active \n" +
+				"or call this command with component name as an argument.")
 			os.Exit(1)
 		}
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -53,9 +53,7 @@ var pushCmd = &cobra.Command{
 
 		// if the componentName is blank then there is no active component set
 		if len(componentName) == 0 {
-			log.Error("No component is set as active.\n" +
-				"Use 'odo component set' to set and existing component as active \n" +
-				"or call this command with component name as an argument.")
+			log.Error("No component is set as active. Use 'odo component set' to set an active component.")
 			os.Exit(1)
 		}
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -51,10 +51,10 @@ var pushCmd = &cobra.Command{
 		}
 		componentName := context.Component(argComponent)
 
-		// if the componentName is blank then there is not active component set
+		// if the componentName is blank then there is no active component set
 		if len(componentName) == 0 {
 			log.Error(`No component is set as active.
-Use 'odo component set' to set and existing component as active or call this command with component name as and argument.`)
+Use 'odo component set' to set and existing component as active or call this command with component name as an argument.`)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
added a check for componentName being set before pushing

## Was the change discussed in an issue?
fixes #1016 

## How to test changes?
remove the `~/.kube/odo` from your local computer then go to any local component source, try `odo push --local .`
