### PR TITLE
Removes unnecessary newlines / outputs

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -170,14 +170,14 @@ func Errorf(format string, a ...interface{}) {
 // Error will output in an appropriate "progress" manner
 func Error(a ...interface{}) {
 	red := color.New(color.FgRed).SprintFunc()
-	fmt.Fprintf(os.Stderr, " %s%s%s\n", red("✗"), suffixSpacing, fmt.Sprintln(a...))
+	fmt.Fprintf(os.Stderr, "%s%s%s%s", prefixSpacing, red("✗"), suffixSpacing, fmt.Sprintln(a...))
 }
 
 // Info will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Info(a ...interface{}) {
 	bold := color.New(color.Bold).SprintFunc()
-	fmt.Printf("%s\n", bold(fmt.Sprintln(a...)))
+	fmt.Printf("%s", bold(fmt.Sprintln(a...)))
 }
 
 // Infof will simply print out information on a new (bolded) line

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -427,7 +427,7 @@ func (co *CreateOptions) Run() (err error) {
 	}
 
 	if !co.wait {
-		log.Info("This may take few moments to be ready")
+		log.Info("This may take a few moments to be ready")
 	}
 
 	return

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -24,7 +24,7 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 		if context == "" {
 			log.Error(errors.Cause(err))
 		} else {
-			log.Errorf(fmt.Sprintf("%s\n", context), a...)
+			log.Errorf(fmt.Sprintf("%s", context), a...)
 		}
 		os.Exit(1)
 	}

--- a/tests/e2e/java_test.go
+++ b/tests/e2e/java_test.go
@@ -38,7 +38,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 			// Deploy the git repo / wildfly example
 			cmpCreateLog := runCmdShouldPass("odo create wildfly javaee-git-test --git " + warGitRepo + " -w")
-			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take few moments to be ready"))
+			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take a few moments to be ready"))
 			buildName := runCmdShouldPass("oc get builds --output='name' | grep javaee-git-test | cut -d '/' -f 2")
 			Expect(buildName).To(ContainSubstring("javaee-git-test"))
 			buildStatus := runCmdShouldPass("oc get build " + buildName)
@@ -65,7 +65,7 @@ var _ = Describe("odoJavaE2e", func() {
 		It("Should be able to deploy a git repo that contains a wildfly application without wait flag", func() {
 			// Deploy the git repo / wildfly example
 			cmpCreateLog := runCmdShouldPass("odo create wildfly wo-wait-javaee-git-test --git " + warGitRepo)
-			Expect(cmpCreateLog).Should(ContainSubstring("This may take few moments to be ready"))
+			Expect(cmpCreateLog).Should(ContainSubstring("This may take a few moments to be ready"))
 			buildName := runCmdShouldPass("oc get builds --output='name' | grep wo-wait-javaee-git-test | cut -d '/' -f 2")
 			Expect(buildName).To(ContainSubstring("wo-wait-javaee-git-test"))
 
@@ -104,7 +104,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 		It("Should be able to deploy a .war file using wildfly", func() {
 			cmpCreateLog := runCmdShouldPass("odo create wildfly javaee-war-test --binary " + javaFiles + "/wildfly/ROOT.war -w")
-			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take few moments to be ready"))
+			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take a few moments to be ready"))
 			dcName := runCmdShouldPass("oc get dc | grep javaee-war-test| cut -f 1 -d ' '")
 			// Following the logs
 			runCmdShouldPass("oc logs --version=1 dc/" + dcName)
@@ -132,7 +132,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 			// Deploy the git repo / wildfly example
 			cmpCreateLog := runCmdShouldPass("odo create openjdk18 uberjar-git-test --git " + jarGitRepo + " -w")
-			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take few moments to be ready"))
+			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take a few moments to be ready"))
 			buildName := runCmdShouldPass("oc get builds --output='name' | grep uberjar-git-test | cut -d '/' -f 2")
 			Expect(buildName).To(ContainSubstring("uberjar-git-test"))
 			buildStatus := runCmdShouldPass("oc get build " + buildName)
@@ -160,7 +160,7 @@ var _ = Describe("odoJavaE2e", func() {
 			importOpenJDKImage()
 
 			cmpCreateLog := runCmdShouldPass("odo create openjdk18 sb-jar-test --binary " + javaFiles + "/openjdk/sb.jar -w")
-			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take few moments to be ready"))
+			Expect(cmpCreateLog).ShouldNot(ContainSubstring("This may take a few moments to be ready"))
 
 			dcName := runCmdShouldPass("oc get dc | grep sb-jar-test| cut -f 1 -d ' '")
 			Expect(dcName).To(ContainSubstring("sb-jar-test"))


### PR DESCRIPTION
Removes all unnecessary newlines that were added, this was caused by not
accounting `Sprintln` (which includes a newline...)

Changes:

```sh
github.com/redhat-developer/odo  remove-newline-error ✗                                                                                                                                                                                                                   1d ⚑  ⍉
▶ ./odo create nodejs
 ✗  unable to get current application

github.com/redhat-developer/odo  remove-newline-error ✗                                                                                                                                                                                                                   1d ⚑  ⍉
▶ make bin
go build -ldflags="-w -X github.com/redhat-developer/odo/pkg/odo/cli/version.GITCOMMIT=57603295" -o odo cmd/odo/odo.go

github.com/redhat-developer/odo  remove-newline-error ✗                                                                                                                                                                                                                    1d ⚑
▶ ./odo create nodejs
 ✗  unable to get current application
```

As well as for other output messages:

```sh
github.com/redhat-developer/odo  remove-newline-error ✗                                                                                                                                                                                                                    1d ✚
▶ ./odo push
Pushing changes to component: odo-nodejs-pjfp
 ✓  Waiting for pod to start
 ✓  Copying files to component
 ◐  Building component ✗  Unable to build files
+ set -eo pipefail
+ '[' '!' -z /opt/app-root/src ']'
+ '[' /tmp '!=' /opt/app-root/src ']'
+ '[' /opt/app-root/src '!=' /opt/app-root/src ']'
+ '[' -f /tmp/src/.s2i/bin/assemble ']'
+ '[' -n /usr/libexec/s2i ']'
+ rm -rf /opt/app-root/src/.git
+ /usr/libexec/s2i/assemble
---> Installing application source
---> Building your Node application from source
Current git config
url.https://github.com.insteadof=git@github.com:
url.https://.insteadof=ssh://
url.https://github.com.insteadof=ssh://git@github.com
core.repositoryformatversion=0
core.filemode=true
core.bare=false
core.logallrefupdates=true
remote.origin.url=git@github.com:cdrage/odo.git
remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*
branch.namespace-components.remote=origin
branch.namespace-components.merge=refs/heads/namespace-components
branch.add-logs.remote=origin
branch.add-logs.merge=refs/heads/add-logs
remote.upstream.url=git@github.com:redhat-developer/odo.git
remote.upstream.fetch=+refs/heads/*:refs/remotes/upstream/*
branch.gh-pages.remote=upstream
branch.gh-pages.merge=refs/heads/gh-pages
travis.slug=cdrage/odo
---> Installing dependencies
internal/modules/cjs/loader.js:582
    throw err;
    ^

Error: Cannot find module './package.json'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.Module._load (internal/modules/cjs/loader.js:506:25)
    at Module.require (internal/modules/cjs/loader.js:636:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at [eval]:1:13
    at Script.runInThisContext (vm.js:96:20)
    at Object.runInThisContext (vm.js:303:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at evalScript (internal/bootstrap/node.js:582:27)

 ✗  Building component
 ✗  command terminated with exit code 1
```