### PR TITLE
minor changes to use service IDs and clusters in the Developer QE account

### DIFF
--- a/.ibm/pipelines/kubernetes-tests.sh
+++ b/.ibm/pipelines/kubernetes-tests.sh
@@ -4,7 +4,8 @@ LOGFILE="pr-${GIT_PR_NUMBER}-kubernetes-tests-${BUILD_NUMBER}"
 
 source .ibm/pipelines/functions.sh
 
-ibmcloud login --apikey "${API_KEY}" -r "${IBM_REGION}"
+ibmcloud login --apikey "${API_KEY}"
+ibmcloud target -r "${IBM_REGION}"
 ibmcloud ks cluster config --cluster "${IBM_KUBERNETES_ID}" --admin
 
 cleanup_namespaces

--- a/.ibm/pipelines/openshift-tests.sh
+++ b/.ibm/pipelines/openshift-tests.sh
@@ -19,7 +19,10 @@ cleanup_namespaces
 ) |& tee "/tmp/${LOGFILE}"
 RESULT=${PIPESTATUS[0]}
 
-ibmcloud login --apikey "${API_KEY}" -r "${IBM_REGION}"
+ibmcloud login --apikey "${API_KEY}" 
+ibmcloud target -r "${IBM_REGION}"
+ibmcloud ks cluster config --cluster "${IBM_KUBERNETES_ID}" --admin
+oc login -u apikey -p "${API_KEY}" "${IBM_OPENSHIFT_ENDPOINT}"
 save_logs "${LOGFILE}" "OpenShift Tests" ${RESULT}
 
 exit ${RESULT}

--- a/.ibm/pipelines/openshift-tests.sh
+++ b/.ibm/pipelines/openshift-tests.sh
@@ -21,8 +21,6 @@ RESULT=${PIPESTATUS[0]}
 
 ibmcloud login --apikey "${API_KEY}" 
 ibmcloud target -r "${IBM_REGION}"
-ibmcloud ks cluster config --cluster "${IBM_KUBERNETES_ID}" --admin
-oc login -u apikey -p "${API_KEY}" "${IBM_OPENSHIFT_ENDPOINT}"
 save_logs "${LOGFILE}" "OpenShift Tests" ${RESULT}
 
 exit ${RESULT}


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
**What does this PR do / why we need it:**
Minor changes to use Service IDs and clusters in the developer QE account
For both kubernetes and openshift:
Breaks current login command to first login, then select region:
`ibmcloud login --apikey "${API_KEY}" -r "${IBM_REGION}"`
     v
`ibmcloud login --apikey "${API_KEY}"`
`ibmcloud target -r "${IBM_REGION}"`

For Openshift:
Added downloading of kubeconfig (noted that when using Service IDs it requires kubeconfig before oc login)
Added oc login command

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
