### PR TITLE
fix typos and style in 2.5.0 blog post

### DIFF
--- a/docs/website/blog/2022-01-14-odo-v2.5.0.md
+++ b/docs/website/blog/2022-01-14-odo-v2.5.0.md
@@ -15,7 +15,7 @@ slug: odo-250-release
 
 ### Support for ephemeral field in Devfile `volumes` definition ([#5279](https://github.com/redhat-developer/odo/pull/5279) [@feloy](https://github.com/feloy))
 
-odo now supports Devfile volumes that are defined as ephemeral. If volume is defined with `ephemeral: true` odo will create it as Kubernetes `emptyDir` volume.
+odo now supports Devfile volumes that are defined as ephemeral. If a volume is defined with `ephemeral: true` odo will create it as a Kubernetes `emptyDir` volume.
 
 Example of an ephemeral volume definition inside `devfile.yaml`
 
@@ -28,7 +28,7 @@ Example of an ephemeral volume definition inside `devfile.yaml`
 
 ### Delete outerloop resources with `odo delete --deploy`([PR#5276](https://github.com/redhat-developer/odo/pull/5276) [@valaparthvi](https://github.com/valaparthvi))
 
-Now you can delete resources that were deployed using `odo deploy` command using `odo delete` command with `--deploy` flag.
+You can now delete resources that were deployed using odo deploy via the odo delete --deploy command.
 `odo delete --all` now deletes everything from the cluster related to the given Devfile including outer-loop resources.
 
 |Delete command| Deletes resources from cluster | Deletes local `devfile.yaml` |
@@ -40,19 +40,20 @@ Now you can delete resources that were deployed using `odo deploy` command using
 
 ### Add suppport for cpuLimit, cpuRequest and memoryRequest ([PR#5252](https://github.com/redhat-developer/odo/pull/5252) [@anandrkskd](https://github.com/anandrkskd))
 
-odo now supports specifying additional resource constrains for `container` components in Devfile as introduced in Devfile v2.1.0.
+odo now supports specifying additional resource constraints for `container` components in Devfile as introduced by Devfile v2.1.0.
 
 You can use the following constraints:
-| Devfile container field | Kubernetes equivalent in Pod definition | Description |
-| - | - | -|
-|`memoryLimit`| `spec.containers[].resources.limits.memory` | Describes the maximum allowed memory for the container. |
-|`memoryRequest`| `spec.containers[].resources.requests.cpu`  | Describes the minimum memory that the container requires. |
-|`cpuLimit`| `spec.containers[].resources.limits.cpu` | Describes the maximum allowed CPU cores for the container  |
-|`cpuRequest`| `spec.containers[].resources.requests.cpu` | Describes the minimum number of CPU cores that the container requires.|
+
+| Devfile container field | Kubernetes equivalent in Pod specification (`spec.containers[].`)  | Description |
+|-|-|-|
+|`memoryLimit`| `resources.limits.memory` | Describes the maximum allowed memory for the container. |
+|`memoryRequest`| `resources.requests.cpu`  | Describes the minimum memory that the container requires. |
+|`cpuLimit`| `resources.limits.cpu` | Describes the maximum allowed CPU cores for the container  |
+|`cpuRequest`| `resources.requests.cpu` | Describes the minimum number of CPU cores that the container requires. |
 
 You can learn more about resource management in [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) section in [Kubernetes documentation](https://kubernetes.io/docs/)
 
-Example of a Devfile container with all resource constraints:
+Example of a Devfile container with all available resource constraints:
 
 ```yaml
 components:
@@ -73,13 +74,13 @@ components:
 
 You can specify custom Service Binding mappings using `odo link` command.
 
-For example, following link command
+For example, with the following link command
 
 ```sh
 odo link PostgresCluster/hippo --map pgVersion='{{ .database.spec.postgresVersion }}'
 ```
 
-Will generate `ServiceBinding` resource similar to
+Odo will generate `ServiceBinding` resource similar to
 
 ```yaml
 apiVersion: binding.operators.coreos.com/v1alpha1
@@ -108,4 +109,4 @@ spec:
 
 You can find more information about how to  [compose custom binding data](https://redhat-developer.github.io/service-binding-operator/userguide/creating-service-bindings/binding-options.html#_compose_custom_binding_data) in [Service Binding Operator Documentation](https://redhat-developer.github.io/service-binding-operator/)
 
-As with every release, you can find the full list of changes and bug fixes on [GitHub release page](https://github.com/redhat-developer/odo/releases/tag/v2.5.0)
+As with every release, you can find the full list of changes and bug fixes on the [GitHub release page](https://github.com/redhat-developer/odo/releases/tag/v2.5.0)

--- a/docs/website/blog/2022-01-14-odo-v2.5.0.md
+++ b/docs/website/blog/2022-01-14-odo-v2.5.0.md
@@ -13,11 +13,12 @@ slug: odo-250-release
 
 ## Notable changes in odo 2.5.0
 
-
 ### Support for ephemeral field in Devfile `volumes` definition ([#5279](https://github.com/redhat-developer/odo/pull/5279) [@feloy](https://github.com/feloy))
+
 odo now supports Devfile volumes that are defined as ephemeral. If volume is defined with `ephemeral: true` odo will create it as Kubernetes `emptyDir` volume.
 
 Example of an ephemeral volume definition inside `devfile.yaml`
+
 ```yaml
 - name: volume-test
   volume:
@@ -25,10 +26,10 @@ Example of an ephemeral volume definition inside `devfile.yaml`
     ephemeral: true
 ```
 
-
 ### Delete outerloop resources with `odo delete --deploy`([PR#5276](https://github.com/redhat-developer/odo/pull/5276) [@valaparthvi](https://github.com/valaparthvi))
-Now you can delete resoures that were deployed using `odo deploy` command using `odo delete` command with `--deploy` flag.
-`odo delete --all` now deletes everything from the cluster related to give Devfile incudling outerloop resources.
+
+Now you can delete resources that were deployed using `odo deploy` command using `odo delete` command with `--deploy` flag.
+`odo delete --all` now deletes everything from the cluster related to the given Devfile including outer-loop resources.
 
 |Delete command| Deletes resources from cluster | Deletes local `devfile.yaml` |
 |-|-|-|
@@ -37,11 +38,11 @@ Now you can delete resoures that were deployed using `odo deploy` command using 
 |`odo delete --all`| YES (deletes all resources created by odo) | YES|
 
 
-
 ### Add suppport for cpuLimit, cpuRequest and memoryRequest ([PR#5252](https://github.com/redhat-developer/odo/pull/5252) [@anandrkskd](https://github.com/anandrkskd))
-odo now supports specifing additional resource contstrains for `container` components in Devfile as introduced in Devfile v2.1.0.
 
-You can use following constrains:
+odo now supports specifying additional resource constrains for `container` components in Devfile as introduced in Devfile v2.1.0.
+
+You can use the following constraints:
 | Devfile container field | Kubernetes equivalent in Pod definition | Description |
 | - | - | -|
 |`memoryLimit`| `spec.containers[].resources.limits.memory` | Describes the maximum allowed memory for the container. |
@@ -49,11 +50,9 @@ You can use following constrains:
 |`cpuLimit`| `spec.containers[].resources.limits.cpu` | Describes the maximum allowed CPU cores for the container  |
 |`cpuRequest`| `spec.containers[].resources.requests.cpu` | Describes the minimum number of CPU cores that the container requires.|
 
-You can lear more about resource mamagement in [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) section in [Kubernetes documentation](https://kubernetes.io/docs/)
+You can learn more about resource management in [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) section in [Kubernetes documentation](https://kubernetes.io/docs/)
 
-
-
-Example of a Devfile container with all resource constrains:
+Example of a Devfile container with all resource constraints:
 
 ```yaml
 components:
@@ -70,15 +69,18 @@ components:
       mountSources: true
 ```
 
-
 ### Adds mapping support to odo link ([PR#5237](https://github.com/redhat-developer/odo/pull/5237) [@dharmit](https://github.com/dharmit))
+
 You can specify custom Service Binding mappings using `odo link` command.
 
-For example following link command
+For example, following link command
+
+```sh
+odo link PostgresCluster/hippo --map pgVersion='{{ .database.spec.postgresVersion }}'
 ```
- odo link PostgresCluster/hippo --map pgVersion='{{ .database.spec.postgresVersion }}'
-```
-Will generate `ServiceBinding` resource similar to 
+
+Will generate `ServiceBinding` resource similar to
+
 ```yaml
 apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
@@ -103,7 +105,7 @@ spec:
     name: hippo
     version: v1beta1
 ```
+
 You can find more information about how to  [compose custom binding data](https://redhat-developer.github.io/service-binding-operator/userguide/creating-service-bindings/binding-options.html#_compose_custom_binding_data) in [Service Binding Operator Documentation](https://redhat-developer.github.io/service-binding-operator/)
 
-
-As with every release, you can find full list of changes and bug fixes on [GitHub release page](https://github.com/redhat-developer/odo/releases/tag/v2.5.0)
+As with every release, you can find the full list of changes and bug fixes on [GitHub release page](https://github.com/redhat-developer/odo/releases/tag/v2.5.0)

--- a/docs/website/blog/2022-01-14-odo-v2.5.0.md
+++ b/docs/website/blog/2022-01-14-odo-v2.5.0.md
@@ -26,10 +26,10 @@ Example of an ephemeral volume definition inside `devfile.yaml`
     ephemeral: true
 ```
 
-### Delete outerloop resources with `odo delete --deploy`([PR#5276](https://github.com/redhat-developer/odo/pull/5276) [@valaparthvi](https://github.com/valaparthvi))
+### Delete outer loop resources with `odo delete --deploy`([PR#5276](https://github.com/redhat-developer/odo/pull/5276) [@valaparthvi](https://github.com/valaparthvi))
 
 You can now delete resources that were deployed using odo deploy via the odo delete --deploy command.
-`odo delete --all` now deletes everything from the cluster related to the given Devfile including outer-loop resources.
+`odo delete --all` now deletes everything from the cluster related to the given Devfile including outer loop resources.
 
 |Delete command| Deletes resources from cluster | Deletes local `devfile.yaml` |
 |-|-|-|


### PR DESCRIPTION
/kind documentation

I merged the original blog post by accident :-/  (https://github.com/redhat-developer/odo/pull/5349)
This fixes some of the style errors and typos.