### PR TITLE
Fixing #1278: Changing cleanup to run as needed

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -2,15 +2,14 @@ package e2e
 
 import (
 	"bytes"
+	"fmt"
+	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-
-	"fmt"
-	"os/exec"
-	"time"
 )
 
 func runCmd(cmdS string) string {
@@ -166,5 +165,25 @@ func pollNonRetCmdStdOutForString(cmdStr string, timeout time.Duration, check fu
 				return true, nil
 			}
 		}
+	}
+}
+
+// cleanUpAfterProjects cleans up projects, after deleting them
+func cleanUpAfterProjects(projects []string) {
+	for _, p := range projects {
+		deleteProject(p)
+	}
+	// Logout of current user to ensure state
+	runCmd("oc logout")
+}
+
+// deletes a specified project
+func deleteProject(project string) {
+	var waitOut bool
+	if len(project) > 0 {
+		waitOut = waitForCmdOut(fmt.Sprintf("odo project delete -f %s", project), 10, func(out string) bool {
+			return strings.Contains(out, fmt.Sprintf("Deleted project : %s", project))
+		})
+		Expect(waitOut).To(BeTrue())
 	}
 }

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -8,88 +8,74 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const baseOdoProjectDelete = "odo project delete -f "
-
 var _ = Describe("odoLoginE2e", func() {
 	// user related constants
-	const loginTestUser = "testdeveloper"
-	const loginTestUserPassword = "testdeveloper"
-	const odoTestProject1 = "testproject1"
-
-	// Comand related constants
-	const baseOdoLoginCommand = "odo login"
-	const baseOdoProjectCreate = "odo project create"
-	const ocWhoamiCommand = "oc whoami"
-	const ocTokenCommand = "oc whoami -t"
+	const loginTestBaseUser = "testdeveloper"
+	const loginTestUserPassword = "developer"
 
 	// variables to be used in test
 	var session string
-	var backToCurrentUserCommand string
-	var testUserLoginCommand string
-	var testUserLoginCommandWithToken string
-	var testUserLoginFailCommandWithToken string
-	var testUserCreateProject1Command string
+	var testUserToken string
+	var testUser string
 
 	Describe("Check for successful login and logout", func() {
 		Context("Initialize", func() {
 			It("Should initialize some variables", func() {
-				// Save currently logged in users token, so we can get back to that context after being done
-				t := runCmd(ocTokenCommand)
-				backToCurrentUserCommand = fmt.Sprintf("%s -t %s", baseOdoLoginCommand, t)
-				testUserLoginCommand = fmt.Sprintf("%s -u %s -p %s", baseOdoLoginCommand, loginTestUser, loginTestUserPassword)
-				testUserCreateProject1Command = fmt.Sprintf("%s %s", baseOdoProjectCreate, odoTestProject1)
-				testUserLoginFailCommandWithToken = fmt.Sprintf("%s -t verybadtoken", baseOdoLoginCommand)
+				// Logout of current user to ensure state
+				runCmd("oc logout")
 			})
 		})
 
 		Context("Run login tests with no active projects, having default is also considered as not having active project", func() {
 			AfterEach(func() {
-				runCmd(backToCurrentUserCommand)
+				// Log out of whoever is logged in
+				runCmd("oc logout")
 			})
 
 			It("Should login successfully with username and password without any projects with appropriate message", func() {
-				session = runCmd(testUserLoginCommand)
+				session = runCmd(fmt.Sprintf("odo login -u %s -p %s", loginTestBaseUser, loginTestUserPassword))
 				Expect(session).To(ContainSubstring("Login successful"))
 				Expect(session).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
 				Expect(session).To(ContainSubstring("odo project create <project-name>"))
-				session = runCmd(ocWhoamiCommand)
-				Expect(session).To(ContainSubstring(loginTestUser))
-				token := runCmd(ocTokenCommand)
+				session = runCmd("oc whoami")
+				Expect(session).To(ContainSubstring(loginTestBaseUser))
 				// One initialization needs one login, hence it happens here
-				testUserLoginCommandWithToken = fmt.Sprintf("%s -t %s", baseOdoLoginCommand, token)
+				testUserToken = runCmd("oc whoami -t")
 			})
 
 			It("Should login successfully with token without any projects with appropriate message", func() {
-				session = runCmd(testUserLoginCommandWithToken)
+				session = runCmd(fmt.Sprintf("odo login -t %s", testUserToken))
 				Expect(session).To(ContainSubstring("Logged into"))
 				Expect(session).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
 				Expect(session).To(ContainSubstring("odo project create <project-name>"))
-				session = runCmd(ocWhoamiCommand)
-				Expect(session).To(ContainSubstring(loginTestUser))
+				session = runCmd("oc whoami")
+				Expect(session).To(ContainSubstring(loginTestBaseUser))
 			})
 
 			It("Should fail login on invalid token with appropriate message", func() {
-				session = runFailCmd(testUserLoginFailCommandWithToken, 1)
+				session = runFailCmd("odo login -t verybadtoken", 1)
 				Expect(session).To(ContainSubstring("The token provided is invalid or expired"))
-				runCmd(testUserLoginCommand)
+				runCmd(fmt.Sprintf("oc login -t %s", testUserToken))
 			})
 		})
 
 		Context("Run login tests with single active project", func() {
 			AfterEach(func() {
-				deleteProject(odoTestProject1)
-				runCmd(backToCurrentUserCommand)
+				runCmd("oc logout")
 			})
 
 			It("Should login successfully with username and password single project with appropriate message", func() {
-				runCmd(testUserLoginCommand)
-				runCmd(testUserCreateProject1Command)
-				runCmd(backToCurrentUserCommand)
-				session = runCmd(testUserLoginCommand)
+				// Initialise for test
+				testUser = fmt.Sprintf("%s%s", loginTestBaseUser, "1")
+				runCmd(fmt.Sprintf("oc login -u %s -p %s", testUser, loginTestUserPassword))
+				runCmd("oc new-project testproject1")
+				runCmd("oc logout")
+				session = runCmd("odo login -u %s -p %s")
 				Expect(session).To(ContainSubstring("Login successful"))
-				Expect(session).To(ContainSubstring(odoTestProject1))
-				session = runCmd(ocWhoamiCommand)
-				Expect(session).To(ContainSubstring(loginTestUser))
+				Expect(session).To(ContainSubstring("testproject1"))
+				session = runCmd("oc whoami -t")
+				Expect(session).To(ContainSubstring("testproject1"))
+				deleteProject("testproject1")
 			})
 		})
 	})
@@ -98,7 +84,7 @@ var _ = Describe("odoLoginE2e", func() {
 func deleteProject(project string) {
 	var waitOut bool
 	if len(project) > 0 {
-		waitOut = waitForCmdOut(fmt.Sprintf("%s %s", baseOdoProjectDelete, project), 10, func(out string) bool {
+		waitOut = waitForCmdOut(fmt.Sprintf("odo project delete %s", project), 10, func(out string) bool {
 			return strings.Contains(out, fmt.Sprintf("Deleted project : %s", project))
 		})
 		Expect(waitOut).To(BeTrue())

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -68,12 +68,12 @@ var _ = Describe("odoLoginE2e", func() {
 			It("Should login successfully with username and password single project with appropriate message", func() {
 				// Initialise for test
 				runCmd(fmt.Sprintf("oc login -u %s -p %s", loginTestUserForSingleProject1, loginTestUserPassword))
-				runCmd(fmt.Sprintf("oc new-project %s", odoTestProjectForSingleProject1))
+				runCmd(fmt.Sprintf("odo project create %s", odoTestProjectForSingleProject1))
 				runCmd("oc logout")
 				session = runCmd(fmt.Sprintf("odo login -u %s -p %s", loginTestUserForSingleProject1, loginTestUserPassword))
 				Expect(session).To(ContainSubstring("Login successful"))
 				Expect(session).To(ContainSubstring(odoTestProjectForSingleProject1))
-				session = runCmd("oc whoami -t")
+				session = runCmd("oc whoami")
 				Expect(session).To(ContainSubstring(loginTestUserForSingleProject1))
 			})
 		})

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -79,21 +78,3 @@ var _ = Describe("odoLoginE2e", func() {
 		})
 	})
 })
-
-func cleanUpAfterProjects(projects []string) {
-	for _, p := range projects {
-		deleteProject(p)
-	}
-	// Logout of current user to ensure state
-	runCmd("oc logout")
-}
-
-func deleteProject(project string) {
-	var waitOut bool
-	if len(project) > 0 {
-		waitOut = waitForCmdOut(fmt.Sprintf("odo project delete -f %s", project), 10, func(out string) bool {
-			return strings.Contains(out, fmt.Sprintf("Deleted project : %s", project))
-		})
-		Expect(waitOut).To(BeTrue())
-	}
-}

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var currentUserToken string
+
 var _ = Describe("odoLoginE2e", func() {
 	// user related constants
 	const loginTestUserForNoProject = "developernoproject"
@@ -22,6 +24,8 @@ var _ = Describe("odoLoginE2e", func() {
 	Describe("Check for successful login and logout", func() {
 		Context("Initialize", func() {
 			It("Should initialize some variables", func() {
+				// Save current user information
+				currentUserToken = runCmd("oc whoami -t")
 				// Logout of current user to ensure state
 				runCmd("oc logout")
 			})
@@ -29,8 +33,8 @@ var _ = Describe("odoLoginE2e", func() {
 
 		Context("Run login tests with no active projects, having default is also considered as not having active project", func() {
 			AfterEach(func() {
-				// Log out of whoever is logged in
-				runCmd("oc logout")
+				// Log in as original user
+				runCmd(fmt.Sprintf("oc login --token %s", currentUserToken))
 			})
 
 			It("Should login successfully with username and password without any projects with appropriate message", func() {
@@ -84,7 +88,8 @@ func cleanUpAfterProjects(projects []string) {
 	for _, p := range projects {
 		deleteProject(p)
 	}
-	runCmd("oc logout")
+	// log back in as original user
+	runCmd(fmt.Sprintf("oc login --token %s", currentUserToken))
 }
 
 func deleteProject(project string) {

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var currentUserToken string
-
 var _ = Describe("odoLoginE2e", func() {
 	// user related constants
 	const loginTestUserForNoProject = "developernoproject"
@@ -24,8 +22,6 @@ var _ = Describe("odoLoginE2e", func() {
 	Describe("Check for successful login and logout", func() {
 		Context("Initialize", func() {
 			It("Should initialize some variables", func() {
-				// Save current user information
-				currentUserToken = runCmd("oc whoami -t")
 				// Logout of current user to ensure state
 				runCmd("oc logout")
 			})
@@ -33,8 +29,8 @@ var _ = Describe("odoLoginE2e", func() {
 
 		Context("Run login tests with no active projects, having default is also considered as not having active project", func() {
 			AfterEach(func() {
-				// Log in as original user
-				runCmd(fmt.Sprintf("oc login --token %s", currentUserToken))
+				// Logout of current user to ensure state
+				runCmd("oc logout")
 			})
 
 			It("Should login successfully with username and password without any projects with appropriate message", func() {
@@ -88,14 +84,14 @@ func cleanUpAfterProjects(projects []string) {
 	for _, p := range projects {
 		deleteProject(p)
 	}
-	// log back in as original user
-	runCmd(fmt.Sprintf("oc login --token %s", currentUserToken))
+	// Logout of current user to ensure state
+	runCmd("oc logout")
 }
 
 func deleteProject(project string) {
 	var waitOut bool
 	if len(project) > 0 {
-		waitOut = waitForCmdOut(fmt.Sprintf("odo project delete %s", project), 10, func(out string) bool {
+		waitOut = waitForCmdOut(fmt.Sprintf("odo project delete -f %s", project), 10, func(out string) bool {
 			return strings.Contains(out, fmt.Sprintf("Deleted project : %s", project))
 		})
 		Expect(waitOut).To(BeTrue())

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -56,7 +56,7 @@ var _ = Describe("odoLoginE2e", func() {
 			It("Should fail login on invalid token with appropriate message", func() {
 				session = runFailCmd("odo login -t verybadtoken", 1)
 				Expect(session).To(ContainSubstring("The token provided is invalid or expired"))
-				runCmd(fmt.Sprintf("oc login -t %s", testUserToken))
+				runCmd(fmt.Sprintf("oc login --token %s", testUserToken))
 			})
 		})
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See title
 - Project deletion does not happen now when it is not needed
 - Project deletion, when run only targets specific projects

## Was the change discussed in an issue?
fixes #1278 

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>