### PR TITLE
adding example java docs

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -91,7 +91,7 @@ Build and run WildFly applications on CentOS 7. For more information about using
 
 ### java 
 
-Java can be used to deploy binary artifact
+Java can be used to deploy binary artifact, for example:
 
 ```sh
   git clone https://github.com/spring-projects/spring-petclinic.git
@@ -109,4 +109,3 @@ WildFly can deploy a binary application.
   wget -O example.war 'https://github.com/appuio/hello-world-war/blob/master/repo/ch/appuio/hello-world-war/1.0.0/hello-world-war-1.0.0.war?raw=true'
   odo create wildfly --binary example.war
 ```
-

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-Odo is compatible with any language or runtime listed within OpenShift's catalog of component types. To create url for component, see the [cli reference for `odo url`](cli-reference.md#url).
+Odo is compatible with any language or runtime listed within OpenShift's catalog of component types. In order to access the component over the web, you can create a URL using `odo url create`.
 
 This can be found by using `odo catalog list components`.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-Odo is compatible with any language or runtime listed within OpenShift's catalog of component types.
+Odo is compatible with any language or runtime listed within OpenShift's catalog of component types. To create url for component, see the [cli reference for `odo url`](cli-reference.md#url).
 
 This can be found by using `odo catalog list components`.
 
@@ -10,6 +10,7 @@ Example:
 NAME        PROJECT       TAGS
 dotnet      openshift     2.0,latest
 httpd       openshift     2.4,latest
+java        openshift     8,latest
 nginx       openshift     1.10,1.12,1.8,latest
 nodejs      openshift     0.10,4,6,8,latest
 perl        openshift     5.16,5.20,5.24,latest
@@ -28,6 +29,14 @@ Build and serve static content via httpd on CentOS 7. For more information about
 
 ```sh
   odo create httpd --git https://github.com/openshift/httpd-ex.git
+```
+
+### java 
+
+Build and run fat JAR Java applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/fabric8io-images/s2i/blob/master/README.md.
+
+```sh
+  odo create java --git https://github.com/spring-projects/spring-petclinic.git
 ```
 
 ### nodejs
@@ -80,6 +89,18 @@ Build and run WildFly applications on CentOS 7. For more information about using
 
 ## Binary example
 
+### java 
+
+Java can be used to deploy binary artifact
+
+```sh
+  git clone https://github.com/spring-projects/spring-petclinic.git
+  cd spring-petclinic
+  mvn package
+  odo create java test3 --binary target/*.jar
+  odo push
+```
+
 ### wildfly
 
 WildFly can deploy a binary application.
@@ -88,3 +109,4 @@ WildFly can deploy a binary application.
   wget -O example.war 'https://github.com/appuio/hello-world-war/blob/master/repo/ch/appuio/hello-world-war/1.0.0/hello-world-war-1.0.0.war?raw=true'
   odo create wildfly --binary example.war
 ```
+


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
fixes #???
#839, but does not completely resolve. #839 suggests that the getting started page include java. This makes sense, but is a more involved rewrite. I would suggest the team 1) split 839 and 2) use the example from the katacoda to rewrite the getting started docs for java and node

## How to test changes?
It's a doc change.

A couple notes:

- due to #1152, I cannot use any of the red hat repos for java examples as they need --context-dir support. Thus, I'm using Spring Pet Clinic here. 
- I think it would be good to refactor this whole page to include all commands needed for a working example (e.g. `odo push` & `odo url create`). Creating the component is only one part of the job and makes the docs a bit confusing.
