### PR TITLE
Fix #1269: Refactor logout command to use Complete/Validate/Run pattern.

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -108,7 +108,7 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 		component.NewCmdUpdate(component.RecommendedUpdateCommandName, util.GetFullName(fullName, component.RecommendedUpdateCommandName)),
 		component.NewCmdWatch(component.RecommendedWatchCommandName, util.GetFullName(fullName, component.RecommendedWatchCommandName)),
 		login.NewCmdLogin(),
-		logout.NewCmdLogout(),
+		logout.NewCmdLogout(logout.RecommendedCommandName, util.GetFullName(fullName, logout.RecommendedCommandName)),
 		project.NewCmdProject(project.RecommendedCommandName, util.GetFullName(fullName, project.RecommendedCommandName)),
 		service.NewCmdService(service.RecommendedCommandName, util.GetFullName(fullName, service.RecommendedCommandName)),
 		storage.NewCmdStorage(storage.RecommendedCommandName, util.GetFullName(fullName, storage.RecommendedCommandName)),

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -1,31 +1,63 @@
 package logout
 
 import (
-	"os"
-
+	"fmt"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	"os"
 )
 
-var logoutCmd = &cobra.Command{
-	Use:   "logout",
-	Short: "Log out of the current OpenShift session",
-	Long:  "Log out of the current OpenShift session",
-	Example: `  # Logout
-  odo logout
-	`,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		context := genericclioptions.NewContext(cmd)
-		client := context.Client
-		err := client.RunLogout(os.Stdout)
-		odoutil.LogErrorAndExit(err, "")
-	},
+// RecommendedCommandName is the recommended command name
+const RecommendedCommandName = "logout"
+
+var example = templates.Examples(`  # Logout
+  %[1]s
+`)
+
+// LogoutOptions encapsulates the options for the odo logout command
+type LogoutOptions struct {
+	*genericclioptions.Context
+}
+
+// NewLogoutOptions creates a new LogoutOptions instance
+func NewLogoutOptions() *LogoutOptions {
+	return &LogoutOptions{}
+}
+
+// Complete completes LogoutOptions after they've been created
+func (o *LogoutOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.Context = genericclioptions.NewContext(cmd)
+	return
+}
+
+// Validate validates the LogoutOptions based on completed values
+func (o *LogoutOptions) Validate() (err error) {
+	return
+}
+
+// Run contains the logic for the odo logout command
+func (o *LogoutOptions) Run() (err error) {
+	return o.Client.RunLogout(os.Stdout)
 }
 
 // NewCmdLogout implements the logout odo command
-func NewCmdLogout() *cobra.Command {
+func NewCmdLogout(name, fullName string) *cobra.Command {
+	o := NewLogoutOptions()
+	logoutCmd := &cobra.Command{
+		Use:     name,
+		Short:   "Log out of the current OpenShift session",
+		Long:    "Log out of the current OpenShift session",
+		Example: fmt.Sprintf(example, fullName),
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			odoutil.LogErrorAndExit(o.Complete(name, cmd, args), "")
+			odoutil.LogErrorAndExit(o.Validate(), "")
+			odoutil.LogErrorAndExit(o.Run(), "")
+		},
+	}
+
 	// Add a defined annotation in order to appear in the help menu
 	logoutCmd.Annotations = map[string]string{"command": "utility"}
 	logoutCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See $SUBJECT

## Was the change discussed in an issue?
fixes #1269 

## How to test changes?
Check that `odo logout` still works as expected.
