### PR TITLE
List all sub-commands within odo help

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/redhat-developer/odo/pkg/odo/cli/application"
 	"github.com/redhat-developer/odo/pkg/odo/cli/catalog"
@@ -117,5 +118,37 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 		version.NewCmdVersion(version.RecommendedCommandName, util.GetFullName(fullName, version.RecommendedCommandName)),
 	)
 
+	utils.VisitCommands(rootCmd, reconfigureCmdWithSubcmd)
+
 	return rootCmd
+}
+
+// reconfigureCmdWithSubcmd ...
+func reconfigureCmdWithSubcmd(cmd *cobra.Command) {
+	if len(cmd.Commands()) == 0 {
+		return
+	}
+
+	if cmd.Args == nil {
+		cmd.Args = cobra.ArbitraryArgs
+	}
+	if cmd.RunE == nil {
+		cmd.RunE = ShowSubcommands
+	}
+
+	var strs []string
+	for _, subcmd := range cmd.Commands() {
+		strs = append(strs, strings.Split(subcmd.Use, " ")[0])
+	}
+
+	cmd.Short += " (" + strings.Join(strs, ", ") + ")"
+}
+
+// ShowSubcommands ...
+func ShowSubcommands(cmd *cobra.Command, args []string) error {
+	var strs []string
+	for _, subcmd := range cmd.Commands() {
+		strs = append(strs, subcmd.Use)
+	}
+	return fmt.Errorf("Use one of available subcommands: %s", strings.Join(strs, ", "))
 }

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -52,7 +52,7 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 	// componentCmd represents the component command
 	var componentCmd = &cobra.Command{
 		Use:   name,
-		Short: "Components of application.",
+		Short: "Components of an application",
 		Example: fmt.Sprintf("%s\n%s\n\n  See sub-commands individually for more examples, e.g. %s %s -h",
 			componentGetCmd.Example,
 			componentSetCmd.Example,

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -60,8 +60,8 @@ func NewCmdLog(name, fullName string) *cobra.Command {
 
 	var logCmd = &cobra.Command{
 		Use:     fmt.Sprintf("%s [component_name]", name),
-		Short:   "Retrieve the log for the given component.",
-		Long:    `Retrieve the log for the given component.`,
+		Short:   "Retrieve the log for the given component",
+		Long:    `Retrieve the log for the given component`,
 		Example: fmt.Sprintf(logExample, fullName),
 		Args:    cobra.RangeArgs(0, 1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -31,3 +31,11 @@ func NewCmdUtils(name, fullName string) *cobra.Command {
 	utilsCmd.AddCommand(configurationCmd, terminalCmd)
 	return utilsCmd
 }
+
+// VisitCommands ...
+func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
+	f(cmd)
+	for _, child := range cmd.Commands() {
+		VisitCommands(child, f)
+	}
+}


### PR DESCRIPTION
This PR changes the following help page to list all the sub-commands of
each "root" command. For example:

```sh
Other Commands:
  app         Perform application operations (create, delete, describe, get, list, set)
  catalog     Catalog related operations (describe, list, search)
  project     Perform project operations (create, delete, get, list, set)
  service     Perform service catalog operations (create, delete, list)
  storage     Perform storage operations (create, delete, list, mount, unmount)
  url         Expose component to the outside world (create, delete, list)
```

Closes https://github.com/redhat-developer/odo/issues/1257