### PR TITLE
[wip] Start container with go-init

### DIFF
--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -222,6 +222,6 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 // overrideContainerArgs overrides the container's entrypoint with supervisord
 func overrideContainerArgs(container *corev1.Container) {
 	klog.V(2).Infof("Updating container %v entrypoint with supervisord", container.Name)
-	container.Command = append(container.Command, adaptersCommon.SupervisordBinaryPath)
-	container.Args = append(container.Args, "-c", adaptersCommon.SupervisordConfFile)
+	container.Command = append(container.Command, "/opt/odo/bin/go-init")
+	container.Args = append(container.Args, "-main", adaptersCommon.SupervisordBinaryPath+" -c "+adaptersCommon.SupervisordConfFile)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

Fixes #5242 

**What does this PR do / why we need it**:

odo were starting containers with `go-init` using DeploymentConfigs, but is starting containers directly with `supervisord` using Deployments.

Starting containers with `go-init` is important to handle zombie processes on containers.

