### PR TITLE
add -o json for delete cmds

### DIFF
--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -31,13 +31,12 @@ var deleteExample = ktemplates.Examples(`  # Delete component named 'frontend'.
 // DeleteOptions is a container to attach complete, validate and run pattern
 type DeleteOptions struct {
 	componentForceDeleteFlag bool
-	outputFormat             string
 	*ComponentOptions
 }
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, "", &ComponentOptions{}}
+	return &DeleteOptions{false, &ComponentOptions{}}
 }
 
 // Complete completes log args

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -34,9 +34,6 @@ type ProjectDeleteOptions struct {
 	// force delete doesn't ask the user for confirmation
 	projectForceDeleteFlag bool
 
-	// json formatted output
-	outputFormat string
-
 	// generic context options common to all commands
 	*genericclioptions.Context
 }

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -27,7 +27,6 @@ var (
 type URLDeleteOptions struct {
 	urlName            string
 	urlForceDeleteFlag bool
-	outputFormat       string
 	*genericclioptions.Context
 }
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
add -o json option for delete commands

## Was the change discussed in an issue?

https://github.com/redhat-developer/odo/issues/1383

## How to test changes?
run below commands with `-o json` option and validate it works as defined in the issue #1383 
```
    odo component delete
    odo project delete
    odo storage delete 
    odo url delete

```