### PR TITLE
Remove arg 'name' from Complete method

### DIFF
--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -41,7 +41,7 @@ func NewDeleteOptions() *DeleteOptions {
 }
 
 // Complete completes DeleteOptions after they've been created
-func (o *DeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -40,7 +40,7 @@ func NewDescribeOptions() *DescribeOptions {
 }
 
 // Complete completes DescribeOptions after they've been created
-func (o *DescribeOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DescribeOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -38,7 +38,7 @@ func NewListOptions() *ListOptions {
 }
 
 // Complete completes ListOptions after they've been created
-func (o *ListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	return
 }

--- a/pkg/odo/cli/build_images/build_images.go
+++ b/pkg/odo/cli/build_images/build_images.go
@@ -39,7 +39,7 @@ func NewBuildImagesOptions() *BuildImagesOptions {
 }
 
 // Complete completes LoginOptions after they've been created
-func (o *BuildImagesOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *BuildImagesOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag).IsOffline())
 	if err != nil {
 		return err

--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -57,7 +57,7 @@ func NewDescribeComponentOptions() *DescribeComponentOptions {
 }
 
 // Complete completes DescribeComponentOptions after they've been created
-func (o *DescribeComponentOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DescribeComponentOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.componentName = args[0]
 
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).IsOffline())

--- a/pkg/odo/cli/catalog/describe/service.go
+++ b/pkg/odo/cli/catalog/describe/service.go
@@ -40,7 +40,7 @@ func NewDescribeServiceOptions() *DescribeServiceOptions {
 }
 
 // Complete completes DescribeServiceOptions after they've been created
-func (o *DescribeServiceOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DescribeServiceOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -35,7 +35,7 @@ func NewListComponentsOptions() *ListComponentsOptions {
 }
 
 // Complete completes ListComponentsOptions after they've been created
-func (o *ListComponentsOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ListComponentsOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.catalogDevfileList, err = catalog.ListDevfileComponents("")
 	if err != nil {
 		return err

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -36,7 +36,7 @@ func NewServiceOptions() *ServiceOptions {
 }
 
 // Complete completes ListServicesOptions after they've been created
-func (o *ServiceOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ServiceOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/catalog/search/component.go
+++ b/pkg/odo/cli/catalog/search/component.go
@@ -34,7 +34,7 @@ func NewSearchComponentOptions() *SearchComponentOptions {
 }
 
 // Complete completes SearchComponentOptions after they've been created
-func (o *SearchComponentOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *SearchComponentOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/catalog/search/service.go
+++ b/pkg/odo/cli/catalog/search/service.go
@@ -33,7 +33,7 @@ func NewSearchServiceOptions() *SearchServiceOptions {
 }
 
 // Complete completes SearchServiceOptions after they've been created
-func (o *SearchServiceOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *SearchServiceOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -62,8 +62,8 @@ func (o *commonLinkOptions) getLinkType() string {
 }
 
 // Complete completes LinkOptions after they've been created
-func (o *commonLinkOptions) complete(name string, cmdline cmdline.Cmdline, args []string, context string) (err error) {
-	o.operationName = name
+func (o *commonLinkOptions) complete(cmdline cmdline.Cmdline, args []string, context string) (err error) {
+	o.operationName = cmdline.GetName()
 	o.suppliedName = args[0]
 
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(context))

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -21,7 +21,7 @@ type ComponentOptions struct {
 }
 
 // Complete completes component options
-func (co *ComponentOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (co *ComponentOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	co.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		co.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).IsOffline())

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -119,7 +119,7 @@ func NewCreateOptions() *CreateOptions {
 	}
 }
 
-func (co *CreateOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (co *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	// GETTERS
 	// Get context
 	co.Context, err = getContext(co.nowFlag, cmdline)

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -68,7 +68,7 @@ func NewDeleteOptions() *DeleteOptions {
 }
 
 // Complete completes log args
-func (do *DeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (do *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	do.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(do.contextFlag))
 	return err
 }

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -44,14 +44,14 @@ func NewDescribeOptions() *DescribeOptions {
 }
 
 // Complete completes describe args
-func (do *DescribeOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (do *DescribeOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	if do.contextFlag == "" {
 		do.contextFlag, err = os.Getwd()
 		if err != nil {
 			return err
 		}
 	}
-	err = do.ComponentOptions.Complete(name, cmdline, args)
+	err = do.ComponentOptions.Complete(cmdline, args)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -41,7 +41,7 @@ func NewExecOptions() *ExecOptions {
 }
 
 // Complete completes exec args
-func (eo *ExecOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (eo *ExecOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	// gets the command args passed after the dash i.e `--`
 	eo.command, err = cmdline.GetArgsAfterDashes(args)
 	if err != nil || len(eo.command) <= 0 {

--- a/pkg/odo/cli/component/get.go
+++ b/pkg/odo/cli/component/get.go
@@ -39,7 +39,7 @@ func NewGetOptions() *GetOptions {
 }
 
 // Complete completes get args
-func (gto *GetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (gto *GetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	gto.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -75,10 +75,10 @@ func NewLinkOptions() *LinkOptions {
 }
 
 // Complete completes LinkOptions after they've been created
-func (o *LinkOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *LinkOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.commonLinkOptions.devfilePath = location.DevfileLocation(o.contextFlag)
 
-	err = o.complete(name, cmdline, args, o.contextFlag)
+	err = o.complete(cmdline, args, o.contextFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -56,7 +56,7 @@ func NewListOptions() *ListOptions {
 }
 
 // Complete completes log args
-func (lo *ListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (lo *ListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 
 	lo.devfilePath = location.DevfileLocation(lo.contextFlag)
 

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -41,7 +41,7 @@ func NewLogOptions() *LogOptions {
 }
 
 // Complete completes log args
-func (lo *LogOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (lo *LogOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	lo.ComponentOptions.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(lo.contextFlag))
 	return err
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -94,7 +94,7 @@ func (po *PushOptions) GetComponentContext() string {
 }
 
 // Complete completes push args
-func (po *PushOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (po *PushOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	po.CompleteDevfilePath()
 	devfileExists := util.CheckPathExists(po.DevfilePath)
 

--- a/pkg/odo/cli/component/status.go
+++ b/pkg/odo/cli/component/status.go
@@ -51,7 +51,7 @@ func NewStatusOptions() *StatusOptions {
 }
 
 // Complete completes status args
-func (so *StatusOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (so *StatusOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	so.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(so.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -49,7 +49,7 @@ func NewTestOptions() *TestOptions {
 }
 
 // Complete completes TestOptions after they've been created
-func (to *TestOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (to *TestOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	to.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(to.contextFlag))
 	return
 }

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -53,8 +53,8 @@ func NewUnlinkOptions() *UnlinkOptions {
 }
 
 // Complete completes UnlinkOptions after they've been created
-func (o *UnlinkOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
-	err = o.complete(name, cmdline, args, o.contextFlag)
+func (o *UnlinkOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
+	err = o.complete(cmdline, args, o.contextFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -65,7 +65,7 @@ func NewWatchOptions() *WatchOptions {
 }
 
 // Complete completes watch args
-func (wo *WatchOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (wo *WatchOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	wo.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(wo.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -59,7 +59,7 @@ func NewSetOptions() *SetOptions {
 }
 
 // Complete completes SetOptions after they've been created
-func (o *SetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *SetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	params := genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.GetComponentContext())
 	if o.nowFlag {
 		params.CreateAppIfNeeded().RequireRouteAvailability()

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -54,7 +54,7 @@ func NewUnsetOptions() *UnsetOptions {
 }
 
 // Complete completes UnsetOptions after they've been created
-func (o *UnsetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *UnsetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	params := genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.GetComponentContext())
 	if o.nowFlag {
 		params.CreateAppIfNeeded().RequireRouteAvailability()

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -38,7 +38,7 @@ func NewViewOptions() *ViewOptions {
 }
 
 // Complete completes ViewOptions after they've been created
-func (o *ViewOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ViewOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	params := genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag)
 	o.Context, err = genericclioptions.New(params)
 	return err

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -47,7 +47,7 @@ func NewInfoOptions() *InfoOptions {
 }
 
 // Complete completes all the required options for port-forward cmd.
-func (o *InfoOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *InfoOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -73,7 +73,7 @@ func NewPortForwardOptions() *PortForwardOptions {
 }
 
 // Complete completes all the required options for port-forward cmd.
-func (o *PortForwardOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *PortForwardOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -36,7 +36,7 @@ func NewDeployOptions() *DeployOptions {
 }
 
 // Complete DeployOptions after they've been created
-func (o *DeployOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/env/set.go
+++ b/pkg/odo/cli/env/set.go
@@ -59,7 +59,7 @@ func NewSetOptions() *SetOptions {
 }
 
 // Complete completes SetOptions after they've been created
-func (o *SetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *SetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.cfg, err = envinfo.NewEnvSpecificInfo(o.contextFlag)
 	if err != nil {
 		return errors.Wrap(err, "failed to load environment file")

--- a/pkg/odo/cli/env/unset.go
+++ b/pkg/odo/cli/env/unset.go
@@ -53,7 +53,7 @@ func NewUnsetOptions() *UnsetOptions {
 }
 
 // Complete completes UnsetOptions after they've been created
-func (o *UnsetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *UnsetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.cfg, err = envinfo.NewEnvSpecificInfo(o.contextFlag)
 	if err != nil {
 		return errors.Wrap(err, "failed to load environment file")

--- a/pkg/odo/cli/env/view.go
+++ b/pkg/odo/cli/env/view.go
@@ -42,7 +42,7 @@ func NewViewOptions() *ViewOptions {
 }
 
 // Complete completes ViewOptions after they've been created
-func (o *ViewOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ViewOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.cfg, err = envinfo.NewEnvSpecificInfo(o.contextFlag)
 	if err != nil {
 		return errors.Wrap(err, "failed to load environment file")

--- a/pkg/odo/cli/login/login.go
+++ b/pkg/odo/cli/login/login.go
@@ -47,7 +47,7 @@ func NewLoginOptions() *LoginOptions {
 }
 
 // Complete completes LoginOptions after they've been created
-func (o *LoginOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *LoginOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	if len(args) == 1 {
 		o.server = args[0]
 	}

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -30,7 +30,7 @@ func NewLogoutOptions() *LogoutOptions {
 }
 
 // Complete completes LogoutOptions after they've been created
-func (o *LogoutOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *LogoutOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	return
 }

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -42,7 +42,7 @@ func NewSetOptions() *SetOptions {
 }
 
 // Complete completes SetOptions after they've been created
-func (o *SetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *SetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.paramName = args[0]
 	o.paramValue = args[1]
 	return

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -41,7 +41,7 @@ func NewUnsetOptions() *UnsetOptions {
 }
 
 // Complete completes UnsetOptions after they've been created
-func (o *UnsetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *UnsetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.paramName = args[0]
 	return
 }

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -30,7 +30,7 @@ func NewViewOptions() *ViewOptions {
 }
 
 // Complete completes ViewOptions after they've been created
-func (o *ViewOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ViewOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	return
 }
 

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -48,7 +48,7 @@ func NewProjectCreateOptions() *ProjectCreateOptions {
 }
 
 // Complete completes ProjectCreateOptions after they've been created
-func (pco *ProjectCreateOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (pco *ProjectCreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	pco.projectName = args[0]
 	pco.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -50,7 +50,7 @@ func NewProjectDeleteOptions() *ProjectDeleteOptions {
 }
 
 // Complete completes ProjectDeleteOptions after they've been created
-func (pdo *ProjectDeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (pdo *ProjectDeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	pdo.projectName = args[0]
 	pdo.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	return err

--- a/pkg/odo/cli/project/get.go
+++ b/pkg/odo/cli/project/get.go
@@ -41,7 +41,7 @@ func NewProjectGetOptions() *ProjectGetOptions {
 }
 
 // Complete completes ProjectGetOptions after they've been created
-func (pgo *ProjectGetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (pgo *ProjectGetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	pgo.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	return err
 }

--- a/pkg/odo/cli/project/list.go
+++ b/pkg/odo/cli/project/list.go
@@ -38,7 +38,7 @@ func NewProjectListOptions() *ProjectListOptions {
 }
 
 // Complete completes ProjectListOptions after they've been created
-func (plo *ProjectListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (plo *ProjectListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	plo.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	return err
 }

--- a/pkg/odo/cli/project/set.go
+++ b/pkg/odo/cli/project/set.go
@@ -49,7 +49,7 @@ func NewProjectSetOptions() *ProjectSetOptions {
 }
 
 // Complete completes ProjectSetOptions after they've been created
-func (pso *ProjectSetOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (pso *ProjectSetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	pso.projectName = args[0]
 	pso.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {

--- a/pkg/odo/cli/registry/add.go
+++ b/pkg/odo/cli/registry/add.go
@@ -52,7 +52,7 @@ func NewAddOptions() *AddOptions {
 }
 
 // Complete completes AddOptions after they've been created
-func (o *AddOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *AddOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.operation = "add"
 	o.registryName = args[0]
 	o.registryURL = args[1]

--- a/pkg/odo/cli/registry/delete.go
+++ b/pkg/odo/cli/registry/delete.go
@@ -48,7 +48,7 @@ func NewDeleteOptions() *DeleteOptions {
 }
 
 // Complete completes DeleteOptions after they've been created
-func (o *DeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.operation = "delete"
 	o.registryName = args[0]
 	o.registryURL = ""

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -42,7 +42,7 @@ func NewListOptions() *ListOptions {
 }
 
 // Complete completes ListOptions after they've been created
-func (o *ListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	return nil
 }
 

--- a/pkg/odo/cli/registry/update.go
+++ b/pkg/odo/cli/registry/update.go
@@ -49,7 +49,7 @@ func NewUpdateOptions() *UpdateOptions {
 }
 
 // Complete completes UpdateOptions after they've been created
-func (o *UpdateOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *UpdateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.operation = "update"
 	o.registryName = args[0]
 	o.registryURL = args[1]

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -71,7 +71,7 @@ func NewCreateOptions() *CreateOptions {
 }
 
 // Complete completes CreateOptions after they've been created
-func (o *CreateOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -49,7 +49,7 @@ func NewDeleteOptions() *DeleteOptions {
 }
 
 // Complete completes DeleteOptions after they've been created
-func (o *DeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/service/describe.go
+++ b/pkg/odo/cli/service/describe.go
@@ -43,7 +43,7 @@ func NewDescribeOptions() *DescribeOptions {
 	return &DescribeOptions{}
 }
 
-func (o *DescribeOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DescribeOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -39,7 +39,7 @@ func NewServiceListOptions() *ServiceListOptions {
 }
 
 // Complete completes ServiceListOptions after they've been created
-func (o *ServiceListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ServiceListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -53,7 +53,7 @@ func NewStorageCreateOptions() *CreateOptions {
 }
 
 // Complete completes CreateOptions after they've been created
-func (o *CreateOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -44,7 +44,7 @@ func NewStorageDeleteOptions() *DeleteOptions {
 }
 
 // Complete completes DeleteOptions after they've been created
-func (o *DeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -47,7 +47,7 @@ func NewStorageListOptions() *ListOptions {
 }
 
 // Complete completes ListOptions after they've been created
-func (o *ListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/telemetry/telemetry.go
+++ b/pkg/odo/cli/telemetry/telemetry.go
@@ -23,7 +23,7 @@ func NewTelemetryOptions() *TelemetryOptions {
 	return &TelemetryOptions{}
 }
 
-func (o *TelemetryOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *TelemetryOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	err = json.Unmarshal([]byte(args[0]), &o.telemetryData)
 	return err
 }

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -80,7 +80,7 @@ func NewURLCreateOptions() *CreateOptions {
 }
 
 // Complete completes CreateOptions after they've been Created
-func (o *CreateOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	params := genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.GetComponentContext()).RequireRouteAvailability()
 	if o.nowFlag {
 		params.CreateAppIfNeeded()

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -43,7 +43,7 @@ func NewURLDeleteOptions() *DeleteOptions {
 }
 
 // Complete completes DeleteOptions after they've been Deleted
-func (o *DeleteOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.GetComponentContext()))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -47,7 +47,7 @@ func NewURLListOptions() *ListOptions {
 }
 
 // Complete completes ListOptions after they've been Listed
-func (o *ListOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *ListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
 	if err != nil {
 		return err

--- a/pkg/odo/cli/utils/terminal.go
+++ b/pkg/odo/cli/utils/terminal.go
@@ -74,7 +74,7 @@ func NewTerminalOptions() *TerminalOptions {
 }
 
 // Complete completes TerminalOptions after they've been created
-func (o *TerminalOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *TerminalOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	o.shellType = args[0]
 	return
 }

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -45,7 +45,7 @@ func NewVersionOptions() *VersionOptions {
 }
 
 // Complete completes VersionOptions after they have been created
-func (o *VersionOptions) Complete(name string, cmdline cmdline.Cmdline, args []string) (err error) {
+func (o *VersionOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	if !o.clientFlag {
 		// Let's fetch the info about the server, ignoring errors
 		client, err := kclient.New()

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Runnable interface {
-	Complete(name string, cmdline cmdline.Cmdline, args []string) error
+	Complete(cmdline cmdline.Cmdline, args []string) error
 	Validate() error
 	Run() error
 }
@@ -83,7 +83,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	util.LogErrorAndExit(checkConflictingFlags(cmd, args), "")
 	// Run completion, validation and run.
 	// Only upload data to segment for completion and validation if a non-nil error is returned.
-	err = o.Complete(cmd.Name(), cmdline.NewCobra(cmd), args)
+	err = o.Complete(cmdline.NewCobra(cmd), args)
 	if err != nil {
 		startTelemetry(cmd, err, startTime)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
This PR cleans up less used 'name' arg of the Complete method

**Which issue(s) this PR fixes**:

Fixes #5311 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Ensure that none of the tests break.
The refactor was done using IDE's change signature feature, so I'm pretty sure all the `Complete` method usages are covered.