### PR TITLE
Fixing #1017: Intercepting login message and customising the message message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,17 @@ jobs:
         - oc login -u developer
         - make test-main-e2e
 
+    # Run odo login e2e tests
+    - <<: *base-test
+      stage: test
+      name: "Odo Login e2e tests"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make bin
+        - sudo cp odo /usr/bin
+        - oc login -u developer
+        - make test-odo-login-e2e
+
     # Run component e2e tests
     - <<: *base-test
       stage: test

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,8 @@ else
 endif
 
 # Run login e2e tests
-.PHONY: test-login-e2e
-test-login-e2e:
+.PHONY: test-odologin-e2e
+test-odo-login-e2e:
 ifdef TIMEOUT
 	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoLoginE2e" -ginkgo.succinct -timeout $(TIMEOUT)
 else

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,15 @@ else
 	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoWatchE2e" -ginkgo.succinct
 endif
 
+# Run login e2e tests
+.PHONY: test-login-e2e
+test-login-e2e:
+ifdef TIMEOUT
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoLoginE2e" -ginkgo.succinct -timeout $(TIMEOUT)
+else
+	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoLoginE2e" -ginkgo.succinct
+endif
+
 # Run all e2e tests
 .PHONY: test-e2e
 test-e2e:

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -53,7 +53,8 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 	}
 	// Process the messages returned by openshift login code and print our message
 	originalOutMsg := loginOutBuffer.Bytes()
-	loginSuccessMsg := bytes.Replace(bytes.Replace(originalOutMsg, []byte("new-project"), []byte("project create"), -1), []byte("<projectname>"), []byte("<project-name>"), -1)
+	loginSuccessMsg := bytes.Replace(originalOutMsg, []byte("new-project"), []byte("project create"), -1)
+	loginSuccessMsg = bytes.Replace(loginSuccessMsg, []byte("<projectname>"), []byte("<project-name>"), -1)
 	loginSuccessMsg = bytes.TrimRight(loginSuccessMsg, "\n")
 	odolog.Successf("%s\n", loginSuccessMsg)
 

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	"github.com/openshift/origin/pkg/oc/cli/login"
@@ -56,8 +57,11 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 	var extraOut string
 	// If new-project is present in original message, then ask user to do the same in our message
 	if bytes.Contains(originalOutMsg, []byte("new-project")) {
-		extraOut = " No project? create one\n\todo project create <projectname>"
+		extraOut = "\nYou don't have any projects. You can try to create a new project, by running\n\n\todo project create <projectname>\n"
 	}
-	odolog.Successf("Logged in to \"%s\" as \"%s\"%s", a.Server, a.Username, extraOut)
+	odolog.Successf("Logged in to \"%s\" as \"%s\"", a.Server, a.Username)
+	if len(extraOut) > 0 {
+		fmt.Println(extraOut)
+	}
 	return nil
 }

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 
 	"github.com/openshift/origin/pkg/oc/cli/login"
@@ -54,14 +53,8 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 	}
 	// Process the messages returned by openshift login code and print our message
 	originalOutMsg := loginOutBuffer.Bytes()
-	var extraOut string
-	// If new-project is present in original message, then ask user to do the same in our message
-	if bytes.Contains(originalOutMsg, []byte("new-project")) {
-		extraOut = "\nYou don't have any projects. You can try to create a new project, by running\n\n\todo project create <projectname>\n"
-	}
-	odolog.Successf("Logged in to \"%s\" as \"%s\"", a.Server, a.Username)
-	if len(extraOut) > 0 {
-		fmt.Println(extraOut)
-	}
+	loginSuccessMsg := bytes.TrimRight(bytes.Replace(originalOutMsg, []byte("new-project"), []byte("project create"), -1), "\n")
+	odolog.Successf("%s\n", loginSuccessMsg)
+
 	return nil
 }

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -53,7 +53,8 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 	}
 	// Process the messages returned by openshift login code and print our message
 	originalOutMsg := loginOutBuffer.Bytes()
-	loginSuccessMsg := bytes.TrimRight(bytes.Replace(originalOutMsg, []byte("new-project"), []byte("project create"), -1), "\n")
+	loginSuccessMsg := bytes.Replace(bytes.Replace(originalOutMsg, []byte("new-project"), []byte("project create"), -1), []byte("<projectname>"), []byte("<project-name>"), -1)
+	loginSuccessMsg = bytes.TrimRight(loginSuccessMsg, "\n")
 	odolog.Successf("%s\n", loginSuccessMsg)
 
 	return nil

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -1,16 +1,19 @@
 package auth
 
 import (
+	"bytes"
 	"os"
 
 	"github.com/openshift/origin/pkg/oc/cli/login"
+	odolog "github.com/redhat-developer/odo/pkg/log"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 // Login takes of authentication part and returns error if there any
 func Login(server, username, password, token, caAuth string, skipTLS bool) error {
-
+	//loginOutBuffer is created to intercept out msgs of login code
+	loginOutBuffer := &bytes.Buffer{}
 	a := login.LoginOptions{
 		Server:         server,
 		CommandName:    "odo",
@@ -22,7 +25,7 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 		Token:          token,
 		PathOptions:    &clientcmd.PathOptions{GlobalFile: clientcmd.RecommendedHomeFile, EnvVar: clientcmd.RecommendedConfigPathEnvVar, ExplicitFileFlag: "config", LoadingRules: &clientcmd.ClientConfigLoadingRules{ExplicitPath: ""}},
 		RequestTimeout: 0,
-		IOStreams:      genericclioptions.IOStreams{Out: os.Stdout, In: os.Stdin},
+		IOStreams:      genericclioptions.IOStreams{Out: loginOutBuffer, In: os.Stdin},
 	}
 
 	// initialize client-go client and read starting kubeconfig file
@@ -48,6 +51,13 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 	if err != nil {
 		return err
 	}
-
+	// Process the messages returned by openshift login code and print our message
+	originalOutMsg := loginOutBuffer.Bytes()
+	var extraOut string
+	// If new-project is present in original message, then ask user to do the same in our message
+	if bytes.Contains(originalOutMsg, []byte("new-project")) {
+		extraOut = " No project? create one\n\todo project create <projectname>"
+	}
+	odolog.Successf("Logged in to \"%s\" as \"%s\"%s", a.Server, a.Username, extraOut)
 	return nil
 }

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,10 +44,13 @@ var _ = Describe("odoLoginE2e", func() {
 		Context("Run login tests", func() {
 			AfterEach(func() {
 				projects := strings.Split(runCmd("oc projects -q"), "\n")
+				var waitOut bool
 				for _, p := range projects {
 					if len(p) > 0 {
-						runCmd(fmt.Sprintf("%s %s", baseOdoProjectDelete, p))
-						time.Sleep(180 * time.Millisecond)
+						waitOut = waitForCmdOut(fmt.Sprintf("%s %s", baseOdoProjectDelete, p), 10, func(out string) bool {
+							return strings.Contains(out, fmt.Sprintf("Deleted project : %s", p))
+						})
+						Expect(waitOut).To(BeTrue())
 					}
 				}
 				runCmd(backToCurrentUserCommand)

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -49,7 +49,7 @@ var _ = Describe("odoLoginE2e", func() {
 				for _, p := range projects {
 					if len(p) > 0 {
 						runCmd(fmt.Sprintf("%s %s", baseOdoProjectDelete, p))
-						time.Sleep(240)
+						time.Sleep(100)
 					}
 				}
 				runCmd(backToCurrentUserCommand)

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -49,7 +49,7 @@ var _ = Describe("odoLoginE2e", func() {
 				for _, p := range projects {
 					if len(p) > 0 {
 						runCmd(fmt.Sprintf("%s %s", baseOdoProjectDelete, p))
-						time.Sleep(100)
+						time.Sleep(100 * time.Millisecond)
 					}
 				}
 				runCmd(backToCurrentUserCommand)

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -14,7 +14,6 @@ var _ = Describe("odoLoginE2e", func() {
 	const loginTestUser = "testdeveloper"
 	const loginTestUserPassword = "testdeveloper"
 	const odoTestProject1 = "testproject1"
-	const odoTestProject2 = "testproject2"
 
 	// Comand related constants
 	const baseOdoLoginCommand = "odo login"
@@ -30,7 +29,6 @@ var _ = Describe("odoLoginE2e", func() {
 	var testUserLoginCommandWithToken string
 	var testUserLoginFailCommandWithToken string
 	var testUserCreateProject1Command string
-	var testUserCreateProject2Command string
 
 	Describe("Check for successful login and logout", func() {
 		Context("Initialize", func() {
@@ -40,7 +38,6 @@ var _ = Describe("odoLoginE2e", func() {
 				backToCurrentUserCommand = fmt.Sprintf("%s -t %s", baseOdoLoginCommand, t)
 				testUserLoginCommand = fmt.Sprintf("%s -u %s -p %s", baseOdoLoginCommand, loginTestUser, loginTestUserPassword)
 				testUserCreateProject1Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject1)
-				testUserCreateProject2Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject2)
 				testUserLoginFailCommandWithToken = fmt.Sprintf("%s -t verybadtoken", baseOdoLoginCommand)
 			})
 		})

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -1,0 +1,91 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odoLoginE2e", func() {
+	// user related constants
+	const loginTestUser = "testdeveloper"
+	const loginTestUserPassword = "testdeveloper"
+	const odoTestProject1 = "testproject1"
+	const odoTestProject2 = "testproject2"
+
+	// Comand related constants
+	const baseOdoLoginCommand = "odo login"
+	const baseOdoProjectCreate = "odo project create"
+	const baseOdoProjectDelete = "odo project delete -f "
+	const ocWhoamiCommand = "oc whoami"
+	const ocTokenCommand = "oc whoami -t"
+
+	// variables to be used in test
+	var session string
+	var backToCurrentUserCommand string
+	var testUserLoginCommand string
+	var testUserLoginCommandWithToken string
+	var testUserCreateProject1Command string
+	var testUserCreateProject2Command string
+
+	Describe("Check for successful login and logout", func() {
+		Context("Initialize", func() {
+			It("Should initialize some variables", func() {
+				// Save currently logged in users token, so we can get back to that context after being done
+				t := runCmd(ocTokenCommand)
+				backToCurrentUserCommand = fmt.Sprintf("%s -t %s", baseOdoLoginCommand, t)
+				testUserLoginCommand = fmt.Sprintf("%s -u %s -p %s", baseOdoLoginCommand, loginTestUser, loginTestUserPassword)
+				testUserCreateProject1Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject1)
+				testUserCreateProject2Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject2)
+			})
+		})
+		Context("Run login tests", func() {
+			AfterEach(func() {
+				t := runCmd("oc projects -q")
+				projects := strings.Split(t, "\n")
+				for _, p := range projects {
+					if len(p) > 0 {
+						runCmd(fmt.Sprintf("%s %s", baseOdoProjectDelete, p))
+						time.Sleep(240)
+					}
+				}
+				runCmd(backToCurrentUserCommand)
+			})
+
+			It("Should login successfully with username and password without any projects with appropriate message", func() {
+				session = runCmd(testUserLoginCommand)
+				Expect(session).To(ContainSubstring("Login successful"))
+				Expect(session).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
+				Expect(session).To(ContainSubstring("odo project create <project-name>"))
+				session = runCmd(ocWhoamiCommand)
+				Expect(session).To(ContainSubstring(loginTestUser))
+				token := runCmd(ocTokenCommand)
+				// One initialization needs one login, hence it happens here
+				testUserLoginCommandWithToken = fmt.Sprintf("%s -t %s", baseOdoLoginCommand, token)
+			})
+
+			It("Should login successfully with token without any projects with appropriate message", func() {
+				session = runCmd(testUserLoginCommandWithToken)
+				Expect(session).To(ContainSubstring("Logged into"))
+				Expect(session).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
+				Expect(session).To(ContainSubstring("odo project create <project-name>"))
+				session = runCmd(ocWhoamiCommand)
+				Expect(session).To(ContainSubstring(loginTestUser))
+			})
+
+			It("Should login successfully with username and password single project with appropriate message", func() {
+				runCmd(testUserLoginCommand)
+				runCmd(testUserCreateProject1Command)
+				runCmd(backToCurrentUserCommand)
+				session = runCmd(testUserLoginCommand)
+				Expect(session).To(ContainSubstring("Login successful"))
+				Expect(session).To(ContainSubstring(odoTestProject1))
+				session = runCmd(ocWhoamiCommand)
+				Expect(session).To(ContainSubstring(loginTestUser))
+			})
+		})
+	})
+})

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -44,12 +44,11 @@ var _ = Describe("odoLoginE2e", func() {
 
 		Context("Run login tests", func() {
 			AfterEach(func() {
-				t := runCmd("oc projects -q")
-				projects := strings.Split(t, "\n")
+				projects := strings.Split(runCmd("oc projects -q"), "\n")
 				for _, p := range projects {
 					if len(p) > 0 {
 						runCmd(fmt.Sprintf("%s %s", baseOdoProjectDelete, p))
-						time.Sleep(100 * time.Millisecond)
+						time.Sleep(180 * time.Millisecond)
 					}
 				}
 				runCmd(backToCurrentUserCommand)

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -28,6 +28,7 @@ var _ = Describe("odoLoginE2e", func() {
 	var backToCurrentUserCommand string
 	var testUserLoginCommand string
 	var testUserLoginCommandWithToken string
+	var testUserLoginFailCommandWithToken string
 	var testUserCreateProject1Command string
 	var testUserCreateProject2Command string
 
@@ -40,8 +41,10 @@ var _ = Describe("odoLoginE2e", func() {
 				testUserLoginCommand = fmt.Sprintf("%s -u %s -p %s", baseOdoLoginCommand, loginTestUser, loginTestUserPassword)
 				testUserCreateProject1Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject1)
 				testUserCreateProject2Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject2)
+				testUserLoginFailCommandWithToken = fmt.Sprintf("%s -t verybadtoken", baseOdoLoginCommand)
 			})
 		})
+
 		Context("Run login tests", func() {
 			AfterEach(func() {
 				t := runCmd("oc projects -q")
@@ -85,6 +88,12 @@ var _ = Describe("odoLoginE2e", func() {
 				Expect(session).To(ContainSubstring(odoTestProject1))
 				session = runCmd(ocWhoamiCommand)
 				Expect(session).To(ContainSubstring(loginTestUser))
+			})
+
+			It("Should fail login on invalid token with appropriate message", func() {
+				session = runFailCmd(testUserLoginFailCommandWithToken, 1)
+				Expect(session).To(ContainSubstring("The token provided is invalid or expired"))
+				runCmd(testUserLoginCommand)
 			})
 		})
 	})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See title 
- Adding buffer to replace os.Stdout and intercept output of login
- Customizing a message from odo based on what was intercepted, so if new-project
is present in original message, appropriate addition is done to odo message
- Printing custom message for login success case.

## Was the change discussed in an issue?
fixes #1017 

## How to test changes?
<!-- Please describe the steps to test the PR -->
Run `odo login -u user` with or without any active projects


Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>