### PR TITLE
Rationalize the use of --wait for link/unlink

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -270,7 +270,7 @@ func CreateFromPath(client *occlient.Client, params occlient.CreateArgs) error {
 		}
 
 		podSelector := fmt.Sprintf("deploymentconfig=%s", selectorLabels)
-		_, err = client.WaitAndGetPod(podSelector)
+		_, err = client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
 		if err != nil {
 			return err
 		}
@@ -440,7 +440,7 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 	podSelector := fmt.Sprintf("deploymentconfig=%s", dc.Name)
 
 	// Wait for Pod to be in running state otherwise we can't sync data to it.
-	pod, err := client.WaitAndGetPod(podSelector)
+	pod, err := client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
 	if err != nil {
 		return errors.Wrapf(err, "error while waiting for pod  %s", podSelector)
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2657,7 +2657,7 @@ func TestWaitAndGetPod(t *testing.T) {
 			})
 
 			podSelector := fmt.Sprintf("deploymentconfig=%s", tt.podName)
-			pod, err := fkclient.WaitAndGetPod(podSelector)
+			pod, err := fkclient.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
 
 			if !tt.wantErr == (err != nil) {
 				t.Errorf(" client.WaitAndGetPod(string) unexpected error %v, wantErr %v", err, tt.wantErr)

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -66,7 +66,7 @@ DB_PASSWORD=secret`
 
 // LinkOptions encapsulates the options for the odo link command
 type LinkOptions struct {
-	wait bool
+	waitForTarget bool
 	*commonLinkOptions
 }
 
@@ -86,7 +86,7 @@ func (o *LinkOptions) Complete(name string, cmd *cobra.Command, args []string) (
 
 // Validate validates the LinkOptions based on completed values
 func (o *LinkOptions) Validate() (err error) {
-	err = o.validate(o.wait)
+	err = o.validate(o.waitForTarget)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,8 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	}
 
 	linkCmd.PersistentFlags().StringVar(&o.port, "port", "", "Port of the backend to which to link")
-	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled, the link command will wait for the service to be provisioned")
+	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
+	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 
 	// Add a defined annotation in order to appear in the help menu
 	linkCmd.Annotations = map[string]string{"command": "component"}

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -82,7 +82,7 @@ func NewCmdUnlink(name, fullName string) *cobra.Command {
 	}
 
 	unlinkCmd.PersistentFlags().StringVar(&o.port, "port", "", "Port of the backend to which to unlink")
-	unlinkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
+	unlinkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is deleted")
 
 	// Add a defined annotation in order to appear in the help menu
 	unlinkCmd.Annotations = map[string]string{"command": "component"}

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -82,6 +82,7 @@ func NewCmdUnlink(name, fullName string) *cobra.Command {
 	}
 
 	unlinkCmd.PersistentFlags().StringVar(&o.port, "port", "", "Port of the backend to which to unlink")
+	unlinkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 
 	// Add a defined annotation in order to appear in the help menu
 	unlinkCmd.Annotations = map[string]string{"command": "component"}

--- a/tests/e2e/link_test.go
+++ b/tests/e2e/link_test.go
@@ -74,7 +74,7 @@ var _ = Describe("odoLinkE2e", func() {
 		})
 
 		It("should link backend to service", func() {
-			runCmdShouldPass("odo link mysql-persistent -w --component backend")
+			runCmdShouldPass("odo link mysql-persistent --wait-for-target --component backend")
 
 			// ensure that the proper envFrom entry was created
 			envFromOutput :=

--- a/tests/e2e/service_test.go
+++ b/tests/e2e/service_test.go
@@ -60,7 +60,7 @@ var _ = Describe("odoServiceE2e", func() {
 			})
 
 			It("Should be able to link the spring boot application to the postgresql DB", func() {
-				runCmdShouldPass("odo link dh-postgresql-apb -w")
+				runCmdShouldPass("odo link dh-postgresql-apb -w --wait-for-target")
 
 				waitForCmdOut("odo service list | sed 1d", 1, func(output string) bool {
 					return strings.Contains(output, "dh-postgresql-apb") &&


### PR DESCRIPTION
We now:
* Re-purpose `wait` to enforce waiting for the pod being updated to be
in running state (meaning that is can be immediately used by
other tools)
* Introduce `wait-for-target` that would do what wait does currently

## Was the change discussed in an issue?
Fixes #1337 

## How to test changes?
When using link/unlink with the `-w` flag should no wait until the component has been redeployed.
If the flag is not specified, the command returns immediately.

The old `-w` flag is now `--wait-for-target`. Use it when linking to a service to have odo wait until the service has been fully provisioned.
