### PR TITLE
Do not use closed writer when pushing files to pod.

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2739,7 +2739,7 @@ func (c *Client) CopyFile(localPath string, targetPodName string, targetPath str
 
 	// cmdArr will run inside container
 	cmdArr := []string{"tar", "xf", "-", "-C", targetPath, "--strip", "1"}
-	err := c.ExecCMDInContainer(targetPodName, cmdArr, writer, writer, reader, false)
+	err := c.ExecCMDInContainer(targetPodName, cmdArr, nil, nil, reader, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Get rid of `io: read/write on closed pipe` error.

## Was the change discussed in an issue?
fixes #1286.
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
See issue #1286. description.