### PR TITLE
Delete outerloop resources with undeploy

### DIFF
--- a/docs/website/docs/command-reference/create.md
+++ b/docs/website/docs/command-reference/create.md
@@ -3,7 +3,7 @@ title: odo create
 sidebar_position: 3
 ---
 
-odo uses the (_devfile_)[https://devfile.io] to store the configuration of and describe the resources like storage, services, etc. of a component. The _odo create_ command allows you to generate this file.
+odo uses the [_devfile_](https://devfile.io) to store the configuration of and describe the resources like storage, services, etc. of a component. The _odo create_ command allows you to generate this file.
 
 ## Creating a component
 
@@ -17,7 +17,7 @@ Here `nodejs` is the type of the component and `mynodejs` is the name of the com
 
 > Note: for a list of all the supported component types, run `odo catalog list components`.
 
-If your source code exists outside of the current directory, the `--context` flag can be used to specify the path. For example, if the source for the nodejs component was in a folder called `node-backend` relative to the current working directory, you could run:
+If your source code exists outside the current directory, the `--context` flag can be used to specify the path. For example, if the source for the nodejs component was in a folder called `node-backend` relative to the current working directory, you could run:
 
 ```
 odo create nodejs mynodejs --context ./node-backend

--- a/docs/website/docs/command-reference/delete.md
+++ b/docs/website/docs/command-reference/delete.md
@@ -3,7 +3,9 @@ title: odo delete
 sidebar_position: 2
 ---
 
-### Deleting a component
+`odo delete` command is useful for deleting resources that are managed by odo.
+
+## Deleting a component
 
 To delete a _devfile_ component, you can execute `odo delete`.
 
@@ -16,7 +18,7 @@ If it is not pushed, the command would exit with an error stating that it could 
 
 Use `-f` or `--force` flag to avoid the confirmation questions. 
 
-### Un-deploying Devfile Kubernetes components
+## Un-deploying Devfile Kubernetes components
 
 To undeploy the Devfile Kubernetes components deployed with `odo deploy` from the cluster, you can execute the `odo delete` command with `--deploy` flag:
 ```shell
@@ -25,14 +27,14 @@ odo delete --deploy
 
 Use `-f` or `--force` flag to avoid the confirmation questions.
 
-### Delete Everything
+## Delete Everything
 
 To delete a _devfile_ component, the Devfile Kubernetes component(deployed via `odo deploy`), Devfile, and the local configuration, you can execute the `odo delete` command with `--all` flag:
 ```shell
 odo delete --all
 ```
 
-### Available Flags
+## Available Flags
 * `-f`, `--force` - Use this flag to avoid the confirmation questions.
 * `-w`, `--wait` - Use this flag to wait for component deletion, and it's dependant; this does not work with the un-deployment.
 Check the [documentation on flags](flags.md) to see more flags available.

--- a/docs/website/docs/command-reference/delete.md
+++ b/docs/website/docs/command-reference/delete.md
@@ -1,0 +1,38 @@
+---
+title: odo delete
+sidebar_position: 2
+---
+
+### Deleting a component
+
+To delete a _devfile_ component, you can execute `odo delete`.
+
+```shell
+odo delete
+```
+
+If the component is pushed to the cluster, running the above command will delete the component from the cluster, and it's dependant storage, url, secrets, and other resources.
+If it is not pushed, the command would exit with an error stating that it could not find the resources on the cluster.
+
+Use `-f` or `--force` flag to avoid the confirmation questions. 
+
+### Un-deploying Devfile Kubernetes components
+
+To undeploy the Devfile Kubernetes component deployed with `odo deploy` from the cluster, you can execute the `odo delete` command with `--deploy` flag:
+```shell
+odo delete --deploy
+```
+
+Use `-f` or `--force` flag to avoid the confirmation questions.
+
+### Delete Everything
+
+To delete a _devfile_ component, the Devfile Kubernetes component(deployed via `odo deploy`), Devfile, and the local configuration, you can execute the `odo delete` command with `--all` flag:
+```shell
+odo delete --all
+```
+
+### Available Flags
+* `-f`, `--force` - Use this flag to avoid the confirmation questions.
+* `-w`, `--wait` - Use this flag to wait for component deletion, and it's dependant; this does not work with the un-deployment.
+Check the [documentation on flags](flags.md) to see more flags available.

--- a/docs/website/docs/command-reference/delete.md
+++ b/docs/website/docs/command-reference/delete.md
@@ -18,7 +18,7 @@ Use `-f` or `--force` flag to avoid the confirmation questions.
 
 ### Un-deploying Devfile Kubernetes components
 
-To undeploy the Devfile Kubernetes component deployed with `odo deploy` from the cluster, you can execute the `odo delete` command with `--deploy` flag:
+To undeploy the Devfile Kubernetes components deployed with `odo deploy` from the cluster, you can execute the `odo delete` command with `--deploy` flag:
 ```shell
 odo delete --deploy
 ```

--- a/docs/website/docs/command-reference/flags.md
+++ b/docs/website/docs/command-reference/flags.md
@@ -1,5 +1,5 @@
 ---
-title: Flags
+title: Common Flags
 sidebar_position: 50
 ---
 

--- a/docs/website/docs/command-reference/flags.md
+++ b/docs/website/docs/command-reference/flags.md
@@ -6,7 +6,7 @@ sidebar_position: 50
 ### Available Flags
 Following are the flags commonly available with almost every odo command.
 * `--context` - Use this flag to set the context directory where the component is defined.
-* `--project` - Use this flag to set the project for the component; defaults to the project defined in the  local configuration; if none is available, then current project
+* `--project` - Use this flag to set the project for the component; defaults to the project defined in the  local configuration; if none is available, then current project on the cluster
 * `--app` - Use this flag to set the application of the component; defaults to the application defined in the local configuration; if none is available, then _app_
 * `--kubeconfig` - Use this flag to set path to the kubeconfig if not using the default configuration
 * `--show-log` - Use this flag to see the logs from deletion.

--- a/docs/website/docs/command-reference/flags.md
+++ b/docs/website/docs/command-reference/flags.md
@@ -9,7 +9,7 @@ Following are the flags commonly available with almost every odo command.
 * `--project` - Use this flag to set the project for the component; defaults to the project defined in the  local configuration; if none is available, then current project on the cluster
 * `--app` - Use this flag to set the application of the component; defaults to the application defined in the local configuration; if none is available, then _app_
 * `--kubeconfig` - Use this flag to set path to the kubeconfig if not using the default configuration
-* `--show-log` - Use this flag to see the logs from deletion.
+* `--show-log` - Use this flag to see the logs
 * `-v`, `--v` - Use this flag to set the verbosity level. See (Logging in odo)[https://github.com/redhat-developer/odo/wiki/Logging-in-odo] for more information.
 * `-h`, `--help` - Use this flag to get help on a command
 

--- a/docs/website/docs/command-reference/flags.md
+++ b/docs/website/docs/command-reference/flags.md
@@ -1,0 +1,16 @@
+---
+title: Flags
+sidebar_position: 50
+---
+
+### Available Flags
+Following are the flags commonly available with almost every odo command.
+* `--context` - Use this flag to set the context directory where the component is defined.
+* `--project` - Use this flag to set the project for the component; defaults to the project defined in the  local configuration; if none is available, then current project
+* `--app` - Use this flag to set the application of the component; defaults to the application defined in the local configuration; if none is available, then _app_
+* `--kubeconfig` - Use this flag to set path to the kubeconfig if not using the default configuration
+* `--show-log` - Use this flag to see the logs from deletion.
+* `-v`, `--v` - Use this flag to set the verbosity level. See (Logging in odo)[https://github.com/redhat-developer/odo/wiki/Logging-in-odo] for more information.
+* `-h`, `--help` - Use this flag to get help on a command
+
+**Note:** Some flags might not be available in some commands, run the command with `--help` to get a list of all the available flags.

--- a/pkg/devfile/adapters/common/apply.go
+++ b/pkg/devfile/adapters/common/apply.go
@@ -3,4 +3,5 @@ package common
 // ApplyClient is a wrapper around ApplyComponent which runs an apply command on a component
 type ApplyClient interface {
 	ApplyComponent(component string) error
+	UnApplyComponent(component string) error
 }

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -16,6 +16,7 @@ import (
 // command encapsulates a command meant to be executed either directly or as part of a composite
 type command interface {
 	Execute(show bool) error
+	UnExecute() error
 }
 
 // New returns a new command implementation based on the specified devfile command and the known commands

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -152,6 +152,11 @@ func GetTestCommand(data data.DevfileData, devfileTestCmd string) (runCommand de
 	return getCommand(data, devfileTestCmd, devfilev1.TestCommandGroupKind)
 }
 
+// GetTestCommand iterates through the components in the devfile and returns the deploy command
+func GetDeployCommand(data data.DevfileData, devfileDeployCmd string) (deployCommand devfilev1.Command, err error) {
+	return getCommand(data, devfileDeployCmd, devfilev1.DeployCommandGroupKind)
+}
+
 // ValidateAndGetPushDevfileCommands validates the build and the run command,
 // if provided through odo push or else checks the devfile for devBuild and devRun.
 // It returns the build and run commands if its validated successfully, error otherwise.

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -152,7 +152,7 @@ func GetTestCommand(data data.DevfileData, devfileTestCmd string) (runCommand de
 	return getCommand(data, devfileTestCmd, devfilev1.TestCommandGroupKind)
 }
 
-// GetTestCommand iterates through the components in the devfile and returns the deploy command
+// GetDeployCommand iterates through the components in the devfile and returns the deploy command
 func GetDeployCommand(data data.DevfileData, devfileDeployCmd string) (deployCommand devfilev1.Command, err error) {
 	return getCommand(data, devfileDeployCmd, devfilev1.DeployCommandGroupKind)
 }

--- a/pkg/devfile/adapters/common/command_apply.go
+++ b/pkg/devfile/adapters/common/command_apply.go
@@ -25,3 +25,8 @@ func (s applyCommand) Execute(show bool) error {
 	err := s.adapter.ApplyComponent(s.component)
 	return err
 }
+
+func (s applyCommand) UnExecute() error {
+	err := s.adapter.UnApplyComponent(s.component)
+	return err
+}

--- a/pkg/devfile/adapters/common/command_composite.go
+++ b/pkg/devfile/adapters/common/command_composite.go
@@ -24,3 +24,14 @@ func (c compositeCommand) Execute(show bool) error {
 	}
 	return nil
 }
+
+func (c compositeCommand) UnExecute() error {
+	// UnExecute the commands in order
+	for _, command := range c.cmds {
+		err := command.UnExecute()
+		if err != nil {
+			return fmt.Errorf("command execution failed: %v", err)
+		}
+	}
+	return nil
+}

--- a/pkg/devfile/adapters/common/command_simple.go
+++ b/pkg/devfile/adapters/common/command_simple.go
@@ -107,3 +107,7 @@ func (s execCommand) Execute(show bool) error {
 
 	return nil
 }
+
+func (s execCommand) UnExecute() error {
+	return nil
+}

--- a/pkg/devfile/adapters/common/command_supervisor.go
+++ b/pkg/devfile/adapters/common/command_supervisor.go
@@ -67,3 +67,7 @@ func (s supervisorCommand) Execute(show bool) error {
 	}
 	return nil
 }
+
+func (s supervisorCommand) UnExecute() error {
+	return nil
+}

--- a/pkg/devfile/adapters/common/generic.go
+++ b/pkg/devfile/adapters/common/generic.go
@@ -228,3 +228,7 @@ func (a GenericAdapter) ExecDevfileEvent(events []string, eventType DevfileEvent
 func (a GenericAdapter) ApplyComponent(component string) error {
 	return nil
 }
+
+func (a GenericAdapter) UnApplyComponent(component string) error {
+	return nil
+}

--- a/pkg/devfile/adapters/common/interface.go
+++ b/pkg/devfile/adapters/common/interface.go
@@ -19,4 +19,5 @@ type ComponentAdapter interface {
 	Log(follow bool, command devfilev1.Command) (io.ReadCloser, error)
 	Exec(command []string) error
 	Deploy() error
+	UnDeploy() error
 }

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -119,3 +119,7 @@ func (k Adapter) StartSupervisordCtlStatusWatch() {
 func (k Adapter) ApplyComponent(component string) error {
 	return k.componentAdapter.ApplyComponent(component)
 }
+
+func (k Adapter) UnApplyComponent(component string) error {
+	return k.componentAdapter.UnApplyComponent(component)
+}

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -46,6 +46,10 @@ func (k Adapter) Deploy() error {
 	return k.componentAdapter.Deploy()
 }
 
+func (k Adapter) UnDeploy() error {
+	return k.componentAdapter.UnDeploy()
+}
+
 // CheckSupervisordCommandStatus calls the component adapter's CheckSupervisordCommandStatus
 func (k Adapter) CheckSupervisordCommandStatus(command devfilev1.Command) error {
 	err := k.componentAdapter.CheckSupervisordCommandStatus(command)

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -812,6 +812,44 @@ func (a Adapter) Deploy() error {
 	return a.ExecuteDevfileCommand(deployCmd, true)
 }
 
+func (a Adapter) UnDeploy() error {
+	//// Instantiate the .group.kind=deploy command
+	//commands, err := a.Devfile.Data.GetCommands(parsercommon.DevfileOptions{
+	//	CommandOptions: parsercommon.CommandOptions{
+	//		CommandGroupKind: devfilev1.DeployCommandGroupKind,
+	//	},
+	//})
+	//if err != nil {
+	//	return nil
+	//}
+	//
+	//if len(commands) == 0 {
+	//	return errors.New("error deploying, no default deploy command found in devfile")
+	//}
+	//
+	//if len(commands) > 1 {
+	//	return errors.New("more than one default deploy command found in devfile, should not happen")
+	//}
+	//
+	//deployCmd := commands[0]
+	//// Get a list of all the available commands
+	//allCommands, err := a.Devfile.Data.GetCommands(parsercommon.DevfileOptions{})
+	//if err != nil {
+	//	return err
+	//}
+	//// Get the .group.kind=deploy command
+	//c, err := common.New(deployCmd, common.GetCommandsMap(allCommands), &a)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//// Get the .group.kind=deploy command
+	//// Iterate through the commands from .group.kind=deploy and find the command that contains kubernetes
+	//// Get GVK, GVR
+	//// call the DeleteDynamicResource method of kClient.Interface and delete
+	return nil
+}
+
 // ExecuteDevfileCommand executes the devfile command
 func (a Adapter) ExecuteDevfileCommand(command devfilev1.Command, show bool) error {
 	commands, err := a.Devfile.Data.GetCommands(parsercommon.DevfileOptions{})

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -689,7 +689,3 @@ func TestAdapter_generateDeploymentObjectMeta(t *testing.T) {
 		})
 	}
 }
-
-func Test_getApplyComponent(t *testing.T) {
-
-}

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -689,3 +689,7 @@ func TestAdapter_generateDeploymentObjectMeta(t *testing.T) {
 		})
 	}
 }
+
+func Test_getApplyComponent(t *testing.T) {
+
+}

--- a/pkg/devfile/adapters/kubernetes/component/component.go
+++ b/pkg/devfile/adapters/kubernetes/component/component.go
@@ -10,6 +10,7 @@ import (
 // componentToApply represents a devfile component that can be applied
 type componentToApply interface {
 	Apply(devfileObj parser.DevfileObj, devfilePath string) error
+	UnApply(devfilePath string) error
 }
 
 // createComponent returns an instance of a devfile component specific to its type (image, kubernetes, etc)

--- a/pkg/devfile/adapters/kubernetes/component/component_image.go
+++ b/pkg/devfile/adapters/kubernetes/component/component_image.go
@@ -19,3 +19,7 @@ func newComponentImage(component devfilev1.Component) componentImage {
 func (o componentImage) Apply(devfileObj parser.DevfileObj, devfilePath string) error {
 	return image.BuildPushSpecificImage(devfileObj, devfilePath, o.component, true)
 }
+
+func (o componentImage) UnApply(devfilePath string) error {
+	return nil
+}

--- a/pkg/devfile/adapters/kubernetes/component/component_kubernetes.go
+++ b/pkg/devfile/adapters/kubernetes/component/component_kubernetes.go
@@ -55,3 +55,20 @@ func (o componentKubernetes) Apply(devfileObj parser.DevfileObj, devfilePath str
 	}
 	return nil
 }
+
+func (o componentKubernetes) UnApply(devfilePath string) error {
+	// Parse the component's Kubernetes manifest
+	u, err := service.GetK8sComponentAsUnstructured(o.component.Kubernetes, devfilePath, devfilefs.DefaultFs{})
+	if err != nil {
+		return err
+	}
+
+	// Get the REST mappings
+	gvr, err := o.client.GetRestMappingFromUnstructured(u)
+	if err != nil {
+		return err
+	}
+	log.Infof("Un-deploying the Kubernetes %s: %s", u.GetKind(), u.GetName())
+	// Un-deploy the K8s manifest
+	return o.client.DeleteDynamicResource(u.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource)
+}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -51,12 +51,12 @@ type DeleteOptions struct {
 	*ComponentOptions
 
 	// Flags
-	contextFlag  string
-	forceFlag    bool
-	allFlag      bool
-	waitFlag     bool
-	showLogFlag  bool
-	undeployFlag bool
+	contextFlag string
+	forceFlag   bool
+	allFlag     bool
+	waitFlag    bool
+	showLogFlag bool
+	deployFlag  bool
 }
 
 // NewDeleteOptions returns new instance of DeleteOptions
@@ -83,7 +83,7 @@ func (do *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	klog.V(4).Infof("args: %#v", do)
 
 	// odo delete --deploy || odo delete --all
-	if do.undeployFlag || do.allFlag {
+	if do.deployFlag || do.allFlag {
 		if do.forceFlag || ui.Proceed("Are you sure you want to undeploy?") {
 			err = do.DevfileUnDeploy()
 			if err != nil {
@@ -95,7 +95,7 @@ func (do *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	}
 
 	// odo delete || odo delete --all
-	if !do.undeployFlag || do.allFlag {
+	if !do.deployFlag || do.allFlag {
 		if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component: %s?", do.EnvSpecificInfo.GetName())) {
 			err = do.DevfileComponentDelete()
 			if err != nil {
@@ -236,7 +236,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.forceFlag, "force", "f", false, "Delete component without prompting")
 	componentDeleteCmd.Flags().BoolVarP(&do.allFlag, "all", "a", false, "Delete component and local config")
 	componentDeleteCmd.Flags().BoolVarP(&do.waitFlag, "wait", "w", false, "Wait for complete deletion of component and its dependent")
-	componentDeleteCmd.Flags().BoolVarP(&do.undeployFlag, "deploy", "d", false, "Undeploy the Devfile Kubernetes Component deployed via `odo deploy`")
+	componentDeleteCmd.Flags().BoolVarP(&do.deployFlag, "deploy", "d", false, "Undeploy the Devfile Kubernetes Component deployed via `odo deploy`")
 
 	componentDeleteCmd.Flags().BoolVar(&do.showLogFlag, "show-log", false, "If enabled, logs will be shown when deleted")
 

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -236,7 +236,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.forceFlag, "force", "f", false, "Delete component without prompting")
 	componentDeleteCmd.Flags().BoolVarP(&do.allFlag, "all", "a", false, "Delete component and local config")
 	componentDeleteCmd.Flags().BoolVarP(&do.waitFlag, "wait", "w", false, "Wait for complete deletion of component and its dependent")
-	componentDeleteCmd.Flags().BoolVarP(&do.undeployFlag, "deploy", "d", false, "Undeploy")
+	componentDeleteCmd.Flags().BoolVarP(&do.undeployFlag, "deploy", "d", false, "Undeploy the Devfile Kubernetes Component deployed via `odo deploy`")
 
 	componentDeleteCmd.Flags().BoolVar(&do.showLogFlag, "show-log", false, "If enabled, logs will be shown when deleted")
 

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -51,11 +51,12 @@ type DeleteOptions struct {
 	*ComponentOptions
 
 	// Flags
-	contextFlag string
-	forceFlag   bool
-	allFlag     bool
-	waitFlag    bool
-	showLogFlag bool
+	contextFlag  string
+	forceFlag    bool
+	allFlag      bool
+	waitFlag     bool
+	showLogFlag  bool
+	undeployFlag bool
 }
 
 // NewDeleteOptions returns new instance of DeleteOptions
@@ -80,6 +81,11 @@ func (do *DeleteOptions) Validate() error {
 func (do *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	klog.V(4).Infof("component delete called")
 	klog.V(4).Infof("args: %#v", do)
+
+	if do.undeployFlag {
+		return do.DevfileUnDeploy()
+	}
+
 	if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component: %s?", do.EnvSpecificInfo.GetName())) {
 		err = do.DevfileComponentDelete()
 		if err != nil {
@@ -219,6 +225,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.forceFlag, "force", "f", false, "Delete component without prompting")
 	componentDeleteCmd.Flags().BoolVarP(&do.allFlag, "all", "a", false, "Delete component and local config")
 	componentDeleteCmd.Flags().BoolVarP(&do.waitFlag, "wait", "w", false, "Wait for complete deletion of component and its dependent")
+	componentDeleteCmd.Flags().BoolVarP(&do.undeployFlag, "deploy", "d", false, "Undeploy")
 
 	componentDeleteCmd.Flags().BoolVar(&do.showLogFlag, "show-log", false, "If enabled, logs will be shown when deleted")
 

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -83,16 +83,31 @@ func (do *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	klog.V(4).Infof("args: %#v", do)
 
 	if do.undeployFlag {
-		return do.DevfileUnDeploy()
+		if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to undeploy?")) {
+			return do.DevfileUnDeploy()
+		} else {
+			log.Error("Aborting the un-deployment")
+		}
+	} else {
+		if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component: %s?", do.EnvSpecificInfo.GetName())) {
+			err = do.DevfileComponentDelete()
+			if err != nil {
+				log.Errorf("error occurred while deleting component, cause: %v", err)
+			}
+		} else {
+			log.Error("Aborting deletion of component")
+		}
 	}
 
-	if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component: %s?", do.EnvSpecificInfo.GetName())) {
+	if do.allFlag {
+		err := do.DevfileUnDeploy()
+		if err != nil {
+			log.Errorf("error occurred while un-deploying, cause: %v", err)
+		}
 		err = do.DevfileComponentDelete()
 		if err != nil {
 			log.Errorf("error occurred while deleting component, cause: %v", err)
 		}
-	} else {
-		log.Error("Aborting deletion of component")
 	}
 
 	if do.allFlag {

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -1,6 +1,9 @@
 package component
 
 import (
+	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	devfilefs "github.com/devfile/library/pkg/testingutil/filesystem"
+	"github.com/redhat-developer/odo/pkg/service"
 	"os"
 	"reflect"
 	"strings"
@@ -164,6 +167,79 @@ func (lo LogOptions) DevfileComponentLog() error {
 	}
 
 	return util.DisplayLog(lo.followFlag, rd, os.Stdout, componentName, -1)
+}
+
+// Get the .group.kind=deploy command
+// Iterate through the commands from .group.kind=deploy and find the command that contains kubernetes
+// Get GVK, GVR
+// call the DeleteDynamicResource method of kClient.Interface and delete
+func (do *DeleteOptions) DevfileUnDeploy() error {
+	devObj, err := devfile.ParseAndValidateFromFile(do.GetDevfilePath())
+	if err != nil {
+		return err
+	}
+	deployGroupCmd, err := devObj.Data.GetCommands(parsercommon.DevfileOptions{
+		CommandOptions: parsercommon.CommandOptions{
+			CommandGroupKind: devfilev1.DeployCommandGroupKind,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if len(deployGroupCmd) == 0 {
+		return errors.New("error deploying, no default deploy command found in devfile")
+	}
+	if len(deployGroupCmd) > 1 {
+		return errors.New("more than one default deploy command found in devfile, should not happen")
+	}
+	deployCmd := deployGroupCmd[0]
+
+	// Only get commands of type Apply; those are the only ones we're concerned with for now
+	allApplyCommands, err := devObj.Data.GetCommands(parsercommon.DevfileOptions{
+		CommandOptions: parsercommon.CommandOptions{
+			CommandType: devfilev1.ApplyCommandType,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	// Get components of type Kubernetes
+	kubeComponents, err := devObj.Data.GetComponents(parsercommon.DevfileOptions{
+		ComponentOptions: parsercommon.ComponentOptions{ComponentType: devfilev1.KubernetesComponentType},
+	})
+	if err != nil {
+		return err
+	}
+
+	var component devfilev1.Component
+	var requiredCommands []devfilev1.Command
+	for _, commandId := range deployCmd.Composite.Commands {
+		for _, cmd := range allApplyCommands {
+			if cmd.Id == commandId {
+				requiredCommands = append(requiredCommands, cmd)
+			}
+		}
+	}
+	for _, cmp := range kubeComponents {
+		for _, cmd := range requiredCommands {
+			if cmd.Apply.Component == cmp.Name {
+				component = cmp
+				break
+			}
+		}
+	}
+	//------------------------------------------------------------------------------------------------------------------
+	u, err := service.GetK8sComponentAsUnstructured(component.Kubernetes, do.GetDevfilePath(), devfilefs.DefaultFs{})
+	if err != nil {
+		return err
+	}
+	gvr, err := do.KClient.GetRestMappingFromUnstructured(u)
+	if err != nil {
+		return err
+	}
+	err = do.KClient.DeleteDynamicResource(u.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource)
+
+	return err
 }
 
 // DevfileComponentDelete deletes the devfile component

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -166,10 +166,7 @@ func (lo LogOptions) DevfileComponentLog() error {
 	return util.DisplayLog(lo.followFlag, rd, os.Stdout, componentName, -1)
 }
 
-// Get the .group.kind=deploy command
-// Iterate through the commands from .group.kind=deploy and find the command that contains kubernetes
-// Get GVK, GVR
-// call the DeleteDynamicResource method of kClient.Interface and delete
+// DevfileUnDeploy undeploys the devfile kubernetes components
 func (do *DeleteOptions) DevfileUnDeploy() error {
 	devObj, err := devfile.ParseAndValidateFromFile(do.GetDevfilePath())
 	if err != nil {
@@ -182,7 +179,7 @@ func (do *DeleteOptions) DevfileUnDeploy() error {
 		Namespace: do.KClient.GetCurrentNamespace(),
 	}
 
-	devfileHandler, err := adapters.NewComponentAdapter(componentName, do.componentContext, do.GetApplication(), devObj, kc)
+	devfileHandler, err := adapters.NewComponentAdapter(componentName, do.contextFlag, do.GetApplication(), devObj, kc)
 	if err != nil {
 		return err
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -546,6 +546,7 @@ func isOperatorBackedService(client kclient.ClientInterface, u unstructured.Unst
 	return false, nil
 }
 
+// GetK8sComponentAsUnstructured parses the Inlined/URI K8s of the devfile K8s component
 func GetK8sComponentAsUnstructured(component *devfile.KubernetesComponent, context string, fs devfilefs.Filesystem) (unstructured.Unstructured, error) {
 	strCRD := component.Inlined
 	var err error

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -272,4 +272,41 @@ var _ = Describe("odo devfile delete command tests", func() {
 			Expect(helper.VerifyFileExists(path.Join(commonVar.Context, devfile))).To(BeTrue())
 		})
 	})
+	When("odo deploy is run", func() {
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
+			helper.Cmd("odo", "create").ShouldPass()
+		})
+		When("executing the odo delete command with the --deploy flag", func() {
+			var stdOut string
+			BeforeEach(func() {
+				stdOut = helper.Cmd("odo", "delete", "--deploy").ShouldPass().Out()
+			})
+			It("should successfully delete the deploy resources", func() {
+				Expect(stdOut).To(ContainSubstring("successfully deleted the deploy"))
+				Expect(stdOut).ToNot(ContainSubstring("successfully deleted the component"))
+			})
+		})
+		When("executing the odo delete command with -a flag", func() {
+			var stdOut string
+			BeforeEach(func() {
+				stdOut = helper.Cmd("odo", "delete", "-a").ShouldPass().Out()
+			})
+			It("should successfully delete the deploy resources", func() {
+				Expect(stdOut).To(ContainSubstring("successfully deleted the component"))
+				Expect(stdOut).To(ContainSubstring("successfully deleted the deploy"))
+			})
+		})
+		When("executing the odo delete", func() {
+			var stdOut string
+			BeforeEach(func() {
+				stdOut = helper.Cmd("odo", "delete").ShouldPass().Out()
+			})
+			It("should successfully delete the deploy resources", func() {
+				Expect(stdOut).To(ContainSubstring("successfully deleted the component"))
+				Expect(stdOut).ToNot(ContainSubstring("successfully deleted the deploy"))
+			})
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -46,6 +46,25 @@ var _ = Describe("odo devfile delete command tests", func() {
 		It("should delete the component", func() {
 			helper.Cmd("odo", "delete", "-f").ShouldPass()
 		})
+		When("odo deploy is run", func() {
+			BeforeEach(func() {
+				// requires a different devfile
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
+				helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
+			})
+			It("should successfully delete the deploy resources with --deploy flag", func() {
+				stdOut := helper.Cmd("odo", "delete", "--deploy", "-f").ShouldPass().Out()
+				Expect(stdOut).To(ContainSubstring("Un-deploying the Kubernetes Deployment"))
+			})
+			It("should successfully delete the deploy resources", func() {
+				stdOut := helper.Cmd("odo", "delete", "-a", "-f").ShouldPass().Out()
+				Expect(stdOut).To(ContainSubstring("Un-deploying the Kubernetes Deployment"))
+			})
+			It("should successfully delete the component, but the deployed resources should remain intact", func() {
+				stdOut := helper.Cmd("odo", "delete", "-f").ShouldPass().Out()
+				Expect(stdOut).ToNot(ContainSubstring("Un-deploying the Kubernetes"))
+			})
+		})
 
 		When("the component is pushed", func() {
 			BeforeEach(func() {
@@ -270,43 +289,6 @@ var _ = Describe("odo devfile delete command tests", func() {
 			Expect(helper.VerifyFileExists(path.Join(commonVar.Context, devfile))).To(BeTrue())
 			helper.Cmd("odo", "delete", "--all", "-f").ShouldPass()
 			Expect(helper.VerifyFileExists(path.Join(commonVar.Context, devfile))).To(BeTrue())
-		})
-	})
-	When("odo deploy is run", func() {
-		BeforeEach(func() {
-			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
-			helper.Cmd("odo", "create").ShouldPass()
-		})
-		When("executing the odo delete command with the --deploy flag", func() {
-			var stdOut string
-			BeforeEach(func() {
-				stdOut = helper.Cmd("odo", "delete", "--deploy").ShouldPass().Out()
-			})
-			It("should successfully delete the deploy resources", func() {
-				Expect(stdOut).To(ContainSubstring("successfully deleted the deploy"))
-				Expect(stdOut).ToNot(ContainSubstring("successfully deleted the component"))
-			})
-		})
-		When("executing the odo delete command with -a flag", func() {
-			var stdOut string
-			BeforeEach(func() {
-				stdOut = helper.Cmd("odo", "delete", "-a").ShouldPass().Out()
-			})
-			It("should successfully delete the deploy resources", func() {
-				Expect(stdOut).To(ContainSubstring("successfully deleted the component"))
-				Expect(stdOut).To(ContainSubstring("successfully deleted the deploy"))
-			})
-		})
-		When("executing the odo delete", func() {
-			var stdOut string
-			BeforeEach(func() {
-				stdOut = helper.Cmd("odo", "delete").ShouldPass().Out()
-			})
-			It("should successfully delete the deploy resources", func() {
-				Expect(stdOut).To(ContainSubstring("successfully deleted the component"))
-				Expect(stdOut).ToNot(ContainSubstring("successfully deleted the deploy"))
-			})
 		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -64,6 +64,18 @@ var _ = Describe("odo devfile delete command tests", func() {
 				stdOut := helper.Cmd("odo", "delete", "-f").ShouldPass().Out()
 				Expect(stdOut).ToNot(ContainSubstring("Un-deploying the Kubernetes"))
 			})
+			When("outside the context directory", func() {
+				BeforeEach(func() {
+					helper.Chdir(commonVar.OriginalWorkingDirectory)
+				})
+				AfterEach(func() {
+					helper.Chdir(commonVar.Context)
+				})
+				It("should successfully undeploy", func() {
+					helper.Cmd("odo", "delete", "--deploy", "-f", "--context", commonVar.Context).ShouldPass()
+				})
+			})
+
 		})
 
 		When("the component is pushed", func() {

--- a/tests/integration/devfile/cmd_devfile_deploy_test.go
+++ b/tests/integration/devfile/cmd_devfile_deploy_test.go
@@ -30,6 +30,9 @@ var _ = Describe("odo devfile deploy command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
 			helper.Cmd("odo", "create").ShouldPass()
 		})
+		AfterEach(func() {
+			helper.Cmd("odo", "delete", "-a").ShouldPass()
+		})
 		It("should run odo deploy", func() {
 			stdout := helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 			By("building and pushing image to registry", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
This PR deletes the outerloop resources deployed with `odo deploy`
**Which issue(s) this PR fixes**:

Fixes #5246 

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```sh
mkdir /tmp/abc; cd /tmp/abc
export ODOPATH=/home/pvala/go/src/github.com/redhat-developer/odo
cp -r $ODOPATH/tests/examples/source/nodejs/* . 
cp $ODOPATH/tests/examples/source/devfiles/nodejs/devfile-deploy.yaml devfile.yaml
odo create
odo deploy
```
Next, try the following commands:
1. `odo delete --deploy`
2. `odo delete`
3. `odo delete -af`

TODO:
1. Add documentation for `odo delete --deploy`
2. Add klog logs
3. Remove the unused `GetDeployCommand`