### PR TITLE
Use functions from devfile library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-git/v5 v5.3.0
 	github.com/go-openapi/spec v0.19.5
-	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.5.0
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c
 	github.com/kubernetes-sigs/service-catalog v0.3.1
 	github.com/kylelemons/godebug v1.1.0
@@ -56,7 +54,7 @@ require (
 	k8s.io/cli-runtime v0.22.0-rc.0
 	k8s.io/client-go v0.22.2
 	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.10.0
+	k8s.io/klog/v2 v2.10.0 // indirect
 	k8s.io/kubectl v0.22.1
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/controller-runtime v0.10.2

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/zalando/go-keyring"
 
+	dfutil "github.com/devfile/library/pkg/util"
 	indexSchema "github.com/devfile/registry-support/index/generator/schema"
 	registryLibrary "github.com/devfile/registry-support/registry-library/library"
 
@@ -192,20 +193,20 @@ func getRegistryDevfiles(preferenceClient preference.Client, registry Registry) 
 	}
 	registry.URL = URL
 	indexLink := registry.URL + indexPath
-	request := util.HTTPRequestParams{
+	request := dfutil.HTTPRequestParams{
 		URL: indexLink,
 	}
 
 	secure := registryUtil.IsSecure(preferenceClient, registry.Name)
 	if secure {
-		token, e := keyring.Get(fmt.Sprintf("%s%s", util.CredentialPrefix, registry.Name), registryUtil.RegistryUser)
+		token, e := keyring.Get(fmt.Sprintf("%s%s", dfutil.CredentialPrefix, registry.Name), registryUtil.RegistryUser)
 		if e != nil {
 			return nil, errors.Wrap(e, "unable to get secure registry credential from keyring")
 		}
 		request.Token = token
 	}
 
-	jsonBytes, err := util.HTTPGetRequest(request, preferenceClient.GetRegistryCacheTime())
+	jsonBytes, err := dfutil.HTTPGetRequest(request, preferenceClient.GetRegistryCacheTime())
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to download the devfile index.json from %s", indexLink)
 	}
@@ -217,7 +218,7 @@ func getRegistryDevfiles(preferenceClient preference.Client, registry Registry) 
 			log.Warning("Error while cleaning up cache dir.")
 		}
 		// we try once again
-		jsonBytes, err := util.HTTPGetRequest(request, preferenceClient.GetRegistryCacheTime())
+		jsonBytes, err := dfutil.HTTPGetRequest(request, preferenceClient.GetRegistryCacheTime())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to download the devfile index.json from %s", indexLink)
 		}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -8,25 +8,27 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/devfile/api/v2/pkg/devfile"
-
-	v1 "k8s.io/api/apps/v1"
-
 	"github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	dfutil "github.com/devfile/library/pkg/util"
+
+	applabels "github.com/redhat-developer/odo/pkg/application/labels"
+	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
-	"github.com/redhat-developer/odo/pkg/service"
-
-	"github.com/pkg/errors"
-	applabels "github.com/redhat-developer/odo/pkg/application/labels"
-	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/preference"
+	"github.com/redhat-developer/odo/pkg/service"
 	urlpkg "github.com/redhat-developer/odo/pkg/url"
 	"github.com/redhat-developer/odo/pkg/util"
+
 	servicebinding "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
+
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -77,7 +79,7 @@ func GetDefaultComponentName(cfg preference.Client, componentPath string, compon
 	prefix = util.TruncateString(prefix, componentRandomNamePartsMaxLen)
 
 	// Generate unique name for the component using prefix and unique random suffix
-	componentName, err := util.GetRandomName(
+	componentName, err := dfutil.GetRandomName(
 		fmt.Sprintf("%s-%s", componentType, prefix),
 		componentNameMaxLen,
 		existingComponentNames,
@@ -309,7 +311,7 @@ func ListDevfileComponentsInPath(client kclient.ClientInterface, paths []string)
 // The first returned parameter is a bool indicating if a component with the given name already exists or not
 // The second returned parameter is the error that might occurs while execution
 func Exists(client kclient.ClientInterface, componentName, applicationName string) (bool, error) {
-	deploymentName, err := util.NamespaceOpenShiftObject(componentName, applicationName)
+	deploymentName, err := dfutil.NamespaceOpenShiftObject(componentName, applicationName)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to create namespaced name")
 	}

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -5,12 +5,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/devfile/library/pkg/devfile/parser/data"
+	"github.com/kylelemons/godebug/pretty"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
+	"github.com/devfile/library/pkg/devfile/parser/data"
 	"github.com/devfile/library/pkg/testingutil"
-	"github.com/kylelemons/godebug/pretty"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/util"
 )
 
@@ -1741,7 +1743,7 @@ func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 
 func getExecCommand(id string, group devfilev1.CommandGroupKind) devfilev1.Command {
 	if len(id) == 0 {
-		id = fmt.Sprintf("%s-%s", "cmd", util.GenerateRandomString(10))
+		id = fmt.Sprintf("%s-%s", "cmd", dfutil.GenerateRandomString(10))
 	}
 	commands := [...]string{"ls -la", "pwd"}
 	components := [...]string{"alias1", "alias2"}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -8,34 +8,34 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/pointer"
+	"github.com/pkg/errors"
 
-	"github.com/devfile/library/pkg/devfile/generator"
+	"github.com/redhat-developer/odo/pkg/component"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/devfile"
-	"github.com/redhat-developer/odo/pkg/envinfo"
-	"github.com/redhat-developer/odo/pkg/preference"
-	"github.com/redhat-developer/odo/pkg/service"
-	"github.com/redhat-developer/odo/pkg/util"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/pkg/errors"
-	"k8s.io/klog"
-
-	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes/storage"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes/utils"
+	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/preference"
+	"github.com/redhat-developer/odo/pkg/service"
 	storagepkg "github.com/redhat-developer/odo/pkg/storage"
 	"github.com/redhat-developer/odo/pkg/sync"
+	"github.com/redhat-developer/odo/pkg/util"
+
+	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/library/pkg/devfile/generator"
+	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	dfutil "github.com/devfile/library/pkg/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 )
 
 const supervisorDStatusWaitTimeInterval = 1
@@ -146,12 +146,12 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	// Validate the devfile build and run commands
 	log.Info("\nValidation")
 	s := log.Spinner("Validating the devfile")
-	err = util.ValidateK8sResourceName("component name", a.ComponentName)
+	err = dfutil.ValidateK8sResourceName("component name", a.ComponentName)
 	if err != nil {
 		return err
 	}
 
-	err = util.ValidateK8sResourceName("component namespace", parameters.EnvSpecificInfo.GetNamespace())
+	err = dfutil.ValidateK8sResourceName("component namespace", parameters.EnvSpecificInfo.GetNamespace())
 	if err != nil {
 		return err
 	}
@@ -457,7 +457,7 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 	// This annotated value will later be used when listing the components; we do this to list/describe and stay inline with the component type value set in the devfile.
 	annotatedComponentType := component.GetComponentTypeFromDevfileMetadata(a.AdapterContext.Devfile.Data.GetMetadata())
 	if annotatedComponentType != component.NotAvailable {
-		componentType = strings.TrimSuffix(util.ExtractComponentType(componentType), "-")
+		componentType = strings.TrimSuffix(dfutil.ExtractComponentType(componentType), "-")
 	}
 
 	labels := componentlabels.GetLabels(componentName, a.AppName, true)

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/devfile/library/pkg/devfile/generator"
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	dfutil "github.com/devfile/library/pkg/util"
 
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
-	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/storage"
 	storagepkg "github.com/redhat-developer/odo/pkg/storage"
@@ -76,7 +76,7 @@ func GetPersistentVolumesAndVolumeMounts(devfileObj devfileParser.DevfileObj, co
 		for _, containerComp := range containerComponents {
 			for _, volumeMount := range containerComp.Container.VolumeMounts {
 				if volName == volumeMount.Name {
-					containerNameToMountPaths[containerComp.Name] = append(containerNameToMountPaths[containerComp.Name], envinfo.GetVolumeMountPath(volumeMount))
+					containerNameToMountPaths[containerComp.Name] = append(containerNameToMountPaths[containerComp.Name], generator.GetVolumeMountPath(volumeMount))
 				}
 			}
 		}
@@ -104,7 +104,7 @@ func GetEphemeralVolumesAndVolumeMounts(devfileObj devfileParser.DevfileObj, con
 		for _, containerComp := range containerComponents {
 			for _, volumeMount := range containerComp.Container.VolumeMounts {
 				if volName == volumeMount.Name {
-					containerNameToMountPaths[containerComp.Name] = append(containerNameToMountPaths[containerComp.Name], envinfo.GetVolumeMountPath(volumeMount))
+					containerNameToMountPaths[containerComp.Name] = append(containerNameToMountPaths[containerComp.Name], generator.GetVolumeMountPath(volumeMount))
 				}
 			}
 		}

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -4,21 +4,23 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/pkg/errors"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/storage"
 	storagepkg "github.com/redhat-developer/odo/pkg/storage"
 	storagelabels "github.com/redhat-developer/odo/pkg/storage/labels"
-	"github.com/redhat-developer/odo/pkg/util"
+
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // VolumeInfo is a struct to hold the pvc name and the volume name to create a volume.
@@ -178,7 +180,7 @@ func addVolumeMountToContainers(containers []corev1.Container, initContainers []
 
 // generateVolumeNameFromPVC generates a volume name based on the pvc name
 func generateVolumeNameFromPVC(pvc string) (volumeName string, err error) {
-	volumeName, err = util.NamespaceOpenShiftObject(pvc, "vol")
+	volumeName, err = dfutil.NamespaceOpenShiftObject(pvc, "vol")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -8,16 +8,18 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
-
-	"github.com/pkg/errors"
-	"k8s.io/klog"
-
 	"github.com/redhat-developer/odo/pkg/util"
+
+	"k8s.io/klog"
 )
 
 type RUNMode string
@@ -203,7 +205,7 @@ func (esi *EnvSpecificInfo) DeleteEnvDirIfEmpty() error {
 
 // DeleteEnvInfoFile deletes the envinfo.yaml file if it exists
 func (esi *EnvSpecificInfo) DeleteEnvInfoFile() error {
-	return util.DeletePath(esi.Filename)
+	return dfutil.DeletePath(esi.Filename)
 }
 
 // IsSet uses reflection to get the parameter from the envinfo struct, currently
@@ -385,5 +387,5 @@ func asLocallySupportedParameter(param string) (string, bool) {
 
 // GetLocallySupportedParameters returns the name of the supported global parameters
 func GetLocallySupportedParameters() []string {
-	return util.GetSortedKeys(supportedLocalParameterDescriptions)
+	return dfutil.GetSortedKeys(supportedLocalParameterDescriptions)
 }

--- a/pkg/envinfo/storage.go
+++ b/pkg/envinfo/storage.go
@@ -2,6 +2,7 @@ package envinfo
 
 import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/library/pkg/devfile/generator"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
@@ -43,7 +44,7 @@ func (ei *EnvInfo) ListStorage() ([]localConfigProvider.LocalStorage, error) {
 					Name:      volumeMount.Name,
 					Size:      vol.Size,
 					Ephemeral: vol.Ephemeral,
-					Path:      GetVolumeMountPath(volumeMount),
+					Path:      generator.GetVolumeMountPath(volumeMount),
 					Container: component.Name,
 				})
 			}
@@ -51,15 +52,4 @@ func (ei *EnvInfo) ListStorage() ([]localConfigProvider.LocalStorage, error) {
 	}
 
 	return storageList, nil
-}
-
-// GetVolumeMountPath gets the volume mount's path.
-// To be moved to devfile/library.
-func GetVolumeMountPath(volumeMount devfilev1.VolumeMount) string {
-	// if there is no volume mount path, default to volume mount name as per devfile schema
-	if volumeMount.Path == "" {
-		volumeMount.Path = "/" + volumeMount.Name
-	}
-
-	return volumeMount.Path
 }

--- a/pkg/envinfo/storage_test.go
+++ b/pkg/envinfo/storage_test.go
@@ -11,41 +11,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/testingutil"
 )
 
-func TestGetVolumeMountPath(t *testing.T) {
-
-	tests := []struct {
-		name        string
-		volumeMount devfilev1.VolumeMount
-		wantPath    string
-	}{
-		{
-			name: "Case 1: Mount Path is present",
-			volumeMount: devfilev1.VolumeMount{
-				Name: "name1",
-				Path: "/path1",
-			},
-			wantPath: "/path1",
-		},
-		{
-			name: "Case 2: Mount Path is absent",
-			volumeMount: devfilev1.VolumeMount{
-				Name: "name1",
-			},
-			wantPath: "/name1",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			path := GetVolumeMountPath(tt.volumeMount)
-
-			if path != tt.wantPath {
-				t.Errorf("TestGetVolumeMountPath error: mount path mismatch, expected: %v got: %v", tt.wantPath, path)
-			}
-		})
-	}
-
-}
-
 func TestEnvInfo_ListStorage(t *testing.T) {
 	type fields struct {
 		devfileObj parser.DevfileObj

--- a/pkg/init/backend/flags.go
+++ b/pkg/init/backend/flags.go
@@ -7,9 +7,9 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	dfutil "github.com/devfile/library/pkg/util"
 
 	"github.com/redhat-developer/odo/pkg/preference"
-	"github.com/redhat-developer/odo/pkg/util"
 )
 
 const (
@@ -50,7 +50,7 @@ func (o *FlagsBackend) Validate(flags map[string]string) error {
 		return errors.New("--devfile-registry parameter cannot be used with --devfile-path")
 	}
 
-	err := util.ValidateK8sResourceName("name", flags[FLAG_NAME])
+	err := dfutil.ValidateK8sResourceName("name", flags[FLAG_NAME])
 	if err != nil {
 		return err
 	}

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
+	dfutil "github.com/devfile/library/pkg/util"
 
 	"github.com/redhat-developer/odo/pkg/catalog"
 	"github.com/redhat-developer/odo/pkg/init/asker"
@@ -17,7 +18,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/preference"
 	"github.com/redhat-developer/odo/pkg/segment"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
-	"github.com/redhat-developer/odo/pkg/util"
 )
 
 type InitClient struct {
@@ -81,7 +81,7 @@ func (o *InitClient) downloadDirect(URL string, dest string) error {
 	if strings.HasPrefix(parsedURL.Scheme, "http") {
 		downloadSpinner := log.Spinnerf("Downloading devfile from %q", URL)
 		defer downloadSpinner.End(false)
-		params := util.HTTPRequestParams{
+		params := dfutil.HTTPRequestParams{
 			URL: URL,
 		}
 		devfileData, err := o.registryClient.DownloadFileInMemory(params)

--- a/pkg/init/registry/interface.go
+++ b/pkg/init/registry/interface.go
@@ -3,13 +3,12 @@ package registry
 
 import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/devfile/registry-support/registry-library/library"
-
-	"github.com/redhat-developer/odo/pkg/util"
 )
 
 type Client interface {
 	PullStackFromRegistry(registry string, stack string, destDir string, options library.RegistryOptions) error
-	DownloadFileInMemory(params util.HTTPRequestParams) ([]byte, error)
+	DownloadFileInMemory(params dfutil.HTTPRequestParams) ([]byte, error)
 	DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedToken string, contextDir string, verbose bool) error
 }

--- a/pkg/init/registry/mock.go
+++ b/pkg/init/registry/mock.go
@@ -7,10 +7,11 @@ package registry
 import (
 	reflect "reflect"
 
-	v1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	library "github.com/devfile/registry-support/registry-library/library"
 	gomock "github.com/golang/mock/gomock"
-	util "github.com/redhat-developer/odo/pkg/util"
+
+	v1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dfutil "github.com/devfile/library/pkg/util"
+	library "github.com/devfile/registry-support/registry-library/library"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,7 +38,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // DownloadFileInMemory mocks base method.
-func (m *MockClient) DownloadFileInMemory(params util.HTTPRequestParams) ([]byte, error) {
+func (m *MockClient) DownloadFileInMemory(params dfutil.HTTPRequestParams) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadFileInMemory", params)
 	ret0, _ := ret[0].([]byte)

--- a/pkg/init/registry/registry.go
+++ b/pkg/init/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/devfile/registry-support/registry-library/library"
 
 	"github.com/redhat-developer/odo/pkg/component"
@@ -20,7 +21,7 @@ func (o RegistryClient) PullStackFromRegistry(registry string, stack string, des
 }
 
 // DownloadFileInMemory uses the url to download the file and return bytes
-func (o RegistryClient) DownloadFileInMemory(params util.HTTPRequestParams) ([]byte, error) {
+func (o RegistryClient) DownloadFileInMemory(params dfutil.HTTPRequestParams) ([]byte, error) {
 	return util.DownloadFileInMemory(params)
 }
 

--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -6,8 +6,9 @@ import (
 	"net"
 	"time"
 
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog"
@@ -16,7 +17,7 @@ import (
 // isServerUp returns true if server is up and running
 // server parameter has to be a valid url
 func isServerUp(server string, timeout time.Duration) bool {
-	address, err := util.GetHostWithPort(server)
+	address, err := dfutil.GetHostWithPort(server)
 	if err != nil {
 		klog.V(3).Infof("Unable to parse url %s (%s)", server, err)
 	}

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -4,16 +4,19 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/devfile/library/pkg/devfile/parser"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
-	"github.com/redhat-developer/odo/pkg/util"
-	"github.com/spf13/cobra"
+
 	"k8s.io/klog"
 )
 
@@ -137,7 +140,7 @@ func GatherName(devObj parser.DevfileObj, devfilePath string) (string, error) {
 	}
 
 	// 2. Use the folder name as a last resort if nothing else exists
-	sourcePath, err := util.GetAbsPath(devfilePath)
+	sourcePath, err := dfutil.GetAbsPath(devfilePath)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get source path")
 	}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes/component"
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/odo/pkg/devfile"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
+	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes/component"
 	"github.com/redhat-developer/odo/pkg/devfile/consts"
 	"github.com/redhat-developer/odo/pkg/log"
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
@@ -21,6 +21,8 @@ import (
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 
 	"k8s.io/klog"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -145,7 +147,7 @@ func (do *DeleteOptions) Run() (err error) {
 			if err != nil {
 				return err
 			}
-			err = util.DeletePath(filepath.Join(do.contextFlag, util.DotOdoDirectory))
+			err = dfutil.DeletePath(filepath.Join(do.contextFlag, util.DotOdoDirectory))
 			if err != nil {
 				return err
 			}
@@ -175,7 +177,7 @@ func (do *DeleteOptions) Run() (err error) {
 					return err
 				}
 
-				empty, err := util.IsEmpty(filepath.Join(do.contextFlag, consts.UriFolder))
+				empty, err := dfutil.IsEmpty(filepath.Join(do.contextFlag, consts.UriFolder))
 				if err != nil && !os.IsNotExist(err) {
 					return err
 				}
@@ -187,7 +189,7 @@ func (do *DeleteOptions) Run() (err error) {
 					}
 				}
 
-				err = util.DeletePath(do.GetDevfilePath())
+				err = dfutil.DeletePath(do.GetDevfilePath())
 				if err != nil {
 					return err
 				}
@@ -215,7 +217,7 @@ func (do *DeleteOptions) Run() (err error) {
 				return err
 			}
 
-			empty, err := util.IsEmpty(filepath.Join(do.contextFlag, consts.UriFolder))
+			empty, err := dfutil.IsEmpty(filepath.Join(do.contextFlag, consts.UriFolder))
 			if err != nil && !os.IsNotExist(err) {
 				return err
 			}
@@ -227,7 +229,7 @@ func (do *DeleteOptions) Run() (err error) {
 				}
 			}
 
-			err = util.DeletePath(do.GetDevfilePath())
+			err = dfutil.DeletePath(do.GetDevfilePath())
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -4,13 +4,13 @@ import (
 	"os"
 	"strings"
 
+	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/redhat-developer/odo/pkg/devfile"
 
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"github.com/redhat-developer/odo/pkg/util"
 
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters"
@@ -57,7 +57,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	componentName := po.EnvSpecificInfo.GetName()
 
 	// Set the source path to either the context or current working directory (if context not set)
-	po.sourcePath, err = util.GetAbsPath(po.componentContext)
+	po.sourcePath, err = dfutil.GetAbsPath(po.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to get source path")
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -8,25 +8,26 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/devfile"
-	"github.com/redhat-developer/odo/pkg/devfile/location"
-	"github.com/redhat-developer/odo/pkg/machineoutput"
-	"github.com/redhat-developer/odo/pkg/project"
-	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
 
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
-
 	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/devfile"
+	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/machineoutput"
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
+	"github.com/redhat-developer/odo/pkg/project"
+	"github.com/redhat-developer/odo/pkg/util"
 
+	dfutil "github.com/devfile/library/pkg/util"
+
+	"k8s.io/klog"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -79,7 +80,7 @@ func (lo *ListOptions) Complete(cmdline cmdline.Cmdline, args []string) (err err
 	} else {
 		// here we use information from user's kubeconfig
 		// as odo list should work in a non-component directory too
-		if util.CheckKubeConfigExist() {
+		if dfutil.CheckKubeConfigExist() {
 			klog.V(4).Infof("New Context")
 			lo.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
 			if err != nil {
@@ -107,7 +108,7 @@ func (lo *ListOptions) Validate() (err error) {
 	}
 	var project, app string
 
-	if !util.CheckKubeConfigExist() {
+	if !dfutil.CheckKubeConfigExist() {
 		project = lo.EnvSpecificInfo.GetNamespace()
 		app = lo.EnvSpecificInfo.GetApplication()
 	} else {

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/odo/pkg/devfile"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
@@ -13,16 +15,15 @@ import (
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
-	ktemplates "k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
-	"k8s.io/klog"
-
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
-	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/redhat-developer/odo/pkg/watch"
-	"github.com/spf13/cobra"
+
+	dfutil "github.com/devfile/library/pkg/util"
+
+	"k8s.io/klog"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
 // WatchRecommendedCommandName is the recommended watch command name
@@ -74,7 +75,7 @@ func (wo *WatchOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		return err
 	}
 	// Set the source path to either the context or current working directory (if context not set)
-	wo.sourcePath, err = util.GetAbsPath(wo.contextFlag)
+	wo.sourcePath, err = dfutil.GetAbsPath(wo.contextFlag)
 	if err != nil {
 		return errors.Wrap(err, "unable to get source path")
 	}
@@ -128,7 +129,7 @@ func (wo *WatchOptions) Run() (err error) {
 			ComponentName:       wo.EnvSpecificInfo.GetName(),
 			ApplicationName:     wo.Context.GetApplication(),
 			Path:                wo.sourcePath,
-			FileIgnores:         util.GetAbsGlobExps(wo.sourcePath, wo.ignoreFlag),
+			FileIgnores:         dfutil.GetAbsGlobExps(wo.sourcePath, wo.ignoreFlag),
 			PushDiffDelay:       wo.delayFlag,
 			StartChan:           nil,
 			ExtChan:             make(chan bool),

--- a/pkg/odo/cli/preference/registry/add.go
+++ b/pkg/odo/cli/preference/registry/add.go
@@ -4,11 +4,8 @@ import (
 	// Built-in packages
 	"fmt"
 
-	util2 "github.com/redhat-developer/odo/pkg/odo/cli/preference/registry/util"
-	"github.com/redhat-developer/odo/pkg/odo/cmdline"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
-
 	// Third-party packages
+	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -16,7 +13,10 @@ import (
 
 	// odo packages
 	"github.com/redhat-developer/odo/pkg/log"
+	util2 "github.com/redhat-developer/odo/pkg/odo/cli/preference/registry/util"
+	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	"github.com/redhat-developer/odo/pkg/util"
 )
 
@@ -92,7 +92,7 @@ func (o *AddOptions) Run() (err error) {
 	}
 
 	if o.tokenFlag != "" {
-		err = keyring.Set(util.CredentialPrefix+o.registryName, o.user, o.tokenFlag)
+		err = keyring.Set(dfutil.CredentialPrefix+o.registryName, o.user, o.tokenFlag)
 		if err != nil {
 			return errors.Wrap(err, "unable to store registry credential to keyring")
 		}

--- a/pkg/odo/cli/preference/registry/delete.go
+++ b/pkg/odo/cli/preference/registry/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	// Third-party packages
+	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -15,7 +16,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
-	"github.com/redhat-developer/odo/pkg/util"
 )
 
 const deleteCommandName = "delete"
@@ -77,7 +77,7 @@ func (o *DeleteOptions) Run() (err error) {
 	}
 
 	if isSecure {
-		err = keyring.Delete(util.CredentialPrefix+o.registryName, o.user)
+		err = keyring.Delete(dfutil.CredentialPrefix+o.registryName, o.user)
 		if err != nil {
 			return errors.Wrap(err, "unable to delete registry credential from keyring")
 		}

--- a/pkg/odo/cli/preference/registry/update.go
+++ b/pkg/odo/cli/preference/registry/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	// Third-party packages
+	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -96,12 +97,12 @@ func (o *UpdateOptions) Run() (err error) {
 	}
 
 	if secureAfterUpdate {
-		err = keyring.Set(util.CredentialPrefix+o.registryName, o.user, o.tokenFlag)
+		err = keyring.Set(dfutil.CredentialPrefix+o.registryName, o.user, o.tokenFlag)
 		if err != nil {
 			return errors.Wrap(err, "unable to store registry credential to keyring")
 		}
 	} else if secureBeforeUpdate && !secureAfterUpdate {
-		err = keyring.Delete(util.CredentialPrefix+o.registryName, o.user)
+		err = keyring.Delete(dfutil.CredentialPrefix+o.registryName, o.user)
 		if err != nil {
 			return errors.Wrap(err, "unable to delete registry credential from keyring")
 		}

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
@@ -16,9 +20,6 @@ import (
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/redhat-developer/odo/pkg/url"
-
-	"github.com/redhat-developer/odo/pkg/util"
-	"github.com/spf13/cobra"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -137,7 +138,7 @@ func (o *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 
 // Validate validates the CreateOptions based on completed values
 func (o *CreateOptions) Validate() (err error) {
-	if !util.CheckOutputFlag(o.GetOutputFlag()) {
+	if !dfutil.CheckOutputFlag(o.GetOutputFlag()) {
 		return fmt.Errorf("given output format %s is not supported", o.GetOutputFlag())
 	}
 

--- a/pkg/odo/cli/utils/terminal.go
+++ b/pkg/odo/cli/utils/terminal.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 
-	util2 "github.com/redhat-developer/odo/pkg/util"
-	"github.com/spf13/cobra"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -115,5 +117,5 @@ func NewCmdTerminal(name, fullName string) *cobra.Command {
 }
 
 func getSupportedShells() []string {
-	return util2.GetSortedKeys(supportedShells)
+	return dfutil.GetSortedKeys(supportedShells)
 }

--- a/pkg/odo/cli/version/notify.go
+++ b/pkg/odo/cli/version/notify.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 const (
@@ -17,12 +18,12 @@ const (
 // tag of the latest release
 func getLatestReleaseTag() (string, error) {
 
-	request := util.HTTPRequestParams{
+	request := dfutil.HTTPRequestParams{
 		URL: VersionFetchURL,
 	}
 
 	// Make request and cache response for 60 minutes
-	body, err := util.HTTPGetRequest(request, 60)
+	body, err := dfutil.HTTPGetRequest(request, 60)
 	if err != nil {
 		return "", errors.Wrap(err, "error getting latest release")
 	}

--- a/pkg/odo/cmdline/cobra.go
+++ b/pkg/odo/cmdline/cobra.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/redhat-developer/odo/pkg/kclient"
-	"github.com/redhat-developer/odo/pkg/odo/util"
-	pkgUtil "github.com/redhat-developer/odo/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/redhat-developer/odo/pkg/kclient"
+	"github.com/redhat-developer/odo/pkg/odo/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 type Cobra struct {
@@ -57,13 +59,13 @@ func (o *Cobra) GetWorkingDirectory() (string, error) {
 
 	// Grab the absolute path of the configuration
 	if contextDir != "" {
-		fAbs, err := pkgUtil.GetAbsPath(contextDir)
+		fAbs, err := dfutil.GetAbsPath(contextDir)
 		if err != nil {
 			return "", err
 		}
 		contextDir = fAbs
 	} else {
-		fAbs, err := pkgUtil.GetAbsPath(".")
+		fAbs, err := dfutil.GetAbsPath(".")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/odo/genericclioptions/util.go
+++ b/pkg/odo/genericclioptions/util.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	pkgUtil "github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 // checkProjectCreateOrDeleteOnlyOnInvalidNamespace errors out if user is trying to create or delete something other than project
@@ -31,7 +33,7 @@ func checkProjectCreateOrDeleteOnlyOnInvalidNamespaceNoFmt(cmdline cmdline.Cmdli
 // .git ignores; or find the .odoignore/.gitignore file in the directory and use that instead.
 func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 	if len(*ignores) == 0 {
-		rules, err := pkgUtil.GetIgnoreRulesFromDirectory(sourcePath)
+		rules, err := dfutil.GetIgnoreRulesFromDirectory(sourcePath)
 		if err != nil {
 			return err
 		}
@@ -40,12 +42,12 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 
 	indexFile := pkgUtil.GetIndexFileRelativeToContext()
 	// check if the ignores flag has the index file
-	if !pkgUtil.In(*ignores, indexFile) {
+	if !dfutil.In(*ignores, indexFile) {
 		*ignores = append(*ignores, indexFile)
 	}
 
 	// check if the ignores flag has the git dir
-	if !pkgUtil.In(*ignores, gitDirName) {
+	if !dfutil.In(*ignores, gitDirName) {
 		*ignores = append(*ignores, gitDirName)
 	}
 

--- a/pkg/odo/util/validation/validators.go
+++ b/pkg/odo/util/validation/validators.go
@@ -5,8 +5,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/redhat-developer/odo/pkg/util"
 	"gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 // NameValidator provides a Validator view of the ValidateName function.
@@ -62,7 +65,7 @@ func PathValidator(path interface{}) error {
 // 8080/tcp, 9090/udp
 func PortsValidator(portsStr interface{}) error {
 	if s, ok := portsStr.(string); ok {
-		_, err := util.GetContainerPortsFromStrings(util.GetSplitValuesFromStr(s))
+		_, err := dfutil.GetContainerPortsFromStrings(dfutil.GetSplitValuesFromStr(s))
 		if err != nil {
 			return err
 		}
@@ -78,7 +81,7 @@ func PortsValidator(portsStr interface{}) error {
 // PORT=8080,PATH=/health
 func KeyEqValFormatValidator(portsStr interface{}) error {
 	if s, ok := portsStr.(string); ok {
-		parts := util.GetSplitValuesFromStr(s)
+		parts := dfutil.GetSplitValuesFromStr(s)
 		for _, part := range parts {
 			kvParts := strings.Split(part, "=")
 			if len(kvParts) != 2 {

--- a/pkg/preference/implem.go
+++ b/pkg/preference/implem.go
@@ -9,12 +9,15 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 // odoSettings holds all odo specific configurations
@@ -437,5 +440,5 @@ func asSupportedParameter(param string) (string, bool) {
 
 // GetSupportedParameters returns the name of the supported parameters
 func GetSupportedParameters() []string {
-	return util.GetSortedKeys(supportedParameterDescriptions)
+	return dfutil.GetSortedKeys(supportedParameterDescriptions)
 }

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/redhat-developer/odo/pkg/kclient"
-	"github.com/redhat-developer/odo/pkg/util"
-
 	"github.com/pkg/errors"
+
+	"github.com/redhat-developer/odo/pkg/kclient"
+
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"k8s.io/klog"
 )
 
@@ -47,7 +49,7 @@ func GetContextProperties(ctx context.Context) map[string]interface{} {
 
 // SetComponentType sets componentType property for telemetry data when a component is created/pushed
 func SetComponentType(ctx context.Context, value string) {
-	setContextProperty(ctx, ComponentType, util.ExtractComponentType(value))
+	setContextProperty(ctx, ComponentType, dfutil.ExtractComponentType(value))
 }
 
 // SetClusterType sets clusterType property for telemetry data when a component is pushed or a project is created/set

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	devfilefs "github.com/devfile/library/pkg/testingutil/filesystem"
+	dfutil "github.com/devfile/library/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -448,7 +449,7 @@ func getDataFromURI(uri, componentContext string, fs devfilefs.Filesystem) (stri
 		return "", err
 	}
 	if len(parsedURL.Host) != 0 && len(parsedURL.Scheme) != 0 {
-		params := util.HTTPRequestParams{
+		params := dfutil.HTTPRequestParams{
 			URL: uri,
 		}
 		dataBytes, err := util.DownloadFileInMemoryWithCache(params, 1)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -12,6 +12,8 @@ import (
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 	"github.com/redhat-developer/odo/pkg/util"
 
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"k8s.io/klog"
 )
 
@@ -86,7 +88,7 @@ func makeTar(srcPath, destPath string, writer io.Writer, files []string, globExp
 
 			if checkFileExistWithFS(fileName, fs) {
 
-				matched, err := util.IsGlobExpMatch(fileName, globExps)
+				matched, err := dfutil.IsGlobExpMatch(fileName, globExps)
 				if err != nil {
 					return err
 				}
@@ -99,7 +101,7 @@ func makeTar(srcPath, destPath string, writer io.Writer, files []string, globExp
 
 				// Yes, now that the file exists, now we need to get the absolute path.. if we don't, then when we pass in:
 				// 'odo push --context foobar' instead of 'odo push --context ~/foobar' it will NOT work..
-				fileAbsolutePath, err := util.GetAbsPath(fileName)
+				fileAbsolutePath, err := dfutil.GetAbsPath(fileName)
 				if err != nil {
 					return err
 				}

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -4,16 +4,20 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/redhat-developer/odo/pkg/kclient/unions"
-
-	"github.com/devfile/library/pkg/devfile/generator"
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
+
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/kclient"
+	"github.com/redhat-developer/odo/pkg/kclient/unions"
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
 	urlLabels "github.com/redhat-developer/odo/pkg/url/labels"
 	"github.com/redhat-developer/odo/pkg/util"
+
+	"github.com/devfile/library/pkg/devfile/generator"
+	dfutil "github.com/devfile/library/pkg/util"
+
+	routev1 "github.com/openshift/api/route/v1"
+
 	appsV1 "k8s.io/api/apps/v1"
 	iextensionsv1 "k8s.io/api/extensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -262,7 +266,7 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 	}
 
 	suffix := util.GetAdler32Value(url.Name + k.appName + k.componentName)
-	ingressName, err := util.NamespaceOpenShiftObject(url.Name, suffix)
+	ingressName, err := dfutil.NamespaceOpenShiftObject(url.Name, suffix)
 	if err != nil {
 		return "", err
 	}
@@ -297,7 +301,7 @@ func (k kubernetesClient) createRoute(url URL, labels map[string]string) (string
 	// as the host name, which is automatically created on openshift,
 	// can become more than 63 chars, which is invalid
 	suffix := util.GetAdler32Value(url.Name + k.appName + k.componentName)
-	routeName, err := util.NamespaceOpenShiftObject(url.Name, suffix)
+	routeName, err := dfutil.NamespaceOpenShiftObject(url.Name, suffix)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to create namespaced name")
 	}

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/devfile/library/pkg/util"
 	"github.com/pkg/errors"
+
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
@@ -137,7 +140,7 @@ func DeleteIndexFile(directory string) error {
 	} else if err != nil {
 		return err
 	}
-	return DeletePath(indexFile)
+	return dfutil.DeletePath(indexFile)
 }
 
 // IndexerRet is a struct that represent return value of RunIndexer function
@@ -293,7 +296,7 @@ func runIndexerWithExistingFileIndex(directory string, ignoreRules []string, rem
 
 				// Yes, now that the file exists, now we need to get the absolute path.. if we don't, then when we pass in:
 				// 'odo push --context foobar' instead of 'odo push --context ~/foobar' it will NOT work..
-				fileAbsolutePath, err := util.GetAbsPath(fileName)
+				fileAbsolutePath, err := dfutil.GetAbsPath(fileName)
 				if err != nil {
 					return IndexerRet{}, err
 				}
@@ -357,12 +360,12 @@ func runIndexerWithExistingFileIndex(directory string, ignoreRules []string, rem
 				}
 			} else {
 				// check the *absolute* path to the file for glob rules
-				fileAbsolutePath, err := GetAbsPath(filepath.Join(directory, fileName))
+				fileAbsolutePath, err := dfutil.GetAbsPath(filepath.Join(directory, fileName))
 				if err != nil {
 					return ret, errors.Wrapf(err, "unable to retrieve absolute path of file %s", fileName)
 				}
 
-				matched, err := util.IsGlobExpMatch(fileAbsolutePath, ignoreRules)
+				matched, err := dfutil.IsGlobExpMatch(fileAbsolutePath, ignoreRules)
 				if err != nil {
 					return IndexerRet{}, err
 				}
@@ -444,7 +447,7 @@ func recursiveChecker(pathOptions recursiveCheckerPathOptions, ignoreRules []str
 	for _, matchedPath := range matchedPathsDir {
 
 		// check if it matches a ignore rule
-		match, err := IsGlobExpMatch(matchedPath, ignoreRules)
+		match, err := dfutil.IsGlobExpMatch(matchedPath, ignoreRules)
 		if err != nil {
 			return IndexerRet{}, err
 		}

--- a/pkg/util/httpcache.go
+++ b/pkg/util/httpcache.go
@@ -1,10 +1,7 @@
 package util
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/devfile/library/pkg/testingutil/filesystem"
 	"k8s.io/klog"
@@ -26,25 +23,6 @@ func cleanDefaultHTTPCacheDir(fs filesystem.Filesystem) error {
 		err := fs.Remove(filepath.Join(httpCacheDir, f.Name()))
 		if err != nil {
 			return err
-		}
-	}
-	return nil
-}
-
-// cleanHttpCache checks cacheDir and deletes all files that were modified more than cacheTime back
-func cleanHttpCache(cacheDir string, cacheTime time.Duration) error {
-	cacheFiles, err := ioutil.ReadDir(cacheDir)
-	if err != nil {
-		return err
-	}
-
-	for _, f := range cacheFiles {
-		if f.ModTime().Add(cacheTime).Before(time.Now()) {
-			klog.V(4).Infof("Removing cache file %s, because it is older than %s", f.Name(), cacheTime.String())
-			err := os.Remove(filepath.Join(cacheDir, f.Name()))
-			if err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/pkg/util/httpcache_test.go
+++ b/pkg/util/httpcache_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/devfile/library/pkg/testingutil/filesystem"
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 func TestCleanDefaultHTTPCacheDir(t *testing.T) {
 	fakeFs := filesystem.NewFakeFs()
 	filesToGenerate := 10
 	for i := 0; i < filesToGenerate; i++ {
-		err := fakeFs.WriteFile(filepath.Join(httpCacheDir, GenerateRandomString(10)), []byte(GenerateRandomString(10)), os.ModePerm)
+		err := fakeFs.WriteFile(filepath.Join(httpCacheDir, dfutil.GenerateRandomString(10)), []byte(dfutil.GenerateRandomString(10)), os.ModePerm)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,81 +4,46 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"hash/adler32"
 	"io"
 	"io/ioutil"
-	"math/big"
-	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"os/user"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
-	"k8s.io/client-go/util/homedir"
-
-	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/fatih/color"
 	"github.com/go-git/go-git/v5"
-	"github.com/gobwas/glob"
-	"github.com/gregjones/httpcache"
-	"github.com/gregjones/httpcache/diskcache"
 	"github.com/pkg/errors"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
-	corev1 "k8s.io/api/core/v1"
-	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+
 	"k8s.io/klog"
 )
 
-const (
-	HTTPRequestTimeout    = 30 * time.Second // HTTPRequestTimeout configures timeout of all HTTP requests
-	ResponseHeaderTimeout = 30 * time.Second // ResponseHeaderTimeout is the timeout to retrieve the server's response headers
-	ModeReadWriteFile     = 0600             // default Permission for a file
-	CredentialPrefix      = "odo-"           // CredentialPrefix is the prefix of the credential that uses to access secure registry
-)
-
-var InvalidKubeconfigError = fmt.Errorf("please provide valid file path for KUBECONFIG env or unset it to use default kubeconfig")
-
-// httpCacheDir determines directory where odo will cache HTTP respones
 var httpCacheDir = filepath.Join(os.TempDir(), "odohttpcache")
-
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
-
-// 63 is the max length of a DeploymentConfig in Openshift
-const maxAllowedNamespacedStringLength = 63
 
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
 var customHomeDir = os.Getenv("CUSTOM_HOMEDIR")
-
-// HTTPRequestParams holds parameters of forming http request
-type HTTPRequestParams struct {
-	URL   string
-	Token string
-}
-
-// DownloadParams holds parameters of forming file download request
-type DownloadParams struct {
-	Request  HTTPRequestParams
-	Filepath string
-}
 
 // ConvertLabelsToSelector converts the given labels to selector
 // To pass operands such as !=, append a ! prefix to the value.
 // For E.g. map[string]string{"app.kubernetes.io/managed-by": "!odo"}
 // Using != operators also means that resource will be filtered even if it doesn't have the key.
 // So a resource not labelled with key "app.kubernetes.io/managed-by" will also be returned.
+// TODO(feloy) sync with devfile library?
 func ConvertLabelsToSelector(labels map[string]string) string {
 	var selector string
 	isFirst := true
@@ -115,53 +80,6 @@ func ConvertLabelsToSelector(labels map[string]string) string {
 		}
 	}
 	return selector
-}
-
-// GenerateRandomString generates a random string of lower case characters of
-// the given size
-func GenerateRandomString(n int) string {
-	b := make([]rune, n)
-
-	for i := range b {
-		// this error is ignored because it fails only when the 2nd arg of Int() is less then 0
-		// which wont happen
-		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letterRunes))))
-		b[i] = letterRunes[n.Int64()]
-	}
-	return string(b)
-}
-
-// In checks if the value is in the array
-func In(arr []string, value string) bool {
-	for _, item := range arr {
-		if item == value {
-			return true
-		}
-	}
-	return false
-}
-
-// NamespaceOpenShiftObject hyphenates applicationName and componentName
-func NamespaceOpenShiftObject(componentName string, applicationName string) (string, error) {
-
-	// Error if it's blank
-	if componentName == "" {
-		return "", errors.New("namespacing: component name cannot be blank")
-	}
-
-	// Error if it's blank
-	if applicationName == "" {
-		return "", errors.New("namespacing: application name cannot be blank")
-	}
-
-	// Return the hyphenated namespaced name
-	originalName := fmt.Sprintf("%s-%s", strings.Replace(componentName, "/", "-", -1), applicationName)
-	truncatedName := TruncateString(originalName, maxAllowedNamespacedStringLength)
-	if originalName != truncatedName {
-		klog.V(4).Infof("The combination of application %s and component %s was too long so the final name was truncated to %s",
-			applicationName, componentName, truncatedName)
-	}
-	return truncatedName, nil
 }
 
 // NamespaceKubernetesObject hyphenates applicationName and componentName
@@ -206,25 +124,11 @@ func NamespaceKubernetesObjectWithTrim(componentName, applicationName string) (s
 	return value, nil
 }
 
-// ExtractComponentType returns only component type part from passed component type(default unqualified, fully qualified, versioned, etc...and their combinations) for use as component name
-// Possible types of parameters:
-// 1. "myproject/python:3.5" -- Return python
-// 2. "python:3.5" -- Return python
-// 3. nodejs -- Return nodejs
-func ExtractComponentType(namespacedVersionedComponentType string) string {
-	s := strings.Split(namespacedVersionedComponentType, "/")
-	versionedString := s[0]
-	if len(s) == 2 {
-		versionedString = s[1]
-	}
-	s = strings.Split(versionedString, ":")
-	return s[0]
-}
-
 // TruncateString truncates passed string to given length
 // Note: if -1 is passed, the original string is returned
 // if appendIfTrunicated is given, then it will be appended to trunicated
 // string
+// TODO(feloy) sync with devfile library?
 func TruncateString(str string, maxLen int, appendIfTrunicated ...string) string {
 	if maxLen == -1 {
 		return str
@@ -239,80 +143,8 @@ func TruncateString(str string, maxLen int, appendIfTrunicated ...string) string
 	return str
 }
 
-// GetAbsPath returns absolute path from passed file path resolving even ~ to user home dir and any other such symbols that are only
-// shell expanded can also be handled here
-func GetAbsPath(path string) (string, error) {
-	// Only shell resolves `~` to home so handle it specially
-	var dir string
-	if strings.HasPrefix(path, "~") {
-		if len(customHomeDir) > 0 {
-			dir = customHomeDir
-		} else {
-			usr, err := user.Current()
-			if err != nil {
-				return path, errors.Wrapf(err, "unable to resolve %s to absolute path", path)
-			}
-			dir = usr.HomeDir
-		}
-
-		if len(path) > 1 {
-			path = filepath.Join(dir, path[1:])
-		} else {
-			path = dir
-		}
-	}
-
-	path, err := filepath.Abs(path)
-	if err != nil {
-		return path, errors.Wrapf(err, "unable to resolve %s to absolute path", path)
-	}
-	return path, nil
-}
-
-// GetRandomName returns a randomly generated name which can be used for naming odo and/or openshift entities
-// prefix: Desired prefix part of the name
-// prefixMaxLen: Desired maximum length of prefix part of random name; if -1 is passed, no limit on length will be enforced
-// existList: List to verify that the returned name does not already exist
-// retries: number of retries to try generating a unique name
-// Returns:
-//		1. randomname: is prefix-suffix, where:
-//				prefix: string passed as prefix or fetched current directory of length same as the passed prefixMaxLen
-//				suffix: 4 char random string
-//      2. error: if requested number of retries also failed to generate unique name
-func GetRandomName(prefix string, prefixMaxLen int, existList []string, retries int) (string, error) {
-	prefix = TruncateString(GetDNS1123Name(strings.ToLower(prefix)), prefixMaxLen)
-	name := fmt.Sprintf("%s-%s", prefix, GenerateRandomString(4))
-
-	//Create a map of existing names for efficient iteration to find if the newly generated name is same as any of the already existing ones
-	existingNames := make(map[string]bool)
-	for _, existingName := range existList {
-		existingNames[existingName] = true
-	}
-
-	// check if generated name is already used in the existList
-	if _, ok := existingNames[name]; ok {
-		prevName := name
-		trial := 0
-		// keep generating names until generated name is not unique. So, loop terminates when name is unique and hence for condition is false
-		for ok {
-			trial = trial + 1
-			prevName = name
-			// Attempt unique name generation from prefix-suffix by concatenating prefix-suffix withrandom string of length 4
-			prevName = fmt.Sprintf("%s-%s", prevName, GenerateRandomString(4))
-			_, ok = existingNames[prevName]
-			if trial >= retries {
-				// Avoid infinite loops and fail after passed number of retries
-				return "", fmt.Errorf("failed to generate a unique name even after %d retrials", retries)
-			}
-		}
-		// If found to be unique, set name as generated name
-		name = prevName
-	}
-	// return name
-	return name, nil
-}
-
 // GetDNS1123Name Converts passed string into DNS-1123 string
+// TODO(feloy) sync with devfile library?
 func GetDNS1123Name(str string) string {
 	nonAllowedCharsRegex := regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 	withReplacedChars := strings.Replace(
@@ -344,6 +176,7 @@ func removeNonAlphaSuffix(input string) string {
 }
 
 // CheckPathExists checks if a path exists or not
+// TODO(feloy) use from devfile library?
 func CheckPathExists(path string) bool {
 	if _, err := filesystem.Get().Stat(path); !os.IsNotExist(err) {
 		// path to file does exist
@@ -353,365 +186,9 @@ func CheckPathExists(path string) bool {
 	return false
 }
 
-// GetHostWithPort parses provided url and returns string formated as
-// host:port even if port was not specifically specified in the origin url.
-// If port is not specified, standart port corresponding to url schema is provided.
-// example: for url https://example.com function will return "example.com:443"
-//          for url https://example.com:8443 function will return "example:8443"
-func GetHostWithPort(inputURL string) (string, error) {
-	u, err := url.Parse(inputURL)
-	if err != nil {
-		return "", errors.Wrapf(err, "error while getting port for url %s ", inputURL)
-	}
-
-	port := u.Port()
-	address := u.Host
-	// if port is not specified try to detect it based on provided scheme
-	if port == "" {
-		portInt, err := net.LookupPort("tcp", u.Scheme)
-		if err != nil {
-			return "", errors.Wrapf(err, "error while getting port for url %s ", inputURL)
-		}
-		port = strconv.Itoa(portInt)
-		address = fmt.Sprintf("%s:%s", u.Host, port)
-	}
-	return address, nil
-}
-
-// GetIgnoreRulesFromDirectory reads the .odoignore file, if present, and reads the rules from it
-// if the .odoignore file is not found, then .gitignore is searched for the rules
-// if both are not found, return empty array
-// directory is the name of the directory to look into for either of the files
-// rules is the array of rules (in string form)
-func GetIgnoreRulesFromDirectory(directory string) ([]string, error) {
-	rules := []string{".git"}
-	// checking for presence of .odoignore file
-	pathIgnore := filepath.Join(directory, ".odoignore")
-	if _, err := os.Stat(pathIgnore); os.IsNotExist(err) || err != nil {
-		// .odoignore doesn't exist
-		// checking presence of .gitignore file
-		pathIgnore = filepath.Join(directory, ".gitignore")
-		if _, err := os.Stat(pathIgnore); os.IsNotExist(err) || err != nil {
-			// both doesn't exist, return empty array
-			return rules, nil
-		}
-	}
-
-	file, err := os.Open(pathIgnore)
-	if err != nil {
-		return nil, err
-	}
-
-	defer file.Close() // #nosec G307
-
-	scanner := bufio.NewReader(file)
-	for {
-		line, _, err := scanner.ReadLine()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-
-			return rules, err
-		}
-		spaceTrimmedLine := strings.TrimSpace(string(line))
-		if len(spaceTrimmedLine) > 0 && !strings.HasPrefix(string(line), "#") && !strings.HasPrefix(string(line), ".git") {
-			rules = append(rules, string(line))
-		}
-	}
-
-	return rules, nil
-}
-
-// GetAbsGlobExps converts the relative glob expressions into absolute glob expressions
-// returns the absolute glob expressions
-func GetAbsGlobExps(directory string, globExps []string) []string {
-	absGlobExps := []string{}
-	for _, globExp := range globExps {
-		// for glob matching with the library
-		// the relative paths in the glob expressions need to be converted to absolute paths
-		absGlobExps = append(absGlobExps, filepath.Join(directory, globExp))
-	}
-	return absGlobExps
-}
-
-// GetSortedKeys retrieves the alphabetically-sorted keys of the specified map
-func GetSortedKeys(mapping map[string]string) []string {
-	keys := make([]string, len(mapping))
-
-	i := 0
-	for k := range mapping {
-		keys[i] = k
-		i++
-	}
-
-	sort.Strings(keys)
-
-	return keys
-}
-
-// GetSplitValuesFromStr returns a slice containing the split string, using ',' as a separator
-func GetSplitValuesFromStr(inputStr string) []string {
-	if len(inputStr) == 0 {
-		return []string{}
-	}
-
-	result := strings.Split(inputStr, ",")
-	for i, value := range result {
-		result[i] = strings.TrimSpace(value)
-	}
-	return result
-}
-
-// GetContainerPortsFromStrings generates ContainerPort values from the array of string port values
-// ports is the array containing the string port values
-func GetContainerPortsFromStrings(ports []string) ([]corev1.ContainerPort, error) {
-	var containerPorts []corev1.ContainerPort
-	for _, port := range ports {
-		splits := strings.Split(port, "/")
-		if len(splits) < 1 || len(splits) > 2 {
-			return nil, fmt.Errorf("unable to parse the port string %s", port)
-		}
-
-		portNumberI64, err := strconv.ParseInt(splits[0], 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("invalid port number %s", splits[0])
-		}
-		portNumber := int32(portNumberI64)
-
-		var portProto corev1.Protocol
-		if len(splits) == 2 {
-			switch strings.ToUpper(splits[1]) {
-			case "TCP":
-				portProto = corev1.ProtocolTCP
-			case "UDP":
-				portProto = corev1.ProtocolUDP
-			default:
-				return nil, fmt.Errorf("invalid port protocol %s", splits[1])
-			}
-		} else {
-			portProto = corev1.ProtocolTCP
-		}
-
-		port := corev1.ContainerPort{
-			Name:          fmt.Sprintf("%d-%s", portNumber, strings.ToLower(string(portProto))),
-			ContainerPort: portNumber,
-			Protocol:      portProto,
-		}
-		containerPorts = append(containerPorts, port)
-	}
-	return containerPorts, nil
-}
-
-// IsGlobExpMatch compiles strToMatch against each of the passed globExps
-// Parameters:
-// strToMatch : a string for matching against the rules
-// globExps : a list of glob patterns to match strToMatch with
-// Returns: true if there is any match else false the error (if any)
-// Notes:
-// Source as well as glob expression to match is changed to forward
-// slashes due to supporting Windows as well as support with the
-// "github.com/gobwas/glob" library that we use.
-func IsGlobExpMatch(strToMatch string, globExps []string) (bool, error) {
-
-	// Replace all backslashes with forward slashes in order for
-	// glob / expression matching to work correctly with
-	// the "github.com/gobwas/glob" library
-	strToMatch = strings.Replace(strToMatch, "\\", "/", -1)
-
-	for _, globExp := range globExps {
-
-		// We replace backslashes with forward slashes for
-		// glob expression / matching support
-		globExp = strings.Replace(globExp, "\\", "/", -1)
-
-		pattern, err := glob.Compile(globExp)
-		if err != nil {
-			return false, err
-		}
-		matched := pattern.Match(strToMatch)
-		if matched {
-			klog.V(4).Infof("ignoring path %s because of glob rule %s", strToMatch, globExp)
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// CheckOutputFlag returns true if specified output format is supported
-func CheckOutputFlag(outputFlag string) bool {
-	if outputFlag == "json" || outputFlag == "" {
-		return true
-	}
-	return false
-}
-
-// RemoveRelativePathFromFiles removes a specified path from a list of files
-func RemoveRelativePathFromFiles(files []string, path string) ([]string, error) {
-
-	removedRelativePathFiles := []string{}
-	for _, file := range files {
-		rel, err := filepath.Rel(path, file)
-		if err != nil {
-			return []string{}, err
-		}
-		removedRelativePathFiles = append(removedRelativePathFiles, rel)
-	}
-
-	return removedRelativePathFiles, nil
-}
-
-// DeletePath deletes a file/directory if it exists and doesn't throw error if it doesn't exist
-func DeletePath(path string) error {
-	_, err := os.Stat(path)
-
-	// reason for double negative is os.IsExist() would be blind to EMPTY FILE.
-	if !os.IsNotExist(err) {
-		return os.Remove(path)
-	}
-	return nil
-}
-
-// HTTPGetFreePort gets a free port from the system
-func HTTPGetFreePort() (int, error) {
-	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		return -1, err
-	}
-	freePort := listener.Addr().(*net.TCPAddr).Port
-	err = listener.Close()
-	if err != nil {
-		return -1, err
-	}
-	return freePort, nil
-}
-
-// IsEmpty checks to see if a directory is empty
-// shamelessly taken from: https://stackoverflow.com/questions/30697324/how-to-check-if-directory-on-path-is-empty
-// this helps detect any edge cases where an empty directory is copied over
-func IsEmpty(name string) (bool, error) {
-	f, err := os.Open(name)
-	if err != nil {
-		return false, err
-	}
-	defer f.Close() // #nosec G307
-
-	_, err = f.Readdirnames(1) // Or f.Readdir(1)
-	if err == io.EOF {
-		return true, nil
-	}
-	return false, err // Either not empty or error, suits both cases
-}
-
-// GetRemoteFilesMarkedForDeletion returns the list of remote files marked for deletion
-func GetRemoteFilesMarkedForDeletion(delSrcRelPaths []string, remoteFolder string) []string {
-	var rmPaths []string
-	for _, delRelPath := range delSrcRelPaths {
-		// since the paths inside the container are linux oriented
-		// so we convert the paths accordingly
-		rmPaths = append(rmPaths, filepath.ToSlash(filepath.Join(remoteFolder, delRelPath)))
-	}
-	return rmPaths
-}
-
-// HTTPGetRequest gets resource contents given URL and token (if applicable)
-// cacheFor determines how long the response should be cached (in minutes), 0 for no caching
-func HTTPGetRequest(request HTTPRequestParams, cacheFor int) ([]byte, error) {
-	// Build http request
-	req, err := http.NewRequest("GET", request.URL, nil)
-	if err != nil {
-		return nil, err
-	}
-	if request.Token != "" {
-		bearer := "Bearer " + request.Token
-		req.Header.Add("Authorization", bearer)
-	}
-
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: ResponseHeaderTimeout,
-		},
-		Timeout: HTTPRequestTimeout,
-	}
-
-	klog.V(4).Infof("HTTPGetRequest: %s", req.URL.String())
-
-	if cacheFor > 0 {
-		// if there is an error during cache setup we show warning and continue without using cache
-		cacheError := false
-		httpCacheTime := time.Duration(cacheFor) * time.Minute
-
-		// make sure that cache directory exists
-		err = os.MkdirAll(httpCacheDir, 0750)
-		if err != nil {
-			cacheError = true
-			klog.WarningDepth(4, "Unable to setup cache: ", err)
-		}
-		err = cleanHttpCache(httpCacheDir, httpCacheTime)
-		if err != nil {
-			cacheError = true
-			klog.WarningDepth(4, "Unable to clean up cache directory: ", err)
-		}
-
-		if !cacheError {
-			httpClient.Transport = httpcache.NewTransport(diskcache.New(httpCacheDir))
-			klog.V(4).Infof("Response will be cached in %s for %s", httpCacheDir, httpCacheTime)
-		} else {
-			klog.V(4).Info("Response won't be cached.")
-		}
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.Header.Get(httpcache.XFromCache) != "" {
-		klog.V(4).Infof("Cached response used.")
-	}
-
-	// We have a non 1xx / 2xx status, return an error
-	if (resp.StatusCode - 300) > 0 {
-		return nil, errors.Errorf("fail to retrive %s: %s", request.URL, http.StatusText(resp.StatusCode))
-	}
-
-	// Process http response
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes, err
-}
-
-// FilterIgnores applies the glob rules on the filesChanged and filesDeleted and filters them
-// returns the filtered results which match any of the glob rules
-func FilterIgnores(filesChanged, filesDeleted, absIgnoreRules []string) (filesChangedFiltered, filesDeletedFiltered []string) {
-	for _, file := range filesChanged {
-		match, err := IsGlobExpMatch(file, absIgnoreRules)
-		if err != nil {
-			continue
-		}
-		if !match {
-			filesChangedFiltered = append(filesChangedFiltered, file)
-		}
-	}
-
-	for _, file := range filesDeleted {
-		match, err := IsGlobExpMatch(file, absIgnoreRules)
-		if err != nil {
-			continue
-		}
-		if !match {
-			filesDeletedFiltered = append(filesDeletedFiltered, file)
-		}
-	}
-	return filesChangedFiltered, filesDeletedFiltered
-}
-
 // IsValidProjectDir checks that the folder to download the project from devfile is
 // either empty or contains the devfile used.
+// TODO(feloy) sync with devfile library?
 func IsValidProjectDir(path string, devfilePath string) error {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
@@ -735,6 +212,7 @@ func IsValidProjectDir(path string, devfilePath string) error {
 // GetAndExtractZip downloads a zip file from a URL with a http prefix or
 // takes an absolute path prefixed with file:// and extracts it to a destination.
 // pathToUnzip specifies the path within the zip folder to extract
+// TODO(feloy) sync with devfile library?
 func GetAndExtractZip(zipURL string, destination string, pathToUnzip string, starterToken string) error {
 	if zipURL == "" {
 		return errors.Errorf("Empty zip url: %s", zipURL)
@@ -752,20 +230,20 @@ func GetAndExtractZip(zipURL string, destination string, pathToUnzip string, sta
 		time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
 		pathToZip = path.Join(os.TempDir(), "_"+time+".zip")
 
-		params := DownloadParams{
-			Request: HTTPRequestParams{
+		params := dfutil.DownloadParams{
+			Request: dfutil.HTTPRequestParams{
 				URL:   zipURL,
 				Token: starterToken,
 			},
 			Filepath: pathToZip,
 		}
-		err := DownloadFile(params)
+		err := dfutil.DownloadFile(params)
 		if err != nil {
 			return err
 		}
 
 		defer func() {
-			if err := DeletePath(pathToZip); err != nil {
+			if err := dfutil.DeletePath(pathToZip); err != nil {
 				klog.Errorf("Could not delete temporary directory for zip file. Error: %s", err)
 			}
 		}()
@@ -789,6 +267,7 @@ func GetAndExtractZip(zipURL string, destination string, pathToUnzip string, sta
 // within the zip file (parameter 1) to an output directory (parameter 2)
 // Source: https://golangcode.com/unzip-files-in-go/
 // pathToUnzip (parameter 3) is the path within the zip folder to extract
+// TODO(feloy) sync with devfile library?
 func Unzip(src, dest, pathToUnzip string) ([]string, error) {
 	var filenames []string
 
@@ -884,39 +363,10 @@ func Unzip(src, dest, pathToUnzip string) ([]string, error) {
 	return filenames, nil
 }
 
-// DownloadFileWithCache downloads the file to the filepath given URL and token (if applicable)
-// cacheFor determines how long the response should be cached (in minutes), 0 for no caching
-func DownloadFileWithCache(params DownloadParams, cacheFor int) error {
-	// Get the data
-	data, err := HTTPGetRequest(params.Request, cacheFor)
-	if err != nil {
-		return err
-	}
-
-	// Create the file
-	out, err := os.Create(params.Filepath)
-	if err != nil {
-		return err
-	}
-	defer out.Close() // #nosec G307
-
-	// Write the data to file
-	_, err = out.Write(data)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DownloadFile downloads the file to the filepath given URL and token (if applicable)
-func DownloadFile(params DownloadParams) error {
-	return DownloadFileWithCache(params, 0)
-}
-
 // DownloadFileInMemory uses the url to download the file and return bytes
-func DownloadFileInMemory(params HTTPRequestParams) ([]byte, error) {
-	data, err := HTTPGetRequest(params, 0)
+// TODO(feloy): sync with devfile library?
+func DownloadFileInMemory(params dfutil.HTTPRequestParams) ([]byte, error) {
+	data, err := dfutil.HTTPGetRequest(params, 0)
 
 	if err != nil {
 		return nil, err
@@ -926,8 +376,8 @@ func DownloadFileInMemory(params HTTPRequestParams) ([]byte, error) {
 }
 
 // DownloadFileInMemoryWithCache uses the url to download the file and return bytes
-func DownloadFileInMemoryWithCache(params HTTPRequestParams, cacheFor int) ([]byte, error) {
-	data, err := HTTPGetRequest(params, cacheFor)
+func DownloadFileInMemoryWithCache(params dfutil.HTTPRequestParams, cacheFor int) ([]byte, error) {
+	data, err := dfutil.HTTPGetRequest(params, cacheFor)
 
 	if err != nil {
 		return nil, err
@@ -936,55 +386,8 @@ func DownloadFileInMemoryWithCache(params HTTPRequestParams, cacheFor int) ([]by
 	return data, nil
 }
 
-// ValidateK8sResourceName sanitizes kubernetes resource name with the following requirements:
-// - Contain at most 63 characters
-// - Contain only lowercase alphanumeric characters or ‘-’
-// - Start with an alphanumeric character
-// - End with an alphanumeric character
-// - Must not contain all numeric values
-func ValidateK8sResourceName(key string, value string) error {
-	requirements := `
-- Contain at most 63 characters
-- Contain only lowercase alphanumeric characters or ‘-’
-- Start with an alphanumeric character
-- End with an alphanumeric character
-- Must not contain all numeric values
-	`
-	err1 := kvalidation.IsDNS1123Label(value)
-	_, err2 := strconv.ParseFloat(value, 64)
-
-	if err1 != nil || err2 == nil {
-		return errors.Errorf("%s \"%s\" is not valid, %s should conform the following requirements: %s", key, value, key, requirements)
-	}
-
-	return nil
-}
-
-// CheckKubeConfigExist checks for existence of kubeconfig
-func CheckKubeConfigExist() bool {
-
-	var kubeconfig string
-
-	if os.Getenv("KUBECONFIG") != "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	} else {
-		if home := homedir.HomeDir(); home != "" {
-			kubeconfig = filepath.Join(home, ".kube", "config")
-			klog.V(4).Infof("using default kubeconfig path %s", kubeconfig)
-		} else {
-			klog.V(4).Infof("no KUBECONFIG provided and cannot fallback to default")
-			return false
-		}
-	}
-
-	if CheckPathExists(kubeconfig) {
-		return true
-	}
-
-	return false
-}
-
 // ValidateURL validates the URL
+// TODO(feloy) sync with devfile library?
 func ValidateURL(sourceURL string) error {
 	// Valid URL needs to satisfy the following requirements:
 	// 1. URL has scheme and host components
@@ -1003,69 +406,6 @@ func ValidateURL(sourceURL string) error {
 	return nil
 }
 
-// ValidateFile validates the file
-func ValidateFile(filePath string) error {
-	// Check if the file path exist
-	file, err := os.Stat(filePath)
-	if err != nil {
-		return err
-	}
-
-	if file.IsDir() {
-		return errors.Errorf("%s exists but it's not a file", filePath)
-	}
-
-	return nil
-}
-
-// CopyFile copies file from source path to destination path
-func CopyFile(srcPath string, dstPath string, info os.FileInfo) error {
-	// In order to avoid file overriding issue, do nothing if source path is equal to destination path
-	if PathEqual(srcPath, dstPath) {
-		return nil
-	}
-	// Check if the source file path exists
-	err := ValidateFile(srcPath)
-	if err != nil {
-		return err
-	}
-
-	// Open source file
-	srcFile, err := os.Open(srcPath)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close() // #nosec G307
-
-	// Create destination file
-	dstFile, err := os.Create(dstPath)
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close() // #nosec G307
-
-	// Ensure destination file has the same file mode with source file
-	err = os.Chmod(dstFile.Name(), info.Mode())
-	if err != nil {
-		return err
-	}
-
-	// Copy file
-	_, err = io.Copy(dstFile, srcFile)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// PathEqual compare the paths to determine if they are equal
-func PathEqual(firstPath string, secondPath string) bool {
-	firstAbsPath, _ := GetAbsPath(firstPath)
-	secondAbsPath, _ := GetAbsPath(secondPath)
-	return firstAbsPath == secondAbsPath
-}
-
 // sliceContainsString checks for existence of given string in given slice
 func sliceContainsString(str string, slice []string) bool {
 	for _, b := range slice {
@@ -1076,14 +416,9 @@ func sliceContainsString(str string, slice []string) bool {
 	return false
 }
 
-// AddFileToIgnoreFile adds a file to the gitignore file. It only does that if the file doesn't exist
-func AddFileToIgnoreFile(gitIgnoreFile, filename string) error {
-	return addFileToIgnoreFile(gitIgnoreFile, filename, filesystem.DefaultFs{})
-}
-
 func addFileToIgnoreFile(gitIgnoreFile, filename string, fs filesystem.Filesystem) error {
 	var data []byte
-	file, err := fs.OpenFile(gitIgnoreFile, os.O_APPEND|os.O_RDWR, ModeReadWriteFile)
+	file, err := fs.OpenFile(gitIgnoreFile, os.O_APPEND|os.O_RDWR, dfutil.ModeReadWriteFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to open .gitignore file")
 	}
@@ -1103,6 +438,7 @@ func addFileToIgnoreFile(gitIgnoreFile, filename string, fs filesystem.Filesyste
 
 // DisplayLog displays logs to user stdout with some color formatting
 // numberOfLastLines limits the number of lines from the output when we are not following it
+// TODO(feloy) sync with devfile library?
 func DisplayLog(followLog bool, rd io.ReadCloser, writer io.Writer, compName string, numberOfLastLines int) (err error) {
 
 	defer rd.Close()

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -16,13 +16,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/pkg/errors"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dfutil "github.com/devfile/library/pkg/util"
+
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+
 	corev1 "k8s.io/api/core/v1"
 )
+
+// TODO(feloy) Move tests to devfile library
 
 func TestNamespaceOpenShiftObject(t *testing.T) {
 
@@ -58,7 +64,7 @@ func TestNamespaceOpenShiftObject(t *testing.T) {
 	for _, tt := range tests {
 		t.Log("Running test: ", tt.testName)
 		t.Run(tt.testName, func(t *testing.T) {
-			name, err := NamespaceOpenShiftObject(tt.componentName, tt.applicationName)
+			name, err := dfutil.NamespaceOpenShiftObject(tt.componentName, tt.applicationName)
 
 			if tt.wantErr && err == nil {
 				t.Errorf("Expected an error, got success")
@@ -104,7 +110,7 @@ func TestExtractComponentType(t *testing.T) {
 	for _, tt := range tests {
 		t.Log("Running test: ", tt.testName)
 		t.Run(tt.testName, func(t *testing.T) {
-			name := ExtractComponentType(tt.componentType)
+			name := dfutil.ExtractComponentType(tt.componentType)
 			if tt.want != name {
 				t.Errorf("Expected %s, got %s", tt.want, name)
 			}
@@ -224,7 +230,7 @@ func TestGetRandomName(t *testing.T) {
 	for _, tt := range tests {
 		t.Log("Running test: ", tt.testName)
 		t.Run(tt.testName, func(t *testing.T) {
-			name, err := GetRandomName(tt.args.prefix, -1, tt.args.existList, 3)
+			name, err := dfutil.GetRandomName(tt.args.prefix, -1, tt.args.existList, 3)
 			if err != nil {
 				t.Errorf("failed to generate a random name. Error %v", err)
 			}
@@ -336,7 +342,7 @@ func TestGenerateRandomString(t *testing.T) {
 	for _, tt := range tests {
 		t.Log("Running test: ", tt.testName)
 		t.Run(tt.testName, func(t *testing.T) {
-			name := GenerateRandomString(tt.strLength)
+			name := dfutil.GenerateRandomString(tt.strLength)
 			r, _ := regexp.Compile(fmt.Sprintf("[a-z]{%d}", tt.strLength))
 			match := r.MatchString(name)
 			if !match {
@@ -388,7 +394,7 @@ func TestGetAbsPath(t *testing.T) {
 				}
 				tt.absPath = absPath
 			}
-			result, err := GetAbsPath(tt.path)
+			result, err := dfutil.GetAbsPath(tt.path)
 			if result != tt.absPath {
 				t.Errorf("Expected %v, got %v", tt.absPath, result)
 			}
@@ -467,7 +473,7 @@ func TestGetHostWithPort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("Testing inputURL: %s", tt.inputURL), func(t *testing.T) {
-			got, err := GetHostWithPort(tt.inputURL)
+			got, err := dfutil.GetHostWithPort(tt.inputURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getHostWithPort() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -614,7 +620,7 @@ func TestGetIgnoreRulesFromDirectory(t *testing.T) {
 			}
 		}
 
-		gotRules, err := GetIgnoreRulesFromDirectory(testDir)
+		gotRules, err := dfutil.GetIgnoreRulesFromDirectory(testDir)
 
 		if err == nil && !tt.wantErr {
 			if !reflect.DeepEqual(gotRules, tt.wantRules) {
@@ -663,7 +669,7 @@ func TestGetAbsGlobExps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			resultExps := GetAbsGlobExps(tt.directoryName, tt.inputRelativeGlobExps)
+			resultExps := dfutil.GetAbsGlobExps(tt.directoryName, tt.inputRelativeGlobExps)
 			if runtime.GOOS == "windows" {
 				for index, element := range resultExps {
 					resultExps[index] = filepath.ToSlash(element)
@@ -693,7 +699,7 @@ func TestGetSortedKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Log("Running test: ", tt.testName)
 		t.Run(tt.testName, func(t *testing.T) {
-			actual := GetSortedKeys(tt.input)
+			actual := dfutil.GetSortedKeys(tt.input)
 			if !reflect.DeepEqual(tt.expected, actual) {
 				t.Errorf("expected: %+v, got: %+v", tt.expected, actual)
 			}
@@ -727,7 +733,7 @@ func TestGetSplitValuesFromStr(t *testing.T) {
 	for _, tt := range tests {
 		t.Log("Running test: ", tt.testName)
 		t.Run(tt.testName, func(t *testing.T) {
-			actual := GetSplitValuesFromStr(tt.input)
+			actual := dfutil.GetSplitValuesFromStr(tt.input)
 			if !reflect.DeepEqual(tt.expected, actual) {
 				t.Errorf("expected: %+v, got: %+v", tt.expected, actual)
 			}
@@ -811,7 +817,7 @@ func TestGetContainerPortsFromStrings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ports, err := GetContainerPortsFromStrings(tt.ports)
+			ports, err := dfutil.GetContainerPortsFromStrings(tt.ports)
 			if err == nil && !tt.wantErr {
 				if !reflect.DeepEqual(tt.containerPorts, ports) {
 					t.Errorf("the ports are not matching, expected %#v, got %#v", tt.containerPorts, ports)
@@ -887,7 +893,7 @@ func TestIsGlobExpMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			matched, err := IsGlobExpMatch(tt.strToMatch, tt.globExps)
+			matched, err := dfutil.IsGlobExpMatch(tt.strToMatch, tt.globExps)
 
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)
@@ -935,7 +941,7 @@ func TestRemoveRelativePathFromFiles(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			// Run function RemoveRelativePathFromFiles
-			output, err := RemoveRelativePathFromFiles(tt.args.input, tt.args.path)
+			output, err := dfutil.RemoveRelativePathFromFiles(tt.args.input, tt.args.path)
 			if runtime.GOOS == "windows" {
 				for index, element := range output {
 					output[index] = filepath.ToSlash(element)
@@ -968,7 +974,7 @@ func TestHTTPGetFreePort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := HTTPGetFreePort()
+			got, err := dfutil.HTTPGetFreePort()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("HTTPGetFreePort() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1018,7 +1024,7 @@ func TestGetRemoteFilesMarkedForDeletion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			remoteFiles := GetRemoteFilesMarkedForDeletion(tt.files, tt.remotePath)
+			remoteFiles := dfutil.GetRemoteFilesMarkedForDeletion(tt.files, tt.remotePath)
 			if !reflect.DeepEqual(tt.want, remoteFiles) {
 				t.Errorf("Expected %s, got %s", tt.want, remoteFiles)
 			}
@@ -1059,10 +1065,10 @@ func TestHTTPGetRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := HTTPRequestParams{
+			request := dfutil.HTTPRequestParams{
 				URL: tt.url,
 			}
-			got, err := HTTPGetRequest(request, 0)
+			got, err := dfutil.HTTPGetRequest(request, 0)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Got: %v, want: %v", got, tt.want)
@@ -1117,7 +1123,7 @@ func TestFilterIgnores(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filterChanged, filterDeleted := FilterIgnores(tt.changedFiles, tt.deletedFiles, tt.ignoredFiles)
+			filterChanged, filterDeleted := dfutil.FilterIgnores(tt.changedFiles, tt.deletedFiles, tt.ignoredFiles)
 
 			if !reflect.DeepEqual(tt.wantChangedFiles, filterChanged) {
 				t.Errorf("Expected %s, got %s", tt.wantChangedFiles, filterChanged)
@@ -1177,13 +1183,13 @@ func TestDownloadFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := false
-			params := DownloadParams{
-				Request: HTTPRequestParams{
+			params := dfutil.DownloadParams{
+				Request: dfutil.HTTPRequestParams{
 					URL: tt.url,
 				},
 				Filepath: tt.filepath,
 			}
-			err := DownloadFile(params)
+			err := dfutil.DownloadFile(params)
 			if err != nil {
 				gotErr = true
 			}
@@ -1244,7 +1250,7 @@ func TestValidateK8sResourceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateK8sResourceName(tt.key, tt.value)
+			err := dfutil.ValidateK8sResourceName(tt.key, tt.value)
 			got := err == nil
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Got %t, want %t", got, tt.want)
@@ -1456,7 +1462,7 @@ func TestDownloadFileInMemory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := DownloadFileInMemory(HTTPRequestParams{URL: tt.url})
+			data, err := DownloadFileInMemory(dfutil.HTTPRequestParams{URL: tt.url})
 			if tt.url != "invalid" && err != nil {
 				t.Errorf("Failed to download file with error %s", err)
 			}
@@ -1596,7 +1602,7 @@ func TestValidateFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := false
-			err := ValidateFile(tt.filePath)
+			err := dfutil.ValidateFile(tt.filePath)
 			if err != nil {
 				gotErr = true
 			}
@@ -1655,7 +1661,7 @@ func TestCopyFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := false
-			err = CopyFile(tt.srcPath, tt.dstPath, info)
+			err = dfutil.CopyFile(tt.srcPath, tt.dstPath, info)
 			if err != nil {
 				gotErr = true
 			}
@@ -1703,7 +1709,7 @@ func TestPathEqual(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := PathEqual(tt.firstPath, tt.secondPath)
+			got := dfutil.PathEqual(tt.firstPath, tt.secondPath)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Got: %t, want %t", got, tt.want)
 			}

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -16,11 +16,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/testingutil"
-	"github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 // setUpF8AnalyticsComponentSrc sets up a mock analytics component source base for observing changes to source files.
@@ -139,7 +141,7 @@ func mockDevFilePush(parameters common.PushParameters, _ WatchParameters) error 
 // commonChecks is the common checker for both the push handlers
 func commonChecks(path string, files []string, delFiles []string, globExps []string) error {
 	sort.Strings(globExps)
-	mockPush.globExps = util.GetAbsGlobExps(path, mockPush.globExps)
+	mockPush.globExps = dfutil.GetAbsGlobExps(path, mockPush.globExps)
 	sort.Strings(mockPush.globExps)
 	if !reflect.DeepEqual(globExps, mockPush.globExps) {
 		fmt.Printf("some of the push parameters are different, wanted: %v, got: %v", mockPush.globExps, globExps)
@@ -813,7 +815,7 @@ func TestWatchAndPush(t *testing.T) {
 				ComponentName: tt.componentName,
 				Path:          basePath,
 				// convert the glob expressions to absolute form for WatchAndPush to work properly
-				FileIgnores:     util.GetAbsGlobExps(basePath, tt.ignores),
+				FileIgnores:     dfutil.GetAbsGlobExps(basePath, tt.ignores),
 				StartChan:       StartChan,
 				ExtChan:         ExtChan,
 				PushDiffDelay:   tt.delayInterval,

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
+	dfutil "github.com/devfile/library/pkg/util"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-developer/odo/pkg/util"
 )
 
 // CreateNewContext create new empty temporary directory
@@ -123,7 +124,7 @@ func CopyExampleFile(filePath, targetDst string) {
 	info, err := os.Stat(src)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = util.CopyFile(src, targetDst, info)
+	err = dfutil.CopyFile(src, targetDst, info)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -152,7 +153,7 @@ func CopyManifestFile(fileName, targetDst string) {
 	info, err := os.Stat(src)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = util.CopyFile(src, targetDst, info)
+	err = dfutil.CopyFile(src, targetDst, info)
 	Expect(err).NotTo(HaveOccurred())
 
 }
@@ -175,7 +176,7 @@ func CopyExampleDevFile(devfilePath, targetDst string) {
 	info, err := os.Stat(src)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = util.CopyFile(src, targetDst, info)
+	err = dfutil.CopyFile(src, targetDst, info)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -223,7 +224,7 @@ func copyDir(src string, dst string, info os.FileInfo) error {
 		return err
 	}
 
-	return util.CopyFile(src, dst, info)
+	return dfutil.CopyFile(src, dst, info)
 }
 
 // CreateFileWithContent creates a file at the given path and writes the given content

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -17,16 +17,17 @@ import (
 	"github.com/redhat-developer/odo/pkg/preference"
 	"github.com/redhat-developer/odo/tests/helper/reporter"
 
+	dfutil "github.com/devfile/library/pkg/util"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/tidwall/gjson"
 )
 
 // RandString returns a random string of given length
 func RandString(n int) string {
-	return util.GenerateRandomString(n)
+	return dfutil.GenerateRandomString(n)
 }
 
 // WaitForCmdOut runs a command until it gets

--- a/tests/helper/kubernetes_utils.go
+++ b/tests/helper/kubernetes_utils.go
@@ -6,14 +6,15 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-developer/odo/pkg/util"
+
+	dfutil "github.com/devfile/library/pkg/util"
 )
 
 // copyKubeConfigFile copies default kubeconfig file into current temporary context config file
 func copyKubeConfigFile(kubeConfigFile, tempConfigFile string) {
 	info, err := os.Stat(kubeConfigFile)
 	Expect(err).NotTo(HaveOccurred())
-	err = util.CopyFile(kubeConfigFile, tempConfigFile, info)
+	err = dfutil.CopyFile(kubeConfigFile, tempConfigFile, info)
 	Expect(err).NotTo(HaveOccurred())
 	os.Setenv("KUBECONFIG", tempConfigFile)
 	fmt.Fprintf(GinkgoWriter, "Setting KUBECONFIG=%s\n", tempConfigFile)

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/redhat-developer/odo/pkg/util"
-
 	"github.com/redhat-developer/odo/tests/helper"
+
+	dfutil "github.com/devfile/library/pkg/util"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -134,7 +134,7 @@ func OdoWatchWithDebug(odoV2Watch OdoV2Watch, context, flag string) {
 			}
 
 			if stringsMatched {
-				httpPort, err := util.HTTPGetFreePort()
+				httpPort, err := dfutil.HTTPGetFreePort()
 				Expect(err).NotTo(HaveOccurred())
 				freePort := strconv.Itoa(httpPort)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,7 +226,6 @@ github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.14
 github.com/go-openapi/swag
 # github.com/gobwas/glob v0.2.3
-## explicit
 github.com/gobwas/glob
 github.com/gobwas/glob/compiler
 github.com/gobwas/glob/match
@@ -279,7 +278,6 @@ github.com/googleapis/gnostic/openapiv2
 # github.com/gookit/color v1.4.2
 github.com/gookit/color
 # github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-## explicit
 github.com/gregjones/httpcache
 github.com/gregjones/httpcache/diskcache
 # github.com/hashicorp/errwrap v1.0.0


### PR DESCRIPTION
**What type of PR is this:**

/kind cleanup

**What does this PR do / why we need it:**

Code is duplicated between odo and devfile library. It seems that `util` functions have been copied from odo to devfile library, but odo still uses the local functions.

**Which issue(s) this PR fixes:**

Fixes #5403 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
