### PR TITLE
Add --hostname alias to odo url create

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -38,11 +38,14 @@ var (
 	# Create a URL for the current component with a specific port
 	%[1]s --port 8080
 
+	# Create a URL of ingress kind 
+	%[1]s --port 8080 --ingress
+
 	# Create a URL with a specific name and port
 	%[1]s example --port 8080
 
-	# Create a URL of ingress kind for the current component with a host
-	%[1]s --port 8080 --host example.com --ingress
+	# Create a URL with a subdomain and hostname for example.domain.com
+	%[1]s example --port 8080 --host domain.com
 
 	# Create a secure URL for the current component
 	%[1]s --port 8080 --secure
@@ -216,7 +219,12 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 	}
 	urlCreateCmd.Flags().IntVarP(&o.portFlag, "port", "", -1, "Port number for the url of the component, required in case of components which expose more than one service port")
 	urlCreateCmd.Flags().StringVar(&o.tlsSecretFlag, "tls-secret", "", "TLS secret name for the url of the component if the user bring their own TLS secret")
-	urlCreateCmd.Flags().StringVarP(&o.hostFlag, "host", "", "", "Cluster IP for this URL")
+	urlCreateCmd.Flags().StringVarP(&o.hostFlag, "host", "", "", "Cluster IP for this URL (alias \"--hostname\")")
+
+	// Alias for `--host` in case someone where to enter --hostname by mistake, and then mark it as hidden.
+	urlCreateCmd.Flags().StringVarP(&o.hostFlag, "hostname", "", "", "Alias for --host")
+	urlCreateCmd.Flags().MarkHidden("hostname")
+
 	urlCreateCmd.Flags().BoolVar(&o.ingressFlag, "ingress", false, "Create an Ingress instead of Route on OpenShift clusters")
 	urlCreateCmd.Flags().BoolVarP(&o.secureFlag, "secure", "", false, "Create a secure HTTPS URL")
 	urlCreateCmd.Flags().StringVarP(&o.pathFlag, "path", "", "", "path for this URL")

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -223,7 +223,7 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 
 	// Alias for `--host` in case someone where to enter --hostname by mistake, and then mark it as hidden.
 	urlCreateCmd.Flags().StringVarP(&o.hostFlag, "hostname", "", "", "Alias for --host")
-	urlCreateCmd.Flags().MarkHidden("hostname")
+	_ = urlCreateCmd.Flags().MarkHidden("hostname")
 
 	urlCreateCmd.Flags().BoolVar(&o.ingressFlag, "ingress", false, "Create an Ingress instead of Route on OpenShift clusters")
 	urlCreateCmd.Flags().BoolVarP(&o.secureFlag, "secure", "", false, "Create a secure HTTPS URL")


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Developer-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/PR-Review

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Contributing-to-Docs
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind feature

**What does this PR do / why we need it:**

This adds the --hostname alias to the `odo url create` command since
similar tools such as `oc` use `--hostname` to create routes, and thus
a user may accidently enter --hostname instead.

This PR also reorganized the help usage so it's more inline with
"building up" on each example.

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5379

**PR acceptance criteria:**

- [ ] Unit test

N/A

- [ ] Integration test

N/A

- [X] Documentation

**How to test changes / Special notes to the reviewer:**

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>