### PR TITLE
Use ui.Proceed instead of log.AskF

### DIFF
--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -5,11 +5,11 @@ import (
 	"github.com/redhat-developer/odo/pkg/application"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cli/project"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-	"strings"
 )
 
 const deleteRecommendedCommandName = "delete"
@@ -55,15 +55,7 @@ func (o *DeleteOptions) Run() (err error) {
 		return err
 	}
 
-	var confirmDeletion string
-	if o.force {
-		confirmDeletion = "y"
-	} else {
-		log.Askf("Are you sure you want to delete the application: %v from project: %v? [y/N]: ", o.appName, o.Project)
-		fmt.Scanln(&confirmDeletion)
-	}
-
-	if strings.ToLower(confirmDeletion) == "y" {
+	if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, o.Project)) {
 		err = application.Delete(o.Client, o.appName)
 		if err != nil {
 			return err

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 	"github.com/redhat-developer/odo/pkg/odo/cli/component/ui"
+	commonui "github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"io"
 	"os"
 	"strings"
@@ -251,11 +252,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		}
 		co.CreateArgs.Name = ui.EnterComponentName(defaultComponentName, co.Context)
 
-		if ui.Proceed("Do you wish to set advanced options") {
+		if commonui.Proceed("Do you wish to set advanced options") {
 			co.CreateArgs.Ports = ui.EnterPorts()
 			co.CreateArgs.EnvVars = ui.EnterEnvVars()
 
-			if ui.Proceed("Do you wish to set resource limits") {
+			if commonui.Proceed("Do you wish to set resource limits") {
 				memMax := ui.EnterMemory("maximum", "512Mi")
 				memMin := ui.EnterMemory("minimum", memMax)
 				cpuMax := ui.EnterCPU("maximum", "1")
@@ -274,7 +275,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			}
 		}
 
-		co.CreateArgs.Wait = ui.Proceed("Would you wish to wait until the component is fully ready after after creation")
+		co.CreateArgs.Wait = commonui.Proceed("Would you wish to wait until the component is fully ready after after creation")
 		// needed in order to avoid showing a misleading message at the end of process
 		co.wait = co.CreateArgs.Wait
 

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -163,18 +163,6 @@ func enterGitRef(defaultRef string) string {
 	return path
 }
 
-// Proceed displays a given message and asks the user if they want to proceed
-func Proceed(message string) bool {
-	var response bool
-	prompt := &survey.Confirm{
-		Message: message,
-	}
-	err := survey.AskOne(prompt, &response, survey.Required)
-	ui.HandleError(err)
-
-	return response
-}
-
 // EnterPorts allows the user to specify the ports to be used in a prompt
 func EnterPorts() []string {
 	var portsStr string

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -2,9 +2,8 @@ package project
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/project"
 	"github.com/spf13/cobra"
@@ -27,7 +26,6 @@ var (
 
 // ProjectDeleteOptions encapsulates the options for the odo project delete command
 type ProjectDeleteOptions struct {
-
 	// name of the project
 	projectName string
 
@@ -62,15 +60,7 @@ func (pdo *ProjectDeleteOptions) Validate() (err error) {
 
 // Run runs the project delete command
 func (pdo *ProjectDeleteOptions) Run() (err error) {
-	var confirmDeletion string
-	if pdo.projectForceDeleteFlag {
-		confirmDeletion = "y"
-	} else {
-		log.Askf("Are you sure you want to delete project %v? [y/N]: ", pdo.projectName)
-		fmt.Scanln(&confirmDeletion)
-	}
-
-	if strings.ToLower(confirmDeletion) != "y" {
+	if pdo.projectForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete project %v", pdo.projectName)) {
 		return fmt.Errorf("Aborting deletion of project: %v", pdo.projectName)
 	}
 

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -61,24 +61,23 @@ func (pdo *ProjectDeleteOptions) Validate() (err error) {
 // Run runs the project delete command
 func (pdo *ProjectDeleteOptions) Run() (err error) {
 	if pdo.projectForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete project %v", pdo.projectName)) {
-		return fmt.Errorf("Aborting deletion of project: %v", pdo.projectName)
+		currentProject, err := project.Delete(pdo.Context.Client, pdo.projectName)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Deleted project : %v", pdo.projectName)
+
+		if currentProject != "" {
+			log.Infof("%s has been set as the active project\n", currentProject)
+		} else {
+			// oc errors out as "error: you do not have rights to view project "$deleted_project"."
+			log.Infof("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command")
+		}
+		return
 	}
 
-	currentProject, err := project.Delete(pdo.Context.Client, pdo.projectName)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Deleted project : %v", pdo.projectName)
-
-	if currentProject != "" {
-		log.Infof("%s has been set as the active project\n", currentProject)
-	} else {
-		// oc errors out as "error: you do not have rights to view project "$deleted_project"."
-		log.Infof("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command")
-	}
-
-	return
+	return fmt.Errorf("Aborting deletion of project: %v", pdo.projectName)
 }
 
 // NewCmdProjectDelete creates the project delete command

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -74,7 +74,7 @@ func (pdo *ProjectDeleteOptions) Run() (err error) {
 			// oc errors out as "error: you do not have rights to view project "$deleted_project"."
 			log.Infof("You are not a member of any projects. You can request a project to be created using the `odo project create <project_name>` command")
 		}
-		return
+		return nil
 	}
 
 	return fmt.Errorf("Aborting deletion of project: %v", pdo.projectName)

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/pkg/errors"
+	commonui "github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/util/validation"
 	"strings"
 	"text/template"
@@ -110,7 +111,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 
 		o.ParametersMap = ui.EnterServicePropertiesInteractively(svcPlan)
 		o.ServiceName = ui.EnterServiceNameInteractively(o.ServiceType, "How should we name your service ", o.validateServiceName)
-		o.outputCLI = ui.ShouldOutputNonInteractiveEquivalent()
+		o.outputCLI = commonui.Proceed("Output the non-interactive version of the selected options")
 	} else {
 		o.ServiceType = args[0]
 		// if only one arg is given, then it is considered as service name and service type both

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"strings"
 
 	"github.com/golang/glog"
@@ -58,14 +59,7 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service delete command
 func (o *ServiceDeleteOptions) Run() (err error) {
-	var confirmDeletion string
-	if o.serviceForceDeleteFlag {
-		confirmDeletion = "y"
-	} else {
-		log.Askf("Are you sure you want to delete %v from %v? [y/N] ", o.serviceName, o.Application)
-		_, _ = fmt.Scanln(&confirmDeletion)
-	}
-	if strings.ToLower(confirmDeletion) == "y" {
+	if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v from %v", o.serviceName, o.Application)) {
 		err = svc.DeleteServiceAndUnlinkComponents(o.Client, o.serviceName, o.Application)
 		if err != nil {
 			return fmt.Errorf("unable to delete service %s:\n%v", o.serviceName, err)

--- a/pkg/odo/cli/service/ui/ui.go
+++ b/pkg/odo/cli/service/ui/ui.go
@@ -264,7 +264,7 @@ func enterServicePropertiesInteractively(svcPlan scv1beta1.ClusterServicePlan, s
 	}
 
 	// finally check if we still have plan properties that have not been considered
-	if len(properties) > 0 && ui.Proceed("Provide values for non-required properties") {
+	if len(properties) > 0 && ui.Proceed("Provide values for non-required properties", stdio...) {
 		for _, prop := range properties {
 			addValueFor(prop, values, stdio...)
 		}

--- a/pkg/odo/cli/service/ui/ui.go
+++ b/pkg/odo/cli/service/ui/ui.go
@@ -97,19 +97,6 @@ func EnterServiceNameInteractively(defaultValue, promptText string, validateName
 	return serviceName
 }
 
-// ShouldOutputNonInteractiveEquivalent asks the user if they want to output the equivalent non-interactive command line version
-// of the interactively entered options
-func ShouldOutputNonInteractiveEquivalent() bool {
-	outputCLI := false
-	confirm := &survey.Confirm{
-		Message: "Output the non-interactive version of the selected options",
-	}
-
-	err := survey.AskOne(confirm, &outputCLI, survey.Required)
-	ui.HandleError(err)
-	return outputCLI
-}
-
 // SelectClassInteractively lets the user select target service class from possible options, first filtering by categories then
 // by class name
 func SelectClassInteractively(classesByCategory map[string][]scv1beta1.ClusterServiceClass) (class scv1beta1.ClusterServiceClass, serviceType string) {
@@ -277,23 +264,9 @@ func enterServicePropertiesInteractively(svcPlan scv1beta1.ClusterServicePlan, s
 	}
 
 	// finally check if we still have plan properties that have not been considered
-	if len(properties) > 0 {
-		fillOptionalProps := false
-		confirm := &survey.Confirm{
-			Message: "Provide values for non-required properties",
-		}
-
-		if len(stdio) == 1 {
-			confirm.WithStdio(stdio[0])
-		}
-
-		err := survey.AskOne(confirm, &fillOptionalProps, survey.Required)
-		ui.HandleError(err)
-		if fillOptionalProps {
-
-			for _, prop := range properties {
-				addValueFor(prop, values, stdio...)
-			}
+	if len(properties) > 0 && ui.Proceed("Provide values for non-required properties") {
+		for _, prop := range properties {
+			addValueFor(prop, values, stdio...)
 		}
 	}
 

--- a/pkg/odo/cli/ui/common.go
+++ b/pkg/odo/cli/ui/common.go
@@ -24,3 +24,21 @@ func HandleError(err error) {
 func GetValidatorFor(prop validation.Validatable) survey.Validator {
 	return survey.Validator(validation.GetValidatorFor(prop))
 }
+
+// Proceed displays a given message and asks the user if they want to proceed using the optionally specified Stdio instance (useful
+// for testing purposes)
+func Proceed(message string, stdio ...terminal.Stdio) bool {
+	var response bool
+	prompt := &survey.Confirm{
+		Message: message,
+	}
+
+	if len(stdio) == 1 {
+		prompt.WithStdio(stdio[0])
+	}
+
+	err := survey.AskOne(prompt, &response, survey.Required)
+	HandleError(err)
+
+	return response
+}

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -2,9 +2,8 @@ package url
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/redhat-developer/odo/pkg/url"
@@ -57,15 +56,7 @@ func (o *URLDeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo url delete command
 func (o *URLDeleteOptions) Run() (err error) {
-	var confirmDeletion string
-	if o.urlForceDeleteFlag {
-		confirmDeletion = "y"
-	} else {
-		log.Askf("Are you sure you want to delete the url %v? [y/N]: ", o.urlName)
-		fmt.Scanln(&confirmDeletion)
-	}
-
-	if strings.ToLower(confirmDeletion) == "y" {
+	if o.urlForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the url %v", o.urlName)) {
 
 		err = url.Delete(o.Client, o.urlName, o.Application)
 		if err != nil {

--- a/pkg/odo/cli/utils/config/set.go
+++ b/pkg/odo/cli/utils/config/set.go
@@ -2,11 +2,11 @@ package config
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/config"
-	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
@@ -78,12 +78,9 @@ func (o *SetOptions) Run() (err error) {
 	}
 
 	if !o.configForceFlag {
-		var confirmOveride string
 		if value, ok := cfg.GetConfiguration(o.paramName); ok && (value != nil) {
 			fmt.Printf("%v is already set. Current value is %v.\n", o.paramName, value)
-			log.Askf("Do you want to override it in the config? y/N ")
-			fmt.Scanln(&confirmOveride)
-			if confirmOveride != "y" {
+			if ui.Proceed("Do you want to override it in the config") {
 				fmt.Println("Aborted by the user.")
 				return nil
 			}

--- a/pkg/odo/cli/utils/config/unset.go
+++ b/pkg/odo/cli/utils/config/unset.go
@@ -2,11 +2,11 @@ package config
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/config"
-	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -77,14 +77,9 @@ func (o *UnsetOptions) Run() (err error) {
 	}
 
 	if value, ok := cfg.GetConfiguration(o.paramName); ok && (value != nil) {
-		if !o.configForceFlag {
-			var confirmOveride string
-			log.Askf("Do you want to unset %s in the config? y/N ", o.paramName)
-			fmt.Scanln(&confirmOveride)
-			if confirmOveride != "y" {
-				fmt.Println("Aborted by the user.")
-				return nil
-			}
+		if !o.configForceFlag && !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the config", o.paramName)) {
+			fmt.Println("Aborted by the user.")
+			return nil
 		}
 		err = cfg.DeleteConfiguration(strings.ToLower(o.paramName))
 		if err != nil {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Adding interactive mode to commands has brought along a library that provides UI elements to ask questions to users. It makes sense to use these elements where we ask the user for confirmation. This simplifies client code and makes sure the experience is consistent across commands.

## Was the change discussed in an issue?
No.

## How to test changes?
Any of the `delete` (`app`, `component`, etc.) commands that ask for confirmation should still work as before, though the UI might be a little different.
