### PR TITLE
resolved the incorrect PHONY in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ else
 endif
 
 # Run login e2e tests
-.PHONY: test-odologin-e2e
+.PHONY: test-odo-login-e2e
 test-odo-login-e2e:
 ifdef TIMEOUT
 	go test -v github.com/redhat-developer/odo/tests/e2e --ginkgo.focus="odoLoginE2e" -ginkgo.succinct -timeout $(TIMEOUT)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
resolved the incorrect PHONY in make file for `test-odo-login-e2e`

## Was the change discussed in an issue?
No issue
## How to test changes?
doesn't change the behavior