### PR TITLE
Allow to ovewrite SupervisorD bootrapping image using env variable

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -98,8 +98,11 @@ const (
 	// The length of the string to be generated for names of resources
 	nameLength = 5
 
-	// Image that will be used containing the supervisord binary and assembly scripts
-	bootstrapperImage = "quay.io/openshiftdo/supervisord:0.6.0"
+	// Default Image that will be used containing the supervisord binary and assembly scripts
+	// use getBoostrapperImage() function instead of this variable
+	defaultBootstrapperImage = "quay.io/openshiftdo/supervisord:0.6.0"
+	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
+	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"
 
 	// Create a custom name and (hope) that users don't use the *exact* same name in their deployment
 	supervisordVolumeName = "odo-supervisord-shared-data"
@@ -197,6 +200,13 @@ type Client struct {
 	userClient           userclientset.UserV1Interface
 	KubeConfig           clientcmd.ClientConfig
 	Namespace            string
+}
+
+func getBootstrapperImage() string {
+	if env, ok := os.LookupEnv(bootstrapperImageEnvName); ok {
+		return env
+	}
+	return defaultBootstrapperImage
 }
 
 // New creates a new client

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -304,7 +304,7 @@ func addBootstrapSupervisordInitContainer(dc *appsv1.DeploymentConfig, dcName st
 	dc.Spec.Template.Spec.InitContainers = append(dc.Spec.Template.Spec.InitContainers,
 		corev1.Container{
 			Name:  "copy-supervisord",
-			Image: bootstrapperImage,
+			Image: getBootstrapperImage(),
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      supervisordVolumeName,


### PR DESCRIPTION
ODO_BOOTSTRAPPER_IMAGE overwrites default initContainer image for
SupervisorD bootstrapping. This is especially helpful for debugging and
testing new initContainer images.

## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
fixes #???
<!-- Please do Link issues here. -->

## How to test changes?
```
ODO_BOOTSTRAPPER_IMAGE=quay.io/myrepo/myimage:test odo create nodejs test
```

This will create a new component and use `quay.io/myrepo/myimage:test` as initContainer for bootstrapping SupervisorD (https://github.com/redhat-developer/odo-supervisord-image/blob/master/assemble-and-restart)