### PR TITLE
Remove terminal specific command from e2e component test file

### DIFF
--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -87,7 +87,8 @@ func componentTests(componentCmdPrefix string) {
 			runCmdShouldPass(fmt.Sprintf("odo url create ref-test-%s", t))
 
 			routeURL := determineRouteURL() + "/health"
-			waitForEqualCmd("curl -s "+routeURL+" | grep 'develop' | wc -l | tr -d '\n'", "1", 10)
+			responseStringMatchStatus := matchResponseSubString(routeURL, "develop", 90, 1)
+			Expect(responseStringMatchStatus).Should(BeTrue())
 		})
 
 		It("should be able to create a component with git source", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Update the test file to run it on all oc supported platform including windows
## Was the change discussed in an issue?
fixes Part of #1129
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-cmp-e2e
make test-cmp-sub-e2e