### PR TITLE
Do not fail on no right to list some resource

### DIFF
--- a/pkg/kclient/all.go
+++ b/pkg/kclient/all.go
@@ -77,7 +77,8 @@ func queryAPI(client dynamic.Interface, api apiResource, ns string, selector str
 			LabelSelector: selector,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("listing resources failed (%s): %w", api.GroupVersionResource(), err)
+			klog.V(2).Infof("listing resources failed (%s): %v", api.GroupVersionResource(), err)
+			return nil, nil
 		}
 		out = append(out, resp.Items...)
 


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR fixes the `GetAllResourcesFromSelector` function to not fail when some resource is not allowed to be listed, but only skip it.
