### PR TITLE
remove GetConfiguration from config and preference

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,13 +21,6 @@ const (
 	localConfigAPIVersion = "odo.openshift.io/v1alpha1"
 )
 
-// Info is implemented by configuration managers
-type Info interface {
-	SetConfiguration(parameter string, value string) error
-	GetConfiguration(parameter string) (interface{}, bool)
-	DeleteConfiguration(parameter string) error
-}
-
 // ComponentSettings holds all component related information
 type ComponentSettings struct {
 
@@ -223,24 +216,20 @@ func (lci *LocalConfigInfo) SetConfiguration(parameter string, value interface{}
 
 }
 
-// GetConfiguration uses reflection to get the parameter from the localconfig struct, currently
+// IsSet uses reflection to get the parameter from the localconfig struct, currently
 // it only searches the componentSettings
-func (lci *LocalConfigInfo) GetConfiguration(parameter string) (interface{}, bool) {
+func (lci *LocalConfigInfo) IsSet(parameter string) bool {
 
 	switch strings.ToLower(parameter) {
 	case "cpu":
-		if lci.componentSettings.MinCPU == nil {
-			return nil, true
-		}
-		return *lci.componentSettings.MinCPU, true
+		return (lci.componentSettings.MinCPU != nil && lci.componentSettings.MaxCPU != nil) &&
+			(*lci.componentSettings.MinCPU == *lci.componentSettings.MaxCPU)
 	case "memory":
-		if lci.componentSettings.MinMemory == nil {
-			return nil, true
-		}
-		return *lci.componentSettings.MinMemory, true
+		return (lci.componentSettings.MinMemory != nil && lci.componentSettings.MaxMemory != nil) &&
+			(*lci.componentSettings.MinMemory == *lci.componentSettings.MaxMemory)
 	}
 
-	return util.GetConfiguration(lci.componentSettings, parameter)
+	return util.IsSet(lci.componentSettings, parameter)
 }
 
 // DeleteConfiguration is used to delete config from local odo config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,8 +18,6 @@ func TestSetLocalConfiguration(t *testing.T) {
 	}
 	defer tempConfigFile.Close()
 	os.Setenv(localConfigEnvName, tempConfigFile.Name())
-	trueValue := true
-	falseValue := false
 	minCPUValue := "0.5"
 	maxCPUValue := "2"
 	minMemValue := "500M"
@@ -30,7 +28,6 @@ func TestSetLocalConfiguration(t *testing.T) {
 		parameter      string
 		value          string
 		existingConfig LocalConfig
-		want           interface{}
 	}{
 		// update notification
 		{
@@ -38,66 +35,48 @@ func TestSetLocalConfiguration(t *testing.T) {
 			parameter: Ignore,
 			value:     "true",
 			existingConfig: LocalConfig{
-				componentSettings: ComponentSettings{
-					Ignore: &trueValue,
-				},
+				componentSettings: ComponentSettings{},
 			},
-			want: true,
 		},
 		{
 			name:      fmt.Sprintf("Case 2: %s set true to false", Ignore),
 			parameter: Ignore,
 			value:     "false",
 			existingConfig: LocalConfig{
-				componentSettings: ComponentSettings{
-					Ignore: &falseValue,
-				},
+				componentSettings: ComponentSettings{},
 			},
-			want: false,
 		},
 		{
 			name:      fmt.Sprintf("Case 3: %s to test", Name),
 			parameter: Name,
 			value:     testValue,
 			existingConfig: LocalConfig{
-				componentSettings: ComponentSettings{
-					Name: &testValue,
-				},
+				componentSettings: ComponentSettings{},
 			},
-			want: testValue,
 		},
 		{
 			name:      fmt.Sprintf("Case 5: %s set to %s from 0", MaxCPU, maxCPUValue),
 			parameter: MaxCPU,
 			value:     maxCPUValue,
 			existingConfig: LocalConfig{
-				componentSettings: ComponentSettings{
-					MaxCPU: &maxCPUValue,
-				},
+				componentSettings: ComponentSettings{},
 			},
-			want: maxCPUValue,
 		},
 		{
 			name:      fmt.Sprintf("Case 6: %s set to %s", MinCPU, minCPUValue),
 			parameter: MinCPU,
 			value:     minCPUValue,
 			existingConfig: LocalConfig{
-				componentSettings: ComponentSettings{
-					MinCPU: &minCPUValue,
-				},
+				componentSettings: ComponentSettings{},
 			},
-			want: minCPUValue,
 		},
 		{
 			name:      fmt.Sprintf("Case 6: %s set to %s", MinMemory, minMemValue),
 			parameter: MinMemory,
 			value:     minMemValue,
 			existingConfig: LocalConfig{
-				componentSettings: ComponentSettings{
-					MinMemory: &minMemValue,
-				},
+				componentSettings: ComponentSettings{},
 			},
-			want: minMemValue,
 		},
 	}
 	for _, tt := range tests {
@@ -113,10 +92,10 @@ func TestSetLocalConfiguration(t *testing.T) {
 				t.Error(err)
 			}
 
-			idata, _ := cfg.GetConfiguration(tt.parameter)
+			isSet := cfg.IsSet(tt.parameter)
 
-			if idata != tt.want {
-				t.Errorf("the '%v' is not set to '%v' instead its '%v'", tt.parameter, tt.want, idata)
+			if !isSet {
+				t.Errorf("the '%v' is not set", tt.parameter)
 			}
 
 		})
@@ -206,8 +185,8 @@ func TestLocalUnsetConfiguration(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			idata, ok := cfg.GetConfiguration(tt.parameter)
-			if (idata == nil) || !ok {
+			isSet := cfg.IsSet(tt.parameter)
+			if !isSet {
 				t.Errorf("the '%v' was not set", tt.parameter)
 			}
 
@@ -216,8 +195,8 @@ func TestLocalUnsetConfiguration(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			idata, ok = cfg.GetConfiguration(tt.parameter)
-			if (idata != nil) || !ok {
+			isSet = cfg.IsSet(tt.parameter)
+			if isSet {
 				t.Errorf("the '%v' is not set to nil", tt.parameter)
 			}
 

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -68,14 +67,11 @@ func (o *SetOptions) Run() (err error) {
 	}
 
 	if !o.configForceFlag {
-		if value, ok := cfg.GetConfiguration(o.paramName); ok && (value != nil) {
-			fmt.Printf("%v is already set. Current value is %v.\n", o.paramName, value)
-			if !ui.Proceed("Do you want to override it in the config") {
+		if isSet := cfg.IsSet(o.paramName); isSet {
+			if !ui.Proceed(fmt.Sprintf("%v is already set. Do you want to override it in the config", o.paramName)) {
 				fmt.Println("Aborted by the user.")
 				return nil
 			}
-		} else if !ok {
-			util.LogErrorAndExit(fmt.Errorf("'%s' is not a parameter in the odo config", o.paramName), "")
 		}
 	}
 

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -79,9 +79,8 @@ func (o *UnsetOptions) Run() (err error) {
 		fmt.Println("Local config was successfully updated.")
 
 		return nil
-	} else {
-		return errors.New("config already unset, cannot unset a configuration which is not set")
 	}
+	return errors.New("config already unset, cannot unset a configuration which is not set")
 
 }
 

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -66,7 +66,7 @@ func (o *UnsetOptions) Run() (err error) {
 		return errors.Wrapf(err, "")
 	}
 
-	if value, ok := cfg.GetConfiguration(o.paramName); ok && (value != nil) {
+	if isSet := cfg.IsSet(o.paramName); isSet {
 		if !o.configForceFlag && !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the config", o.paramName)) {
 			fmt.Println("Aborted by the user.")
 			return nil
@@ -79,11 +79,9 @@ func (o *UnsetOptions) Run() (err error) {
 		fmt.Println("Local config was successfully updated.")
 
 		return nil
-		// if its found but nil then show the error
-	} else if ok && (value == nil) {
+	} else {
 		return errors.New("config already unset, cannot unset a configuration which is not set")
 	}
-	return errors.New(o.paramName + " is not a valid configuration variable")
 
 }
 

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -64,14 +63,11 @@ func (o *SetOptions) Run() (err error) {
 	}
 
 	if !o.configForceFlag {
-		if value, ok := cfg.GetConfiguration(o.paramName); ok && (value != nil) {
-			log.Infof("%v is already set. Current value is %v.", o.paramName, value)
-			if !ui.Proceed("Do you want to override it in the config") {
+		if isSet := cfg.IsSet(o.paramName); isSet {
+			if !ui.Proceed("%v is already set. Do you want to override it in the config") {
 				log.Info("Aborted by the user.")
 				return nil
 			}
-		} else if !ok {
-			util.LogErrorAndExit(fmt.Errorf("'%s' is not a parameter in the odo config", o.paramName), "")
 		}
 	}
 

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -63,19 +63,14 @@ func (o *UnsetOptions) Run() (err error) {
 
 	if !o.preferenceForceFlag {
 
-		if value, ok := cfg.GetConfiguration(o.paramName); ok && (value != nil) {
+		if isSet := cfg.IsSet(o.paramName); isSet {
 			if !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the preference", o.paramName)) {
 				log.Infof("Aborted by the user.")
 				return nil
 			}
-			// if its found but nil then show the error
-		} else if ok && (value == nil) {
+		} else {
 			return errors.New("preference already unset, cannot unset a preference which is not set")
-			// if its not a parameter then show error
-		} else if !ok {
-			return errors.Errorf("unknown parameter :'%s' is not a parameter in the odo preference", o.paramName)
 		}
-
 	}
 
 	err = cfg.DeleteConfiguration(strings.ToLower(o.paramName))

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -207,10 +207,9 @@ func (c *PreferenceInfo) DeleteConfiguration(parameter string) error {
 	return nil
 }
 
-// GetConfiguration gets the value of the specified parameter, it returns false in
-// case the value is not part of the struct
-func (c *PreferenceInfo) GetConfiguration(parameter string) (interface{}, bool) {
-	return util.GetConfiguration(c.OdoSettings, parameter)
+// IsSet checks if the value is set in the preference
+func (c *PreferenceInfo) IsSet(parameter string) bool {
+	return util.IsSet(c.OdoSettings, parameter)
 }
 
 // GetTimeout returns the value of Timeout from config

--- a/pkg/util/config_util.go
+++ b/pkg/util/config_util.go
@@ -67,31 +67,6 @@ func WriteToFile(c interface{}, filename string) error {
 	return nil
 }
 
-// GetConfiguration uses reflection to get the parameter from a struct
-// using the name in a case insensitive manner
-// only supports flat structs
-// TODO: support deeper struct using recursion
-func GetConfiguration(info interface{}, parameter string) (interface{}, bool) {
-	imm := reflect.ValueOf(info)
-	if imm.Kind() == reflect.Ptr {
-		imm = imm.Elem()
-	}
-	val := imm.FieldByNameFunc(CaseInsensitive(parameter))
-	if !val.IsValid() {
-
-		return nil, false
-	}
-	if val.IsNil() {
-		return nil, true
-	}
-	// if the value is a Ptr then we need to de-ref it
-	if val.Kind() == reflect.Ptr {
-		return val.Elem().Interface(), true
-	}
-
-	return val.Interface(), true
-}
-
 // IsSet uses reflection to check if a parameter is set in a struct
 // using the name in a case insensitive manner
 // only supports flat structs

--- a/pkg/util/config_util.go
+++ b/pkg/util/config_util.go
@@ -92,6 +92,30 @@ func GetConfiguration(info interface{}, parameter string) (interface{}, bool) {
 	return val.Interface(), true
 }
 
+// IsSet uses reflection to check if a parameter is set in a struct
+// using the name in a case insensitive manner
+// only supports flat structs
+// TODO: support deeper struct using recursion
+func IsSet(info interface{}, parameter string) bool {
+	imm := reflect.ValueOf(info)
+	if imm.Kind() == reflect.Ptr {
+		imm = imm.Elem()
+	}
+	val := imm.FieldByNameFunc(CaseInsensitive(parameter))
+	if !val.IsValid() || val.IsNil() {
+		return false
+	}
+	if val.IsNil() {
+		return false
+	}
+	// if the value is a Ptr then we need to de-ref it
+	if val.Kind() == reflect.Ptr {
+		return true
+	}
+
+	return true
+}
+
 // CaseInsensitive returns a function which compares two words
 // caseinsensitively
 func CaseInsensitive(parameter string) func(word string) bool {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Removes the `GetConfiguration` method and adds `IsSet` method. Uses `IsSet` for checking if the config or preference is set or not.

## Was the change discussed in an issue?
No issue

## How to test changes?
check if `odo config` and `odo preference` work correctly
