### PR TITLE
Update openshift origin client used in e2e tests to v3.11.0

### DIFF
--- a/docs/ci-reference.md
+++ b/docs/ci-reference.md
@@ -1,0 +1,31 @@
+# How to run integration test job in Travis CI
+
+For default oc, use the configuration in .travis.yaml. For example:
+
+```sh
+  # Run main e2e tests
+    - <<: *base-test
+      stage: test
+      name: "Main e2e tests"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make bin
+        - sudo cp odo /usr/bin
+        - oc login -u developer
+        - make test-main-e2e
+```
+
+If the need presents itself to run Odo integration tests against a specific version of Openshift, use env variable `OPENSHIFT_CLIENT_BINARY_URL` to pass the [released](https://github.com/openshift/origin/releases) oc client URL in `.travis.yaml`. For oc v3.10.0, use the configuration:
+
+```sh
+  # Run main e2e tests
+    - <<: *base-test
+      stage: test
+      name: "Main e2e tests"
+      script:
+        - OPENSHIFT_CLIENT_BINARY_URL=https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz ./scripts/oc-cluster.sh
+        - make bin
+        - sudo cp odo /usr/bin
+        - oc login -u developer
+        - make test-main-e2e
+```

--- a/scripts/oc-cluster.sh
+++ b/scripts/oc-cluster.sh
@@ -3,6 +3,9 @@
 ## Script for installing and running `oc cluster up`
 ## Inspired by https://github.com/radanalyticsio/oshinko-cli/blob/master/.travis.yml
 
+## Use this variable to get more control over downloading client binary
+OPENSHIFT_CLIENT_BINARY_URL=${OPENSHIFT_CLIENT_BINARY_URL:-'https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'}
+
 sudo service docker stop
 
 sudo sed -i -e 's/sock/sock --insecure-registry 172.30.0.0\/16/' /etc/default/docker
@@ -12,7 +15,7 @@ sudo service docker start
 sudo service docker status
 
 ## download oc binaries
-sudo wget https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz -O /tmp/openshift-origin-client-tools.tar.gz 2> /dev/null > /dev/null
+sudo wget $OPENSHIFT_CLIENT_BINARY_URL -O /tmp/openshift-origin-client-tools.tar.gz 2> /dev/null > /dev/null
 
 sudo tar -xvzf /tmp/openshift-origin-client-tools.tar.gz --strip-components=1 -C /usr/local/bin
 
@@ -20,7 +23,8 @@ sudo tar -xvzf /tmp/openshift-origin-client-tools.tar.gz --strip-components=1 -C
 oc version
 
 ## below cmd is important to get oc working in ubuntu
-sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v3.10.0 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
+OPENSHIFT_CLIENT_VERSION=`echo $OPENSHIFT_CLIENT_BINARY_URL | awk -F '//' '{print $2}' | cut -d '/' -f 6`
+sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:$OPENSHIFT_CLIENT_VERSION -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
 
 while true; do
     if [ "$1" = "service-catalog" ]; then

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -570,24 +571,25 @@ var _ = Describe("odoe2e", func() {
 			waitForDeleteCmd("odo project list", projName)
 		})
 	})
-	Context("validate odo version cmd with oc version", func() {
-		// test for odo version
-		It("should show the version of OpenShift server", func() {
+
+	Context("validate odo version cmd with other major components version", func() {
+		It("should show the version of odo major components", func() {
 			odoVersion := runCmd("odo version")
+			reOdoVersion := regexp.MustCompile(`^odo\s*v[0-9]+.[0-9]+.[0-9]+\s*\(\w+\)`)
+			odoVersionStringMatch := reOdoVersion.MatchString(odoVersion)
+			rekubernetesVersion := regexp.MustCompile(`Kubernetes:\s*v[0-9]+.[0-9]+.[0-9]+\+\w+`)
+			kubernetesVersionStringMatch := rekubernetesVersion.MatchString(odoVersion)
+			Expect(odoVersionStringMatch).Should(BeTrue())
+			Expect(kubernetesVersionStringMatch).Should(BeTrue())
+		})
 
-			ocServer := runCmd("oc version|grep Server|cut -d ' ' -f 2")
-			ocVersion := runCmd("oc version|grep openshift|cut -d ' ' -f 2")
-			k8sVersion := runCmd("oc version|grep kubernetes|tail -1|cut -d ' ' -f 2")
-
-			Expect(odoVersion).To(ContainSubstring("Server"))
-			Expect(odoVersion).To(ContainSubstring(ocServer))
-			Expect(odoVersion).To(ContainSubstring("OpenShift"))
-			Expect(odoVersion).To(ContainSubstring(ocVersion))
-			Expect(odoVersion).To(ContainSubstring("Kubernetes"))
-			Expect(odoVersion).To(ContainSubstring(k8sVersion))
+		It("should show server login URL", func() {
+			odoVersion := runCmd("odo version")
+			reServerURL := regexp.MustCompile(`Server:\s*https:\/\/([0-9]+.){3}[0-9]+:8443`)
+			serverURLStringMatch := reServerURL.MatchString(odoVersion)
+			Expect(serverURLStringMatch).Should(BeTrue())
 		})
 	})
-
 })
 
 var _ = Describe("updateE2e", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Test should be run on latest available OpenShift release version

## Was the change discussed in an issue?
Mattermost channel - https://chat.openshift.io/developers/pl/cn5ihkt8htdy5emjdeg89ribze
<!-- Please do Link issues here. -->

## How to test changes?
This is CI specific. On master test suite runs on oc version v3.10.0, however with this changes test suite will run on oc v3.11.0
