### PR TITLE
Prevent a link from being created twice

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -201,6 +201,25 @@ func GetComponentPorts(client *occlient.Client, componentName string, applicatio
 	return ports, nil
 }
 
+// GetComponentLinkedSecretNames provides a slice containing the names of the secrets that are present in envFrom
+func GetComponentLinkedSecretNames(client *occlient.Client, componentName string, applicationName string) (secretNames []string, err error) {
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+
+	dc, err := client.GetOneDeploymentConfigFromSelector(componentSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch deployment configs for the selector %v", componentSelector)
+	}
+
+	for _, env := range dc.Spec.Template.Spec.Containers[0].EnvFrom {
+		if env.SecretRef != nil {
+			secretNames = append(secretNames, env.SecretRef.Name)
+		}
+	}
+
+	return secretNames, nil
+}
+
 // CreateFromPath create new component with source or binary from the given local path
 // sourceType indicates the source type of the component and can be either local or binary
 // envVars is the array containing the environment variables

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -102,7 +102,7 @@ func TestGetComponentPorts(t *testing.T) {
 		output  []string
 	}{
 		{
-			name: "Case 1: Invalid/Non-existant component name",
+			name: "Case 1: Invalid/Unexisting component name",
 			args: args{
 				componentName:   "r",
 				applicationName: "app",
@@ -149,6 +149,76 @@ func TestGetComponentPorts(t *testing.T) {
 
 			// The function we are testing
 			output, err := GetComponentPorts(client, tt.args.componentName, tt.args.applicationName)
+
+			// Checks for error in positive cases
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("component List() unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Sort the output and expected o/p in-order to avoid issues due to order as its not important
+			sort.Strings(output)
+			sort.Strings(tt.output)
+
+			// Check if the output is the same as what's expected (tags)
+			// and only if output is more than 0 (something is actually returned)
+			if len(output) > 0 && !(reflect.DeepEqual(output, tt.output)) {
+				t.Errorf("expected tags: %s, got: %s", tt.output, output)
+			}
+		})
+	}
+}
+
+func TestGetComponentLinkedSecretNames(t *testing.T) {
+	type args struct {
+		componentName   string
+		applicationName string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		output  []string
+	}{
+		{
+			name: "Case 1: Invalid/Unexisting component name",
+			args: args{
+				componentName:   "r",
+				applicationName: "app",
+			},
+			wantErr: true,
+			output:  []string{},
+		},
+		{
+			name: "Case 2: Valid params nil env source",
+			args: args{
+				componentName:   "python",
+				applicationName: "app",
+			},
+			output:  []string{},
+			wantErr: false,
+		},
+		{
+			name: "Case 3: Valid params multiple secrets",
+			args: args{
+				componentName:   "nodejs",
+				applicationName: "app",
+			},
+			output:  []string{"s1", "s2"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Fake the client with the appropriate arguments
+			client, fakeClientSet := occlient.FakeNew()
+			fakeClientSet.AppsClientset.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, testingutil.FakeDeploymentConfigs(), nil
+			})
+
+			// The function we are testing
+			output, err := GetComponentLinkedSecretNames(client, tt.args.componentName, tt.args.applicationName)
 
 			// Checks for error in positive cases
 			if !tt.wantErr == (err != nil) {

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -2,7 +2,6 @@ package component
 
 import (
 	"fmt"
-
 	"github.com/golang/glog"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/log"

--- a/pkg/testingutil/deploymentconfigs.go
+++ b/pkg/testingutil/deploymentconfigs.go
@@ -16,11 +16,13 @@ func getContainerPort(containerPort int32, containerProtocol corev1.Protocol) (c
 	}
 }
 
-func getContainer(componentName string, applicationName string, ports []corev1.ContainerPort) corev1.Container {
+func getContainer(componentName string, applicationName string, ports []corev1.ContainerPort,
+	envFromSources []corev1.EnvFromSource) corev1.Container {
 	return corev1.Container{
-		Name:  fmt.Sprintf("%v-%v", componentName, applicationName),
-		Image: fmt.Sprintf("%v-%v", componentName, applicationName),
-		Ports: ports,
+		Name:    fmt.Sprintf("%v-%v", componentName, applicationName),
+		Image:   fmt.Sprintf("%v-%v", componentName, applicationName),
+		Ports:   ports,
+		EnvFrom: envFromSources,
 	}
 }
 
@@ -84,7 +86,7 @@ func FakeDeploymentConfigs() *v1.DeploymentConfigList {
 			ContainerPort: 9090,
 			Protocol:      corev1.ProtocolUDP,
 		},
-	})
+	}, nil)
 	c2 := getContainer(componentName, applicationName, []corev1.ContainerPort{
 		{
 			Name:          fmt.Sprintf("%v-%v-p1", componentName, applicationName),
@@ -96,7 +98,7 @@ func FakeDeploymentConfigs() *v1.DeploymentConfigList {
 			ContainerPort: 10090,
 			Protocol:      corev1.ProtocolUDP,
 		},
-	})
+	}, nil)
 	dc1 := getDeploymentConfig("myproject", componentName, componentType, applicationName, []corev1.Container{c1, c2})
 
 	// DC2 with single container and single port
@@ -108,6 +110,21 @@ func FakeDeploymentConfigs() *v1.DeploymentConfigList {
 			Name:          fmt.Sprintf("%v-%v-p1", componentName, applicationName),
 			ContainerPort: 8080,
 			Protocol:      corev1.ProtocolTCP,
+		},
+	}, []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "s1",
+				},
+			},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "s2",
+				},
+			},
 		},
 	})
 	dc2 := getDeploymentConfig("myproject", componentName, componentType, applicationName, []corev1.Container{c3})
@@ -127,7 +144,7 @@ func FakeDeploymentConfigs() *v1.DeploymentConfigList {
 			ContainerPort: 8090,
 			Protocol:      corev1.ProtocolTCP,
 		},
-	})
+	}, nil)
 	dc3 := getDeploymentConfig("myproject", componentName, componentType, applicationName, []corev1.Container{c4})
 
 	return &v1.DeploymentConfigList{

--- a/tests/e2e/link_test.go
+++ b/tests/e2e/link_test.go
@@ -50,6 +50,11 @@ var _ = Describe("odoLinkE2e", func() {
 			Expect(envFromOutput).To(ContainSubstring("backend"))
 		})
 
+		It("link should fail when linking to the same component again", func() {
+			output := runFailCmd("odo link backend --component frontend", 1)
+			Expect(output).To(ContainSubstring("been linked"))
+		})
+
 		It("should be able to create a service", func() {
 			runCmd("odo service create mysql-persistent")
 
@@ -65,6 +70,11 @@ var _ = Describe("odoLinkE2e", func() {
 			envFromOutput :=
 				runCmd("oc get dc backend-testing -o jsonpath='{.spec.template.spec.containers[0].envFrom}'")
 			Expect(envFromOutput).To(ContainSubstring("mysql-persistent"))
+		})
+
+		It("link should fail when linking to the same service again", func() {
+			output := runFailCmd("odo link mysql-persistent --component backend", 1)
+			Expect(output).To(ContainSubstring("been linked"))
 		})
 
 		It("delete the service", func() {


### PR DESCRIPTION


## What is the purpose of this change? What does it change?
See $SUBJECT

## Was the change discussed in an issue?

Fixes: #1201

## How to test changes?
Create a backend component and then a fronted.
The first attempt to link to the backend should work.
The second one will fail.
Note that when ports are needed, links to a different ports are allowed - but not multiple links to the same port.

Also linking from a component to a service is also only allowed once
