### PR TITLE
Run component test on OpenShift 4.0 cluster

### DIFF
--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -174,7 +174,6 @@ func componentTests(componentCmdPrefix string) {
 			cmpList := runCmdShouldPass(componentCmdPrefix + " list")
 			Expect(cmpList).To(ContainSubstring("wildfly"))
 
-			runCmdShouldPass("oc get dc")
 		})
 
 		It("should update component from binary to binary", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
To run component test on OpenShift 4.0 cluster. Removes some terminal specific operation includes some unnecessary operation and most importantly **trim space** of output check which was failing on 4.0 cluster. 

## Was the change discussed in an issue?
No
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Run ```make test-cmp-e2e``` and ```make test-cmp-sub-e2e``` both on 3.11 and 4.0 cluster


