### PR TITLE
Fixing username as per e2e_test file

### DIFF
--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -12,7 +12,7 @@ KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_D
 export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
 
 # List of users to create
-USERS="developer odonoprojectattemptscreateproject odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
+USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
 
 # Attempt resolution of kubeadmin, only if a CI is set
 if [ -z $CI ]; then


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
To run e2e_test on OpenShift 4.0. Just update the user name which is being used in e2e_test.go as a login user.

## Was the change discussed in an issue?
No
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
As of now make sure the user name "odonoprojectattemptscreate" should be present in e2e_test.go test file.