### PR TITLE
Add -o json  flag to `odo app delete`  

### DIFF
--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -54,18 +54,21 @@ func (o *DeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo command
 func (o *DeleteOptions) Run() (err error) {
+	if o.OutputFlag == "json" {
+		err = application.Delete(o.Client, o.appName)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	// Print App Information which will be deleted
 	err = printDeleteAppInfo(o.Client, o.appName, o.Project)
 	if err != nil {
 		return err
 	}
 
-	if o.OutputFlag == "json" {
-		err = application.Delete(o.Client, o.appName)
-		if err != nil {
-			return err
-		}
-	} else if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, o.Project)) {
+	if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, o.Project)) {
 		err = application.Delete(o.Client, o.appName)
 		if err != nil {
 			return err

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
+	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -45,6 +46,9 @@ func (o *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string)
 
 // Validate validates the DeleteOptions based on completed values
 func (o *DeleteOptions) Validate() (err error) {
+	if !util.CheckOutputFlag(o.OutputFlag) {
+		return fmt.Errorf("given output format %s is not supported", o.OutputFlag)
+	}
 	return ensureAppExists(o.Client, o.appName, o.Project)
 }
 
@@ -56,7 +60,12 @@ func (o *DeleteOptions) Run() (err error) {
 		return err
 	}
 
-	if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, o.Project)) {
+	if o.OutputFlag == "json" {
+		err = application.Delete(o.Client, o.appName)
+		if err != nil {
+			return err
+		}
+	} else if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, o.Project)) {
 		err = application.Delete(o.Client, o.appName)
 		if err != nil {
 			return err
@@ -83,6 +92,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	}
 
 	command.Flags().BoolVarP(&o.force, "force", "f", false, "Delete application without prompting")
+	genericclioptions.AddOutputFlag(command)
 
 	project.AddProjectFlag(command)
 	completion.RegisterCommandHandler(command, completion.AppCompletionHandler)

--- a/tests/e2e/json_test.go
+++ b/tests/e2e/json_test.go
@@ -93,6 +93,14 @@ var _ = Describe("odojsonoutput", func() {
 			Expect(areEqual).To(BeTrue())
 
 		})
+
+		// odo app delete -o json
+		It("should be able to delete app", func() {
+			runCmdShouldPass("odo app create app-deletion-test")
+			// validating that it ran with exit status 0
+			runCmdShouldPass("odo app delete app-deletion-test -o json")
+		})
+
 		// cleanup
 		It("Cleanup", func() {
 			odoDeleteProject("json-test")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
adding -o json flag to `odo app delete`
## Was the change discussed in an issue?

<!-- Please do Link issues here. -->
https://github.com/redhat-developer/odo/issues/1383
## How to test changes?
<!-- Please describe the steps to test the PR -->
`odo app create myapp`
`odo app delete myapp -o json`
and check its exist code is 0 and not asking for user inputs 