### PR TITLE
Add possibility to output non-interactive equivalent command for service create.

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -209,7 +209,7 @@ func (o *ServiceCreateOptions) Run() (err error) {
 You can see the current status by executing 'odo service list'`)
 	equivalent := o.outputNonInteractiveEquivalent()
 	if len(equivalent) > 0 {
-		log.Info("Equivalent command:\n" + equivalent)
+		log.Info("Equivalent command:\n" + ui.StyledOutput(equivalent, "cyan"))
 	}
 	return
 }
@@ -227,7 +227,12 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			util.LogErrorAndExit(o.Complete(name, cmd, args), "")
 			util.LogErrorAndExit(o.Validate(), "")
-			util.LogErrorAndExit(o.Run(), "")
+			equivalent := o.outputNonInteractiveEquivalent()
+			if len(equivalent) > 0 {
+				log.Info("Equivalent command:")
+				fmt.Println(ui.StyledOutput(equivalent, "cyan"))
+			}
+			//util.LogErrorAndExit(o.Run(), "")
 		},
 	}
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -227,12 +227,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			util.LogErrorAndExit(o.Complete(name, cmd, args), "")
 			util.LogErrorAndExit(o.Validate(), "")
-			equivalent := o.outputNonInteractiveEquivalent()
-			if len(equivalent) > 0 {
-				log.Info("Equivalent command:")
-				fmt.Println(ui.StyledOutput(equivalent, "cyan"))
-			}
-			//util.LogErrorAndExit(o.Run(), "")
+			util.LogErrorAndExit(o.Run(), "")
 		},
 	}
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/odo/util/validation"
 	"strings"
+	"text/template"
 
 	"github.com/golang/glog"
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -18,7 +20,12 @@ import (
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
 
-const createRecommendedCommandName = "create"
+const (
+	createRecommendedCommandName = "create"
+	equivalentTemplate           = `Equivalent command:
+{{.}}
+`
+)
 
 var (
 	createExample = ktemplates.Examples(`
@@ -39,16 +46,20 @@ For a full list of service types, use: 'odo catalog list services'`)
 type ServiceCreateOptions struct {
 	// parameters hold the user-provided values for service class parameters via flags (populated by cobra)
 	parameters []string
-	// plan is the selected service plan
-	plan string
-	// serviceType corresponds to the service class name
-	serviceType string
-	// serviceName is how the service will be named and known by odo
-	serviceName string
-	// parametersMap is populated from the flag-provided values (parameters) and/or the interactive mode and is the expected format by the business logic
-	parametersMap map[string]string
+	// Plan is the selected service plan
+	Plan string
+	// ServiceType corresponds to the service class name
+	ServiceType string
+	// ServiceName is how the service will be named and known by odo
+	ServiceName string
+	// ParametersMap is populated from the flag-provided values (parameters) and/or the interactive mode and is the expected format by the business logic
+	ParametersMap map[string]string
 	// interactive specifies whether the command operates in interactive mode or not
 	interactive bool
+	// outputCLI specifies whether to output the non-interactive version of the command or not
+	outputCLI bool
+	// CmdFullName records the command's full name
+	CmdFullName string
 	// generic context options common to all commands
 	*genericclioptions.Context
 }
@@ -74,7 +85,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		if err != nil {
 			return fmt.Errorf("unable to retrieve service classes: %v", err)
 		}
-		class, o.serviceType = ui.SelectClassInteractively(classesByCategory)
+		class, o.ServiceType = ui.SelectClassInteractively(classesByCategory)
 
 		plans, err := client.GetMatchingPlans(class)
 		if err != nil {
@@ -85,25 +96,26 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		// if there is only one available plan, we select it
 		if len(plans) == 1 {
 			for k, v := range plans {
-				o.plan = k
+				o.Plan = k
 				svcPlan = v
 			}
-			glog.V(4).Infof("Plan %s was automatically selected since it's the only one available for service %s", o.plan, o.serviceType)
+			glog.V(4).Infof("Plan %s was automatically selected since it's the only one available for service %s", o.Plan, o.ServiceType)
 		} else {
 			// otherwise select the plan interactively
-			o.plan = ui.SelectPlanNameInteractively(plans, "Which service plan should we use ")
-			svcPlan = plans[o.plan]
+			o.Plan = ui.SelectPlanNameInteractively(plans, "Which service plan should we use ")
+			svcPlan = plans[o.Plan]
 		}
 
-		o.parametersMap = ui.EnterServicePropertiesInteractively(svcPlan)
-		o.serviceName = ui.EnterServiceNameInteractively(o.serviceType, "How should we name your service ", o.validateServiceName)
+		o.ParametersMap = ui.EnterServicePropertiesInteractively(svcPlan)
+		o.ServiceName = ui.EnterServiceNameInteractively(o.ServiceType, "How should we name your service ", o.validateServiceName)
+		o.outputCLI = ui.ShouldOutputNonInteractiveEquivalent()
 	} else {
-		o.serviceType = args[0]
+		o.ServiceType = args[0]
 		// if only one arg is given, then it is considered as service name and service type both
-		o.serviceName = o.serviceType
+		o.ServiceName = o.ServiceType
 		// if two args are given, first is service type and second one is service name
 		if len(args) == 2 {
-			o.serviceName = args[1]
+			o.ServiceName = args[1]
 		}
 	}
 
@@ -122,9 +134,26 @@ func (o *ServiceCreateOptions) validateServiceName(i interface{}) (err error) {
 		return err
 	}
 	if exists {
-		return fmt.Errorf("%s service already exists in the current application", o.serviceName)
+		return fmt.Errorf("%s service already exists in the current application", o.ServiceName)
 	}
 	return
+}
+
+func (o *ServiceCreateOptions) outputNonInteractiveEquivalent() string {
+	if o.outputCLI {
+		var tpl bytes.Buffer
+		t := template.Must(template.New("service-create-cli").Parse(
+			"{{.CmdFullName}} {{.ServiceType}}" +
+				"{{if .ServiceName}} {{.ServiceName}}{{end}}" +
+				"{{if .Plan}} --plan {{.Plan}}{{end}}" +
+				"{{range $key, $value := .ParametersMap}} -p{{$key}}={{$value}}{{end}}"))
+		e := t.Execute(&tpl, o)
+		if e != nil {
+			panic(e) // shouldn't happen
+		}
+		return strings.TrimSpace(tpl.String())
+	}
+	return ""
 }
 
 // Validate validates the ServiceCreateOptions based on completed values
@@ -135,14 +164,14 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 	}
 
 	// make sure the service type exists
-	classPtr, err := o.Client.GetClusterServiceClass(o.serviceType)
+	classPtr, err := o.Client.GetClusterServiceClass(o.ServiceType)
 	if err != nil {
 		return errors.Wrap(err, "unable to create service because Service Catalog is not enabled in your cluster")
 	}
 	if classPtr == nil {
-		return fmt.Errorf("service %v doesn't exist\nRun 'odo catalog list services' to see a list of supported services.\n", o.serviceType)
+		return fmt.Errorf("service %v doesn't exist\nRun 'odo catalog list services' to see a list of supported services.\n", o.ServiceType)
 	}
-	if len(o.plan) == 0 {
+	if len(o.Plan) == 0 {
 		plans, err := o.Client.GetMatchingPlans(*classPtr)
 		if err != nil {
 			return err
@@ -150,15 +179,15 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 		// when the plan has not been supplied, if there is only one available plan, we select it
 		if len(plans) == 1 {
 			for k := range plans {
-				o.plan = k
+				o.Plan = k
 			}
-			glog.V(4).Infof("Plan %s was automatically selected since it's the only one available for service %s", o.plan, o.serviceType)
+			glog.V(4).Infof("Plan %s was automatically selected since it's the only one available for service %s", o.Plan, o.ServiceType)
 		} else {
-			return fmt.Errorf("no plan was supplied for service %v.\nPlease select one of: %v\n", o.serviceType, strings.Join(ui.GetServicePlanNames(plans), ","))
+			return fmt.Errorf("no plan was supplied for service %v.\nPlease select one of: %v\n", o.ServiceType, strings.Join(ui.GetServicePlanNames(plans), ","))
 		}
 	} else {
 		// when the plan has been supplied, we need to make sure it exists
-		if ok, err := o.Client.DoesPlanExist(o.plan); !ok {
+		if ok, err := o.Client.DoesPlanExist(o.Plan); !ok {
 			if err != nil {
 				return err
 			}
@@ -167,25 +196,30 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("plan %s is invalid for service %v.\nPlease select one of: %v\n", o.plan, o.serviceType, strings.Join(ui.GetServicePlanNames(plans), ","))
+			return fmt.Errorf("plan %s is invalid for service %v.\nPlease select one of: %v\n", o.Plan, o.ServiceType, strings.Join(ui.GetServicePlanNames(plans), ","))
 		}
 	}
 	//validate service name
-	return o.validateServiceName(o.serviceName)
+	return o.validateServiceName(o.ServiceName)
 }
 
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
-	err = svc.CreateService(o.Client, o.serviceName, o.serviceType, o.plan, o.parametersMap, o.Application)
-	log.Successf(`Service '%s' was created`, o.serviceName)
+	err = svc.CreateService(o.Client, o.ServiceName, o.ServiceType, o.Plan, o.ParametersMap, o.Application)
+	log.Successf(`Service '%s' was created`, o.ServiceName)
 	log.Info(`Progress of the provisioning will not be reported and might take a long time.
 You can see the current status by executing 'odo service list'`)
+	equivalent := o.outputNonInteractiveEquivalent()
+	if len(equivalent) > 0 {
+		log.Info("Equivalent command:\n" + equivalent)
+	}
 	return
 }
 
 // NewCmdServiceCreate implements the odo service create command.
 func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	o := NewServiceCreateOptions()
+	o.CmdFullName = fullName
 	serviceCreateCmd := &cobra.Command{
 		Use:     name + " <service_type> --plan <plan_name> [service_name]",
 		Short:   createShortDesc,
@@ -198,7 +232,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 			util.LogErrorAndExit(o.Run(), "")
 		},
 	}
-	serviceCreateCmd.Flags().StringVar(&o.plan, "plan", "", "The name of the plan of the service to be created")
+	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringSliceVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")
 	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
 	completion.RegisterCommandFlagHandler(serviceCreateCmd, "plan", completion.ServicePlanCompletionHandler)

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -25,7 +25,7 @@ const (
 	equivalentTemplate           = "{{.CmdFullName}} {{.ServiceType}}" +
 		"{{if .ServiceName}} {{.ServiceName}}{{end}}" +
 		"{{if .Plan}} --plan {{.Plan}}{{end}}" +
-		"{{range $key, $value := .ParametersMap}} -p{{$key}}={{$value}}{{end}}"
+		"{{range $key, $value := .ParametersMap}} -p {{$key}}={{$value}}{{end}}"
 )
 
 var (

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -139,6 +139,7 @@ func (o *ServiceCreateOptions) validateServiceName(i interface{}) (err error) {
 	return
 }
 
+// outputNonInteractiveEquivalent outputs the populated options as the equivalent command that would be used in non-interactive mode
 func (o *ServiceCreateOptions) outputNonInteractiveEquivalent() string {
 	if o.outputCLI {
 		var tpl bytes.Buffer

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -22,9 +22,10 @@ import (
 
 const (
 	createRecommendedCommandName = "create"
-	equivalentTemplate           = `Equivalent command:
-{{.}}
-`
+	equivalentTemplate           = "{{.CmdFullName}} {{.ServiceType}}" +
+		"{{if .ServiceName}} {{.ServiceName}}{{end}}" +
+		"{{if .Plan}} --plan {{.Plan}}{{end}}" +
+		"{{range $key, $value := .ParametersMap}} -p{{$key}}={{$value}}{{end}}"
 )
 
 var (
@@ -143,11 +144,7 @@ func (o *ServiceCreateOptions) validateServiceName(i interface{}) (err error) {
 func (o *ServiceCreateOptions) outputNonInteractiveEquivalent() string {
 	if o.outputCLI {
 		var tpl bytes.Buffer
-		t := template.Must(template.New("service-create-cli").Parse(
-			"{{.CmdFullName}} {{.ServiceType}}" +
-				"{{if .ServiceName}} {{.ServiceName}}{{end}}" +
-				"{{if .Plan}} --plan {{.Plan}}{{end}}" +
-				"{{range $key, $value := .ParametersMap}} -p{{$key}}={{$value}}{{end}}"))
+		t := template.Must(template.New("service-create-cli").Parse(equivalentTemplate))
 		e := t.Execute(&tpl, o)
 		if e != nil {
 			panic(e) // shouldn't happen

--- a/pkg/odo/cli/service/create_test.go
+++ b/pkg/odo/cli/service/create_test.go
@@ -79,7 +79,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 				ServiceType:   "foo",
 				ParametersMap: map[string]string{"param1": "value1", "param2": "value2"},
 			},
-			expected: RecommendedCommandName + " foo -pparam1=value1 -pparam2=value2",
+			expected: RecommendedCommandName + " foo -p param1=value1 -p param2=value2",
 		},
 		{
 			name: "all",
@@ -91,7 +91,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 				Plan:          "plan",
 				ParametersMap: map[string]string{"param1": "value1", "param2": "value2"},
 			},
-			expected: RecommendedCommandName + " foo name --plan plan -pparam1=value1 -pparam2=value2",
+			expected: RecommendedCommandName + " foo name --plan plan -p param1=value1 -p param2=value2",
 		},
 	}
 

--- a/pkg/odo/cli/service/create_test.go
+++ b/pkg/odo/cli/service/create_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestOutputNonInteractiveEquivalent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  ServiceCreateOptions
+		expected string
+	}{
+		{
+			name: "when output is not requested, should return empty string",
+			options: ServiceCreateOptions{
+				CmdFullName: RecommendedCommandName,
+				outputCLI:   false,
+				ServiceType: "foo",
+			},
+			expected: "",
+		},
+		{
+			name: "just service class",
+			options: ServiceCreateOptions{
+				CmdFullName: RecommendedCommandName,
+				outputCLI:   true,
+				ServiceType: "foo",
+			},
+			expected: RecommendedCommandName + " foo",
+		},
+		{
+			name: "just service class and name",
+			options: ServiceCreateOptions{
+				CmdFullName: RecommendedCommandName,
+				outputCLI:   true,
+				ServiceType: "foo",
+				ServiceName: "myservice",
+			},
+			expected: RecommendedCommandName + " foo myservice",
+		},
+		{
+			name: "service class, name and plan",
+			options: ServiceCreateOptions{
+				CmdFullName: RecommendedCommandName,
+				outputCLI:   true,
+				ServiceType: "foo",
+				ServiceName: "myservice",
+				Plan:        "dev",
+			},
+			expected: RecommendedCommandName + " foo myservice --plan dev",
+		},
+		{
+			name: "service class and plan",
+			options: ServiceCreateOptions{
+				CmdFullName: RecommendedCommandName,
+				outputCLI:   true,
+				ServiceType: "foo",
+				Plan:        "dev",
+			},
+			expected: RecommendedCommandName + " foo --plan dev",
+		},
+		{
+			name: "service class and empty params",
+			options: ServiceCreateOptions{
+				CmdFullName:   RecommendedCommandName,
+				outputCLI:     true,
+				ServiceType:   "foo",
+				ParametersMap: map[string]string{},
+			},
+			expected: RecommendedCommandName + " foo",
+		},
+		{
+			name: "service class and params",
+			options: ServiceCreateOptions{
+				CmdFullName:   RecommendedCommandName,
+				outputCLI:     true,
+				ServiceType:   "foo",
+				ParametersMap: map[string]string{"param1": "value1", "param2": "value2"},
+			},
+			expected: RecommendedCommandName + " foo -pparam1=value1 -pparam2=value2",
+		},
+		{
+			name: "all",
+			options: ServiceCreateOptions{
+				CmdFullName:   RecommendedCommandName,
+				outputCLI:     true,
+				ServiceType:   "foo",
+				ServiceName:   "name",
+				Plan:          "plan",
+				ParametersMap: map[string]string{"param1": "value1", "param2": "value2"},
+			},
+			expected: RecommendedCommandName + " foo name --plan plan -pparam1=value1 -pparam2=value2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.options.outputNonInteractiveEquivalent()
+			if tt.expected != actual {
+				t.Errorf("expected '%s', got '%s'", tt.expected, actual)
+			}
+		})
+	}
+
+}

--- a/pkg/odo/cli/service/ui/ui.go
+++ b/pkg/odo/cli/service/ui/ui.go
@@ -97,6 +97,19 @@ func EnterServiceNameInteractively(defaultValue, promptText string, validateName
 	return serviceName
 }
 
+// ShouldOutputNonInteractiveEquivalent asks the user if they want to output the equivalent non-interactive command line version
+// of the interactively entered options
+func ShouldOutputNonInteractiveEquivalent() bool {
+	outputCLI := false
+	confirm := &survey.Confirm{
+		Message: "Output the non-interactive version of the selected options",
+	}
+
+	err := survey.AskOne(confirm, &outputCLI, survey.Required)
+	ui.HandleError(err)
+	return outputCLI
+}
+
 // SelectClassInteractively lets the user select target service class from possible options, first filtering by categories then
 // by class name
 func SelectClassInteractively(classesByCategory map[string][]scv1beta1.ClusterServiceClass) (class scv1beta1.ClusterServiceClass, serviceType string) {

--- a/pkg/odo/cli/service/ui/ui.go
+++ b/pkg/odo/cli/service/ui/ui.go
@@ -169,9 +169,15 @@ func classInfoItem(name, value string) string {
 
 	if len(value) > 0 {
 		// display the name using the default color, in bold and then reset style right after
-		return ansi.ColorCode("default+b") + name + ansi.ColorCode("reset") + ": " + value + "\n"
+		return StyledOutput(name, "default+b") + ": " + value + "\n"
 	}
 	return ""
+}
+
+// StyledOutput returns an ANSI color code to style the specified text accordingly, issuing a reset code when done using the
+// https://github.com/mgutz/ansi#style-format format
+func StyledOutput(text, style string) string {
+	return ansi.ColorCode(style) + text + ansi.ColorCode("reset")
 }
 
 const defaultColumnNumberBeforeWrap = 80


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Users might explore creating a service using the interactive mode and would like to see the equivalent command in non-interactive mode so that it can be used in a script.

## Was the change discussed in an issue?
No.

## How to test changes?
Create a service interactively: `odo service create` and asks for the equivalent command at the end of the process. Check that the resulting command line results in the equivalent service being created.