### PR TITLE
Adds mapping support to odo link

### DIFF
--- a/docs/website/docs/command-reference/link.md
+++ b/docs/website/docs/command-reference/link.md
@@ -178,6 +178,17 @@ PostgresCluster/database     Yes (backend)      Pushed     2h5m43s
 $ odo link PostgresCluster/hippo --map pgVersion='{{ .database.spec.postgresVersion }}'
 ```
 
+After a link operation, do `odo push` as usual. Upon successful completion of push operation, you can run below command from your backend component directory to validate if custom mapping got injected properly:
+
+```shell
+odo exec -- env | grep pgVersion
+```
+Example output:
+```shell
+$ odo exec -- env | grep pgVersion
+pgVersion=13
+```
+
 ### To inline or not?
 
 You can stick to the default behaviour wherein `odo link` will generate a manifest file for the link under `kubernetes/` directory, or you could use `--inlined` flag if you prefer to store everything in a single `devfile.yaml` file. It doesn't matter what you use for this functionality of adding custom mappings.

--- a/docs/website/docs/command-reference/link.md
+++ b/docs/website/docs/command-reference/link.md
@@ -1,0 +1,183 @@
+---
+title: odo link
+sidebar_position: 4
+---
+
+`odo link` command helps link an odo component to an Operator backed service or another odo component. It does this by using [Service Binding Operator](https://github.com/redhat-developer/service-binding-operator). At the time of writing this, odo makes use of the Service Binding library and not the Operator itself to achieve the desired functionality.
+
+In this document we will cover various options to create link between a component & a service, and a component & another component. The steps in this document are going to be based on the [odo quickstart project](https://github.com/dharmit/odo-quickstart/) that we covered in [Quickstart guide](/docs/getting-started/quickstart). The outputs mentioned in this document are based on commands executed on [minikube cluster](/docs/getting-started/cluster-setup/kubernetes).
+
+This document assumes that you know how to [create components](/docs/command-reference/create) and [services](/docs/command-reference/service). It also assumes that you have cloned the [odo quickstart project](https://github.com/dharmit/odo-quickstart/). Terminology used in this document:
+
+- *quickstart project*: git clone of the odo quickstart project having below directory structure:
+    ```shell
+    $ tree -L 1
+    .
+    ├── backend
+    ├── frontend
+    ├── postgrescluster.yaml
+    ├── quickstart.code-workspace
+    └── README.md
+    
+    2 directories, 3 files
+    ```
+- *backend component*: `backend` directory in above tree structure
+- *frontend component*: `frontend` directory in above tree structure
+- *Postgres service*: Operator backed service created from *backend component* using the `odo service create --from-file ../postgrescluster.yaml` command.
+
+## Various linking options
+
+odo provides various options to link a component with an Operator backed service or another odo component. All these options (or flags) can be used irrespective of whether you are linking a component to a service or another component.
+
+### Default behaviour
+
+By default, `odo link` creates a directory named `kubernetes/` in your component directory and stores the information (YAML manifests) about services and links in it. When you do `odo push`, odo compares these manifests with the state of the things on the Kubernetes cluster and decides whether it needs to create, modify or destroy resources to match what is specified by the user.
+
+### The `--inlined` flag
+
+If you specified `--inlined` flag to the `odo link` command, odo will store the link information inline in the `devfile.yaml` in the component directory instead of creating a file under `kubernetes/` directory. The behaviour of `--inlined` flag is similar in both the `odo link` and `odo service create` commands. This flag is helpful if you would like everything to be stored in a single `devfile.yaml`. You will have to remember to use `--inlined` flag with each `odo link` and `odo service create` commands that you execute for the component.
+
+### The `--map` flag
+
+At times, you might want to add more binding information to the component than what is available by default. For example, if you are linking the component with a service and would like to bind some information from the service's spec (short for specification), you could use the `--map` flag. Note that odo doesn't do any validation against the spec of the service/component being linked. Using this flag is recommended only if you are comfortable with reading the Kubernetes YAML manifests.
+
+## Examples
+
+### Default `odo link`
+
+We will link the backend component with the Postgres service using default `odo link` command. For the backend component, make sure that your component and service are pushed to the cluster:
+
+```shell
+$ odo list
+APP     NAME        PROJECT       TYPE       STATE      MANAGED BY ODO
+app     backend     myproject     spring     Pushed     Yes
+
+
+$ odo service list
+NAME                      MANAGED BY ODO     STATE      AGE
+PostgresCluster/hippo     Yes (backend)      Pushed     59m41s
+
+```
+
+Now, run `odo link` to link the backend component with the Postgres service:
+```shell
+odo link PostgresCluster/hippo
+```
+Example output:
+```shell
+$ odo link PostgresCluster/hippo
+ ✓  Successfully created link between component "backend" and service "PostgresCluster/hippo"
+
+To apply the link, please use `odo push`
+
+$ odo push
+```
+And then run `odo push` for the link to actually get created on the Kubernetes cluster.
+
+Upon successful `odo push`, you can notice a few things:
+1. When you open the URL for the application deployed by backend component, it shows you a list of todo items in the database. For example, for below `odo url list` output, we will append the path where todos are listed:
+  ```shell
+  $ odo url list
+  Found the following URLs for component backend
+  NAME         STATE      URL                                       PORT     SECURE     KIND
+  8080-tcp     Pushed     http://8080-tcp.192.168.39.112.nip.io     8080     false      ingress
+  
+  ```
+  The correct path for such URL would be - http://8080-tcp.192.168.39.112.nip.io/api/v1/todos. Note that exact URL would be different for your setup. Also note that there are no todos in the database unless you add some, so the URL might just show an empty JSON object.
+2. You can see binding information related to Postgres service injected into the backend component. This binding information is injected, by default, as environment variables, so you can check it out using:
+  ```shell
+  # below command filters environment variables with either HIPPO or POSTGRES in their name
+  $ odo exec -- env | grep -e "HIPPO\|POSTGRES" 
+  ```
+  Few of these variables are used in the backend component's `src/main/resources/application.properties` file so that the Java Springboot application can connect to the Postgres database service.
+3. odo has created a directory called `kubernetes/` in your backend component's directory which contains below files. 
+  ```shell
+  $ ls kubernetes 
+  odo-service-backend-postgrescluster-hippo.yaml  odo-service-hippo.yaml
+  ```
+  This files contains the information (YAML manifests) about two things:
+    1. `odo-service-hippo.yaml` - the Postgres service we created using `odo service create --from-file ../postgrescluster.yaml` command.
+    2. `odo-service-backend-postgrescluster-hippo.yaml` - the link we created using `odo link` command.
+  
+### `odo link` with `--inlined`
+
+Using `--inlined` flag with `odo link` command does the exact same thing to our application (that is, injects binding information) as an `odo link` command without the flag does. However, the subtle difference is that in above case we saw two manifest files under `kubernetes/` directory — one for the Postgres service and other for the link between the backend component and this service — but when we pass `--inlined` flag, odo does not create a file under `kubernetes/` directory to store the YAML manifest, but stores it inline in the `devfile.yaml` file.
+
+To see this, let's unlink our component from the Postgres service first:
+
+```shell
+odo unlink PostgresCluster/hippo
+```
+Example output:
+```shell
+$ odo unlink PostgresCluster/hippo
+ ✓  Successfully unlinked component "backend" from service "PostgresCluster/hippo"
+
+To apply the changes, please use `odo push`
+```
+To unlink them on the cluster, run `odo push`. Now if you take a look at the `kubernetes/` directory, you'll see only one file in it:
+```shell
+$ ls kubernetes 
+odo-service-hippo.yaml
+```
+Next, let's use the `--inlined` flag to create a link:
+```shell
+odo link PostgresCluster/hippo --inlined
+```
+Example output:
+```shell
+$ odo link PostgresCluster/hippo --inlined
+ ✓  Successfully created link between component "backend" and service "PostgresCluster/hippo"
+
+To apply the link, please use `odo push`
+```
+Just like the time without `--inlined` flag, you need to do `odo push` for the link to get created on the cluster. But where did odo store the configuration/manifest required to create this link? odo stores this in `devfile.yaml`. You can see an entry like below in this file:
+```yaml
+ kubernetes:
+    inlined: |
+      apiVersion: binding.operators.coreos.com/v1alpha1
+      kind: ServiceBinding
+      metadata:
+        creationTimestamp: null
+        name: backend-postgrescluster-hippo
+      spec:
+        application:
+          group: apps
+          name: backend-app
+          resource: deployments
+          version: v1
+        bindAsFiles: false
+        detectBindingResources: true
+        services:
+        - group: postgres-operator.crunchydata.com
+          id: hippo
+          kind: PostgresCluster
+          name: hippo
+          version: v1beta1
+      status:
+        secret: ""
+  name: backend-postgrescluster-hippo
+```
+Now if you were to do `odo unlink PostgresCluster/hippo`, odo would first remove the link information from the `devfile.yaml` and then a subsequent `odo push` would delete the link from the cluster.
+
+## Custom bindings
+
+`odo link` accepts the flag `--map` which can inject custom binding information into the component. Such binding information will be fetched from the manifest of the resource we are linking to our component. For example, speaking in context of the backend component and Postgres service, we can inject information from the Postgres service's manifest ([`postgrescluster.yaml` file](https://github.com/dharmit/odo-quickstart/blob/main/postgrescluster.yaml)) into the backend component.
+
+Considering the name of your `PostgresCluster` service is `hippo` (check the output of `odo service list` if your PostgresCluster service is named differently), if we wanted to inject the value of `postgresVersion` from that YAML definition into our backend component:
+```shell
+odo link PostgresCluster/hippo --map pgVersion='{{ .hippo.spec.postgresVersion }}'
+```
+Note that, if the name of your Postgres service is different from `hippo`, you will have to specify that in the above command in place `.hippo`. For example, if your `PostgresCluster` service is named as `database`, you would change the link command to as shown below:
+
+```shell
+$ odo service list
+NAME                      MANAGED BY ODO     STATE      AGE
+PostgresCluster/database     Yes (backend)      Pushed     2h5m43s
+
+$ odo link PostgresCluster/hippo --map pgVersion='{{ .database.spec.postgresVersion }}'
+```
+
+### To inline or not?
+
+You can stick to the default behaviour wherein `odo link` will generate a manifest file for the link under `kubernetes/` directory, or you could use `--inlined` flag if you prefer to store everything in a single `devfile.yaml` file. It doesn't matter what you use for this functionality of adding custom mappings.

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -11,6 +11,9 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	svc "github.com/redhat-developer/odo/pkg/service"
+
+	v1 "k8s.io/api/core/v1"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	servicebinding "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
@@ -80,7 +83,8 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 
 		// TODO find the service using an app name to link components in other apps
 		// requires modification of the app flag or finding some other way
-		s, err := o.Context.Client.GetKubeClient().GetOneService(o.suppliedName, o.EnvSpecificInfo.GetApplication())
+		var s *v1.Service
+		s, err = o.Context.Client.GetKubeClient().GetOneService(o.suppliedName, o.EnvSpecificInfo.GetApplication())
 		if kerrors.IsNotFound(err) {
 			return fmt.Errorf("couldn't find component named %q. Refer %q to see list of running components", o.suppliedName, "odo list")
 		}

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -193,9 +193,6 @@ func (o *commonLinkOptions) validate() (err error) {
 	var svcFullName string
 
 	if o.isTargetAService {
-		if !o.csvSupport {
-			return fmt.Errorf("operator hub is required for linking to services")
-		}
 		// let's validate if the service exists
 		svcFullName = strings.Join([]string{o.serviceType, o.serviceName}, "/")
 		svcExists, err := svc.OperatorSvcExists(o.KClient, svcFullName)

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -224,7 +224,10 @@ func (o *commonLinkOptions) validate() (err error) {
 			return err
 		}
 		if !found {
-			return fmt.Errorf("failed to unlink the %s %q since no link was found in the configuration referring this %s", o.getLinkType(), svcFullName, o.getLinkType())
+			if o.getLinkType() == "service" {
+				return fmt.Errorf("failed to unlink the %s %q since no link was found in the configuration referring this %s", o.getLinkType(), svcFullName, o.getLinkType())
+			}
+			return fmt.Errorf("failed to unlink the %s %q since no link was found in the configuration referring this %s", o.getLinkType(), o.suppliedName, o.getLinkType())
 		}
 		return nil
 	}
@@ -308,10 +311,7 @@ func (o *commonLinkOptions) getServiceBindingName(componentName string) string {
 		return o.name
 	}
 	if !o.isTargetAService {
-		// TODO: ugly way to split o.serviceName of the format <component-name>-<app-name>
-		// This is a result of refactoring which helped improve bunch of complete and validate functions
-		serviceName := strings.Split(o.serviceName, "-")[0]
-		return strings.Join([]string{componentName, serviceName}, "-")
+		return strings.Join([]string{componentName, o.serviceName}, "-")
 	}
 	return strings.Join([]string{componentName, strings.ToLower(o.serviceType), o.serviceName}, "-")
 }

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -151,17 +151,6 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 			},
 		}
 	} else {
-		// TODO find the service using an app name to link components in other apps
-		// requires modification of the app flag or finding some other way
-		s, err := o.Context.Client.GetKubeClient().GetOneService(o.suppliedName, o.EnvSpecificInfo.GetApplication())
-		if kerrors.IsNotFound(err) {
-			return fmt.Errorf("couldn't find component named %q. Refer %q to see list of running components", o.suppliedName, "odo list")
-		}
-		if err != nil {
-			return err
-		}
-		o.serviceName = s.Name
-
 		service = servicebinding.Service{
 			Id: &o.serviceName, // Id field is helpful if user wants to inject mappings (custom binding data)
 			NamespacedRef: servicebinding.NamespacedRef{
@@ -319,7 +308,10 @@ func (o *commonLinkOptions) getServiceBindingName(componentName string) string {
 		return o.name
 	}
 	if !o.isTargetAService {
-		return strings.Join([]string{componentName, o.serviceName}, "-")
+		// TODO: ugly way to split o.serviceName of the format <component-name>-<app-name>
+		// This is a result of refactoring which helped improve bunch of complete and validate functions
+		serviceName := strings.Split(o.serviceName, "-")[0]
+		return strings.Join([]string{componentName, serviceName}, "-")
 	}
 	return strings.Join([]string{componentName, strings.ToLower(o.serviceType), o.serviceName}, "-")
 }

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -115,6 +115,7 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVarP(&o.inlined, "inlined", "", false, "Puts the link definition in the devfile instead of a separate file")
 	linkCmd.PersistentFlags().StringVar(&o.name, "name", "", "Name of the created ServiceBinding resource")
 	linkCmd.PersistentFlags().BoolVar(&o.bindAsFiles, "bind-as-files", false, "If enabled, configuration values will be mounted as files, instead of declared as environment variables")
+	linkCmd.PersistentFlags().StringArrayVarP(&o.mappings, "map", "", []string{}, "Mappings (custom binding data) to be added to the component; each map should be specified as <key>=<value>")
 	linkCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--component` flag

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -1,12 +1,11 @@
 package service
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -80,14 +79,9 @@ func (o *CreateOptions) Complete(name string, cmd *cobra.Command, args []string)
 	}
 	// we convert the param list provided in the format of key=value list
 	// to a map
-	o.ParametersMap = make(map[string]string)
-	for _, kv := range o.parameters {
-		kvSlice := strings.Split(kv, "=")
-		// key value not provided in format of key=value
-		if len(kvSlice) != 2 {
-			return errors.New("parameters not provided in key=value format")
-		}
-		o.ParametersMap[kvSlice[0]] = kvSlice[1]
+	o.ParametersMap, err = util.MapFromParameters(o.parameters)
+	if err != nil {
+		return err
 	}
 
 	err = validDevfileDirectory(o.componentContext)

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -299,6 +299,8 @@ func ThrowContextError() error {
 Or use the command from inside a directory containing an odo component.`)
 }
 
+// MapFromParameters takes an array of strings which are of the format "key=value" and returns a map from these
+// It returns error if any of the string in the array doesn't adhere to "key=value" format
 func MapFromParameters(params []string) (map[string]string, error) {
 	paramsMap := make(map[string]string)
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -298,3 +298,18 @@ func ThrowContextError() error {
 	return errors.Errorf(`Please specify the application name and project name
 Or use the command from inside a directory containing an odo component.`)
 }
+
+func MapFromParameters(params []string) (map[string]string, error) {
+	paramsMap := make(map[string]string)
+
+	for _, kv := range params {
+		kvSlice := strings.Split(kv, "=")
+		// key value not provided in format of key=value
+		if len(kvSlice) != 2 {
+			return nil, errors.New("parameters not provided in key=value format")
+		}
+		paramsMap[kvSlice[0]] = kvSlice[1]
+	}
+
+	return paramsMap, nil
+}

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -305,7 +305,7 @@ func MapFromParameters(params []string) (map[string]string, error) {
 	paramsMap := make(map[string]string)
 
 	for _, kv := range params {
-		kvSlice := strings.Split(kv, "=")
+		kvSlice := strings.SplitN(kv, "=", 2)
 		// key value not provided in format of key=value
 		if len(kvSlice) != 2 {
 			return nil, errors.New("parameters not provided in key=value format")

--- a/pkg/odo/util/cmdutils_test.go
+++ b/pkg/odo/util/cmdutils_test.go
@@ -1,6 +1,9 @@
 package util
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestGetFullName(t *testing.T) {
 	parent := "odo foo"
@@ -9,5 +12,42 @@ func TestGetFullName(t *testing.T) {
 	actual := GetFullName(parent, child)
 	if expected != actual {
 		t.Errorf("test failed, expected %s, got %s", expected, actual)
+	}
+}
+
+func TestMapFromParameters1(t *testing.T) {
+	type args struct {
+		params []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "Case 1: All valid parameters with =",
+			args:    args{params: []string{"key1=value1", "key2=value2"}},
+			want:    map[string]string{"key1": "value1", "key2": "value2"},
+			wantErr: false,
+		},
+		{
+			name:    "Case 2: One invalid parameter without =",
+			args:    args{params: []string{"key1=value1", "key2 value2"}},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MapFromParameters(tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MapFromParameters() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MapFromParameters() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/tests/examples/operators/redis.yaml
+++ b/tests/examples/operators/redis.yaml
@@ -1,7 +1,7 @@
 apiVersion: redis.redis.opstreelabs.in/v1beta1
 kind: Redis
 metadata:
-  name: redis-standalone
+  name: redis
 spec:
   redisExporter:
     enabled: true

--- a/tests/integration/operatorhub/cmd_link_test.go
+++ b/tests/integration/operatorhub/cmd_link_test.go
@@ -300,7 +300,7 @@ var _ = Describe("odo link command tests for OperatorHub", func() {
 						stdOut := helper.Cmd("odo", "exec", "--context", commonVar.Context, "--", "cat", "/bindings/"+componentName+"-redis-"+serviceName+"/image").ShouldPass().Out()
 						Expect(stdOut).To(ContainSubstring(imageMappingValue))
 						stdOut = helper.Cmd("odo", "exec", "--context", commonVar.Context, "--", "cat", "/bindings/"+componentName+"-redis-"+serviceName+"/key").ShouldPass().Out()
-						Expect(stdOut).To(Equal("value"))
+						Expect(stdOut).To(ContainSubstring("value"))
 					})
 				})
 			})

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -18,6 +18,7 @@ import (
 var _ = Describe("odo service command tests for OperatorHub", func() {
 
 	var commonVar helper.CommonVar
+	var redisServiceName = "redis"
 
 	BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
@@ -200,8 +201,8 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 					})
 
 					It("should fail if the provided service doesn't exist in the namespace", func() {
-						stdOut := helper.Cmd("odo", "link", "Redis/redis-standalone").ShouldFail().Err()
-						Expect(stdOut).To(ContainSubstring("couldn't find service named %q", "Redis/redis-standalone"))
+						stdOut := helper.Cmd("odo", "link", fmt.Sprintf("Redis/%s", redisServiceName)).ShouldFail().Err()
+						Expect(stdOut).To(ContainSubstring("couldn't find service named %q", fmt.Sprintf("Redis/%s", redisServiceName)))
 					})
 				})
 
@@ -226,7 +227,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 						})
 
 						AfterEach(func() {
-							helper.Cmd("odo", "service", "delete", "Redis/redis-standalone", "-f").ShouldPass()
+							helper.Cmd("odo", "service", "delete", fmt.Sprintf("Redis/%s", redisServiceName), "-f").ShouldPass()
 							helper.Cmd("odo", "push").ShouldPass()
 						})
 


### PR DESCRIPTION
- Sticking to SBO library v0.9.0 because the feature can be implemented
  using it just fine.
- ~Docs doesn't cover `--bind-as-files`. I would prefer to keep it in a
  separate PR.~ `--bind-as-files` docs e8dfa50.
- Added `id` field to the ServiceBinding resource created by odo and it
  defaults to same name as that of service's. No option to change the
  `id` itself.
- Removed a hyphen from the `redis.yaml` file because it caused `odo
  push` for a link using the `--map` flag to fail due to it.

**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
$subject. We need it for the users to be able to inject custom binding data while linking

**Which issue(s) this PR fixes**:

Fixes #4937 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Considering the backend component and postgres service from [odo quickstart guide](https://odo.dev/docs/getting-started/quickstart/), try linking using:
```sh
$ odo link PostgresCluster/hippo --map pgVersion='{{ .database.spec.postgresVersion }}'
$ odo exec -- env | grep pgVersion
```