### PR TITLE
fix comment override for windows test

### DIFF
--- a/.ibm/pipelines/windows-test.sh
+++ b/.ibm/pipelines/windows-test.sh
@@ -21,7 +21,7 @@ echo "RESULT: $RESULT"
 source .ibm/pipelines/functions.sh
 ibmcloud login --apikey "${API_KEY}" -r "${IBM_REGION}"
 sshpass -p $WINDOWS_PASSWORD scp  -o StrictHostKeyChecking=no Administrator@$WINDOWS_IP:/tmp/${LOGFILE}   /tmp/${LOGFILE}
-save_logs "${LOGFILE}" "OpenShift Windows Tests"  $RESULT
+save_logs "${LOGFILE}" "Windows Tests (OCP)"  $RESULT
 
 # cleanup 
 sshpass -p $WINDOWS_PASSWORD ssh Administrator@$WINDOWS_IP    -o StrictHostKeyChecking=no rm -rf /tmp/windows-test-script.ps1


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**
/kind tests

**What does this PR do / why we need it:**
We have running windows tests running, but it override the comment from openshift tests on PR. This PR will fix it. 
**Which issue(s) this PR fixes:**
Fixes #5300 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
