### PR TITLE
Add newlines for help menu, modify odo service create help

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -21,12 +21,14 @@ var (
     # Create new postgresql service from service catalog using dev plan and name my-postgresql-db.
     %[1]s dh-postgresql-apb my-postgresql-db --plan dev -p postgresql_user=luke -p postgresql_password=secret`)
 
+	createShortDesc = `Create a new service from service catalog using the plan defined and deploy it on OpenShift.`
+
 	createLongDesc = ktemplates.LongDesc(`
 Create a new service from service catalog using the plan defined and deploy it on OpenShift.
-If service name is not provided, service type value will be used. The plan to be used must be passed along the service type
-using this convention <service_type>/<plan>. The parameters to configure the service are passed as a list of key=value pairs.
-The list of the parameters and their type is defined according to the plan selected.
-A full list of service types that can be deployed are available using: 'odo catalog list services'`)
+
+A --plan must be passed along with the service type. Parameters to configure the service are passed as key=value pairs.
+
+For a full list of service types, use: 'odo catalog list services'`)
 )
 
 // ServiceCreateOptions encapsulates the options for the odo service create command
@@ -116,7 +118,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	o := NewServiceCreateOptions()
 	serviceCreateCmd := &cobra.Command{
 		Use:     name + " <service_type> --plan <plan_name> [service_name]",
-		Short:   "Create a new service",
+		Short:   createShortDesc,
 		Long:    createLongDesc,
 		Example: fmt.Sprintf(createExample, fullName),
 		Args:    cobra.RangeArgs(1, 2),

--- a/pkg/odo/cli/service/service.go
+++ b/pkg/odo/cli/service/service.go
@@ -15,8 +15,7 @@ import (
 // RecommendedCommandName is the recommended service command name
 const RecommendedCommandName = "service"
 
-var serviceLongDesc = ktemplates.LongDesc(`
-Perform service catalog operations, limited to template service broker and OpenShift Ansible Broker only.`)
+var serviceLongDesc = ktemplates.LongDesc(`Perform service catalog operations, limited to template service broker and OpenShift Ansible Broker only.`)
 
 // NewCmdService implements the odo service command
 func NewCmdService(name, fullName string) *cobra.Command {
@@ -27,7 +26,7 @@ func NewCmdService(name, fullName string) *cobra.Command {
 		Use:   name,
 		Short: "Perform service catalog operations",
 		Long:  serviceLongDesc,
-		Example: fmt.Sprintf("%s\n%s\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s",
 			serviceCreateCmd.Example,
 			serviceDeleteCmd.Example,
 			serviceListCmd.Example),


### PR DESCRIPTION
`ktemplates` removes all extra newlines. Example output has been
modified to use `\n\n`.

Before:

```sh
Examples:
  # Create new postgresql service from service catalog using dev plan and name my-postgresql-db.
  odo service create dh-postgresql-apb my-postgresql-db --plan dev -p postgresql_user=luke -p postgresql_password=secret
  # Delete the service named 'mysql-persistent'
  odo service delete mysql-persistent
  # List all services in the application
  odo service list
```

After:

```sh
Examples:
  # Create new postgresql service from service catalog using dev plan and name my-postgresql-db.
  odo service create dh-postgresql-apb my-postgresql-db --plan dev -p postgresql_user=luke -p postgresql_password=secret

  # Delete the service named 'mysql-persistent'
  odo service delete mysql-persistent

  # List all services in the application
  odo service list
```

`odo service create --help` has been modified and truncated into a
simpler long description.