### PR TITLE
Avoid use of odo core package in testsuite

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/redhat-developer/odo/pkg/config"
 )
 
 // TODO: A neater way to provide odo path. Currently we assume \
@@ -86,11 +84,11 @@ var _ = Describe("odoe2e", func() {
 	})
 
 	Context("odo utils config", func() {
-		It("should get blank for updatenotification by default globally as its not set", func() {
+		It("should get globally availaible default parameters", func() {
 			configOutput := runCmdShouldPass("odo utils config view --global")
-			Expect(configOutput).To(ContainSubstring(config.UpdateNotificationSetting))
-			Expect(configOutput).To(ContainSubstring(config.NamePrefixSetting))
-			Expect(configOutput).To(ContainSubstring(config.TimeoutSetting))
+			Expect(configOutput).To(ContainSubstring("UpdateNotification"))
+			Expect(configOutput).To(ContainSubstring("NamePrefix"))
+			Expect(configOutput).To(ContainSubstring("Timeout"))
 		})
 		It("should be checking to see if timeout is shown as blank globally as its not set", func() {
 			configOutput := runCmdShouldPass("odo utils config view --global|grep Timeout")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Odo core package should not be the part of test suite as it brings dependency in test and more importantly user specific scenario will be compromised. 

## Was the change discussed in an issue?
No
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-main-e2e
