### PR TITLE
Fix odo describe panic without the context directory

### DIFF
--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -47,36 +47,6 @@ func (cfd *ComponentFullDescription) copyFromComponentDesc(component *Component)
 	return json.Unmarshal(d, cfd)
 }
 
-// loadStoragesFromClientAndLocalConfig collects information about storages both locally and from the cluster.
-func (cfd *ComponentFullDescription) loadStoragesFromClientAndLocalConfig(client kclient.ClientInterface, configProvider localConfigProvider.LocalConfigProvider, componentName string, applicationName string, componentDesc *Component) error {
-	var storages storage.StorageList
-	var err error
-
-	// if component is pushed call ListWithState which gets storages from localconfig and cluster
-	// this result is already in mc readable form
-	if componentDesc.Status.State == StateTypePushed {
-		storageClient := storage.NewClient(storage.ClientOptions{
-			Client:              client,
-			LocalConfigProvider: configProvider,
-		})
-
-		storages, err = storageClient.List()
-		if err != nil {
-			return err
-		}
-	} else {
-		// otherwise simply fetch storagelist locally
-		storageLocal, err := configProvider.ListStorage()
-		if err != nil {
-			return err
-		}
-		// convert to machine readable format
-		storages = storage.ConvertListLocalToMachine(storageLocal)
-	}
-	cfd.Spec.Storage = storages
-	return nil
-}
-
 // fillEmptyFields fills any fields that are empty in the ComponentFullDescription
 func (cfd *ComponentFullDescription) fillEmptyFields(componentDesc Component, componentName string, applicationName string, projectName string) {
 	// fix missing names in case it is in not in description

--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -79,7 +79,7 @@ func (cfd *ComponentFullDescription) loadStoragesFromClientAndLocalConfig(client
 
 // fillEmptyFields fills any fields that are empty in the ComponentFullDescription
 func (cfd *ComponentFullDescription) fillEmptyFields(componentDesc Component, componentName string, applicationName string, projectName string) {
-	// fix missing names in case it in not in description
+	// fix missing names in case it is in not in description
 	if len(cfd.Name) <= 0 {
 		cfd.Name = componentName
 	}

--- a/pkg/envinfo/storage.go
+++ b/pkg/envinfo/storage.go
@@ -56,7 +56,7 @@ func (ei *EnvInfo) ValidateStorage(storage localConfigProvider.LocalStorage) err
 		return nil
 	}
 
-	//check if specified container exists or not (if specified)
+	// check if specified container exists or not (if specified)
 	containerExists := false
 	containers, err := ei.GetContainers()
 	if err != nil {
@@ -91,7 +91,7 @@ func (ei *EnvInfo) GetStorage(name string) (*localConfigProvider.LocalStorage, e
 
 // CreateStorage sets the storage related information in the local configuration
 func (ei *EnvInfo) CreateStorage(storage localConfigProvider.LocalStorage) error {
-	//initialize volume mount and volume container
+	// initialize volume mount and volume container
 	vm := []devfilev1.VolumeMount{
 		{
 			Name: storage.Name,

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -187,7 +187,7 @@ func (k kubernetesClient) ListFromCluster() (StorageList, error) {
 
 // List lists pvc based Storage and local Storage with respective states
 func (k kubernetesClient) List() (StorageList, error) {
-	if k.localConfigProvider == nil {
+	if !k.localConfigProvider.Exists() {
 		return StorageList{}, fmt.Errorf("no local config was provided")
 	}
 

--- a/pkg/storage/kubernetes_test.go
+++ b/pkg/storage/kubernetes_test.go
@@ -619,7 +619,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 			mockLocalConfig.EXPECT().GetName().Return(tt.fields.generic.componentName).AnyTimes()
 			mockLocalConfig.EXPECT().GetApplication().Return(tt.fields.generic.appName).AnyTimes()
 			mockLocalConfig.EXPECT().ListStorage().Return(tt.returnedLocalStorage, nil)
-
+			mockLocalConfig.EXPECT().Exists().Return(true)
 			tt.fields.generic.localConfigProvider = mockLocalConfig
 
 			k := kubernetesClient{

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -87,7 +87,7 @@ func (k kubernetesClient) List() (URLList, error) {
 	}
 
 	localMap := make(map[string]URL)
-	if k.localConfigProvider != nil {
+	if k.localConfigProvider.Exists() {
 		// get the URLs present on the localConfigProvider
 		localURLS, err := k.localConfigProvider.ListURLs()
 		if err != nil {

--- a/pkg/url/kubernetes_test.go
+++ b/pkg/url/kubernetes_test.go
@@ -404,7 +404,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 
 			mockLocalConfig := localConfigProvider.NewMockLocalConfigProvider(ctrl)
 			mockLocalConfig.EXPECT().ListURLs().Return(tt.returnedLocalURLs, nil)
-
+			mockLocalConfig.EXPECT().Exists().Return(true)
 			fkclient, fkclientset := kclient.FakeNewWithIngressSupports(true, false)
 			fkclient.Namespace = "default"
 

--- a/pkg/url/status_test.go
+++ b/pkg/url/status_test.go
@@ -161,6 +161,7 @@ func TestGetURLsForKubernetes(t *testing.T) {
 			mockLocalConfig := localConfigProvider.NewMockLocalConfigProvider(ctrl)
 			mockLocalConfig.EXPECT().GetName().Return(componentName).AnyTimes()
 			mockLocalConfig.EXPECT().GetApplication().Return("app")
+			mockLocalConfig.EXPECT().Exists().Return(true)
 			mockLocalConfig.EXPECT().ListURLs().Return(tt.envURLs, nil)
 
 			// Initialising the fakeclient


### PR DESCRIPTION

**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
This PR fixes the panic caused when running odo describe without the context directory.
**Which issue(s) this PR fixes:**

Fixes #5245

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```sh
odo create nodejs mynode --app myapp --project myproject
odo push
<cd outside the context directory>
odo describe mynode --app myapp --project myproject
```
