### PR TITLE
Add the linked components and services to odo describe

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -48,7 +48,7 @@ type Description struct {
 	Env                []corev1.EnvVar       `json:"environment,omitempty"`
 	Storage            []storage.StorageInfo `json:"storage,omitempty"`
 	LinkedComponents   map[string][]string   `json:"linkedComponents,omitempty"`
-	LinkedServices     []string              `json:"linkedComponents,omitempty"`
+	LinkedServices     []string              `json:"linkedServices,omitempty"`
 }
 
 // GetComponentDir returns source repo name

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -845,7 +845,7 @@ func GetComponentDesc(client *occlient.Client, componentName string, application
 		return componentDesc, errors.Wrap(err, "unable to get envVars list")
 	}
 
-	linkedServices := make([]string, 0)
+	linkedServices := make([]string, 0, 5)
 	linkedComponents := make(map[string][]string)
 	linkedSecretNames, err := GetComponentLinkedSecretNames(client, componentName, applicationName)
 	if err != nil {

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -151,7 +151,7 @@ var applicationDeleteCmd = &cobra.Command{
 		var confirmDeletion string
 
 		// Print App Information which will be deleted
-		err := printDeleteAppInfo(client, appName)
+		err := printDeleteAppInfo(client, appName, projectName)
 		odoutil.LogErrorAndExit(err, "")
 		exists, err := application.Exists(client, appName)
 		odoutil.LogErrorAndExit(err, "")
@@ -298,7 +298,7 @@ var applicationDescribeCmd = &cobra.Command{
 				appName, len(componentList), len(serviceList))
 			if len(componentList) > 0 {
 				for _, currentComponent := range componentList {
-					componentDesc, err := component.GetComponentDesc(client, currentComponent.Name, appName)
+					componentDesc, err := component.GetComponentDesc(client, currentComponent.Name, appName, projectName)
 					odoutil.LogErrorAndExit(err, "")
 					odoutil.PrintComponentInfo(currentComponent.Name, componentDesc)
 					fmt.Println("--------------------------------------")
@@ -359,14 +359,14 @@ func AddApplicationFlag(cmd *cobra.Command) {
 }
 
 // printDeleteAppInfo will print things which will be deleted
-func printDeleteAppInfo(client *occlient.Client, appName string) error {
+func printDeleteAppInfo(client *occlient.Client, appName string, projectName string) error {
 	componentList, err := component.List(client, appName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Component list")
 	}
 
 	for _, currentComponent := range componentList {
-		componentDesc, err := component.GetComponentDesc(client, currentComponent.Name, appName)
+		componentDesc, err := component.GetComponentDesc(client, currentComponent.Name, appName, projectName)
 		if err != nil {
 			return errors.Wrap(err, "unable to get component description")
 		}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -32,7 +32,7 @@ var describeCmd = &cobra.Command{
 		} else {
 			componentName = context.Component(args[0])
 		}
-		componentDesc, err := component.GetComponentDesc(client, componentName, applicationName)
+		componentDesc, err := component.GetComponentDesc(client, componentName, applicationName, context.Project)
 		odoutil.LogErrorAndExit(err, "")
 
 		odoutil.PrintComponentInfo(componentName, componentDesc)

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -82,6 +83,20 @@ func PrintComponentInfo(currentComponentName string, componentDesc component.Des
 			fmt.Printf(" - %v exposed via %v\n", url.GetURLString(componentUrl), componentUrl.Port)
 		}
 
+	}
+	// Linked services
+	if len(componentDesc.LinkedServices) > 0 {
+		fmt.Print("Linked Services: ")
+		fmt.Printf("%v\n", strings.Join(componentDesc.LinkedServices, ","))
+	}
+	// Linked components
+	if len(componentDesc.LinkedComponents) > 0 {
+		fmt.Println("\nLinked Components")
+		for name, ports := range componentDesc.LinkedComponents {
+			if len(ports) > 0 {
+				fmt.Printf("Name: %v - Port(s): %v\n", name, strings.Join(ports, ","))
+			}
+		}
 	}
 }
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -91,7 +91,7 @@ func PrintComponentInfo(currentComponentName string, componentDesc component.Des
 	}
 	// Linked components
 	if len(componentDesc.LinkedComponents) > 0 {
-		fmt.Println("\nLinked Components")
+		fmt.Println("Linked Components")
 		for name, ports := range componentDesc.LinkedComponents {
 			if len(ports) > 0 {
 				fmt.Printf("Name: %v - Port(s): %v\n", name, strings.Join(ports, ","))

--- a/tests/e2e/link_test.go
+++ b/tests/e2e/link_test.go
@@ -50,6 +50,14 @@ var _ = Describe("odoLinkE2e", func() {
 			Expect(envFromOutput).To(ContainSubstring("backend"))
 		})
 
+		It("describe should show the linked service", func() {
+			describeOutput := runCmd("odo describe frontend")
+
+			// ensure that the output contains the component and port
+			Expect(describeOutput).To(ContainSubstring("backend"))
+			Expect(describeOutput).To(ContainSubstring("8080"))
+		})
+
 		It("link should fail when linking to the same component again", func() {
 			output := runFailCmd("odo link backend --component frontend", 1)
 			Expect(output).To(ContainSubstring("been linked"))
@@ -82,6 +90,13 @@ var _ = Describe("odoLinkE2e", func() {
 		It("link should fail when linking to the same service again", func() {
 			output := runFailCmd("odo link mysql-persistent --component backend", 1)
 			Expect(output).To(ContainSubstring("been linked"))
+		})
+
+		It("describe should show the linked service", func() {
+			describeOutput := runCmd("odo describe backend")
+
+			// ensure that the output contains the service
+			Expect(describeOutput).To(ContainSubstring("mysql-persistent"))
 		})
 
 		It("delete the service", func() {

--- a/tests/e2e/link_test.go
+++ b/tests/e2e/link_test.go
@@ -50,7 +50,7 @@ var _ = Describe("odoLinkE2e", func() {
 			Expect(envFromOutput).To(ContainSubstring("backend"))
 		})
 
-		It("describe should show the linked service", func() {
+		It("describe on the frontend should show the linked backend component", func() {
 			describeOutput := runCmd("odo describe frontend")
 
 			// ensure that the output contains the component and port
@@ -92,7 +92,7 @@ var _ = Describe("odoLinkE2e", func() {
 			Expect(output).To(ContainSubstring("been linked"))
 		})
 
-		It("describe should show the linked service", func() {
+		It("describe on the backend should show the linked mysql service", func() {
 			describeOutput := runCmd("odo describe backend")
 
 			// ensure that the output contains the service


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See $SUBJECT

## Was the change discussed in an issue?
Fixes #1202

## How to test changes?
```
odo create nodejs frontend
odo describe # you shouldn't see any linked components or services

odo create python backend
odo describe # you shouldn't see any linked components or services

odo link backend --component frontend
odo describe frontend # you should the backend linked to the frontend

odo service create mongodb-ephemeral
odo link -w mongodb-ephemeral
odo describe # the mongodb service should now be visible in the output  
```
