### PR TITLE
Set timeout for interactive tests Expects

### DIFF
--- a/tests/helper/helper_interactive.go
+++ b/tests/helper/helper_interactive.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"log"
 	"os/exec"
+	"time"
 
 	"github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
@@ -25,7 +26,7 @@ func RunInteractive(command []string, test func(*expect.Console, *bytes.Buffer))
 
 	term := vt10x.New(vt10x.WithWriter(pts))
 
-	c, err := expect.NewConsole(expect.WithStdin(ptm), expect.WithStdout(term), expect.WithCloser(pts, ptm))
+	c, err := expect.NewConsole(expect.WithStdin(ptm), expect.WithStdout(term), expect.WithCloser(pts, ptm), expect.WithDefaultTimeout(3*time.Minute))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR sets a timeout on each Expect during interactive integration tests, so tests do not run infinitely if the expected string does not come
