### PR TITLE
Allow odo deploy without envfile

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -108,10 +108,10 @@ func retrieveCmdNamespace(cmdline cmdline.Cmdline) (componentNamespace string, e
 	return componentNamespace, nil
 }
 
-// gatherName parses the Devfile and retrieves an appropriate name in two ways.
+// GatherName parses the Devfile and retrieves an appropriate name in two ways.
 // 1. If metadata.name exists, we use it
 // 2. If metadata.name does NOT exist, we use the folder name where the devfile.yaml is located
-func gatherName(devObj parser.DevfileObj, devfilePath string) (string, error) {
+func GatherName(devObj parser.DevfileObj, devfilePath string) (string, error) {
 
 	metadata := devObj.Data.GetMetadata()
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -172,7 +172,7 @@ func (po *PushOptions) setupEnvFile(envFileInfo *envinfo.EnvSpecificInfo, cmdlin
 		if len(args) == 1 {
 			name = args[0]
 		} else {
-			name, err = gatherName(po.Devfile, po.DevfilePath)
+			name, err = GatherName(po.Devfile, po.DevfilePath)
 			if err != nil {
 				return errors.Wrap(err, "unable to gather a name to apply to the env.yaml file")
 			}

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes"
+	"github.com/redhat-developer/odo/pkg/envinfo"
+	"github.com/redhat-developer/odo/pkg/odo/cli/component"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
@@ -40,6 +43,28 @@ func (o *DeployOptions) Complete(name string, cmdline cmdline.Cmdline, args []st
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err
+	}
+
+	envFileInfo, err := envinfo.NewEnvSpecificInfo(o.contextFlag)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve configuration information")
+	}
+	if !envFileInfo.Exists() {
+		var cmpName string
+		cmpName, err = component.GatherName(o.EnvSpecificInfo.GetDevfileObj(), o.GetDevfilePath())
+		if err != nil {
+			return errors.Wrap(err, "unable to retrieve component name")
+		}
+		err = envFileInfo.SetComponentSettings(envinfo.ComponentSettings{Name: cmpName, Project: o.GetProject(), AppName: "app"})
+		if err != nil {
+			return errors.Wrap(err, "failed to write new env.yaml file")
+		}
+
+	} else if envFileInfo.GetComponentSettings().Project != o.GetProject() {
+		err = envFileInfo.SetConfiguration("project", o.GetProject())
+		if err != nil {
+			return errors.Wrap(err, "failed to update project in env.yaml file")
+		}
 	}
 	return
 }

--- a/pkg/odo/cmdline/cobra.go
+++ b/pkg/odo/cmdline/cobra.go
@@ -146,6 +146,10 @@ func (o *Cobra) CheckIfConfigurationNeeded() (bool, error) {
 		if firstChildCommand.Name() == "service" && (o.cmd.Name() == "create" || o.cmd.Name() == "delete") {
 			return true, nil
 		}
+		// Case 11 : if command is deploy
+		if o.cmd.Name() == "deploy" {
+			return true, nil
+		}
 
 	} else {
 		return true, nil

--- a/tests/integration/devfile/cmd_devfile_deploy_test.go
+++ b/tests/integration/devfile/cmd_devfile_deploy_test.go
@@ -28,7 +28,6 @@ var _ = Describe("odo devfile deploy command tests", func() {
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
-			helper.Cmd("odo", "create").ShouldPass()
 		})
 		AfterEach(func() {
 			helper.Cmd("odo", "delete", "-a").ShouldPass()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

- [x] context does not fail when .odo/env is not present
- [ ] create the env file when not present, to save current project

**Which issue(s) this PR fixes**:

Fixes #5289

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
