### PR TITLE
Adding way to get around resolution of user.Current().in randomuid environments

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -177,6 +177,7 @@ func (c *Client) GetImageStreams(namespace string) ([]imagev1.ImageStream, error
 
   You can see the entire test function `TestGetImageStream` in [pkg/occlient/occlient_test.go](https://github.com/redhat-developer/odo/blob/master/pkg/occlient/occlient_test.go)
 
+**NOTE**: You can use environment variable CUSTOM_HOMEDIR to specify a custom home directory. It can be used in environments where a user and home directory are not resolveable.
 
 ## Integration tests
 

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -451,7 +451,7 @@ func TestGetDefaultComponentName(t *testing.T) {
 				testingutil.ConfigDetails{
 					FileName:      "odo-test-config",
 					Config:        testingutil.FakeOdoConfig("odo-test-config", false, ""),
-					ConfigPathEnv: "ODOCONFIG",
+					ConfigPathEnv: "GLOBALODOCONFIG",
 				}, testingutil.ConfigDetails{
 					FileName:      "kube-test-config",
 					Config:        testingutil.FakeKubeClientConfig(),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,10 @@ const (
 	DefaultTimeout = 1
 )
 
+// This value can be provided to set a seperate directory for users 'homedir' resolution
+// note for mocking purpose ONLY
+var customHomeDir = os.Getenv("CUSTOM_HOMEDIR")
+
 // Info is implemented by configuration managers
 type Info interface {
 	SetConfiguration(parameter string, value string) error
@@ -110,6 +114,10 @@ type LocalConfigInfo struct {
 func getGlobalConfigFile() (string, error) {
 	if env, ok := os.LookupEnv(globalConfigEnvName); ok {
 		return env, nil
+	}
+
+	if len(customHomeDir) != 0 {
+		return filepath.Join(customHomeDir, ".odo", configFileName), nil
 	}
 
 	currentUser, err := user.Current()

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -35,7 +35,7 @@ func TestDelete(t *testing.T) {
 		testingutil.ConfigDetails{
 			FileName:      "odo-test-config",
 			Config:        testingutil.FakeOdoConfig("odo-test-config", false, ""),
-			ConfigPathEnv: "ODOCONFIG",
+			ConfigPathEnv: "GLOBALODOCONFIG",
 		}, testingutil.ConfigDetails{
 			FileName:      "kube-test-config",
 			Config:        testingutil.FakeKubeClientConfig(),

--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -14,6 +14,10 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// This value can be provided to set a seperate directory for users 'homedir' resolution
+// note for mocking purpose ONLY
+var customHomeDir = os.Getenv("CUSTOM_HOMEDIR")
+
 // ConfigDetails struct holds configuration details(odo and/or kube config)
 type ConfigDetails struct {
 	FileName      string
@@ -23,11 +27,19 @@ type ConfigDetails struct {
 
 // getConfFolder generates a mock config folder for the unit testing
 func getConfFolder() (string, error) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return "", err
+	var confLocation string
+	// If custom home dir is set, skip checking for user.Current to place config
+	if len(customHomeDir) != 0 {
+		confLocation = customHomeDir
+	} else {
+		currentUser, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		confLocation = currentUser.HomeDir
 	}
-	dir, err := ioutil.TempDir(currentUser.HomeDir, ".odo")
+
+	dir, err := ioutil.TempDir(confLocation, ".odo")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/testingutil/configs_test.go
+++ b/pkg/testingutil/configs_test.go
@@ -1,0 +1,45 @@
+package testingutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestCustomHomeDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		wanterr bool
+	}{
+		{
+			name:    "Test if specifying customDir results in appropriate resolution of config dir",
+			wanterr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldCustomHomeDir := customHomeDir
+			var err error
+			customHomeDir, err = ioutil.TempDir("", "testconf")
+			if err != nil {
+				t.Error(err.Error())
+			}
+			odoConfigFile, kubeConfigFile, err := SetUp(
+				ConfigDetails{
+					FileName:      "odo-test-config",
+					Config:        FakeOdoConfig("odo-test-config", false, ""),
+					ConfigPathEnv: "GLOBALODOCONFIG",
+				}, ConfigDetails{
+					FileName:      "kube-test-config",
+					Config:        FakeKubeClientConfig(),
+					ConfigPathEnv: "KUBECONFIG",
+				},
+			)
+			defer CleanupEnv([]*os.File{odoConfigFile, kubeConfigFile}, t)
+			if err != nil {
+				t.Errorf("failed to create mock odo and kube config files. Error %v", err)
+			}
+			customHomeDir = oldCustomHomeDir
+		})
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,9 +2,7 @@ package util
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
-	corev1 "k8s.io/api/core/v1"
 	"net/url"
 	"os"
 	"os/user"
@@ -12,6 +10,9 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNamespaceOpenShiftObject(t *testing.T) {
@@ -507,12 +508,17 @@ func TestGetAbsPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			switch tt.path {
 			case "~":
-				usr, err := user.Current()
-				if err != nil {
-					t.Errorf("Failed to get absolute path corresponding to `~`. Error %v", err)
-					return
+				if len(customHomeDir) > 0 {
+					tt.absPath = customHomeDir
+				} else {
+					usr, err := user.Current()
+					if err != nil {
+						t.Errorf("Failed to get absolute path corresponding to `~`. Error %v", err)
+						return
+					}
+					tt.absPath = usr.HomeDir
 				}
-				tt.absPath = usr.HomeDir
+
 			case ".":
 				absPath, err := os.Getwd()
 				if err != nil {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This is needed for getting UTs to run on OpenShift CI where
we login to build root as randomUID

## Was the change discussed in an issue?
 #1411
<!-- Please do Link issues here. -->


Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>