### PR TITLE
Doc: create instances from any service class

### DIFF
--- a/pkg/odo/cli/service/service.go
+++ b/pkg/odo/cli/service/service.go
@@ -14,7 +14,7 @@ import (
 // RecommendedCommandName is the recommended service command name
 const RecommendedCommandName = "service"
 
-var serviceLongDesc = ktemplates.LongDesc(`Perform service catalog operations, limited to template service broker and OpenShift Ansible Broker only.`)
+var serviceLongDesc = ktemplates.LongDesc(`Perform service catalog operations`)
 
 // NewCmdService implements the odo service command
 func NewCmdService(name, fullName string) *cobra.Command {


### PR DESCRIPTION
Fix in-line/cmd docs to reflect that we can add any service that is visible in `svcat get classes -o=json` ( ie, any ClusterServiceClass ), and not just those from the Template Service Broker.