### PR TITLE
Add wait flag to service create

### DIFF
--- a/tests/e2e/service_test.go
+++ b/tests/e2e/service_test.go
@@ -13,7 +13,7 @@ var _ = Describe("odoServiceE2e", func() {
 
 	Context("odo service creation", func() {
 		It("should be able to create a service", func() {
-			runCmd("odo service create mysql-persistent")
+			runCmd("odo service create mysql-persistent -w")
 			waitForCmdOut("oc get serviceinstance -o name", 1, func(output string) bool {
 				return strings.Contains(output, "mysql-persistent")
 			})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Add wait flag to service create and also use spinners to display progress

## Was the change discussed in an issue?
Fixes: #1144, #1063

## How to test changes?
Both
`odo service create mongodb-ephemeral --plan default -p MONGODB_VERSION=3.2`

and 

`odo service create mongodb-ephemeral --plan default -p MONGODB_VERSION=3.2 -w` should work with the latter waiting for the service to come up fully
