### PR TITLE
Updating re to run e2e_test on 4.0 cluster

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -388,8 +388,8 @@ var _ = Describe("odoe2e", func() {
 				runCmdShouldPass("odo create " + curProj + "/nodejs nodejs --local " + tmpDir + "/nodejs-ex")
 				runCmdShouldPass("odo push")
 
-				// get the name of the pod
-				podName := getPodNameOfComp("nodejs")
+				// get the name of running pod
+				podName := getRunningPodNameOfComp("nodejs")
 
 				// verify that the views folder got pushed
 				runCmdShouldPass("oc exec " + podName + " -- ls -lai /opt/app-root/src | grep views")
@@ -408,8 +408,8 @@ var _ = Describe("odoe2e", func() {
 				runCmdShouldPass("odo create " + curProj + "/nodejs push-odoignore-flag-example --local " + tmpDir + "/nodejs-ex")
 				runCmdShouldPass("odo push --ignore tests/,README.md")
 
-				// get the name of the pod
-				podName := getPodNameOfComp("push-odoignore-flag-example")
+				// get the name of running pod
+				podName := getRunningPodNameOfComp("push-odoignore-flag-example")
 
 				// verify that the views folder got pushed
 				runCmdShouldPass("oc exec " + podName + " -- ls -lai /opt/app-root/src | grep views")
@@ -802,7 +802,7 @@ var _ = Describe("odoe2e", func() {
 
 		It("should show server login URL", func() {
 			odoVersion := runCmdShouldPass("odo version")
-			reServerURL := regexp.MustCompile(`Server:\s*https:\/\/([0-9]+.){3}[0-9]+:8443`)
+			reServerURL := regexp.MustCompile(`Server:\s*https:\/\/(.+\.com|([0-9]+.){3}[0-9]+):[0-9]{4}`)
 			serverURLStringMatch := reServerURL.MatchString(odoVersion)
 			Expect(serverURLStringMatch).Should(BeTrue())
 		})

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -174,14 +174,14 @@ func matchResponseSubString(url, match string, retry, sleep int) bool {
 	return false
 }
 
-// This function executes oc command and returns pod name of a delopyed component by passing
-// component name as a argument
-func getPodNameOfComp(compName string) string {
+// This function executes oc command and returns the running pod name of a delopyed
+// component by passing component name as a argument
+func getRunningPodNameOfComp(compName string) string {
 	stdOut, stdErr, _ := cmdRunner("oc get pods")
 	if stdErr != "" {
 		return stdErr
 	}
-	re := regexp.MustCompile(compName + `-\S+`)
-	podName := re.FindString(stdOut)
+	re := regexp.MustCompile(`(` + compName + `-\S+)\s+\S+\s+Running`)
+	podName := re.FindStringSubmatch(stdOut)[1]
 	return strings.TrimSpace(podName)
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
To run the e2e_test file on OpenShift 4.0 cluster. re updated for few scenarios

## Was the change discussed in an issue?
Partly #1431
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Run ```test-main-e2e``` on OpenShift 4.0 cluster