### PR TITLE
Pin the openjdk18 image version we are using in our e2e tests

### DIFF
--- a/tests/e2e/java_test.go
+++ b/tests/e2e/java_test.go
@@ -192,6 +192,6 @@ var _ = Describe("odoJavaE2e", func() {
 
 func importOpenJDKImage() {
 	// we need to import the openjdk image which is used for jars because it's not available by default
-	runCmd("oc import-image openjdk18 --from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift --confirm")
+	runCmd("oc import-image openjdk18 --from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.5 --confirm")
 	runCmd("oc annotate istag/openjdk18:latest tags=builder --overwrite")
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
This is needed because it seems like the latest 1.6 version has broken
the binary builds (see https://issues.jboss.org/browse/SB-1172 for a
similar issue).
Note that version 1.6 of the builder image was released yesterday which coincides with the timing when our builds started to break

## Was the change discussed in an issue?
No, but it should fix the e2e test issues we have been having with java

## How to test changes?
CI should pass
