### PR TITLE
WIP: Fix odo component describe without context fails and discrepancies in human readable and machine-readable output

### DIFF
--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -1,158 +1,149 @@
 package component
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/devfile/library/pkg/devfile/parser"
 	v1 "k8s.io/api/apps/v1"
 	"path/filepath"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
-	"github.com/redhat-developer/odo/pkg/localConfigProvider"
 	"github.com/redhat-developer/odo/pkg/service"
 
-	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/storage"
 	urlpkg "github.com/redhat-developer/odo/pkg/url"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ComponentFullDescriptionSpec represents the complete description of the component
-type ComponentFullDescriptionSpec struct {
-	App     string              `json:"app,omitempty"`
-	Type    string              `json:"type,omitempty"`
-	Source  string              `json:"source,omitempty"`
-	URL     urlpkg.URLList      `json:"urls,omitempty"`
-	Storage storage.StorageList `json:"storages,omitempty"`
-	Env     []corev1.EnvVar     `json:"env,omitempty"`
-	Ports   []string            `json:"ports,omitempty"`
-}
-
-// ComponentFullDescription describes a component fully
-type ComponentFullDescription struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ComponentFullDescriptionSpec `json:"spec,omitempty"`
-	Status            ComponentStatus              `json:"status,omitempty"`
-}
-
-// copyFromComponentDescription copies over all fields from Component that can be copied
-func (cfd *ComponentFullDescription) copyFromComponentDesc(component *Component) error {
-	d, err := json.Marshal(component)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(d, cfd)
-}
-
 // fillEmptyFields fills any fields that are empty in the ComponentFullDescription
-func (cfd *ComponentFullDescription) fillEmptyFields(componentDesc Component, componentName string, applicationName string, projectName string) {
-	// fix missing names in case it is in not in description
-	if len(cfd.Name) <= 0 {
-		cfd.Name = componentName
+func (cmp *Component) fillEmptyFields(componentName string, applicationName string, projectName string) {
+	// fix missing names in case it in not in description
+	if len(cmp.Name) <= 0 {
+		cmp.Name = componentName
 	}
 
-	if len(cfd.Namespace) <= 0 {
-		cfd.Namespace = projectName
+	if len(cmp.Namespace) <= 0 {
+		cmp.Namespace = projectName
 	}
 
-	if len(cfd.Kind) <= 0 {
-		cfd.Kind = "Component"
+	if len(cmp.Kind) <= 0 {
+		cmp.Kind = "Component"
 	}
 
-	if len(cfd.APIVersion) <= 0 {
-		cfd.APIVersion = apiVersion
+	if len(cmp.APIVersion) <= 0 {
+		cmp.APIVersion = apiVersion
 	}
 
-	if len(cfd.Spec.App) <= 0 {
-		cfd.Spec.App = applicationName
+	if len(cmp.Spec.App) <= 0 {
+		cmp.Spec.App = applicationName
 	}
-	cfd.Spec.Ports = componentDesc.Spec.Ports
 }
 
 // NewComponentFullDescriptionFromClientAndLocalConfigProvider gets the complete description of the component from cluster
-func NewComponentFullDescriptionFromClientAndLocalConfigProvider(client kclient.ClientInterface, envInfo *envinfo.EnvSpecificInfo, componentName string, applicationName string, projectName string, context string) (*ComponentFullDescription, error) {
-	cfd := &ComponentFullDescription{}
-	var state State
-	if client == nil {
-		state = StateTypeUnknown
-	} else {
-		state = GetComponentState(client, componentName, applicationName)
-	}
-	var componentDesc Component
-	var devfile devfileParser.DevfileObj
-	var err error
-	var configLinks []string
-	componentDesc, devfile, err = GetComponentFromDevfile(envInfo)
+func NewComponentFullDescriptionFromClientAndLocalConfigProvider(client kclient.ClientInterface, envInfo *envinfo.EnvSpecificInfo, componentName string, applicationName string, projectName string, context string) (*Component, error) {
+	// Read component from the devfile
+	componentDesc, devfileObj, err := GetComponentFromDevfile(envInfo)
 	if err != nil {
-		return cfd, err
+		return &componentDesc, err
 	}
-	configLinks, err = service.ListDevfileLinks(devfile, context)
 
-	if err != nil {
-		return cfd, err
-	}
-	err = cfd.copyFromComponentDesc(&componentDesc)
-	if err != nil {
-		return cfd, err
-	}
-	cfd.Status.State = state
 	var deployment *v1.Deployment
-	if state == StateTypePushed {
-		componentDescFromCluster, e := getRemoteComponentMetadata(client, componentName, applicationName, false, false)
-		if e != nil {
-			return cfd, e
-		}
-		cfd.Spec.Env = componentDescFromCluster.Spec.Env
-		cfd.Spec.Type = componentDescFromCluster.Spec.Type
-		cfd.Status.LinkedServices = componentDescFromCluster.Status.LinkedServices
-		// Obtain the deployment to correctly instantiate the Storage and URL client and get information
-		deployment, err = client.GetOneDeployment(componentName, applicationName)
+	// user has access to the cluster
+	if client != nil {
+		var componentDescFromCluster Component
+		componentDescFromCluster, err = getRemoteComponentMetadata(client, componentName, applicationName, false, false)
+		// component was not found on the cluster
 		if err != nil {
-			// ideally the error should not occur since we have already established that the component exists on the cluster
-			return cfd, err
+			// if local component is not the same as user asked component,
+			// then return a simple component with user provided information with state as to Unknown
+			if componentName != componentDesc.Name {
+				componentDesc = Component{}
+				componentDesc.Status.State = StateTypeUnknown
+				componentDesc.fillEmptyFields(componentName, applicationName, projectName)
+				return &componentDesc, nil
+			} else {
+				// since local component and user asked component are same, we can assume that the component has not been pushed yet,
+				// hence set it's state to Not Pushed
+				componentDesc.Status.State = StateTypeNotPushed
+			}
+		} else {
+			// component was found on the cluster
+
+			// if the user asked component was found on the cluster, but is not the same as local component,
+			// then set local component obtained from the devfile to reflect the remote component;
+			// also nullify the devfileObj since it becomes irrelevant to the information user wants
+			if componentName != componentDesc.Name {
+				componentDesc = componentDescFromCluster
+				devfileObj = parser.DevfileObj{}
+			} else {
+				// if both remote and local component are same, then assign the necessary remote data into the local data
+				componentDesc.Status.State = componentDescFromCluster.Status.State
+				componentDesc.Annotations = componentDescFromCluster.Annotations
+				componentDesc.Labels = componentDescFromCluster.Labels
+				componentDesc.CreationTimestamp = componentDescFromCluster.CreationTimestamp
+				componentDesc.Spec.Env = append(componentDesc.Spec.Env, componentDescFromCluster.Spec.Env...)
+				componentDesc.Spec.Type = componentDescFromCluster.Spec.Type
+				componentDesc.Status.LinkedServices = componentDescFromCluster.Status.LinkedServices
+			}
+			// Obtain the deployment to correctly instantiate the Storage and URL client and get information
+			deployment, err = client.GetOneDeployment(componentName, applicationName)
+			if err != nil {
+				// ideally the error should not occur since we have already established that the component exists on the cluster
+				return &componentDesc, err
+			}
+		}
+	} else {
+		// user does not have access to the cluster
+
+		// if local component is not the same as user asked component,
+		// then return a simple component with user provided information with state as to Unknown
+		if componentName != componentDesc.Name {
+			componentDesc = Component{}
+			componentDesc.Status.State = StateTypeUnknown
+			componentDesc.fillEmptyFields(componentName, applicationName, projectName)
+			return &componentDesc, nil
+		} else {
+			// if the user asked component is same as the local component, then set it's status to Not Pushed
+			componentDesc.Status.State = StateTypeNotPushed
 		}
 	}
+	// Fill empty fields (especially APIVersion, and Kind)
+	componentDesc.fillEmptyFields(componentName, applicationName, projectName)
 
+	envInfo.SetDevfileObj(devfileObj)
+
+	// Obtain the information (about Storage, URL, and Links) because that is not parsed from the devfile so far
+	// Get links
+	var configLinks []string
+	configLinks, err = service.ListDevfileLinks(devfileObj, context)
+	if err != nil {
+		return &componentDesc, err
+	}
 	for _, link := range configLinks {
 		found := false
-		for _, linked := range cfd.Status.LinkedServices {
+		for _, linked := range componentDesc.Status.LinkedServices {
 			if linked.ServiceName == link {
 				found = true
 				break
 			}
 		}
 		if !found {
-			cfd.Status.LinkedServices = append(cfd.Status.LinkedServices, SecretMount{
+			componentDesc.Status.LinkedServices = append(componentDesc.Status.LinkedServices, SecretMount{
 				ServiceName: link,
 			})
 		}
 	}
 
-	cfd.fillEmptyFields(componentDesc, componentName, applicationName, projectName)
-
+	// Obtain URLs information
 	var urls urlpkg.URLList
-
 	var routeSupported bool
-	var e error
-	if client == nil {
-		routeSupported = false
-	} else {
-		routeSupported, e = client.IsRouteSupported()
-		if e != nil {
-			// we assume if there was an error then the cluster is not connected
-			routeSupported = false
-		}
+	if client != nil {
+		// we assume if there was an error then the cluster is not connected
+		routeSupported, _ = client.IsRouteSupported()
 	}
 
-	var configProvider localConfigProvider.LocalConfigProvider
-	envInfo.SetDevfileObj(devfile)
-	configProvider = envInfo
-
 	urlClient := urlpkg.NewClient(urlpkg.ClientOptions{
-		LocalConfigProvider: configProvider,
+		LocalConfigProvider: envInfo,
 		Client:              client,
 		IsRouteSupported:    routeSupported,
 		Deployment:          deployment,
@@ -162,7 +153,9 @@ func NewComponentFullDescriptionFromClientAndLocalConfigProvider(client kclient.
 	if err != nil {
 		log.Warningf("URLs couldn't not be retrieved: %v", err)
 	}
-	cfd.Spec.URL = urls
+	// We explicitly do not fill in Spec.URL for describe because,
+	// it is essentially a list of URL names, which seems redundant when the detailed URLSpec is available
+	componentDesc.Spec.URLSpec = urls.Items
 
 	// Obtain Storage information
 	var storages storage.StorageList
@@ -178,28 +171,24 @@ func NewComponentFullDescriptionFromClientAndLocalConfigProvider(client kclient.
 	if err != nil {
 		log.Warningf("Storages couldn't not be retrieved: %v", err)
 	}
-	cfd.Spec.Storage = storages
+	componentDesc.Spec.StorageSpec = storages.Items
 
-	return cfd, nil
+	return &componentDesc, nil
+
 }
 
 // Print prints the complete information of component onto stdout (Note: long term this function should not need to access any parameters, but just print the information in struct)
-func (cfd *ComponentFullDescription) Print(client kclient.ClientInterface) error {
+func (cmp *Component) Print(client kclient.ClientInterface) error {
 	// TODO: remove the need to client here print should just deal with printing
-	log.Describef("Component Name: ", cfd.GetName())
-	log.Describef("Type: ", cfd.Spec.Type)
-
-	// Source
-	if cfd.Spec.Source != "" {
-		log.Describef("Source: ", cfd.Spec.Source)
-	}
+	log.Describef("Component Name: ", cmp.GetName())
+	log.Describef("Type: ", cmp.Spec.Type)
 
 	// Env
-	if cfd.Spec.Env != nil {
+	if cmp.Spec.Env != nil {
 
 		// Retrieve all the environment variables
 		var output string
-		for _, env := range cfd.Spec.Env {
+		for _, env := range cmp.Spec.Env {
 			output += fmt.Sprintf(" · %v=%v\n", env.Name, env.Value)
 		}
 
@@ -212,11 +201,11 @@ func (cfd *ComponentFullDescription) Print(client kclient.ClientInterface) error
 	}
 
 	// Storage
-	if len(cfd.Spec.Storage.Items) > 0 {
+	if len(cmp.Spec.StorageSpec) > 0 {
 
 		// Gather the output
 		var output string
-		for _, store := range cfd.Spec.Storage.Items {
+		for _, store := range cmp.Spec.StorageSpec {
 			eph := ""
 			if store.Spec.Ephemeral != nil {
 				if *store.Spec.Ephemeral {
@@ -237,10 +226,10 @@ func (cfd *ComponentFullDescription) Print(client kclient.ClientInterface) error
 	}
 
 	// URL
-	if len(cfd.Spec.URL.Items) > 0 {
+	if len(cmp.Spec.URLSpec) > 0 {
 		var output string
 		// if the component is not pushed
-		for _, componentURL := range cfd.Spec.URL.Items {
+		for _, componentURL := range cmp.Spec.URLSpec {
 			if componentURL.Status.State == urlpkg.StateTypePushed {
 				output += fmt.Sprintf(" · %v exposed via %v\n", urlpkg.GetURLString(componentURL.Spec.Protocol, componentURL.Spec.Host, ""), componentURL.Spec.Port)
 			} else {
@@ -254,11 +243,11 @@ func (cfd *ComponentFullDescription) Print(client kclient.ClientInterface) error
 	}
 
 	// Linked services
-	if len(cfd.Status.LinkedServices) > 0 {
+	if len(cmp.Status.LinkedServices) > 0 {
 
 		// Gather the output
 		var output string
-		for _, linkedService := range cfd.Status.LinkedServices {
+		for _, linkedService := range cmp.Status.LinkedServices {
 
 			if linkedService.SecretName == "" {
 				output += fmt.Sprintf(" · %s\n", linkedService.ServiceName)
@@ -266,7 +255,7 @@ func (cfd *ComponentFullDescription) Print(client kclient.ClientInterface) error
 			}
 
 			// Let's also get the secrets / environment variables that are being passed in.. (if there are any)
-			secrets, err := client.GetSecret(linkedService.SecretName, cfd.GetNamespace())
+			secrets, err := client.GetSecret(linkedService.SecretName, cmp.GetNamespace())
 			if err != nil {
 				return err
 			}
@@ -306,24 +295,4 @@ func (cfd *ComponentFullDescription) Print(client kclient.ClientInterface) error
 
 	}
 	return nil
-}
-
-// GetComponent returns a component representation
-func (cfd *ComponentFullDescription) GetComponent() Component {
-	cmp := NewComponent(cfd.Name)
-	cmp.Spec.App = cfd.Spec.App
-	cmp.Spec.Ports = cfd.Spec.Ports
-	cmp.Spec.Type = cfd.Spec.Type
-	cmp.Spec.StorageSpec = cfd.Spec.Storage.Items
-	cmp.Spec.URLSpec = cfd.Spec.URL.Items
-	for _, url := range cfd.Spec.URL.Items {
-		cmp.Spec.URL = append(cmp.Spec.URL, url.Name)
-	}
-	for _, storage := range cfd.Spec.Storage.Items {
-		cmp.Spec.Storage = append(cmp.Spec.URL, storage.Name)
-	}
-	cmp.ObjectMeta.Namespace = cfd.ObjectMeta.Namespace
-	cmp.Status = cfd.Status
-	cmp.Spec.Env = cfd.Spec.Env
-	return cmp
 }

--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -57,18 +57,14 @@ func NewComponentFullDescriptionFromClientAndLocalConfigProvider(client kclient.
 	if hasAccessToCluster {
 		var componentDescFromCluster Component
 		componentDescFromCluster, err = getRemoteComponentMetadata(client, componentName, applicationName, false, false)
-		// TODO: Move these to functions?
 		componentFoundInCluster := err == nil
 
 		// component was not found on the cluster
 		if !componentFoundInCluster {
-			// if local component is not the same as user asked component,
-			// then return a simple component with user provided information with state as to Unknown
+			// if local component is not the same as user asked component, then set the state to Unknown
 			if !userMatchesDevfile {
-				// TODO: Move this to function
 				componentDesc = Component{}
 				componentDesc.Status.State = StateTypeUnknown
-				devfileObj = parser.DevfileObj{}
 			} else {
 				// since local component and user asked component are same, we can assume that the component has not been pushed yet,
 				// hence set it's state to Not Pushed

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"github.com/kylelemons/godebug/pretty"
 	"reflect"
 	"regexp"
 	"testing"
@@ -223,7 +224,7 @@ func TestList(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(tt.output, results) {
-				t.Errorf("expected output:\n%#v\n\ngot:\n%#v", tt.output, results)
+				t.Errorf("List() error, difference at %v", pretty.Compare(tt.output, results))
 			}
 		})
 	}

--- a/pkg/component/pushed_component.go
+++ b/pkg/component/pushed_component.go
@@ -222,6 +222,7 @@ func GetPushedComponent(c kclient.ClientInterface, componentName, applicationNam
 		Client:     c,
 		Deployment: d,
 	})
+
 	return newPushedComponent(applicationName, &devfileComponent{d: *d}, c, storageClient, urlClient), nil
 }
 

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -22,11 +22,10 @@ type Component struct {
 type ComponentSpec struct {
 	App         string            `json:"app,omitempty"`
 	Type        string            `json:"type,omitempty"`
-	Source      string            `json:"source,omitempty"`
 	URL         []string          `json:"url,omitempty"`
-	URLSpec     []url.URL         `json:"-"`
+	URLSpec     []url.URL         `json:"urlSpec,omitempty"`
 	Storage     []string          `json:"storage,omitempty"`
-	StorageSpec []storage.Storage `json:"-"`
+	StorageSpec []storage.Storage `json:"storageSpec,omitempty"`
 	Env         []corev1.EnvVar   `json:"env,omitempty"`
 	Ports       []string          `json:"ports,omitempty"`
 }

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -24,6 +24,7 @@ type ComponentOptions struct {
 func (co *ComponentOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
 	co.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 	if err != nil {
+		// TODO: add a check for ignorable errors.
 		co.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).IsOffline())
 		if err != nil {
 			return err

--- a/pkg/odo/cli/component/create_helpers.go
+++ b/pkg/odo/cli/component/create_helpers.go
@@ -57,6 +57,6 @@ func (co *CreateOptions) DevfileJSON() error {
 	if err != nil {
 		return err
 	}
-	machineoutput.OutputSuccess(cfd.GetComponent())
+	machineoutput.OutputSuccess(cfd)
 	return nil
 }

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -152,23 +152,22 @@ func checkConflictingFlags(cmd *cobra.Command, args []string) error {
 	context := stringFlagLookup(cmd, "context")
 	component := stringFlagLookup(cmd, "component")
 	all, _ := strconv.ParseBool(stringFlagLookup(cmd, "all"))
-	// TODO: Move this to a method under DeleteOptions, similar to CreateOptions.checkConflictingFlags
-	if cmd.Name() == "delete" {
-		if cmd.HasParent() {
-			if cmd.Parent().Name() == "odo" || cmd.Parent().Name() == "component" {
-				var componentName string
-				if len(args) > 0 {
-					componentName = args[0]
-				}
-				if (context != "") && (project != "" || componentName != "") {
-					return fmt.Errorf("cannot provide --project or component name when --context is provided")
-				}
-				if project != "" && componentName == "" && app == "" {
-					return fmt.Errorf("cannot provide --project without --app and component name")
-				}
-				if all && ((componentName != "" && app != "" && project != "") || (componentName != "")) {
-					return fmt.Errorf("cannot provide --all when component name, --app and --project are provided")
-				}
+
+	if cmd.Name() == "delete" || cmd.Name() == "describe" {
+		if (cmd.Parent().Name() == "odo" || cmd.Parent().Name() == "component") && (cmd.Parent().Name() != "app") {
+			var componentName string
+			if len(args) > 0 {
+				componentName = args[0]
+			}
+			if (context != "") && (project != "" || componentName != "" || app != "") {
+				return fmt.Errorf("cannot provide --project, --app, or component name when --context is provided")
+			}
+			if componentName == "" && (app != "" || project != "") {
+				return fmt.Errorf("cannot provide --app or --project without a component name")
+			}
+
+			if all && ((componentName != "" && app != "" && project != "") || (componentName != "")) {
+				return fmt.Errorf("cannot provide --all when component name, --app and --project are provided")
 			}
 		}
 	}

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -160,31 +160,25 @@ func checkConflictingFlags(cmd *cobra.Command, args []string) error {
 				componentName = args[0]
 			}
 			var msgArgs []string
-			if context != "" {
-				if project != "" {
-					msgArgs = append(msgArgs, "--project")
-				}
-				if app != "" {
-					msgArgs = append(msgArgs, "--app")
-				}
-				if componentName != "" {
-					msgArgs = append(msgArgs, "component name")
-				}
+			if project != "" {
+				msgArgs = append(msgArgs, "--project")
+			}
+			if app != "" {
+				msgArgs = append(msgArgs, "--app")
+			}
+			if componentName != "" {
+				msgArgs = append(msgArgs, "component name")
+			}
+
+			if context != "" && len(msgArgs) != 0 {
 				return fmt.Errorf("cannot provide %vwhen --context is provided", strings.Join(msgArgs, ", "))
 			}
 
-			if componentName == "" {
-				if app != "" {
-					msgArgs = append(msgArgs, "--app")
-				}
-				if project != "" {
-					msgArgs = append(msgArgs, "--project")
-				}
+			if componentName == "" && len(msgArgs) != 0 {
 				return fmt.Errorf("cannot provide %v without a component name", strings.Join(msgArgs, ", "))
 			}
-
-			if all && ((componentName != "" && app != "" && project != "") || (componentName != "")) {
-				return fmt.Errorf("cannot provide --all when component name, --app and --project are provided")
+			if all {
+				return fmt.Errorf("cannot provide --all when %v is provided", strings.Join(msgArgs, ", "))
 			}
 		}
 	}

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -159,11 +159,28 @@ func checkConflictingFlags(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				componentName = args[0]
 			}
-			if (context != "") && (project != "" || componentName != "" || app != "") {
-				return fmt.Errorf("cannot provide --project, --app, or component name when --context is provided")
+			var msgArgs []string
+			if context != "" {
+				if project != "" {
+					msgArgs = append(msgArgs, "--project")
+				}
+				if app != "" {
+					msgArgs = append(msgArgs, "--app")
+				}
+				if componentName != "" {
+					msgArgs = append(msgArgs, "component name")
+				}
+				return fmt.Errorf("cannot provide %vwhen --context is provided", strings.Join(msgArgs, ", "))
 			}
-			if componentName == "" && (app != "" || project != "") {
-				return fmt.Errorf("cannot provide --app or --project without a component name")
+
+			if componentName == "" {
+				if app != "" {
+					msgArgs = append(msgArgs, "--app")
+				}
+				if project != "" {
+					msgArgs = append(msgArgs, "--project")
+				}
+				return fmt.Errorf("cannot provide %v without a component name", strings.Join(msgArgs, ", "))
 			}
 
 			if all && ((componentName != "" && app != "" && project != "") || (componentName != "")) {

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -177,7 +177,7 @@ func checkConflictingFlags(cmd *cobra.Command, args []string) error {
 			if componentName == "" && len(msgArgs) != 0 {
 				return fmt.Errorf("cannot provide %v without a component name", strings.Join(msgArgs, ", "))
 			}
-			if all {
+			if all && len(msgArgs) != 0 {
 				return fmt.Errorf("cannot provide --all when %v is provided", strings.Join(msgArgs, ", "))
 			}
 		}

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -73,15 +73,10 @@ func CheckOutputFlag(outputFlag string) error {
 }
 
 // PrintComponentInfo prints Component Information like path, URL & storage
-func PrintComponentInfo(client kclient.ClientInterface, currentComponentName string, componentDesc component.Component, applicationName string, project string) error {
+func PrintComponentInfo(client kclient.ClientInterface, currentComponentName string, componentDesc component.Component, project string) error {
 
 	log.Describef("Component Name: ", currentComponentName)
 	log.Describef("Type: ", componentDesc.Spec.Type)
-
-	// Source
-	if componentDesc.Spec.Source != "" {
-		log.Describef("Source: ", componentDesc.Spec.Source)
-	}
 
 	// Env
 	if componentDesc.Spec.Env != nil {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -25,6 +25,8 @@ const (
 	StateTypeNotPushed = "Not Pushed"
 	// StateTypeLocallyDeleted means that Storage was deleted from the local config, but it is still present on the cluster
 	StateTypeLocallyDeleted = "Locally Deleted"
+	// StateTypeUnknown means that Storage is present on the cluster/container, but might not be present locally
+	StateTypeUnknown = "Unknown"
 )
 
 // StorageSpec indicates size and path of storage

--- a/pkg/url/types.go
+++ b/pkg/url/types.go
@@ -57,6 +57,8 @@ const (
 	StateTypeNotPushed = "Not Pushed"
 	// StateTypeLocallyDeleted means that URL was deleted from the local config, but it is still present on the cluster/container
 	StateTypeLocallyDeleted = "Locally Deleted"
+	// StateTypeUnknown means that URL is present on the cluster/container, but might not be present locally
+	StateTypeUnknown = "Unknown"
 )
 
 // NewURL gives machine readable URL definition

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -125,7 +125,7 @@ var _ = Describe("odo devfile create command tests", func() {
 		It("should successfully create the devfile component and show json output for non connected cluster", func() {
 			output := helper.Cmd("odo", "create", "nodejs", "--context", newContext, "-o", "json").WithEnv("KUBECONFIG=/no/such/path", "GLOBALODOCONFIG="+os.Getenv("GLOBALODOCONFIG")).ShouldPass().Out()
 			values := gjson.GetMany(output, "kind", "metadata.name", "status.state")
-			Expect(helper.GjsonMatcher(values, []string{"Component", "nodejs", "Unknown"})).To(Equal(true))
+			Expect(helper.GjsonMatcher(values, []string{"Component", "nodejs", "Not Pushed"})).To(Equal(true))
 		})
 
 		When("the cluster is unreachable", func() {
@@ -156,7 +156,7 @@ var _ = Describe("odo devfile create command tests", func() {
 			It("should successfully create the devfile component and show json output", func() {
 				output := helper.Cmd("odo", "create", "nodejs", "--context", newContext, "-o", "json").WithEnv("KUBECONFIG="+newKubeConfigPath, "GLOBALODOCONFIG="+os.Getenv("GLOBALODOCONFIG")).ShouldPass().Out()
 				values := gjson.GetMany(output, "kind", "metadata.name", "status.state")
-				Expect(helper.GjsonMatcher(values, []string{"Component", "nodejs", "Unknown"})).To(Equal(true))
+				Expect(helper.GjsonMatcher(values, []string{"Component", "nodejs", "Not Pushed"})).To(Equal(true))
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
This PR fixes the panic caused when running odo describe without access to the context directory. It also fixes discrepancies between human readable and machine readable output. It also removes an extra struct, making use of existing ones.

**Which issue(s) this PR fixes:**
Fixes #5344
Fixes #5245 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Test this with the following scenarios
1. Within the component's context directory, run `odo describe` and JSON 
2. Within the component's context directory, run `odo describe <comp_name> --app --project` and JSON 
3. Outside the component's context directory, run `odo describe` for a non-pushed component and JSON
4. Outside the component's context directory, run `odo describe` for a pushed component and JSON
5. Within the component's context directory, run `odo describe` for a pushed component that does not belong to the context directory and JSON
6. Within the component's context directory, run `odo describe` for a non-pushed component that does not belong to the context directory and JSON
