### PR TITLE
Clean-up after command refactoring

### DIFF
--- a/pkg/odo/cli/catalog/catalog.go
+++ b/pkg/odo/cli/catalog/catalog.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RecommendedCatalogCommandName is the recommended catalog command name
-const RecommendedCatalogCommandName = "catalog"
+const RecommendedCommandName = "catalog"
 
 // NewCmdCatalog implements the odo catalog command
 func NewCmdCatalog(name, fullName string) *cobra.Command {

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -95,7 +95,7 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 
 	rootCmd.AddCommand(
 		application.NewCmdApplication(application.RecommendedCommandName, util.GetFullName(fullName, application.RecommendedCommandName)),
-		catalog.NewCmdCatalog(catalog.RecommendedCatalogCommandName, util.GetFullName(fullName, catalog.RecommendedCatalogCommandName)),
+		catalog.NewCmdCatalog(catalog.RecommendedCommandName, util.GetFullName(fullName, catalog.RecommendedCommandName)),
 		component.NewCmdComponent(component.RecommendedComponentCommandName, util.GetFullName(fullName, component.RecommendedComponentCommandName)),
 		component.NewCmdCreate(component.RecommendedCreateCommandName, util.GetFullName(fullName, component.RecommendedCreateCommandName)),
 		component.NewCmdDelete(component.RecommendedDeleteCommandName, util.GetFullName(fullName, component.RecommendedDeleteCommandName)),

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -47,7 +47,7 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 		// 'odo component' is the same as 'odo component get'
 		// 'odo component <component_name>' is the same as 'odo component set <component_name>'
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) > 0 && args[0] != "get" && args[0] != "set" {
+			if len(args) > 0 && args[0] != RecommendedGetCommandName && args[0] != RecommendedSetCommandName {
 				componentSetCmd.Run(cmd, args)
 			} else {
 				componentGetCmd.Run(cmd, args)

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -44,7 +44,7 @@ func NewProjectDeleteOptions() *ProjectDeleteOptions {
 	return &ProjectDeleteOptions{}
 }
 
-// Complete completes ProjectDeleteOptions after they've been deleted
+// Complete completes ProjectDeleteOptions after they've been created
 func (pdo *ProjectDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	pdo.projectName = args[0]
 	pdo.Context = genericclioptions.NewContext(cmd)

--- a/pkg/odo/cli/project/get.go
+++ b/pkg/odo/cli/project/get.go
@@ -39,7 +39,7 @@ func NewProjectGetOptions() *ProjectGetOptions {
 	return &ProjectGetOptions{}
 }
 
-// Complete completes ProjectGetOptions after they've been getd
+// Complete completes ProjectGetOptions after they've been created
 func (pgo *ProjectGetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	pgo.Context = genericclioptions.NewContext(cmd)
 	return

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RecommendedCommandName is the recommended service command name
+// RecommendedCommandName is the recommended project command name
 const RecommendedCommandName = "project"
 
 // NewCmdProject implements the project odo command

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -35,7 +35,7 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 		// 'odo project' is the same as 'odo project get'
 		// 'odo project <project_name>' is the same as 'odo project set <project_name>'
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) > 0 && args[0] != "get" && args[0] != "set" {
+			if len(args) > 0 && args[0] != getRecommendedCommandName && args[0] != setRecommendedCommandName {
 				projectSetCmd.Run(cmd, args)
 			} else {
 				projectGetCmd.Run(cmd, args)

--- a/pkg/odo/cli/project/set.go
+++ b/pkg/odo/cli/project/set.go
@@ -43,7 +43,7 @@ func NewProjectSetOptions() *ProjectSetOptions {
 	return &ProjectSetOptions{}
 }
 
-// Complete completes ProjectSetOptions after they've been setd
+// Complete completes ProjectSetOptions after they've been created
 func (pso *ProjectSetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	pso.Context = genericclioptions.NewContext(cmd)
 	pso.projectName = args[0]

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -32,12 +32,12 @@ type StorageCreateOptions struct {
 	*genericclioptions.Context
 }
 
-// NewStorageCreateOptions creates a new UrlCreateOptions instance
+// NewStorageCreateOptions creates a new StorageCreateOptions instance
 func NewStorageCreateOptions() *StorageCreateOptions {
 	return &StorageCreateOptions{}
 }
 
-// Complete completes StorageCreateOptions after they've been Created
+// Complete completes StorageCreateOptions after they've been created
 func (o *StorageCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	if len(args) != 0 {

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -35,19 +35,19 @@ type StorageDeleteOptions struct {
 	*genericclioptions.Context
 }
 
-// NewUrlDeleteOptions creates a new UrlDeleteOptions instance
+// NewStorageDeleteOptions creates a new StorageDeleteOptions instance
 func NewStorageDeleteOptions() *StorageDeleteOptions {
 	return &StorageDeleteOptions{}
 }
 
-// Complete completes StorageCreateOptions after they've been Created
+// Complete completes StorageDeleteOptions after they've been created
 func (o *StorageDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	o.storageName = args[0]
 	return
 }
 
-// Validate validates the StorageCreateOptions based on completed values
+// Validate validates the StorageDeleteOptions based on completed values
 func (o *StorageDeleteOptions) Validate() (err error) {
 	exists, err := storage.Exists(o.Client, o.storageName, o.Application)
 
@@ -66,7 +66,7 @@ func (o *StorageDeleteOptions) Validate() (err error) {
 	return
 }
 
-// Run contains the logic for the odo storage create command
+// Run contains the logic for the odo storage delete command
 func (o *StorageDeleteOptions) Run() (err error) {
 	var confirmDeletion string
 	if o.storageForceDeleteFlag {

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -41,12 +41,12 @@ type StorageListOptions struct {
 	*genericclioptions.Context
 }
 
-// NewStorageListOptions creates a new UrlCreateOptions instance
+// NewStorageListOptions creates a new StorageListOptions instance
 func NewStorageListOptions() *StorageListOptions {
 	return &StorageListOptions{}
 }
 
-// Complete completes StorageListOptions after they've been Created
+// Complete completes StorageListOptions after they've been created
 func (o *StorageListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	if o.storageListAllFlag {

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -32,12 +32,12 @@ type StorageMountOptions struct {
 	*genericclioptions.Context
 }
 
-// NewStorageCreateOptions creates a new UrlCreateOptions instance
+// NewStorageMountOptions creates a new StorageMountOptions instance
 func NewStorageMountOptions() *StorageMountOptions {
 	return &StorageMountOptions{}
 }
 
-// Complete completes StorageMountOptions after they've been Created
+// Complete completes StorageMountOptions after they've been created
 func (o *StorageMountOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	o.storageName = args[0]
@@ -63,7 +63,7 @@ func (o *StorageMountOptions) Validate() (err error) {
 	return
 }
 
-// Run contains the logic for the odo storage list command
+// Run contains the logic for the odo storage mount command
 func (o *StorageMountOptions) Run() (err error) {
 	err = storage.Mount(o.Client, storagePath, o.storageName, o.Component(), o.Application)
 	if err != nil {
@@ -73,7 +73,7 @@ func (o *StorageMountOptions) Run() (err error) {
 	return
 }
 
-// NewCmdStorageCreate implements the odo storage create command.
+// NewCmdStorageMount implements the odo storage mount command.
 func NewCmdStorageMount(name, fullName string) *cobra.Command {
 	o := NewStorageMountOptions()
 	storageMountCmd := &cobra.Command{

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -29,6 +29,7 @@ var (
 
 type StorageMountOptions struct {
 	storageName string
+	storagePath string
 	*genericclioptions.Context
 }
 
@@ -65,7 +66,7 @@ func (o *StorageMountOptions) Validate() (err error) {
 
 // Run contains the logic for the odo storage mount command
 func (o *StorageMountOptions) Run() (err error) {
-	err = storage.Mount(o.Client, storagePath, o.storageName, o.Component(), o.Application)
+	err = storage.Mount(o.Client, o.storagePath, o.storageName, o.Component(), o.Application)
 	if err != nil {
 		return
 	}
@@ -89,7 +90,7 @@ func NewCmdStorageMount(name, fullName string) *cobra.Command {
 		},
 	}
 
-	storageMountCmd.Flags().StringVar(&storagePath, "path", "", "Path to mount the storage on")
+	storageMountCmd.Flags().StringVar(&o.storagePath, "path", "", "Path to mount the storage on")
 	_ = storageMountCmd.MarkFlagRequired("path")
 
 	projectCmd.AddProjectFlag(storageMountCmd)

--- a/pkg/odo/cli/storage/storage.go
+++ b/pkg/odo/cli/storage/storage.go
@@ -11,12 +11,7 @@ import (
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
 
-var (
-	storageSize            string
-	storagePath            string
-	storageForceDeleteflag bool
-)
-
+// RecommendedCommandName is the recommended command name
 const RecommendedCommandName = "storage"
 
 var (

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -43,12 +43,12 @@ type StorageUnMountOptions struct {
 	*genericclioptions.Context
 }
 
-// NewStorageCreateOptions creates a new UrlCreateOptions instance
+// NewStorageUnMountOptions creates a new StorageUnMountOptions instance
 func NewStorageUnMountOptions() *StorageUnMountOptions {
 	return &StorageUnMountOptions{}
 }
 
-// Complete completes StorageMountOptions after they've been Created
+// Complete completes StorageUnMountOptions after they've been created
 func (o *StorageUnMountOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	// checking if the first character in the argument is a "/", indicating a path or not, indicating a storage name
@@ -60,7 +60,7 @@ func (o *StorageUnMountOptions) Complete(name string, cmd *cobra.Command, args [
 	return
 }
 
-// Validate validates the StorageMountOptions based on completed values
+// Validate validates the StorageUnMountOptions based on completed values
 func (o *StorageUnMountOptions) Validate() (err error) {
 	// checking if the first character in the argument is a "/", indicating a path or not, indicating a storage name
 	if len(o.storagePath) > 0 {
@@ -84,7 +84,7 @@ func (o *StorageUnMountOptions) Validate() (err error) {
 	return
 }
 
-// Run contains the logic for the odo storage list command
+// Run contains the logic for the odo storage unmount command
 func (o *StorageUnMountOptions) Run() (err error) {
 	err = storage.Unmount(o.Client, o.storageName, o.Component(), o.Application, true)
 	if err != nil {
@@ -95,7 +95,7 @@ func (o *StorageUnMountOptions) Run() (err error) {
 	return
 }
 
-// NewCmdStorageCreate implements the odo storage create command.
+// NewCmdStorageUnMount implements the odo storage unmount command.
 func NewCmdStorageUnMount(name, fullName string) *cobra.Command {
 	o := NewStorageUnMountOptions()
 	storageUnMountCmd := &cobra.Command{


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Fixes:
- documentation issues
- missed global variable usage
- use command name constants where possible

## Was the change discussed in an issue?
No.

## How to test changes?
Everything should still work as expected. Only change that could have an impact is on `storage mount` where global variable use was replaced by options field.
