### PR TITLE
Removing unnecessary sleep from e2e_test scenario

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -213,7 +213,7 @@ var _ = Describe("odoe2e", func() {
 				// TODO: add tests for --git
 				curProj = strings.TrimSuffix(runCmd("oc project -q"), "\n")
 				// Sleep until status tags and their annotations are created
-				time.Sleep(15 * time.Second)
+				// time.Sleep(15 * time.Second)
 				runCmd("odo create " + curProj + "/nodejs nodejs --local " + tmpDir + "/nodejs-ex")
 				runCmd("odo push")
 			})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Remove unnecessary sleep so that the test cost in terms of time will be reduced.

## Was the change discussed in an issue?
On mattermost channel - https://chat.openshift.io/developers/pl/emb5de64cjbafbgspex11pkgqy
<!-- Please do Link issues here. -->
https://chat.openshift.io/developers/pl/emb5de64cjbafbgspex11pkgqy
## How to test changes?
<!-- Please describe the steps to test the PR -->
```make test-main-e2e```
However i would recommend try to run this more than 3 times concurrently. May be the impact can be observed if the machine or operation slow down in-between. As of now I just commented out the sleep statement, if it works as per our exception then will remove the sleep statement form the file before merge. 

I will try the same operation through travis ui. 
