### PR TITLE
Ensure that listing catalog components ignores hidden ones

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -43,7 +43,9 @@ func Search(client *occlient.Client, name string) ([]string, error) {
 
 	// do a partial search in all the components
 	for _, component := range componentList {
-		if strings.Contains(component.Name, name) {
+		// we only show components that contain the search term and that have at least non-hidden tag
+		// since a component with all hidden tags is not shown in the odo catalog list components either
+		if strings.Contains(component.Name, name) && len(component.NonHiddenTags) > 0 {
 			result = append(result, component.Name)
 		}
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -79,7 +79,8 @@ func TestVersionExist(t *testing.T) {
 				t.Errorf("VersionExist() unexpected error %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if len(fakeClientSet.ImageClientset.Actions()) != 2 { // 1 call for current project + 1 call from openshift project
+			// 1 call for current project + 1 call from openshift project for each of the ImageStream and ImageStreamTag
+			if len(fakeClientSet.ImageClientset.Actions()) != 4 {
 				t.Errorf("expected 2 ImageClientset.Actions() in VersionExist, got: %v", fakeClientSet.ImageClientset.Actions())
 			}
 
@@ -96,35 +97,65 @@ func TestVersionExist(t *testing.T) {
 
 func TestList(t *testing.T) {
 	type args struct {
-		name      string
-		namespace string
-		tags      []string
+		name       string
+		namespace  string
+		tags       []string
+		hiddenTags []string
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantErr  bool
-		wantTags []string
+		name              string
+		args              args
+		wantErr           bool
+		wantAllTags       []string
+		wantNonHiddenTags []string
 	}{
 		{
-			name: "Case 1: Valid image output with one tag",
+			name: "Case 1: Valid image output with one tag which is not hidden",
 			args: args{
-				name:      "foobar",
-				namespace: "openshift",
-				tags:      []string{"latest"},
+				name:       "foobar",
+				namespace:  "openshift",
+				tags:       []string{"latest"},
+				hiddenTags: []string{},
 			},
-			wantErr:  false,
-			wantTags: []string{"latest"},
+			wantErr:           false,
+			wantAllTags:       []string{"latest"},
+			wantNonHiddenTags: []string{"latest"},
 		},
 		{
-			name: "Case 2: Valid image output with multiple tags",
+			name: "Case 2: Valid image output with one tag which is hidden",
 			args: args{
-				name:      "foobar",
-				namespace: "openshift",
-				tags:      []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+				name:       "foobar",
+				namespace:  "openshift",
+				tags:       []string{"latest"},
+				hiddenTags: []string{"latest"},
 			},
-			wantErr:  false,
-			wantTags: []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+			wantErr:           false,
+			wantAllTags:       []string{"latest"},
+			wantNonHiddenTags: []string{},
+		},
+		{
+			name: "Case 3: Valid image output with multiple tags none of which are hidden",
+			args: args{
+				name:       "foobar",
+				namespace:  "openshift",
+				tags:       []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+				hiddenTags: []string{},
+			},
+			wantErr:           false,
+			wantAllTags:       []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+			wantNonHiddenTags: []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+		},
+		{
+			name: "Case 4: Valid image output with multiple tags some of which are hidden",
+			args: args{
+				name:       "foobar",
+				namespace:  "openshift",
+				tags:       []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+				hiddenTags: []string{"0.0.1", "1.0.0"},
+			},
+			wantErr:           false,
+			wantAllTags:       []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+			wantNonHiddenTags: []string{"1.0.1", "latest"},
 		},
 		{
 			name: "Case 3: Invalid image output with no tags",
@@ -133,18 +164,21 @@ func TestList(t *testing.T) {
 				namespace: "foo",
 				tags:      []string{},
 			},
-			wantErr:  true,
-			wantTags: []string{},
+			wantErr:           true,
+			wantAllTags:       []string{},
+			wantNonHiddenTags: []string{},
 		},
 		{
-			name: "Case 4: Valid image with output tags from a different namespace",
+			name: "Case 4: Valid image with output tags from a different namespace none of which are hidden",
 			args: args{
-				name:      "foobar",
-				namespace: "foo",
-				tags:      []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+				name:       "foobar",
+				namespace:  "foo",
+				tags:       []string{"1", "2", "4", "latest", "10"},
+				hiddenTags: []string{"1", "2"},
 			},
-			wantErr:  false,
-			wantTags: []string{"1.0.0", "1.0.1", "0.0.1", "latest"},
+			wantErr:           false,
+			wantAllTags:       []string{"1", "2", "4", "latest", "10"},
+			wantNonHiddenTags: []string{"4", "latest", "10"},
 		},
 	}
 
@@ -156,6 +190,9 @@ func TestList(t *testing.T) {
 			fakeClientSet.ImageClientset.PrependReactor("list", "imagestreams", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, testingutil.FakeImageStreams(tt.args.name, tt.args.namespace, tt.args.tags), nil
 			})
+			fakeClientSet.ImageClientset.PrependReactor("list", "imagestreamtags", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, testingutil.FakeImageStreamTags(tt.args.name, tt.args.namespace, tt.args.tags, tt.args.hiddenTags), nil
+			})
 
 			// The function we are testing
 			output, err := List(client)
@@ -165,14 +202,21 @@ func TestList(t *testing.T) {
 				t.Errorf("component List() unexpected error %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if len(fakeClientSet.ImageClientset.Actions()) != 2 { // 1 call for current project + 1 call from openshift project
+			// 1 call for current project + 1 call from openshift project for each of the ImageStream and ImageStreamTag
+			if len(fakeClientSet.ImageClientset.Actions()) != 4 {
 				t.Errorf("expected 2 ImageClientset.Actions() in List, got: %v", fakeClientSet.ImageClientset.Actions())
 			}
 
-			// Check if the output is the same as what's expected (tags)
+			// Check if the output is the same as what's expected (for all tags)
 			// and only if output is more than 0 (something is actually returned)
-			if len(output) > 0 && !(reflect.DeepEqual(output[0].Tags, tt.wantTags)) {
-				t.Errorf("expected tags: %s, got: %s", tt.wantTags, output[0].Tags)
+			if len(output) > 0 && !(reflect.DeepEqual(output[0].AllTags, tt.wantAllTags)) {
+				t.Errorf("expected all tags: %s, got: %s", tt.wantAllTags, output[0].AllTags)
+			}
+
+			// Check if the output is the same as what's expected (for hidden tags)
+			// and only if output is more than 0 (something is actually returned)
+			if len(output) > 0 && !(reflect.DeepEqual(output[0].NonHiddenTags, tt.wantNonHiddenTags)) {
+				t.Errorf("expected non hidden tags: %s, got: %s", tt.wantNonHiddenTags, output[0].NonHiddenTags)
 			}
 
 		})

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -693,6 +693,15 @@ func (c *Client) GetImageStreamImage(imageStream *imagev1.ImageStream, imageTag 
 	return nil, fmt.Errorf("unable to fetch image with tag %s corresponding to imagestream %+v", imageTag, imageStream)
 }
 
+// GetImageStreamTag returns all the ImageStreamTag objects in the given namespace
+func (c *Client) GetImageStreamTags(namespace string) ([]imagev1.ImageStreamTag, error) {
+	imageStreamTagList, err := c.imageClient.ImageStreamTags(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list imagestreamtags")
+	}
+	return imageStreamTagList.Items, nil
+}
+
 // GetExposedPorts returns list of ContainerPorts that are exposed by given image
 func (c *Client) GetExposedPorts(imageStreamImage *imagev1.ImageStreamImage) ([]corev1.ContainerPort, error) {
 	var containerPorts []corev1.ContainerPort

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -693,7 +693,7 @@ func (c *Client) GetImageStreamImage(imageStream *imagev1.ImageStream, imageTag 
 	return nil, fmt.Errorf("unable to fetch image with tag %s corresponding to imagestream %+v", imageTag, imageStream)
 }
 
-// GetImageStreamTag returns all the ImageStreamTag objects in the given namespace
+// GetImageStreamTags returns all the ImageStreamTag objects in the given namespace
 func (c *Client) GetImageStreamTags(namespace string) ([]imagev1.ImageStreamTag, error) {
 	imageStreamTagList, err := c.imageClient.ImageStreamTags(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"github.com/redhat-developer/odo/pkg/catalog"
+	"github.com/redhat-developer/odo/pkg/odo/cli/catalog/util"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	if err != nil {
 		return err
 	}
+	o.catalogList = util.FilterHiddenComponents(o.catalogList)
 
 	return
 }
@@ -68,7 +70,7 @@ func (o *ListComponentsOptions) Run() (err error) {
 				}
 			}
 		}
-		fmt.Fprintln(w, componentName, "\t", component.Namespace, "\t", strings.Join(component.Tags, ","))
+		fmt.Fprintln(w, componentName, "\t", component.Namespace, "\t", strings.Join(component.NonHiddenTags, ","))
 	}
 	w.Flush()
 	return

--- a/pkg/odo/cli/catalog/util/util.go
+++ b/pkg/odo/cli/catalog/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/redhat-developer/odo/pkg/occlient"
 	"os"
 	"strings"
@@ -19,12 +20,26 @@ func DisplayServices(services []occlient.Service) {
 }
 
 // FilterHiddenServices filters out services that should be hidden from the specified list
-func FilterHiddenServices(services []occlient.Service) []occlient.Service {
-	var filteredServices []occlient.Service
-	for _, service := range services {
+func FilterHiddenServices(input []occlient.Service) []occlient.Service {
+	inputLength := len(input)
+	filteredServices := make([]occlient.Service, 0, inputLength)
+	for _, service := range input {
 		if !service.Hidden {
 			filteredServices = append(filteredServices, service)
 		}
 	}
 	return filteredServices
+}
+
+// FilterHiddenComponents filters out components that should be hidden from the specified list
+func FilterHiddenComponents(input []catalog.CatalogImage) []catalog.CatalogImage {
+	inputLength := len(input)
+	filteredComponents := make([]catalog.CatalogImage, 0, inputLength)
+	for _, component := range input {
+		// we keep the image if it has tags that are no hidden
+		if len(component.NonHiddenTags) > 0 {
+			filteredComponents = append(filteredComponents, component)
+		}
+	}
+	return filteredComponents
 }

--- a/pkg/odo/cli/catalog/util/util_test.go
+++ b/pkg/odo/cli/catalog/util/util_test.go
@@ -1,0 +1,116 @@
+package util
+
+import (
+	"github.com/redhat-developer/odo/pkg/catalog"
+	"github.com/redhat-developer/odo/pkg/occlient"
+	"reflect"
+	"testing"
+)
+
+func TestFilterHiddenServices(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []occlient.Service
+		expected []occlient.Service
+	}{
+		{
+			name:     "Case 1: empty input",
+			input:    []occlient.Service{},
+			expected: []occlient.Service{},
+		},
+		{
+			name: "Case 2: non empty input",
+			input: []occlient.Service{
+				{
+					Name:   "n1",
+					Hidden: true,
+				},
+				{
+					Name:   "n2",
+					Hidden: false,
+				},
+				{
+					Name:   "n3",
+					Hidden: true,
+				},
+				{
+					Name:   "n4",
+					Hidden: false,
+				},
+			},
+			expected: []occlient.Service{
+				{
+					Name:   "n2",
+					Hidden: false,
+				},
+				{
+					Name:   "n4",
+					Hidden: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := FilterHiddenServices(tt.input)
+			if !reflect.DeepEqual(tt.expected, output) {
+				t.Errorf("got: %+v, wanted: %+v", output, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterHiddenComponents(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []catalog.CatalogImage
+		expected []catalog.CatalogImage
+	}{
+		{
+			name:     "Case 1: empty input",
+			input:    []catalog.CatalogImage{},
+			expected: []catalog.CatalogImage{},
+		},
+		{
+			name: "Case 2: non empty input",
+			input: []catalog.CatalogImage{
+				{
+					Name:          "n1",
+					NonHiddenTags: []string{"1", "latest"},
+				},
+				{
+					Name:          "n2",
+					NonHiddenTags: []string{},
+				},
+				{
+					Name:          "n3",
+					NonHiddenTags: []string{},
+				},
+				{
+					Name:          "n4",
+					NonHiddenTags: []string{"10"},
+				},
+			},
+			expected: []catalog.CatalogImage{
+				{
+					Name:          "n1",
+					NonHiddenTags: []string{"1", "latest"},
+				},
+				{
+					Name:          "n4",
+					NonHiddenTags: []string{"10"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := FilterHiddenComponents(tt.input)
+			if !reflect.DeepEqual(tt.expected, output) {
+				t.Errorf("got: %+v, wanted: %+v", output, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -260,7 +260,7 @@ var StorageUnMountCompletionHandler = func(cmd *cobra.Command, args parsedArgs, 
 	return completions
 }
 
-// CreateCompletionHandler provides componet type completion in odo create command
+// CreateCompletionHandler provides component type completion in odo create command
 var CreateCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
 	catalogList, err := catalog.List(context.Client)

--- a/pkg/testingutil/imagestreams.go
+++ b/pkg/testingutil/imagestreams.go
@@ -62,7 +62,7 @@ func fakeImageStreamTag(imageName string, version string, namespace string, isHi
 	return image
 }
 
-// FakeImageStreams lists the imagestreams for the reactor
+// FakeImageStreamTags lists the imagestreams for the reactor
 func FakeImageStreamTags(imageName string, namespace string, tags []string, hiddenTags []string) *imagev1.ImageStreamTagList {
 	var list = []imagev1.ImageStreamTag{}
 	for _, tag := range tags {

--- a/pkg/testingutil/imagestreams.go
+++ b/pkg/testingutil/imagestreams.go
@@ -41,3 +41,42 @@ func FakeImageStreams(imageName string, namespace string, tags []string) *imagev
 		Items: []imagev1.ImageStream{*fakeImageStream(imageName, namespace, tags)},
 	}
 }
+
+// fakeImageStreamTag gets imagestreamtag for the reactor
+func fakeImageStreamTag(imageName string, version string, namespace string, isHidden bool) *imagev1.ImageStreamTag {
+	tagsStr := ""
+	if isHidden {
+		tagsStr = "hidden"
+	}
+	image := &imagev1.ImageStreamTag{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imageName + ":" + version,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"tags":    tagsStr,
+				"version": version,
+			},
+		},
+	}
+
+	return image
+}
+
+// FakeImageStreams lists the imagestreams for the reactor
+func FakeImageStreamTags(imageName string, namespace string, tags []string, hiddenTags []string) *imagev1.ImageStreamTagList {
+	var list = []imagev1.ImageStreamTag{}
+	for _, tag := range tags {
+		isHidden := false
+		for _, ht := range hiddenTags {
+			if ht == tag {
+				isHidden = true
+				break
+			}
+		}
+		list = append(list, *fakeImageStreamTag(imageName, tag, namespace, isHidden))
+	}
+
+	return &imagev1.ImageStreamTagList{
+		Items: list,
+	}
+}

--- a/tests/e2e/cmp_test.go
+++ b/tests/e2e/cmp_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"strings"
 
 	"fmt"
 	"io/ioutil"
@@ -106,6 +107,15 @@ var _ = Describe("odoCmpE2e", func() {
 			getProj := runCmd("odo catalog list components")
 			Expect(getProj).To(ContainSubstring("wildfly"))
 			Expect(getProj).To(ContainSubstring("ruby"))
+			Expect(getProj).To(ContainSubstring("nodejs"))
+
+			// check that the nodejs string does not contain the hidden versions
+			lines := strings.Split(strings.Replace(getProj, "\r\n", "\n", -1), "\n")
+			for _, line := range lines {
+				if strings.HasPrefix(line, "nodejs") {
+					Expect(getProj).To(Not(ContainSubstring("0.10")))
+				}
+			}
 		})
 	})
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See $SUBJECT

## Was the change discussed in an issue?
Fixes: #1180 (the components part)

## How to test changes?

`odo catalog list components` should only display non hidden builder images.

The most prominent example is the nodejs builder. 
For that builder the `0.10` and `4` versions are marked as hidden (because they are deprecated) and thus should not show up in the output of the aforementioned command  
