### PR TITLE
Add more verbosity to undeploy

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -848,10 +848,10 @@ func (a Adapter) getDeployCommand() (devfilev1.Command, error) {
 		return devfilev1.Command{}, err
 	}
 	if len(deployGroupCmd) == 0 {
-		return devfilev1.Command{}, errors.New("error deploying, no default deploy command found in devfile")
+		return devfilev1.Command{}, &NoDefaultDeployCommandFoundError{}
 	}
 	if len(deployGroupCmd) > 1 {
-		return devfilev1.Command{}, errors.New("more than one default deploy command found in devfile, should not happen")
+		return devfilev1.Command{}, &MoreThanOneDefaultDeployCommandFoundError{}
 	}
 	return deployGroupCmd[0], nil
 }

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -673,7 +673,7 @@ func (a Adapter) Delete(labels map[string]string, show bool, wait bool) error {
 	if labels == nil {
 		return fmt.Errorf("cannot delete with labels being nil")
 	}
-	log.Infof("\nGathering information for component %s", a.ComponentName)
+	log.Printf("Gathering information for component: %s", a.ComponentName)
 	podSpinner := log.Spinner("Checking status for component")
 	defer podSpinner.End(false)
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -673,7 +673,7 @@ func (a Adapter) Delete(labels map[string]string, show bool, wait bool) error {
 	if labels == nil {
 		return fmt.Errorf("cannot delete with labels being nil")
 	}
-	log.Printf("Gathering information for component: %s", a.ComponentName)
+	log.Printf("Gathering information for component: %q", a.ComponentName)
 	podSpinner := log.Spinner("Checking status for component")
 	defer podSpinner.End(false)
 

--- a/pkg/devfile/adapters/kubernetes/component/component_kubernetes.go
+++ b/pkg/devfile/adapters/kubernetes/component/component_kubernetes.go
@@ -68,7 +68,7 @@ func (o componentKubernetes) UnApply(devfilePath string) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("Un-deploying the Kubernetes %s: %s", u.GetKind(), u.GetName())
+	log.Printf("Un-deploying the Kubernetes %s: %s", u.GetKind(), u.GetName())
 	// Un-deploy the K8s manifest
 	return o.client.DeleteDynamicResource(u.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource)
 }

--- a/pkg/devfile/adapters/kubernetes/component/errors.go
+++ b/pkg/devfile/adapters/kubernetes/component/errors.go
@@ -1,0 +1,13 @@
+package component
+
+type NoDefaultDeployCommandFoundError struct{}
+
+func (e NoDefaultDeployCommandFoundError) Error() string {
+	return "error deploying, no default deploy command found in devfile"
+}
+
+type MoreThanOneDefaultDeployCommandFoundError struct{}
+
+func (e MoreThanOneDefaultDeployCommandFoundError) Error() string {
+	return "more than one default deploy command found in devfile, should not happen"
+}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -227,9 +227,9 @@ func Progressf(format string, a ...interface{}) {
 	}
 }
 
-// Print will output in an appropriate "information" manner; for e.g.
+// Printf will output in an appropriate "information" manner; for e.g.
 // • <message>
-func Print(format string, a ...interface{}) {
+func Printf(format string, a ...interface{}) {
 	if !IsJSON() {
 		fmt.Fprintf(GetStdout(), "%s%s%s%s\n", prefixSpacing, getSpacingString(), suffixSpacing, fmt.Sprintf(format, a...))
 	}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -227,6 +227,14 @@ func Progressf(format string, a ...interface{}) {
 	}
 }
 
+// Print will output in an appropriate "information" manner; for e.g.
+// • <message>
+func Print(format string, a ...interface{}) {
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s%s%s%s\n", prefixSpacing, getSpacingString(), suffixSpacing, fmt.Sprintf(format, a...))
+	}
+}
+
 // Success will output in an appropriate "success" manner
 func Success(a ...interface{}) {
 	if !IsJSON() {

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -80,7 +80,7 @@ func (o *DeleteOptions) Run() (err error) {
 		return o.appClient.Delete(o.appName)
 	}
 
-	// Print App Information which will be deleted
+	// Printf App Information which will be deleted
 	err = printAppInfo(o.appClient, o.appName, o.GetProject())
 	if err != nil {
 		return err

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -80,7 +80,7 @@ func (o *DeleteOptions) Run() (err error) {
 		return o.appClient.Delete(o.appName)
 	}
 
-	// Printf App Information which will be deleted
+	// Print App Information which will be deleted
 	err = printAppInfo(o.appClient, o.appName, o.GetProject())
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -93,7 +93,7 @@ func (do *DeleteOptions) Run() (err error) {
 			if err != nil {
 				// if there is no component in the devfile to undeploy or if the devfile is non-existent, then skip the error log
 				if errors.Is(err, &component.NoDefaultDeployCommandFoundError{}) || !devfileExists {
-					log.Print("no kubernetes component to un-deploy")
+					log.Printf("no kubernetes component to un-deploy")
 				} else {
 					log.Errorf("error occurred while un-deploying, cause: %v", err)
 				}
@@ -110,7 +110,7 @@ func (do *DeleteOptions) Run() (err error) {
 			err = do.DevfileComponentDelete()
 			if err != nil {
 				if !devfileExists {
-					log.Print("no devfile component to delete")
+					log.Printf("no devfile component to delete")
 				} else {
 					log.Errorf("error occurred while deleting component, cause: %v", err)
 				}
@@ -126,7 +126,7 @@ func (do *DeleteOptions) Run() (err error) {
 		// Prompt and delete env folder
 		if do.forceFlag || ui.Proceed("Are you sure you want to delete env folder?") {
 			if !do.EnvSpecificInfo.Exists() {
-				log.Print("env folder doesn't exist for the component")
+				log.Printf("env folder doesn't exist for the component")
 				return nil
 			}
 			if err = util.DeleteIndexFile(filepath.Dir(do.GetDevfilePath())); err != nil {
@@ -151,11 +151,11 @@ func (do *DeleteOptions) Run() (err error) {
 		}
 
 		// Prompt and delete the devfile.yaml
-		successMessage := "Successfully delete devfile.yaml file"
+		successMessage := "Successfully deleted devfile.yaml file"
 		devfileNotExistsMessage := "devfile.yaml does not exist in the current directory"
 		if do.forceFlag {
 			if !devfileExists {
-				log.Print(devfileNotExistsMessage)
+				log.Printf(devfileNotExistsMessage)
 				return nil
 			}
 			if !do.EnvSpecificInfo.IsUserCreatedDevfile() {
@@ -196,7 +196,7 @@ func (do *DeleteOptions) Run() (err error) {
 
 		} else if ui.Proceed("Are you sure you want to delete devfile.yaml?") {
 			if !devfileExists {
-				log.Print(devfileNotExistsMessage)
+				log.Printf(devfileNotExistsMessage)
 				return nil
 			}
 

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -87,7 +87,7 @@ func (o *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 	if err != nil {
 		return err
 	}
-	//if no args are provided and if request is not from file, user wants interactive mode
+	// if no args are provided and if request is not from file, user wants interactive mode
 	if o.fromFileFlag == "" && len(args) == 0 {
 		return fmt.Errorf("odo doesn't support interactive mode for creating Operator backed service")
 	}
@@ -133,7 +133,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	}
 
 	serviceCreateCmd.Flags().BoolVar(&o.inlinedFlag, "inlined", false, "Puts the service definition in the devfile instead of a separate file")
-	serviceCreateCmd.Flags().BoolVar(&o.DryRunFlag, "dry-run", false, "Print the yaml specificiation that will be used to create the operator backed service")
+	serviceCreateCmd.Flags().BoolVar(&o.DryRunFlag, "dry-run", false, "Printf the yaml specificiation that will be used to create the operator backed service")
 	// remove this feature after enabling service create interactive mode for operator backed services
 	serviceCreateCmd.Flags().StringVar(&o.fromFileFlag, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
 

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -133,7 +133,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	}
 
 	serviceCreateCmd.Flags().BoolVar(&o.inlinedFlag, "inlined", false, "Puts the service definition in the devfile instead of a separate file")
-	serviceCreateCmd.Flags().BoolVar(&o.DryRunFlag, "dry-run", false, "Printf the yaml specificiation that will be used to create the operator backed service")
+	serviceCreateCmd.Flags().BoolVar(&o.DryRunFlag, "dry-run", false, "Print the yaml specificiation that will be used to create the operator backed service")
 	// remove this feature after enabling service create interactive mode for operator backed services
 	serviceCreateCmd.Flags().StringVar(&o.fromFileFlag, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
 

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -46,6 +46,15 @@ var _ = Describe("odo devfile delete command tests", func() {
 		It("should delete the component", func() {
 			helper.Cmd("odo", "delete", "-f").ShouldPass()
 		})
+		It("should delete the component, env, odo folders and odo-index-file.json with --all flag", func() {
+			stdOut := helper.Cmd("odo", "delete", "-f", "--all").ShouldPass().Out()
+
+			files := helper.ListFilesInDir(commonVar.Context)
+			Expect(files).To(Not(ContainElement(".odo")))
+			Expect(files).To(Not(ContainElement("devfile.yaml")))
+			Expect(stdOut).To(ContainSubstring("no kubernetes component to un-deploy"))
+		})
+
 		When("odo deploy is run", func() {
 			BeforeEach(func() {
 				// requires a different devfile
@@ -83,11 +92,12 @@ var _ = Describe("odo devfile delete command tests", func() {
 				helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
 			})
 			It("should delete the component, env, odo folders and odo-index-file.json with --all flag", func() {
-				helper.Cmd("odo", "delete", "-f", "--all").ShouldPass()
+				stdOut := helper.Cmd("odo", "delete", "-f", "--all").ShouldPass().Out()
 
 				files := helper.ListFilesInDir(commonVar.Context)
 				Expect(files).To(Not(ContainElement(".odo")))
 				Expect(files).To(Not(ContainElement("devfile.yaml")))
+				Expect(stdOut).To(ContainSubstring("no kubernetes component to un-deploy"))
 			})
 
 			Describe("deleting a component from other component directory", func() {

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -56,6 +56,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 		})
 
 		When("odo deploy is run", func() {
+			undeploymentMessage := "Un-deploying the Kubernetes Component"
 			BeforeEach(func() {
 				// requires a different devfile
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
@@ -63,15 +64,15 @@ var _ = Describe("odo devfile delete command tests", func() {
 			})
 			It("should successfully delete the deploy resources with --deploy flag", func() {
 				stdOut := helper.Cmd("odo", "delete", "--deploy", "-f").ShouldPass().Out()
-				Expect(stdOut).To(ContainSubstring("Un-deploying the Kubernetes Deployment"))
+				Expect(stdOut).To(ContainSubstring(undeploymentMessage))
 			})
 			It("should successfully delete the deploy resources", func() {
 				stdOut := helper.Cmd("odo", "delete", "-a", "-f").ShouldPass().Out()
-				Expect(stdOut).To(ContainSubstring("Un-deploying the Kubernetes Deployment"))
+				Expect(stdOut).To(ContainSubstring(undeploymentMessage))
 			})
 			It("should successfully delete the component, but the deployed resources should remain intact", func() {
 				stdOut := helper.Cmd("odo", "delete", "-f").ShouldPass().Out()
-				Expect(stdOut).ToNot(ContainSubstring("Un-deploying the Kubernetes"))
+				Expect(stdOut).ToNot(ContainSubstring(undeploymentMessage))
 			})
 			When("outside the context directory", func() {
 				BeforeEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR adds more verbosity to un-deploy while executing odo delete -af.
**Which issue(s) this PR fixes**:

Fixes #5321 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/redhat-developer/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```sh
odo create nodejs --starter nodejs-starter
odo push
odo delete -af
```

Output:
```sh
➜ odo delete -fa 
Un-deploying the Kubernetes Deployment
 ✗  no kubernetes component to un-deploy

Gathering information for component nodejs-abc-jtmy
 ✗  Checking status for component [5ms]
 ⚠  pod not found for the selector: app.kubernetes.io/instance=nodejs-abc-jtmy,app.kubernetes.io/part-of=app

Deleting local config
 ✓  Successfully deleted env file
 ✓  Successfully deleted devfile.yaml file
```