### PR TITLE
Fix #1329: Add wait flag to wait for project to be ready.

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -477,7 +477,7 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 	}
 
 	if wait {
-		w, err := c.kubeClient.CoreV1().Namespaces().Watch(metav1.ListOptions{
+		w, err := c.projectClient.Projects().Watch(metav1.ListOptions{
 			FieldSelector: fields.Set{"metadata.name": projectName}.AsSelector().String(),
 		})
 		if err != nil {
@@ -490,7 +490,7 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 			if !ok {
 				break
 			}
-			if e, ok := val.Object.(*corev1.Namespace); ok {
+			if e, ok := val.Object.(*projectv1.Project); ok {
 				glog.V(4).Infof("Project %s now exists", e.Name)
 				return nil
 			}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2747,11 +2747,19 @@ func TestCreateNewProject(t *testing.T) {
 	tests := []struct {
 		name     string
 		projName string
+		wait     bool
 		wantErr  bool
 	}{
 		{
-			name:     "Case 1: valid project name",
+			name:     "Case 1: valid project name, not waiting",
 			projName: "testing",
+			wait:     false,
+			wantErr:  false,
+		},
+		{
+			name:     "Case 2: valid project name, waiting",
+			projName: "testing2",
+			wait:     true,
 			wantErr:  false,
 		},
 
@@ -2767,6 +2775,24 @@ func TestCreateNewProject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fkclient, fkclientset := FakeNew()
 
+			if tt.wait {
+				fkWatch := watch.NewFake()
+				// Change the status
+				go func() {
+					fkWatch.Modify(&projectv1.Project{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tt.projName,
+						},
+					})
+				}()
+				fkclientset.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+					if len(tt.projName) == 0 {
+						return true, nil, fmt.Errorf("error watching project")
+					}
+					return true, fkWatch, nil
+				})
+			}
+
 			fkclientset.ProjClientset.PrependReactor("create", "projectrequests", func(action ktesting.Action) (bool, runtime.Object, error) {
 				proj := projectv1.Project{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2776,20 +2802,34 @@ func TestCreateNewProject(t *testing.T) {
 				return true, &proj, nil
 			})
 
-			err := fkclient.CreateNewProject(tt.projName, false)
+			err := fkclient.CreateNewProject(tt.projName, tt.wait)
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("client.CreateNewProject(string) unexpected error %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if len(fkclientset.ProjClientset.Actions()) != 1 {
-				t.Errorf("expected 1 action in CreateNewProject got: %v", fkclientset.ProjClientset.Actions())
+			actions := fkclientset.ProjClientset.Actions()
+			actionsNb := len(actions)
+			if !tt.wait && actionsNb != 1 {
+				t.Errorf("expected 1 action in CreateNewProject got: %v", actions)
+			}
+			if tt.wait && actionsNb != 2 {
+				t.Errorf("expected 2 actions in CreateNewProject when waiting for project creation got: %v", actions)
 			}
 
 			if err == nil {
-				createdProj := fkclientset.ProjClientset.Actions()[0].(ktesting.CreateAction).GetObject().(*projectv1.ProjectRequest)
+				createdProj := actions[0].(ktesting.CreateAction).GetObject().(*projectv1.ProjectRequest)
 
 				if createdProj.Name != tt.projName {
 					t.Errorf("project name does not match the expected name, expected: %s, got: %s", tt.projName, createdProj.Name)
+				}
+
+				if tt.wait {
+					expectedFields := fields.OneTermEqualSelector("metadata.name", tt.projName)
+					gotFields := actions[1].(ktesting.WatchAction).GetWatchRestrictions().Fields
+
+					if !reflect.DeepEqual(expectedFields, gotFields) {
+						t.Errorf("Fields not matching: expected: %s, got %s", expectedFields, gotFields)
+					}
 				}
 			}
 

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2776,7 +2776,7 @@ func TestCreateNewProject(t *testing.T) {
 				return true, &proj, nil
 			})
 
-			err := fkclient.CreateNewProject(tt.projName)
+			err := fkclient.CreateNewProject(tt.projName, false)
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("client.CreateNewProject(string) unexpected error %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -46,8 +46,8 @@ func SetCurrent(client *occlient.Client, projectName string) error {
 	return nil
 }
 
-func Create(client *occlient.Client, projectName string) error {
-	err := client.CreateNewProject(projectName)
+func Create(client *occlient.Client, projectName string, wait bool) error {
+	err := client.CreateNewProject(projectName, wait)
 	if err != nil {
 		return errors.Wrap(err, "unable to create new project")
 	}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See $SUBJECT.

## Was the change discussed in an issue?
fixes #1329

## How to test changes?
See #1329 for failing scenario that should now be fixed by adding the `-w` flag to the `project create` command to wait for the project to be created before returning.
