### PR TITLE
Cleanup tests namespaces before to run tests

### DIFF
--- a/.ibm/pipelines/functions.sh
+++ b/.ibm/pipelines/functions.sh
@@ -33,3 +33,18 @@ ${NAME} finished ${STATUS}.
 View logs: [TXT](${BASE_URL}/${LOGFILE}.txt) [HTML](${BASE_URL}/${LOGFILE}.html)
 EOF
 }
+
+# Delete namespaces from cluster containing a configmap named config-map-for-cleanup
+# with values: "team: odo" and "type: testing"
+cleanup_namespaces() {
+    PROJECTS=$(kubectl get cm -A | grep config-map-for-cleanup | awk '{ print $1 }')
+    for PROJECT in ${PROJECTS}
+    do
+        TEAM=$(kubectl get configmaps config-map-for-cleanup -n ${PROJECT} -o jsonpath='{.data.team}')
+        TYPE=$(kubectl get configmaps config-map-for-cleanup -n ${PROJECT} -o jsonpath='{.data.type}')
+        if [[ "${TYPE}" -eq "testing" ]] &&  [[ "${TEAM}" -eq "odo" ]]
+        then
+            kubectl delete namespace ${PROJECT} --wait=false
+        fi
+    done
+}

--- a/.ibm/pipelines/kubernetes-tests.sh
+++ b/.ibm/pipelines/kubernetes-tests.sh
@@ -7,6 +7,8 @@ source .ibm/pipelines/functions.sh
 ibmcloud login --apikey "${API_KEY}" -r "${IBM_REGION}"
 ibmcloud ks cluster config --cluster "${IBM_KUBERNETES_ID}" --admin
 
+cleanup_namespaces
+
 (
     set -e
     make install

--- a/.ibm/pipelines/openshift-tests.sh
+++ b/.ibm/pipelines/openshift-tests.sh
@@ -6,6 +6,8 @@ source .ibm/pipelines/functions.sh
 
 oc login -u apikey -p "${API_KEY}" "${IBM_OPENSHIFT_ENDPOINT}"
 
+cleanup_namespaces
+
 (
     set -e
     make install


### PR DESCRIPTION
**What type of PR is this?**

/kind tests

**What does this PR do / why we need it**:

Cleanup namespaces from cluster before to run tests from IBM Pipelines. The script removes all tests namespaces (not only old ones), as we run 1 pipeline only at a time

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
