### PR TITLE
Add notes with regards to listing subcommands.

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -127,7 +127,9 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 	return rootCmd
 }
 
-// reconfigureCmdWithSubcmd ...
+// reconfigureCmdWithSubcmd reconfigures each root command with a list of all subcommands and lists them
+// beside the help output
+// Adapted from: https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cmd/knctl.go#L224
 func reconfigureCmdWithSubcmd(cmd *cobra.Command) {
 	if len(cmd.Commands()) == 0 {
 		return
@@ -148,7 +150,8 @@ func reconfigureCmdWithSubcmd(cmd *cobra.Command) {
 	cmd.Short += " (" + strings.Join(strs, ", ") + ")"
 }
 
-// ShowSubcommands ...
+// ShowSubcommands shows all available subcommands.
+// Adapted from: https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cmd/knctl.go#L224
 func ShowSubcommands(cmd *cobra.Command, args []string) error {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -28,7 +28,8 @@ func NewCmdUtils(name, fullName string) *cobra.Command {
 	return utilsCmd
 }
 
-// VisitCommands ...
+// VisitCommands visits each command within Cobra.
+// Adapted from: https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cobrautil/misc.go#L23
 func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
 	f(cmd)
 	for _, child := range cmd.Commands() {


### PR DESCRIPTION
This code was used from `knctl`:

https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cmd/knctl.go#L183

and

https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cmd/knctl.go#L170

I had forgotten to add comments on the previous PR (had just `...` under
the comments).

This adds some source information to the code.