### PR TITLE
Update help outputs

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -90,7 +90,6 @@ var createExample = ktemplates.Examples(`  # Create new Node.js component with t
 # Create new Node.js git component while specifying a tag
 %[1]s nodejs --git https://github.com/openshift/nodejs-ex.git --ref v1.0.1
 
-
 # Create a new Node.js component of version 6 from the 'openshift' namespace
 %[1]s openshift/nodejs:6 --local /nodejs-ex
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -2,7 +2,9 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 
 	"github.com/pkg/errors"
 	appCmd "github.com/redhat-developer/odo/pkg/odo/cli/application"
@@ -26,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var pushCmdExample = `  # Push source code to the current component
+var pushCmdExample = ktemplates.Examples(`  # Push source code to the current component
 %[1]s
 
 # Push data to the current component from the original source.
@@ -34,7 +36,7 @@ var pushCmdExample = `  # Push source code to the current component
 
 # Push source code in ~/mycode to component called my-component
 %[1]s my-component --local ~/mycode
-  `
+  `)
 
 // PushRecommendedCommandName is the recommended push command name
 const PushRecommendedCommandName = "push"


### PR DESCRIPTION
Updates the help outputs for `odo push` as well as `odo create` (newline
by mistake) in order to make it clearer.

Closes https://github.com/redhat-developer/odo/issues/1398