### PR TITLE
Make it possible to wait for service when creating one in interactive mode.

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -112,6 +112,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.ParametersMap = ui.EnterServicePropertiesInteractively(svcPlan)
 		o.ServiceName = ui.EnterServiceNameInteractively(o.ServiceType, "How should we name your service ", o.validateServiceName)
 		o.outputCLI = commonui.Proceed("Output the non-interactive version of the selected options")
+		o.wait = commonui.Proceed("Wait for the service to be ready")
 	} else {
 		o.ServiceType = args[0]
 		// if only one arg is given, then it is considered as service name and service type both


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See $SUBJECT.

## Was the change discussed in an issue?
No.

## How to test changes?
Create a service in interactive mode and answer `y` when asked if you want to wait for it to be ready and then check that the command actually waits for the service to be ready.
