### PR TITLE
Get CRD correctly

### DIFF
--- a/pkg/odo/cli/service/operator_backend.go
+++ b/pkg/odo/cli/service/operator_backend.go
@@ -121,7 +121,7 @@ func (b *OperatorBackend) ValidateServiceCreate(o *CreateOptions) error {
 			return fmt.Errorf("the %q resource doesn't exist in specified %q operator", b.CustomResource, b.group)
 		}
 
-		crd, err := o.KClient.GetCRDSpec(cr, b.group, b.CustomResource)
+		crd, err := o.KClient.GetCRDSpec(cr, b.group, b.kind)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`b.CustomResource` is an empty string since we removed the `GetCSV`
function in https://github.com/openshift/odo/pull/5107. Using `b.kind`
achieves the same.

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Fixes the `odo service create` failure we found in #5186.

**Which issue(s) this PR fixes**:

Fixes #5186

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
* Tests should pass. 
* `odo service create` command in quickstart should pass