### PR TITLE
Add service plan and parameter completion

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1950,7 +1950,7 @@ func (c *Client) GetClusterServiceClass(serviceName string) (*scv1beta1.ClusterS
 }
 
 // GetClusterPlansFromServiceName returns the plans associated with a service class
-// serviceName is the name of the service class whose plans are required
+// serviceName is the name (the actual id, NOT the external name) of the service class whose plans are required
 // returns array of ClusterServicePlans or error
 func (c *Client) GetClusterPlansFromServiceName(serviceName string) ([]scv1beta1.ClusterServicePlan, error) {
 	opts := metav1.ListOptions{

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -193,5 +193,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	serviceCreateCmd.Flags().StringVar(&o.plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringSliceVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")
 	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
+	completion.RegisterCommandFlagHandler(serviceCreateCmd, "plan", completion.ServicePlanCompletionHandler)
+	completion.RegisterCommandFlagHandler(serviceCreateCmd, "parameters", completion.ServiceParameterCompletionHandler)
 	return serviceCreateCmd
 }

--- a/pkg/odo/cli/service/service.go
+++ b/pkg/odo/cli/service/service.go
@@ -7,7 +7,6 @@ import (
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 
 	"github.com/redhat-developer/odo/pkg/odo/util"
-	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -46,9 +45,6 @@ func NewCmdService(name, fullName string) *cobra.Command {
 	appCmd.AddApplicationFlag(serviceCreateCmd)
 	appCmd.AddApplicationFlag(serviceDeleteCmd)
 	appCmd.AddApplicationFlag(serviceListCmd)
-
-	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
-	completion.RegisterCommandHandler(serviceDeleteCmd, completion.ServiceCompletionHandler)
 
 	return serviceCmd
 }

--- a/pkg/odo/util/completion/completion.go
+++ b/pkg/odo/util/completion/completion.go
@@ -48,7 +48,24 @@ func NewParsedArgs(args complete.Args, cmd *cobra.Command) parsedArgs {
 	typed := getUserTypedCommands(args, cmd)
 	commands, flagValues := getCommandsAndFlags(typed, cmd)
 
-	complete.Log("Parsed flag values: %v", flagValues)
+	complete.Log("Parsed commands values for full input: %v", commands)
+	complete.Log("Parsed flag values for full input: %v", flagValues)
+
+	// this part is meant to handle incomplete flags when other input already exists,
+	// so 2 tokens is the minimum that makes sense
+	if len(typed) > 2 {
+		typedWithoutLast := make([]string, len(typed))
+		copy(typedWithoutLast, typed)
+		typedWithoutLast = typedWithoutLast[:len(typedWithoutLast)-1]
+		_, flagValuesWithoutLast := getCommandsAndFlags(typedWithoutLast, cmd)
+
+		complete.Log("Parsed flag values for input without last: %v", flagValuesWithoutLast)
+
+		// now we merge the two maps
+		for k, v := range flagValuesWithoutLast {
+			flagValues[k] = v
+		}
+	}
 
 	parsed := parsedArgs{
 		original:   args,

--- a/pkg/odo/util/completion/completion.go
+++ b/pkg/odo/util/completion/completion.go
@@ -51,8 +51,14 @@ func NewParsedArgs(args complete.Args, cmd *cobra.Command) parsedArgs {
 	complete.Log("Parsed commands values for full input: %v", commands)
 	complete.Log("Parsed flag values for full input: %v", flagValues)
 
-	// this part is meant to handle incomplete flags when other input already exists,
-	// so 2 tokens is the minimum that makes sense
+	// the parsing above won't work properly when we have previously supplied flags and we are trying to complete
+	// another flag
+	// For example when the user has typed "odo service create --plan prod -p "
+	// the flagValues var above would not contains the plan flag and value
+	// So in the following part of the code we strip the last thing the user added and parse again
+	// any new parsed flags will be added
+	// There is no need to do this extra parsing if the user has not already added a flag. So as a heuristic
+	// we only perform this parsing when at the user has added at least 2 tokens
 	if len(typed) > 2 {
 		typedWithoutLast := make([]string, len(typed))
 		copy(typedWithoutLast, typed)

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -55,6 +55,8 @@ var ServiceClassCompletionHandler = func(cmd *cobra.Command, args parsedArgs, co
 // ServicePlanCompletionHandler provides completion for the the plan of a selected service
 var ServicePlanCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
+	// if we have less than two arguments, it means the use didn't specify the name of the service
+	// meaning that there is no point in providing suggestions
 	if len(args.original.Completed) < 2 {
 		complete.Log("Couldn't extract the service name")
 		return completions

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -64,7 +64,7 @@ var ServicePlanCompletionHandler = func(cmd *cobra.Command, args parsedArgs, con
 
 	complete.Log(fmt.Sprintf("Using input: serviceName = %s", inputServiceName))
 
-	_, servicePlans, err := service.GetServiceClassAndPlans(context.Client, inputServiceName)
+	servicePlans, err := context.Client.GetClusterPlansFromServiceName(inputServiceName)
 	if err != nil {
 		complete.Log("Error retrieving details of service")
 		return completions

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -55,7 +55,7 @@ var ServiceClassCompletionHandler = func(cmd *cobra.Command, args parsedArgs, co
 // ServicePlanCompletionHandler provides completion for the the plan of a selected service
 var ServicePlanCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	// if we have less than two arguments, it means the use didn't specify the name of the service
+	// if we have less than two arguments, it means the user didn't specify the name of the service
 	// meaning that there is no point in providing suggestions
 	if len(args.original.Completed) < 2 {
 		complete.Log("Couldn't extract the service name")

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -66,14 +66,20 @@ var ServicePlanCompletionHandler = func(cmd *cobra.Command, args parsedArgs, con
 
 	complete.Log(fmt.Sprintf("Using input: serviceName = %s", inputServiceName))
 
-	servicePlans, err := context.Client.GetClusterPlansFromServiceName(inputServiceName)
+	clusterServiceClass, err := context.Client.GetClusterServiceClass(inputServiceName)
 	if err != nil {
 		complete.Log("Error retrieving details of service")
 		return completions
 	}
 
+	servicePlans, err := context.Client.GetClusterPlansFromServiceName(clusterServiceClass.Name)
+	if err != nil {
+		complete.Log("Error retrieving details of plans of service")
+		return completions
+	}
+
 	for _, servicePlan := range servicePlans {
-		completions = append(completions, servicePlan.Name)
+		completions = append(completions, servicePlan.Spec.ExternalName)
 	}
 
 	return completions

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -1,8 +1,6 @@
 package completion
 
 import (
-	"encoding/json"
-	"fmt"
 	"github.com/posener/complete"
 	"github.com/redhat-developer/odo/pkg/testingutil"
 	"reflect"
@@ -23,27 +21,8 @@ import (
 )
 
 func TestServicePlanCompletionHandler(t *testing.T) {
-
-	classExternalMetaData := make(map[string]interface{})
-	classExternalMetaDataRaw, err := json.Marshal(classExternalMetaData)
-	if err != nil {
-		fmt.Printf("error occured %v during marshalling", err)
-		return
-	}
-
 	serviceClassList := &scv1beta1.ClusterServiceClassList{
-		Items: []scv1beta1.ClusterServiceClass{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "1dda1477cace09730bd8ed7a6505607e"},
-				Spec: scv1beta1.ClusterServiceClassSpec{
-					CommonServiceClassSpec: scv1beta1.CommonServiceClassSpec{
-						ExternalName:     "class name",
-						ExternalMetadata: &runtime.RawExtension{Raw: classExternalMetaDataRaw},
-					},
-					ClusterServiceBrokerName: "broker name",
-				},
-			},
-		},
+		Items: []scv1beta1.ClusterServiceClass{testingutil.FakeClusterServiceClass("class name", "dummy")},
 	}
 	tests := []struct {
 		name                 string
@@ -114,27 +93,8 @@ func TestServicePlanCompletionHandler(t *testing.T) {
 }
 
 func TestServiceParameterCompletionHandler(t *testing.T) {
-
-	classExternalMetaData := make(map[string]interface{})
-	classExternalMetaDataRaw, err := json.Marshal(classExternalMetaData)
-	if err != nil {
-		fmt.Printf("error occured %v during marshalling", err)
-		return
-	}
-
 	serviceClassList := &scv1beta1.ClusterServiceClassList{
-		Items: []scv1beta1.ClusterServiceClass{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "1dda1477cace09730bd8ed7a6505607e"},
-				Spec: scv1beta1.ClusterServiceClassSpec{
-					CommonServiceClassSpec: scv1beta1.CommonServiceClassSpec{
-						ExternalName:     "class name",
-						ExternalMetadata: &runtime.RawExtension{Raw: classExternalMetaDataRaw},
-					},
-					ClusterServiceBrokerName: "broker name",
-				},
-			},
-		},
+		Items: []scv1beta1.ClusterServiceClass{testingutil.FakeClusterServiceClass("class name", "dummy")},
 	}
 	tests := []struct {
 		name                 string

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -71,10 +71,6 @@ func TestServicePlanCompletionHandler(t *testing.T) {
 		client, fakeClientSet := occlient.FakeNew()
 		context := genericclioptions.NewFakeContext("project", "app", "component", client)
 
-		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-			return true, tt.returnedServiceClass, nil
-		})
-
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, &scv1beta1.ClusterServicePlanList{Items: tt.returnedServicePlan}, nil
 		})

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -71,6 +71,10 @@ func TestServicePlanCompletionHandler(t *testing.T) {
 		client, fakeClientSet := occlient.FakeNew()
 		context := genericclioptions.NewFakeContext("project", "app", "component", client)
 
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, tt.returnedServiceClass, nil
+		})
+
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, &scv1beta1.ClusterServicePlanList{Items: tt.returnedServicePlan}, nil
 		})

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -80,9 +80,8 @@ func TestServicePlanCompletionHandler(t *testing.T) {
 		})
 
 		completions := ServicePlanCompletionHandler(nil, tt.parsedArgs, context)
-		sort.Strings(completions)
 
-		// Sort the output and expected o/p in-order to avoid issues due to order as its not important
+		// Sort the output and expected output in order to avoid false negatives (since ordering of the results is not important)
 		sort.Strings(completions)
 		sort.Strings(tt.output)
 
@@ -203,9 +202,8 @@ func TestServiceParameterCompletionHandler(t *testing.T) {
 		})
 
 		completions := ServiceParameterCompletionHandler(nil, tt.parsedArgs, context)
-		sort.Strings(completions)
 
-		// Sort the output and expected o/p in-order to avoid issues due to order as its not important
+		// Sort the output and expected output in order to avoid false negatives (since ordering of the results is not important)
 		sort.Strings(completions)
 		sort.Strings(tt.output)
 

--- a/pkg/testingutil/services.go
+++ b/pkg/testingutil/services.go
@@ -12,10 +12,17 @@ type M map[string]interface{}
 
 // FakeClusterServiceClass creates a fake service class with the specified name for testing purposes
 func FakeClusterServiceClass(name string, tags ...string) v1beta1.ClusterServiceClass {
+	classExternalMetaData := make(map[string]interface{})
+	classExternalMetaDataRaw, err := json.Marshal(classExternalMetaData)
+	if err != nil {
+		panic(err)
+	}
+
 	class := v1beta1.ClusterServiceClass{
 		Spec: v1beta1.ClusterServiceClassSpec{
 			CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
-				ExternalName: name,
+				ExternalName:     name,
+				ExternalMetadata: &runtime.RawExtension{Raw: classExternalMetaDataRaw},
 			},
 		},
 	}

--- a/pkg/testingutil/services.go
+++ b/pkg/testingutil/services.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -38,6 +39,9 @@ func FakeClusterServiceClass(name string, tags ...string) v1beta1.ClusterService
 // metadata and parameter values
 func FakeClusterServicePlan(name string, planNumber int) v1beta1.ClusterServicePlan {
 	return v1beta1.ClusterServicePlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ClusterServiceClassRef: v1beta1.ClusterObjectReference{
 				Name: "1dda1477cace09730bd8ed7a6505607e",

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -6,7 +6,7 @@
 set -e
 echo "" > coverage.txt
 go test -i -race ./cmd/odo
-for d in $(go list ./... | grep -v vendor | grep -v tests/e2e); do
+for d in $(go list ./... | grep -v vendor | grep -v tests/e2e | grep -v testingutil); do
     # For watch related tests, race check causes issue so disabling them here as race is already tested in other tests when used with `-coverprofile=profile.out`
     if [ "$d" = "github.com/redhat-developer/odo/pkg/component" ]; then
         go test -coverprofile=profile.out -covermode=atomic $d


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See $SUBJECT

## Was the change discussed in an issue?
Fixes: #1171

## How to test changes?
Assuming that the completion scripts have already been setup and that the binary from this PR is on $PATH, a good test would be the following:


Now by execuring

`odo service create $some_service --plan + [TAB]` 

you should yield the various plans

Once you decide on a plan, you can see the required parameters by using

`odo service create $some_service --plan $some_plan -p + [TAB]` 