### PR TITLE
added type meta in config and preference structs

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -102,7 +102,7 @@ func TestSetLocalConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfig()
+			cfg, err := NewLocalConfigInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -196,7 +196,7 @@ func TestLocalUnsetConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfig()
+			cfg, err := NewLocalConfigInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -242,11 +242,22 @@ func TestLocalConfigInitDoesntCreateLocalOdoFolder(t *testing.T) {
 	}
 	os.RemoveAll(filename)
 
-	conf, err := NewLocalConfig()
+	conf, err := NewLocalConfigInfo()
 	if err != nil {
 		t.Errorf("error while creating local config %v", err)
 	}
 	if _, err = os.Stat(conf.Filename); !os.IsNotExist(err) {
 		t.Errorf("local config.yaml shouldn't exist yet")
+	}
+}
+
+func TestMetaTypePopulatedInLocalConfig(t *testing.T) {
+	ci, err := NewLocalConfigInfo()
+
+	if err != nil {
+		t.Error(err)
+	}
+	if ci.APIVersion != localConfigAPIVersion || ci.Kind != localConfigKind {
+		t.Error("the api version and kind in local config are incorrect")
 	}
 }

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfi, err := NewPreference()
+			cfi, err := NewPreferenceInfo()
 			switch test.success {
 			case true:
 				if err != nil {
@@ -220,7 +220,7 @@ func TestSetActiveComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -458,7 +458,7 @@ func TestSetActiveApplication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -649,7 +649,7 @@ func TestAddApplication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -902,7 +902,7 @@ func TestDeleteApplication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -970,7 +970,7 @@ func TestGetTimeout(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -1114,7 +1114,7 @@ func TestDeleteProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -1262,7 +1262,7 @@ func TestSetConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewPreference()
+			cfg, err := NewPreferenceInfo()
 			if err != nil {
 				t.Error(err)
 			}
@@ -1428,5 +1428,16 @@ func TestIsSupportedParameter(t *testing.T) {
 				t.Fail()
 			}
 		})
+	}
+}
+
+func TestMetaTypePopulatedInPreference(t *testing.T) {
+	pi, err := NewPreferenceInfo()
+
+	if err != nil {
+		t.Error(err)
+	}
+	if pi.APIVersion != preferenceAPIVersion || pi.Kind != preferenceKind {
+		t.Error("the api version and kind in preference are incorrect")
 	}
 }

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -29,7 +29,7 @@ func TestNew(t *testing.T) {
 			name: "Test filename is being set",
 			output: &PreferenceInfo{
 				Filename:   tempConfigFile.Name(),
-				Preference: Preference{},
+				Preference: NewPreference(),
 			},
 			success: true,
 		},
@@ -75,7 +75,7 @@ func TestSetActiveComponent(t *testing.T) {
 	}{
 		{
 			name:           "activeComponents nil",
-			existingConfig: Preference{},
+			existingConfig: NewPreference(),
 			component:      "foo",
 			project:        "bar",
 			application:    "app",


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
added a `metav1.TypeMeta` in the `LocalConfig` and `Preference` struct

## Was the change discussed in an issue?
fixes https://github.com/redhat-developer/odo/issues/1365
<!-- Please do Link issues here. -->

## How to test changes?
```
# run
odo preference set timeout 20
# check the ~/.odo/config.yaml for Kind and ApiVersion

# run
odo config set memory 500MiB
# check the <current-dir>/.odo/config.yaml for Kind and ApiVersion

```
