### PR TITLE
This issue fixes the duplication error in the completion handlers

### DIFF
--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -29,6 +29,9 @@ var ServiceCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context
 	}
 
 	for _, class := range services {
+		if args.commands[class.Name] {
+			return nil
+		}
 		completions = append(completions, class.Name)
 	}
 
@@ -46,6 +49,9 @@ var ServiceClassCompletionHandler = func(cmd *cobra.Command, args parsedArgs, co
 
 	complete.Log(fmt.Sprintf("found %d services", len(services)))
 	for _, class := range services {
+		if args.commands[class.Spec.ExternalName] {
+			return nil
+		}
 		completions = append(completions, class.Spec.ExternalName)
 	}
 
@@ -144,6 +150,9 @@ var AppCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *ge
 	}
 
 	for _, app := range applications {
+		if args.commands[app.Name] {
+			return nil
+		}
 		completions = append(completions, app.Name)
 	}
 	return

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -527,7 +527,7 @@ func TestServiceCompletionHandler(t *testing.T) {
 		parsedArgs                    parsedArgs
 	}{
 		{
-			name: "test case 1: no service instance class exists and name not typed",
+			name: "test case 1: no service instance exists and name not typed",
 			parsedArgs: parsedArgs{
 				original: complete.Args{
 					Completed: []string{"delete"},
@@ -566,11 +566,12 @@ func TestServiceCompletionHandler(t *testing.T) {
 			output: []string{"service-1", "service-2"},
 		},
 		{
-			name: "test case 4: multiple service class instance exists and name half typed",
+			name: "test case 4: multiple service class instance exists and name fully typed",
 			parsedArgs: parsedArgs{
 				original: complete.Args{
-					Completed: []string{"delete", "service"},
+					Completed: []string{"delete"},
 				},
+				commands: map[string]bool{"service-1": true},
 			},
 			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{
 				Items: []scv1beta1.ServiceInstance{
@@ -578,22 +579,7 @@ func TestServiceCompletionHandler(t *testing.T) {
 					testingutil.FakeServiceClassInstance("service-2", "mariadb-apb", "prod", "ProvisionedSuccessfully"),
 				},
 			},
-			output: []string{"service-1", "service-2"},
-		},
-		{
-			name: "test case 5: multiple service class instance exists and name fully typed",
-			parsedArgs: parsedArgs{
-				original: complete.Args{
-					Completed: []string{"delete", "service-1"},
-				},
-			},
-			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{
-				Items: []scv1beta1.ServiceInstance{
-					testingutil.FakeServiceClassInstance("service-1", "mariadb-apb", "default", "ProvisionedSuccessfully"),
-					testingutil.FakeServiceClassInstance("service-2", "mariadb-apb", "prod", "ProvisionedSuccessfully"),
-				},
-			},
-			output: []string{"service-1", "service-2"},
+			output: nil,
 		},
 	}
 
@@ -607,6 +593,91 @@ func TestServiceCompletionHandler(t *testing.T) {
 		})
 
 		completions := ServiceCompletionHandler(nil, tt.parsedArgs, context)
+
+		// Sort the output and expected output in order to avoid false negatives (since ordering of the results is not important)
+		sort.Strings(completions)
+		sort.Strings(tt.output)
+
+		if !reflect.DeepEqual(tt.output, completions) {
+			t.Errorf("expected output: %#v,got: %#v", tt.output, completions)
+		}
+	}
+}
+
+func TestServiceClassCompletionHandler(t *testing.T) {
+	tests := []struct {
+		name                   string
+		returnedServiceClasses *scv1beta1.ClusterServiceClassList
+		output                 []string
+		parsedArgs             parsedArgs
+	}{
+		{
+			name: "test case 1: no service class exists and name not typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"create"},
+				},
+			},
+			returnedServiceClasses: &scv1beta1.ClusterServiceClassList{},
+			output:                 []string{},
+		},
+		{
+			name: "test case 2: one service class exists and name not typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"create"},
+				},
+			},
+			returnedServiceClasses: &scv1beta1.ClusterServiceClassList{
+				Items: []scv1beta1.ClusterServiceClass{
+					testingutil.FakeClusterServiceClass("foo"),
+				},
+			},
+			output: []string{"foo"},
+		},
+		{
+			name: "test case 3: multiple service classes exist and name not typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"create"},
+				},
+			},
+			returnedServiceClasses: &scv1beta1.ClusterServiceClassList{
+				Items: []scv1beta1.ClusterServiceClass{
+					testingutil.FakeClusterServiceClass("foo"),
+					testingutil.FakeClusterServiceClass("bar"),
+				},
+			},
+			output: []string{"foo", "bar"},
+		},
+		{
+			name: "test case 4: multiple service classes exist and name fully typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"delete"},
+				},
+				commands: map[string]bool{"foo": true},
+			},
+			returnedServiceClasses: &scv1beta1.ClusterServiceClassList{
+				Items: []scv1beta1.ClusterServiceClass{
+					testingutil.FakeClusterServiceClass("foo"),
+					testingutil.FakeClusterServiceClass("bar"),
+				},
+			},
+			output: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := occlient.FakeNew()
+		context := genericclioptions.NewFakeContext("project", "app", "component", client)
+
+		//fake the services
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, tt.returnedServiceClasses, nil
+		})
+
+		completions := ServiceClassCompletionHandler(nil, tt.parsedArgs, context)
 
 		// Sort the output and expected output in order to avoid false negatives (since ordering of the results is not important)
 		sort.Strings(completions)

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -518,3 +518,102 @@ func TestUnlinkCompletionHandler(t *testing.T) {
 		}
 	}
 }
+
+func TestServiceCompletionHandler(t *testing.T) {
+	tests := []struct {
+		name                          string
+		returnedServiceClassInstances *scv1beta1.ServiceInstanceList
+		output                        []string
+		parsedArgs                    parsedArgs
+	}{
+		{
+			name: "test case 1: no service instance class exists and name not typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"delete"},
+				},
+			},
+			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{},
+			output:                        []string{},
+		},
+		{
+			name: "test case 2: one service class instance exists and name not typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"delete"},
+				},
+			},
+			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					testingutil.FakeServiceClassInstance("service-1", "mariadb-apb", "default", "ProvisionedSuccessfully"),
+				},
+			},
+			output: []string{"service-1"},
+		},
+		{
+			name: "test case 3: multiple service class instance exists and name not typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"delete"},
+				},
+			},
+			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					testingutil.FakeServiceClassInstance("service-1", "mariadb-apb", "default", "ProvisionedSuccessfully"),
+					testingutil.FakeServiceClassInstance("service-2", "mariadb-apb", "prod", "ProvisionedSuccessfully"),
+				},
+			},
+			output: []string{"service-1", "service-2"},
+		},
+		{
+			name: "test case 4: multiple service class instance exists and name half typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"delete", "service"},
+				},
+			},
+			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					testingutil.FakeServiceClassInstance("service-1", "mariadb-apb", "default", "ProvisionedSuccessfully"),
+					testingutil.FakeServiceClassInstance("service-2", "mariadb-apb", "prod", "ProvisionedSuccessfully"),
+				},
+			},
+			output: []string{"service-1", "service-2"},
+		},
+		{
+			name: "test case 5: multiple service class instance exists and name fully typed",
+			parsedArgs: parsedArgs{
+				original: complete.Args{
+					Completed: []string{"delete", "service-1"},
+				},
+			},
+			returnedServiceClassInstances: &scv1beta1.ServiceInstanceList{
+				Items: []scv1beta1.ServiceInstance{
+					testingutil.FakeServiceClassInstance("service-1", "mariadb-apb", "default", "ProvisionedSuccessfully"),
+					testingutil.FakeServiceClassInstance("service-2", "mariadb-apb", "prod", "ProvisionedSuccessfully"),
+				},
+			},
+			output: []string{"service-1", "service-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		client, fakeClientSet := occlient.FakeNew()
+		context := genericclioptions.NewFakeContext("project", "app", "component", client)
+
+		//fake the services
+		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, tt.returnedServiceClassInstances, nil
+		})
+
+		completions := ServiceCompletionHandler(nil, tt.parsedArgs, context)
+
+		// Sort the output and expected output in order to avoid false negatives (since ordering of the results is not important)
+		sort.Strings(completions)
+		sort.Strings(tt.output)
+
+		if !reflect.DeepEqual(tt.output, completions) {
+			t.Errorf("expected output: %#v,got: %#v", tt.output, completions)
+		}
+	}
+}

--- a/pkg/testingutil/services.go
+++ b/pkg/testingutil/services.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -120,4 +123,37 @@ func FakePlanServiceInstanceCreateParameterSchemasRaw() [][]byte {
 	data = append(data, planServiceInstanceCreateParameterSchemaRaw2)
 
 	return data
+}
+
+// FakeServiceClassInstance creates and returns a simple service class instance for testing purpose
+// serviceInstanceName is the name of the service class instance
+// serviceClassName is the name of the service class
+// planName is the name of the plan
+// status is the status of the service instance
+func FakeServiceClassInstance(serviceInstanceName string, serviceClassName string, planName string, status string) scv1beta1.ServiceInstance {
+	var service = scv1beta1.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceInstanceName,
+			Labels: map[string]string{
+				applabels.ApplicationLabel:         "app",
+				componentlabels.ComponentLabel:     serviceInstanceName,
+				componentlabels.ComponentTypeLabel: "dh-mariadb-apb",
+			},
+			Namespace: "myproject",
+		},
+		Spec: scv1beta1.ServiceInstanceSpec{
+			PlanReference: scv1beta1.PlanReference{
+				ClusterServiceClassExternalName: serviceClassName,
+				ClusterServicePlanExternalName:  planName,
+			},
+		},
+		Status: scv1beta1.ServiceInstanceStatus{
+			Conditions: []scv1beta1.ServiceInstanceCondition{
+				{
+					Reason: status,
+				},
+			},
+		},
+	}
+	return service
 }


### PR DESCRIPTION
fixes #1212 

This issue fixes the duplication error in the completion handlers of service names, service class names and app names

How to test : 
Press <tab> multiple times in case of name completion of the above entities. The name should be suggested only once