### PR TITLE
Install redis-operator for s390x

### DIFF
--- a/scripts/configure-cluster/common/setup-operators.sh
+++ b/scripts/configure-cluster/common/setup-operators.sh
@@ -19,6 +19,11 @@ EOF
 if [ $KUBERNETES == "true" ]; then
   # install "redis-oprator" using "kubectl" in "operators" namespace; use "operatorhubio-catalog" catalog source from "olm" namespace
   install_redis_operator kubectl operators operatorhubio-catalog olm
+elif [ $(uname -m) == "s390x" ]; then
+  # create "operator-ibm-catalog" CatalogSource for s390x
+  oc apply -f https://raw.githubusercontent.com/openshift/odo/main/website/manifests/catalog-source-$(uname -m).yaml
+  # install "redis-oprator" using "oc" in "openshift-operators" namespace; use "operator-ibm-catalog" catalog source from "openshift-marketplace" namespace
+  install_redis_operator oc openshift-operators operator-ibm-catalog openshift-marketplace
 else
   # install "redis-oprator" using "oc" in "openshift-operators" namespace; use "community-operators" catalog source from "openshift-marketplace" namespace
   install_redis_operator oc openshift-operators community-operators openshift-marketplace


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind feature
> Feel free to use other [labels](https://github.com/openshift/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.

**What does this PR do / why we need it**:

For Z(s390x),[ redis-operator-s390x image](https://quay.io/repository/ibm/redis-operator-s390x) and [operator-registry-s390x image](https://quay.io/repository/ibm/operator-registry-s390x) has been public on quay.io/ibm , now can use operator-registry-s390x image to create operator-ibm-catalog CatalogSource,  then use operator-ibm-catalog to install reds-operators on s390x.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
