### PR TITLE
Fix #1359: properly detect improper plan.

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2285,12 +2285,6 @@ func (c *Client) GetMatchingPlans(class scv1beta1.ClusterServiceClass) (plans ma
 	return plans, err
 }
 
-// DoesPlanExist checks whether a plan with the specified name exists
-func (c *Client) DoesPlanExist(planName string) (bool, error) {
-	plan, e := c.serviceCatalogClient.ClusterServicePlans().Get(planName, metav1.GetOptions{})
-	return plan != nil, e
-}
-
 // GetClusterServiceClassExternalNamesAndPlans returns the names of all the cluster service
 // classes in the cluster
 func (c *Client) GetClusterServiceClassExternalNamesAndPlans() ([]Service, error) {

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -4971,19 +4971,3 @@ func TestGetMatchingPlans(t *testing.T) {
 		}
 	})
 }
-
-func TestDoesPlanExist(t *testing.T) {
-	name := "foo"
-	client, fakeClientSet := FakeNew()
-	fakeClientSet.ServiceCatalogClientSet.PrependReactor("get", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		if name != action.(ktesting.GetAction).GetName() {
-			t.Errorf("should have have attempted to get service plan '%s'", name)
-		}
-		plan := testingutil.FakeClusterServicePlan(name, 1)
-		return true, &plan, nil
-	})
-
-	if ok, _ := client.DoesPlanExist(name); !ok {
-		t.Error("test failed")
-	}
-}


### PR DESCRIPTION
Remove non-working DoesPlanExist and use GetMatchingPlans instead.

## What is the purpose of this change? What does it change?
See $SUBJECT

## Was the change discussed in an issue?
fixes #1359 

## How to test changes?
See #1359 for failing scenario
