### PR TITLE
`s/openshift/redhat-developer` in changelog script

### DIFF
--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -48,7 +48,7 @@ echo ""
 
 $RUN_GITHUB_CHANGELOG_GENERATOR \
 --max-issues 500 \
---user openshift \
+--user redhat-developer \
 --project odo \
 --no-issues \
 -t $GITHUB_TOKEN \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
We need it so that changelog script doesn't fail

**Which issue(s) this PR fixes**:

Fixes - NA

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
* Generate a GH token for your account from https://github.com/settings/tokens
* Export it using `export GITHUB_TOKEN=<your-token>`
* `cd scripts`
* Try generating changelog using `./changelog-script.sh 2.4.3 main`.