### PR TITLE
use 'odo version --client' in sh scripts

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,7 +99,7 @@ install_odo() {
 
     if command_exists odo; then
         echo_stderr "# 
-odo version \"$(odo version)\" is already installed on your system, running this installer script might case issues with your current installation. If you want to install odo using this script, please remove the current installation of odo from you system.
+odo version \"$(odo version --client)\" is already installed on your system, running this installer script might case issues with your current installation. If you want to install odo using this script, please remove the current installation of odo from you system.
 Aborting now!
 "
         exit 1
@@ -221,7 +221,7 @@ verify_odo() {
     if command_exists odo; then
         echo "
 # Verification complete!
-# odo version \"$(odo version)\" has been installed at $(type -P odo)
+# odo version \"$(odo version --client)\" has been installed at $(type -P odo)
 "
     else
         echo_stderr "

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -11,7 +11,7 @@ mkdir -p $RELEASE_DIR
 if [[ -n $TRAVIS_TAG ]]; then
     echo "Checking if odo version was set to the same version as current tag"
     # use sed to get only semver part
-    bin_version=$(${BIN_DIR}/linux-amd64/odo version | head -1 | sed "s/^odo \(.*\) (.*)$/\1/")
+    bin_version=$(${BIN_DIR}/linux-amd64/odo version --client | head -1 | sed "s/^odo \(.*\) (.*)$/\1/")
     if [ "$TRAVIS_TAG" == "${bin_version}" ]; then
         echo "OK: odo version output is matching current tag"
     else


### PR DESCRIPTION
'odo version --client' will show just odo version without attempting to
connect to a cluster

## What is the purpose of this change? What does it change?
`odo version` is trying to check cluster version. Problem is that if there is no KUBE_CONFIG it fails with an ugly error (reported in #1248). 

`odo version` has `--client` flag that skips the cluster version and shows just odo version.
Odo version is all that our release and install scripts need.

## Was the change discussed in an issue?
workaround for #1248 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
