### PR TITLE
Fix panic with interactive odo create when talking to a disconnected cluster

### DIFF
--- a/pkg/odo/cli/component/create_methods.go
+++ b/pkg/odo/cli/component/create_methods.go
@@ -61,17 +61,21 @@ func (icm InteractiveCreateMethod) FetchDevfileAndCreateComponent(co *CreateOpti
 		if err != nil {
 			return err
 		}
-	} else if co.KClient != nil {
-		// Get the current project if no --project is passed, but --now is passed
-		componentNamespace = ui.EnterDevfileComponentProject(co.KClient.GetCurrentProjectName())
 	} else {
-		var client kclient.ClientInterface
-		client, err = kclient.New()
-		// Continue if an error is encountered
-		if err == nil && client != nil {
-			// Get the current project if no --project is passed and using offline context
-			componentNamespace = ui.EnterDevfileComponentProject(client.GetCurrentProjectName())
+		var currentNamespace string
+		if co.KClient != nil {
+			// Get the current project if no --project is passed, but --now is passed
+			currentNamespace = co.KClient.GetCurrentProjectName()
+		} else {
+			var client kclient.ClientInterface
+			client, err = kclient.New()
+			// if err != nil, currentNamespace will be an empty string
+			if err == nil && client != nil {
+				// Get the current project if no --project is passed and using offline context
+				currentNamespace = client.GetCurrentProjectName()
+			}
 		}
+		componentNamespace = ui.EnterDevfileComponentProject(currentNamespace)
 	}
 
 	co.devfileMetadata.componentType = componentType

--- a/pkg/odo/cli/component/create_methods.go
+++ b/pkg/odo/cli/component/create_methods.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"github.com/redhat-developer/odo/pkg/kclient"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -60,9 +61,15 @@ func (icm InteractiveCreateMethod) FetchDevfileAndCreateComponent(co *CreateOpti
 		if err != nil {
 			return err
 		}
-	} else {
-		// if the user is logged in or if we have cluster information, display the default project
+	} else if co.KClient != nil {
+		// Get the current project if no --project is passed, but --now is passed
 		componentNamespace = ui.EnterDevfileComponentProject(co.KClient.GetCurrentProjectName())
+	} else {
+		client, _ := kclient.New()
+		if client != nil {
+			// Get the current project if no --project is passed and using offline context
+			componentNamespace = ui.EnterDevfileComponentProject(client.GetCurrentProjectName())
+		}
 	}
 
 	co.devfileMetadata.componentType = componentType

--- a/pkg/odo/cli/component/create_methods.go
+++ b/pkg/odo/cli/component/create_methods.go
@@ -65,8 +65,10 @@ func (icm InteractiveCreateMethod) FetchDevfileAndCreateComponent(co *CreateOpti
 		// Get the current project if no --project is passed, but --now is passed
 		componentNamespace = ui.EnterDevfileComponentProject(co.KClient.GetCurrentProjectName())
 	} else {
-		client, _ := kclient.New()
-		if client != nil {
+		var client kclient.ClientInterface
+		client, err = kclient.New()
+		// Continue if an error is encountered
+		if err == nil && client != nil {
 			// Get the current project if no --project is passed and using offline context
 			componentNamespace = ui.EnterDevfileComponentProject(client.GetCurrentProjectName())
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR fixes the panic caused while using odo create interactively with a disconnected cluster
**Which issue(s) this PR fixes**:

Fixes #5283 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. Set the current-context to "".
2. `odo create`
Recreate the above steps on main branch to see the panic.