### PR TITLE
Use variable to run independent test scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - make test-main-e2e
+        - make test-e2e ODO_TEST_SCENARIO="odo-main-e2e"
 
     # Run component e2e tests
     - <<: *base-test
@@ -51,7 +51,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - travis_wait make test-cmp-e2e
+        - travis_wait make test-e2e ODO_TEST_SCENARIO="odo-cmp-e2e"
 
     # Run java e2e tests
     - <<: *base-test
@@ -62,7 +62,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - make test-java-e2e
+        - make test-e2e ODO_TEST_SCENARIO="odo-java-e2e"
 
     # Run source e2e tests
     - <<: *base-test
@@ -73,7 +73,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - make test-source-e2e
+        - make test-e2e ODO_TEST_SCENARIO="odo-source-e2e"
 
     # Run service-catalog e2e tests
     - <<: *base-test
@@ -84,7 +84,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - make test-service-e2e
+        - make test-e2e ODO_TEST_SCENARIO="odo-service-e2e"
 
     # Run link e2e tests
     - <<: *base-test
@@ -95,7 +95,7 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - make test-link-e2e
+        - make test-e2e ODO_TEST_SCENARIO="odo-link-e2e"
 
     # test installation script on linux
     # - stage: test

--- a/Makefile
+++ b/Makefile
@@ -79,67 +79,14 @@ prepare-release: cross
 test:
 	go test -race $(PKGS)
 
-# Run main e2e tests
-.PHONY: test-main-e2e
-test-main-e2e:
-ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoe2e" -ginkgo.succinct -timeout $(TIMEOUT)
-else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoe2e" -ginkgo.succinct
-endif
-
-# Run component e2e tests
-.PHONY: test-cmp-e2e
-test-cmp-e2e:
-ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.succinct -timeout $(TIMEOUT)
-else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.succinct -timeout 15m
-endif
-
-# Run java e2e tests
-.PHONY: test-java-e2e
-test-java-e2e:
-ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoJavaE2e" -ginkgo.succinct -timeout $(TIMEOUT)
-else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoJavaE2e" -ginkgo.succinct
-endif
-
-# Run source e2e tests
-.PHONY: test-source-e2e
-test-source-e2e:
-ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoSourceE2e" -ginkgo.succinct -timeout $(TIMEOUT)
-else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoSourceE2e" -ginkgo.succinct
-endif
-
-# Run service catalog e2e tests
-.PHONY: test-service-e2e
-test-service-e2e:
-ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoServiceE2e" -ginkgo.succinct -timeout $(TIMEOUT)
-else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoServiceE2e" -ginkgo.succinct
-endif
-
-# Run link e2e tests
-.PHONY: test-link-e2e
-test-link-e2e:
-ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoLinkE2e" -ginkgo.succinct -timeout $(TIMEOUT)
-else
-	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoLinkE2e" -ginkgo.succinct
-endif
-
 # Run all e2e tests
 .PHONY: test-e2e
+test-e2e: ODO_TEST_SCENARIO=""
 test-e2e:
 ifdef TIMEOUT
-	go test -v github.com/redhat-developer/odo/tests/e2e -ginkgo.succinct -timeout $(TIMEOUT)
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus=$(ODO_TEST_SCENARIO) -ginkgo.succinct -timeout $(TIMEOUT)
 else
-	go test -v github.com/redhat-developer/odo/tests/e2e -ginkgo.succinct
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus=$(ODO_TEST_SCENARIO) -ginkgo.succinct -timeout 15m
 endif
 
 # create deb and rpm packages using fpm in ./dist/pkgs/

--- a/docs/development.md
+++ b/docs/development.md
@@ -182,20 +182,20 @@ Requirements:
  - A `minishift` or OpenShift environment with Service Catalog enabled
  - `odo` and `oc` binaries in $PATH
 
-To deploy an e2e test:
+To deploy an test availaible in test the suite, one can use a variable `ODO_TEST_SCENARIO`. No use of this variable execute the entire test suite.
 
 ```sh
 # The entire suite
 make test-e2e
 
 # Just the main tests
-make test-main-e2e
+make test-e2e ODO_TEST_SCENARIO="odo-main-e2e"
 
 # Just component tests
-make test-cmp-e2e
+make test-e2e ODO_TEST_SCENARIO="odo-cmp-e2e"
 
 # Just service catalog tests
-make test-service-e2e
+make test-e2e ODO_TEST_SCENARIO="odo-service-e2e"
 ```
 
 Running a subset of tests is possible with ginkgo by using focused specs mechanism

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -31,7 +31,7 @@ func SourceTest(appTestName string, sourceType string, source string) {
 	Expect(getDc).To(ContainSubstring(source))
 }
 
-var _ = Describe("odoCmpE2e", func() {
+var _ = Describe("odo-cmp-e2e", func() {
 	const bootStrapSupervisorURI = "https://github.com/kadel/bootstrap-supervisored-s2i"
 	const initContainerName = "copy-files-to-volume"
 	const wildflyURI1 = "https://github.com/marekjelen/katacoda-odo-backend"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 	curProj = runCmd("oc project -q")
 })
 
-var _ = Describe("odoe2e", func() {
+var _ = Describe("odo-main-e2e", func() {
 	var t = strconv.FormatInt(time.Now().Unix(), 10)
 	var projName = fmt.Sprintf("odo-%s", t)
 	const appTestName = "testing"

--- a/tests/e2e/java_test.go
+++ b/tests/e2e/java_test.go
@@ -8,7 +8,7 @@ import (
 
 const javaFiles = "examples/binary/java/"
 
-var _ = Describe("odoJavaE2e", func() {
+var _ = Describe("odo-java-e2e", func() {
 	const t = "java"
 	var projName = fmt.Sprintf("odo-%s", t)
 

--- a/tests/e2e/link_test.go
+++ b/tests/e2e/link_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var _ = Describe("odoLinkE2e", func() {
+var _ = Describe("odo-link-e2e", func() {
 
 	var t = strconv.FormatInt(time.Now().Unix(), 10)
 	var projName = fmt.Sprintf("odolnk-%s", t)

--- a/tests/e2e/service_test.go
+++ b/tests/e2e/service_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var _ = Describe("odoServiceE2e", func() {
+var _ = Describe("odo-service-e2e", func() {
 
 	Context("odo service creation", func() {
 		It("should be able to create a service", func() {

--- a/tests/e2e/source_test.go
+++ b/tests/e2e/source_test.go
@@ -8,7 +8,7 @@ import (
 
 const sourceExamples = "examples/source/"
 
-var _ = Describe("odoSourceE2e", func() {
+var _ = Describe("odo-source-e2e", func() {
 	const t = "source"
 	var projName = fmt.Sprintf("odo-%s", t)
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Make the test suite more user friendly/independent and reduce the ```.PHONY``` load on Makefile
## Was the change discussed in an issue?
fixes #1138 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
```
make test-e2e ODO_TEST_SCENARIO="test-feature"
```
In ```test-feature``` you can use the available spec. For example 
```
make test-e2e ODO_TEST_SCENARIO="odo-main-e2e"
make test-e2e ODO_TEST_SCENARIO="odo-java-e2e"
make test-e2e ODO_TEST_SCENARIO="odo-source-e2e"
[...]
```
**NOTE:** No use of variable ```ODO_TEST_SCENARIO``` will run the entire test suite. For example 
```
make test-e2e
```