### PR TITLE
use Recreate deployment strategy

### DIFF
--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -26,6 +26,9 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, bui
 		ObjectMeta: commonObjectMeta,
 		Spec: appsv1.DeploymentConfigSpec{
 			Replicas: 1,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.DeploymentStrategyTypeRecreate,
+			},
 			Selector: map[string]string{
 				"deploymentconfig": commonObjectMeta.Name,
 			},
@@ -147,6 +150,9 @@ func generateGitDeploymentConfig(commonObjectMeta metav1.ObjectMeta, image strin
 		ObjectMeta: commonObjectMeta,
 		Spec: appsv1.DeploymentConfigSpec{
 			Replicas: 1,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.DeploymentStrategyTypeRecreate,
+			},
 			Selector: map[string]string{
 				"deploymentconfig": commonObjectMeta.Name,
 			},


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
odo will generate DeplymentConfig with Recreate strategy instead of Rollout. 
More info an be found at #1141


## Was the change discussed in an issue?
fixes #1141

<!-- Please do Link issues here. -->
