### PR TITLE
adding cico script and minishift bring up script

### DIFF
--- a/.cico.pipeline
+++ b/.cico.pipeline
@@ -39,7 +39,7 @@ node('odo') {
                     onmyduffynode '''git clone --single-branch --branch master --depth 1 "https://github.com/redhat-developer/odo.git" ${CLONE_DIR} && 
                     cd  ${CLONE_DIR} && ls -la'''
                 }
-    
+   
                 stage('Build binary') {
                         onmyduffynode '''export PATH=$PATH:/usr/local/go/bin:/root/go/bin &&
                         go version &&
@@ -60,6 +60,14 @@ node('odo') {
                         make test |& tee unit_test.log'''
                 }
 
+                stage('Bringing up minishift') {
+                        onmyduffynode '''cd ${CLONE_DIR} &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh &&
+                        echo "----------finished-provisioning-cluster-----------"
+                        '''
+                }
+ 
                 timeout(20) {
                     stage('Main e2e Test') {
                         onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
@@ -68,13 +76,9 @@ node('odo') {
                         cp odo /usr/local/go/bin &&
                         git branch && 
                         rpm --query centos-release &&
-                        echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh &&
-                        echo "----------finished-provisioning-cluster-----------" &&
                         odo version &&
                         oc whoami &&
-                        make test-main-e2e &&
-                        minishift delete -f 
+                        make test-main-e2e
                         '''
                     }
                 }
@@ -85,15 +89,10 @@ node('odo') {
                         cd ${CLONE_DIR} &&
                         make &&
                         cp odo /usr/local/go/bin &&
-                        git checkout cico-test && 
                         rpm --query centos-release &&
-                        echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh &&
-                        echo "----------finished-provisioning-cluster-----------" &&
                         odo version &&
                         oc whoami &&
-                        make test-cmp-e2e &&
-                        minishift delete -f 
+                        make test-cmp-e2e
                         '''
                     }
                 }
@@ -104,15 +103,10 @@ node('odo') {
                         cd ${CLONE_DIR} &&
                         make &&
                         cp odo /usr/local/go/bin &&
-                        git checkout cico-test && 
                         rpm --query centos-release &&
-                        echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh &&
-                        echo "----------finished-provisioning-cluster-----------" &&
                         odo version &&
                         oc whoami &&
-                        make test-java-e2e &&
-                        minishift delete -f 
+                        make test-java-e2e 
                         '''
                     }
                 }
@@ -123,14 +117,9 @@ node('odo') {
                         cd ${CLONE_DIR} &&
                         make &&
                         cp odo /usr/local/go/bin &&
-                        git checkout cico-test && 
                         rpm --query centos-release &&
-                        echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh service-catalog  &&
-                        echo "----------finished-provisioning-cluster-----------" &&
                         odo version &&
-                        make test-source-e2e &&
-                        minishift delete -f 
+                        make test-source-e2e 
                         '''
                     }
                 }
@@ -141,14 +130,9 @@ node('odo') {
                         cd ${CLONE_DIR} &&
                         make &&
                         cp odo /usr/local/go/bin &&
-                        git checkout cico-test && 
                         rpm --query centos-release &&
-                        echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh service-catalog  &&
-                        echo "----------finished-provisioning-cluster-----------" &&
                         odo version &&
-                        make test-service-e2e &&
-                        minishift delete -f 
+                        make test-service-e2e 
                         '''
                     }
                 }
@@ -159,14 +143,9 @@ node('odo') {
                         cd ${CLONE_DIR} &&
                         make &&
                         cp odo /usr/local/go/bin &&
-                        git checkout cico-test && 
                         rpm --query centos-release &&
-                        echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh service-catalog  &&
-                        echo "----------finished-provisioning-cluster-----------" &&
                         odo version &&
-                        make test-service-e2e &&
-                        minishift delete -f 
+                        make test-link-e2e 
                         '''
                     }
                 }

--- a/.cico.pipeline
+++ b/.cico.pipeline
@@ -63,7 +63,7 @@ node('odo') {
                 stage('Bringing up minishift') {
                         onmyduffynode '''cd ${CLONE_DIR} &&
                         echo "----------starting-cluster-provision-----------" &&
-                        ./scripts/minishift-setup.sh &&
+                        ./scripts/minishift-setup.sh service-catalog &&
                         echo "----------finished-provisioning-cluster-----------"
                         '''
                 }

--- a/.cico.pipeline
+++ b/.cico.pipeline
@@ -1,7 +1,7 @@
 def onmyduffynode(script){
     ansiColor('xterm'){
         timestamps{
-            sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root ${DUFFY_NODE}.ci.centos.org -t \"export REPO=${git_url}; export BRANCH=${ghprbActualCommit};\""' + script + '"'
+            sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root ${DUFFY_NODE}.ci.centos.org -t "' + script + '"'
         }
     }
 }
@@ -15,7 +15,15 @@ def notifyBuild(String buildStatus = 'STARTED') {
     emailext attachmentsPattern: 'odo/*.log', body: "See: ${env.BUILD_URL}", subject: "[${env.JOB_NAME}] Build #${env.BUILD_NUMBER}: ${buildStatus}", to: 'sgk@redhat.com'
 }
 
+def syncrepotoworker() {
+    sh 'rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root " -Ha .' +  " ${DUFFY_NODE}.ci.centos.org:~/${CLONE_DIR}"
+}
+
 node('odo') {
+
+            // clearing the clone env
+            deleteDir()
+            checkout scm
 
             stage('Allocate Node'){
                 env.CICO_API_KEY = readFile("${env.HOME}/duffy.key").trim()
@@ -27,17 +35,27 @@ node('odo') {
                 env.SSID=duffy_rtn[1]
                 env.CLONE_DIR = 'go/src/github.com/redhat-developer/odo'
             }
-    
+
             try{
                 stage('Pre Setup Node'){
                     onmyduffynode '''yum -y install git wget gcc docker &&
                     wget https://dl.google.com/go/go1.11.2.linux-amd64.tar.gz &&
-                    tar -C /usr/local -xzf go1.11.2.linux-amd64.tar.gz'''
+                    tar -C /usr/local -xzf go1.11.2.linux-amd64.tar.gz &&
+                    mkdir -p ${CLONE_DIR}
+                    '''
+                }
+
+                stage('copying the source') {
+                    sh 'pwd && ls -la'
+                    syncrepotoworker()
                 }
     
-                stage('git clone Tests') {
-                    onmyduffynode '''git clone --single-branch --branch master --depth 1 "https://github.com/redhat-developer/odo.git" ${CLONE_DIR} && 
-                    cd  ${CLONE_DIR} && ls -la'''
+                stage('git repo Tests') {
+                    onmyduffynode '''pwd&& 
+                    cd  ${CLONE_DIR} &&
+                    git branch &&
+                    ls -la
+                    '''
                 }
    
                 stage('Build binary') {
@@ -67,7 +85,7 @@ node('odo') {
                         echo "----------finished-provisioning-cluster-----------"
                         '''
                 }
- 
+/* 
                 timeout(20) {
                     stage('Main e2e Test') {
                         onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
@@ -96,7 +114,7 @@ node('odo') {
                         '''
                     }
                 }
-
+*/ /*
                 timeout(20) {
                     stage('Java e2e tests') {
                         onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
@@ -136,7 +154,7 @@ node('odo') {
                         '''
                     }
                 }
-
+*/ /*
                 timeout(20) {
                     stage('Link e2e tests') {
                         onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
@@ -149,8 +167,8 @@ node('odo') {
                         '''
                     }
                 }
-
-            }catch (e){
+*/
+            } catch (e){
                 currentBuild.result = "FAILED"
                 throw e 
             } finally {

--- a/.cico.pipeline
+++ b/.cico.pipeline
@@ -1,0 +1,200 @@
+def onmyduffynode(script){
+    ansiColor('xterm'){
+        timestamps{
+            sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root ${DUFFY_NODE}.ci.centos.org -t \"export REPO=${git_url}; export BRANCH=${ghprbActualCommit};\""' + script + '"'
+        }
+    }
+}
+
+def syncfromduffynode(rsyncpath){
+    sh 'rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root " -Ha --include=' +  rsyncpath +  " ${DUFFY_NODE}.ci.centos.org:~/ ./"
+}
+
+def notifyBuild(String buildStatus = 'STARTED') {
+    buildStatus =  buildStatus ?: 'SUCCESSFUL'
+    emailext attachmentsPattern: 'odo/*.log', body: "See: ${env.BUILD_URL}", subject: "[${env.JOB_NAME}] Build #${env.BUILD_NUMBER}: ${buildStatus}", to: 'sgk@redhat.com'
+}
+
+node('odo') {
+
+            stage('Allocate Node'){
+                env.CICO_API_KEY = readFile("${env.HOME}/duffy.key").trim()
+                duffy_rtn=sh(
+                    script: 'cico --debug node get -f value -c hostname -c comment',
+                    returnStdout: true
+                    ).trim().tokenize(' ')
+                env.DUFFY_NODE=duffy_rtn[0]
+                env.SSID=duffy_rtn[1]
+                env.CLONE_DIR = 'go/src/github.com/redhat-developer/odo'
+            }
+    
+            try{
+                stage('Pre Setup Node'){
+                    onmyduffynode '''yum -y install git wget gcc docker &&
+                    wget https://dl.google.com/go/go1.11.2.linux-amd64.tar.gz &&
+                    tar -C /usr/local -xzf go1.11.2.linux-amd64.tar.gz'''
+                }
+    
+                stage('git clone Tests') {
+                    onmyduffynode '''git clone --single-branch --branch master --depth 1 "https://github.com/redhat-developer/odo.git" ${CLONE_DIR} && 
+                    cd  ${CLONE_DIR} && ls -la'''
+                }
+    
+                stage('Build binary') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin:/root/go/bin &&
+                        go version &&
+                        cd ${CLONE_DIR} && 
+                        make goget-tools &&
+                        make cross &&
+                        tar -cvzf odo-linux-amd64.tar.gz -C dist/bin/linux-amd64 . &&
+                        tar -cvzf odo-linux-arm.tar.gz -C dist/bin/linux-arm . &&
+                        tar -cvzf odo-darwin-amd64.tar.gz -C dist/bin/darwin-amd64 . &&
+                        tar -cvzf odo-windows-amd64.tar.gz -C dist/bin/windows-amd64 . &&
+                        ls -la
+                        '''
+                }
+    
+                stage('Unit Test') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make test |& tee unit_test.log'''
+                }
+
+                timeout(20) {
+                    stage('Main e2e Test') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make &&
+                        cp odo /usr/local/go/bin &&
+                        git branch && 
+                        rpm --query centos-release &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh &&
+                        echo "----------finished-provisioning-cluster-----------" &&
+                        odo version &&
+                        oc whoami &&
+                        make test-main-e2e &&
+                        minishift delete -f 
+                        '''
+                    }
+                }
+
+                timeout(20) {
+                    stage('Component e2e tests') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make &&
+                        cp odo /usr/local/go/bin &&
+                        git checkout cico-test && 
+                        rpm --query centos-release &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh &&
+                        echo "----------finished-provisioning-cluster-----------" &&
+                        odo version &&
+                        oc whoami &&
+                        make test-cmp-e2e &&
+                        minishift delete -f 
+                        '''
+                    }
+                }
+
+                timeout(20) {
+                    stage('Java e2e tests') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make &&
+                        cp odo /usr/local/go/bin &&
+                        git checkout cico-test && 
+                        rpm --query centos-release &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh &&
+                        echo "----------finished-provisioning-cluster-----------" &&
+                        odo version &&
+                        oc whoami &&
+                        make test-java-e2e &&
+                        minishift delete -f 
+                        '''
+                    }
+                }
+
+                timeout(20) {
+                    stage('Source e2e tests') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make &&
+                        cp odo /usr/local/go/bin &&
+                        git checkout cico-test && 
+                        rpm --query centos-release &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh service-catalog  &&
+                        echo "----------finished-provisioning-cluster-----------" &&
+                        odo version &&
+                        make test-source-e2e &&
+                        minishift delete -f 
+                        '''
+                    }
+                }
+
+                timeout(20) {
+                    stage('Service-Catalog e2e tests') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make &&
+                        cp odo /usr/local/go/bin &&
+                        git checkout cico-test && 
+                        rpm --query centos-release &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh service-catalog  &&
+                        echo "----------finished-provisioning-cluster-----------" &&
+                        odo version &&
+                        make test-service-e2e &&
+                        minishift delete -f 
+                        '''
+                    }
+                }
+
+                timeout(20) {
+                    stage('Link e2e tests') {
+                        onmyduffynode '''export PATH=$PATH:/usr/local/go/bin &&
+                        cd ${CLONE_DIR} &&
+                        make &&
+                        cp odo /usr/local/go/bin &&
+                        git checkout cico-test && 
+                        rpm --query centos-release &&
+                        echo "----------starting-cluster-provision-----------" &&
+                        ./scripts/minishift-setup.sh service-catalog  &&
+                        echo "----------finished-provisioning-cluster-----------" &&
+                        odo version &&
+                        make test-service-e2e &&
+                        minishift delete -f 
+                        '''
+                    }
+                }
+
+            }catch (e){
+                currentBuild.result = "FAILED"
+                throw e 
+            } finally {
+                try {
+                    stage('Archive the Logs and binary'){
+                        syncfromduffynode('${CLONE_DIR}/*.log')
+                        syncfromduffynode('${CLONE_DIR}/odo')
+                    }
+                    stage('Archive Artifacts'){
+                        archiveArtifacts artifacts: 'go/src/github.com/redhat-developer/odo/*.log'
+                        archiveArtifacts artifacts: 'go/src/github.com/redhat-developer/odo/*.tar.gz'
+                    }
+                } catch (e){
+                    currentBuild.result = "FAILED"
+                    throw e
+                } finally {
+                    stage('Deallocate Node'){
+                        sh 'cico node done ${SSID}'
+                    }
+                    stage('Notify Recipients'){
+                        notifyBuild(currentBuild.result)
+                    }
+                }
+            }
+}
+

--- a/scripts/minishift-setup.sh
+++ b/scripts/minishift-setup.sh
@@ -21,14 +21,14 @@ ssh-keyscan localhost >> ~/.ssh/known_hosts
 cat ~/.ssh/id_minishift_rsa.pub >> ~/.ssh/authorized_keys 
 
 ## download oc binaries
-sudo wget $OPENSHIFT_CLIENT_BINARY_URL -O /tmp/openshift-origin-client-tools.tar.gz 2> /dev/null > /dev/null
+sudo wget "$OPENSHIFT_CLIENT_BINARY_URL" -O /tmp/openshift-origin-client-tools.tar.gz 2> /dev/null > /dev/null
 
 sudo tar -xvzf /tmp/openshift-origin-client-tools.tar.gz --strip-components=1 -C /usr/local/bin
 ## Get oc version
 oc version
 
 ## download minishift binaries
-sudo wget $MINISHIFT_ARCHIVE_URL -O /tmp/minishift.tgz 2> /dev/null > /dev/null
+sudo wget "$MINISHIFT_ARCHIVE_URL" -O /tmp/minishift.tgz 2> /dev/null > /dev/null
 
 sudo tar -xvzf /tmp/minishift.tgz --strip-components=1 -C /usr/local/bin
 
@@ -36,8 +36,8 @@ sudo tar -xvzf /tmp/minishift.tgz --strip-components=1 -C /usr/local/bin
 minishift version
 
 if [ "$1" = "service-catalog" ]; then
-   MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --vm-driver generic --remote-ipaddress 127.0.0.1 --remote-ssh-user `whoami` --remote-ssh-key ~/.ssh/id_minishift_rsa --extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker" 
+    MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --vm-driver generic --remote-ipaddress "127.0.0.1" --remote-ssh-user $(whoami) --remote-ssh-key ~/.ssh/id_minishift_rsa --extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker" 
 else
-  minishift start --vm-driver generic --remote-ipaddress 127.0.0.1 --remote-ssh-user `whoami` --remote-ssh-key ~/.ssh/id_minishift_rsa
+    minishift start --vm-driver generic --remote-ipaddress "127.0.0.1" --remote-ssh-user $(whoami) --remote-ssh-key ~/.ssh/id_minishift_rsa
 fi  
 minishift status

--- a/scripts/minishift-setup.sh
+++ b/scripts/minishift-setup.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+OPENSHIFT_CLIENT_BINARY_URL=${OPENSHIFT_CLIENT_BINARY_URL:-'https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'}
+MINISHIFT_ARCHIVE_URL=${MINISHIFT_ARCHIVE_URL:-'https://github.com/minishift/minishift/releases/download/v1.30.0/minishift-1.30.0-linux-amd64.tgz'}
+
+ssh-keygen -t rsa -N "" -f ~/.ssh/id_minishift_rsa
+ls ~/.ssh/
+
+# minishift hack https://github.com/minishift/minishift-centos-iso/blob/master/centos-7.template#L83
+touch /etc/rhsm/ca/redhat-uep.pem
+
+sudo systemctl stop docker
+sudo systemctl start docker
+sudo systemctl status docker
+
+sudo systemctl stop firewalld
+sudo systemctl start firewalld
+sudo systemctl status firewalld
+ssh-keyscan localhost >> ~/.ssh/known_hosts
+# adding minishift key to authorized_keys 
+cat ~/.ssh/id_minishift_rsa.pub >> ~/.ssh/authorized_keys 
+
+## download oc binaries
+sudo wget $OPENSHIFT_CLIENT_BINARY_URL -O /tmp/openshift-origin-client-tools.tar.gz 2> /dev/null > /dev/null
+
+sudo tar -xvzf /tmp/openshift-origin-client-tools.tar.gz --strip-components=1 -C /usr/local/bin
+## Get oc version
+oc version
+
+## download minishift binaries
+sudo wget $MINISHIFT_ARCHIVE_URL -O /tmp/minishift.tgz 2> /dev/null > /dev/null
+
+sudo tar -xvzf /tmp/minishift.tgz --strip-components=1 -C /usr/local/bin
+
+## Get minishift version
+minishift version
+
+if [ "$1" = "service-catalog" ]; then
+   MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --vm-driver generic --remote-ipaddress 127.0.0.1 --remote-ssh-user `whoami` --remote-ssh-key ~/.ssh/id_minishift_rsa --extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker" 
+else
+  minishift start --vm-driver generic --remote-ipaddress 127.0.0.1 --remote-ssh-user `whoami` --remote-ssh-key ~/.ssh/id_minishift_rsa
+fi  
+minishift status


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Adding ci.centos jenkinsfile and script to bring up minishift cluster
## Was the change discussed in an issue?
fixes #952 

## How to test changes?
<!-- Please describe the steps to test the PR -->
validate the scripts by compairing with the cico-test branch ones

This will currently do builds only on changes to master, since we are blocked on how to fetch the pr number from the webhook post on jenkins side and consume on jenkinsfile (.cico.pipeline)
