### PR TITLE
Fix typos and invalid URLs in documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,14 @@
 <!-- 
 Thank you for opening a PR! Here are some things you need to know before submitting:
 
-1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Developer-Guidelines
+1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
 2. Label this PR accordingly with the '/kind' line
-3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Writing-and-running-tests
-4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/PR-Review
+3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
+4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline
 
 Documentation:
 
-If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Contributing-to-Docs
+If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
 -->
 
 **What type of PR is this:**

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -1,1 +1,1 @@
-Read the [contribution guide](https://github.com/redhat-developer/odo/wiki/Contributing-to-Docs) for more information on how to contribute to the website.
+Read the [contribution guide](https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing) for more information on how to contribute to the website.

--- a/docs/website/docs/command-reference/flags.md
+++ b/docs/website/docs/command-reference/flags.md
@@ -11,7 +11,7 @@ Following are the flags commonly available with almost every odo command.
 * `--kubeconfig` - Use this flag to set path to the kubeconfig if not using the default configuration
 * `--show-log` - Use this flag to see the logs
 *  `-f`, `--force` - Use this flag to tell the command not to prompt user for confirmation
-* `-v`, `--v` - Use this flag to set the verbosity level. See (Logging in odo)[https://github.com/redhat-developer/odo/wiki/Logging-in-odo] for more information.
+* `-v`, `--v` - Use this flag to set the verbosity level. See [Logging in odo](https://github.com/redhat-developer/odo/wiki/Dev:-Logging-in-odo) for more information.
 * `-h`, `--help` - Use this flag to get help on a command
 
 **Note:** Some flags might not be available in some commands, run the command with `--help` to get a list of all the available flags.

--- a/docs/website/docs/contribution.md
+++ b/docs/website/docs/contribution.md
@@ -2,10 +2,10 @@
 title:  Contributing to odo
 sidebar_position: 50
 ---
-* [Contributing to code](https://github.com/redhat-developer/odo/wiki/Developer-Guidelines)
-* [Writing and running tests](https://github.com/redhat-developer/odo/wiki/Writing-and-running-tests)
-* [Contributing to docs](https://github.com/redhat-developer/odo/wiki/Contributing-to-Docs)
-* [Release Guideline](https://github.com/redhat-developer/odo/wiki/Release-Guideline)
-* [Reviewing PR](https://github.com/redhat-developer/odo/wiki/PR-Review)
-* [Logging in odo](https://github.com/redhat-developer/odo/wiki/Logging-in-odo)
-* [Getting involved in the community](https://github.com/redhat-developer/odo/wiki/Getting-involved-in-the-Community)
+* [Contributing to code](https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines)
+* [Writing and running tests](https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests)
+* [Contributing to docs](https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing)
+* [Release Guideline](https://github.com/redhat-developer/odo/wiki/Release:-New-version-of-odo)
+* [Reviewing PR](https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline)
+* [Logging in odo](https://github.com/redhat-developer/odo/wiki/Dev:-Logging-in-odo)
+* [Getting involved in the community](https://github.com/redhat-developer/odo/wiki/Community:-Getting-involved)

--- a/docs/website/docs/getting-started/features.md
+++ b/docs/website/docs/getting-started/features.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 By using `odo`, application developers can develop, test, debug, and deploy microservices based applications on Kubernetes without having a deep understanding of the platform.
 
-`odo` follows *create and push* workflow. As a user, when you *create*, the information (or manifest) is stored in a configuration file. When you *push* it gets created on the Kubernetes cluster. All of this gets stored in the Kubernetes API for seamless accessability and function.
+`odo` follows *create and push* workflow. As a user, when you *create*, the information (or manifest) is stored in a configuration file. When you *push* it gets created on the Kubernetes cluster. All of this gets stored in the Kubernetes API for seamless accessibility and function.
 
 `odo` uses *deploy and link* commands to link components and services together. `odo` achieves this by creating and deploying services based on [Kubernetes Operators](https://github.com/operator-framework/) in the cluster. Services can be created using any of the operators available on [OperatorHub.io](https://operatorhub.io). Upon linking this service, `odo` injects the service configuration into the service. Your application can then use this configuration to communicate with the Operator backed service.
 

--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -11,13 +11,13 @@ We abstract the complex concepts of Kubernetes so you can focus on one thing: `c
 
 Choose your favourite framework and `odo` will deploy it *fast* and *often* to your container orchestrator cluster.
 
-`odo` is focused on [inner loop](./intro#what-is-inner-loop-and-outer-loop) development as well as tooling that would helps users transition to the [outer loop](./intro#what-is-inner-loop-and-outer-loop).
+`odo` is focused on [inner loop](./intro#what-is-inner-loop-and-outer-loop) development as well as tooling that would help users transition to the [outer loop](./intro#what-is-inner-loop-and-outer-loop).
 
 Brendan Burns, one of the co-founders of Kubernetes, said in the [book Kubernetes Patterns](https://www.redhat.com/cms/managed-files/cm-oreilly-kubernetes-patterns-ebook-f19824-201910-en.pdf):
 
 > It (Kubernetes) is the foundation on which applications will be built, and it provides a large library of APIs and tools for building these applications, but it does little to provide the application or container developer with any hints or guidance for how these various pieces can be combined into a complete, reliable system that satisfies their business needs and goals.
 
-`odo` satisfies that need by making Kubernetes development *super easy* for application developers and cloud engineer.
+`odo` satisfies that need by making Kubernetes development *super easy* for application developers and cloud engineers.
 
 ### What is "inner loop" and "outer loop"?
 

--- a/docs/website/docs/using-odo/create-component.md
+++ b/docs/website/docs/using-odo/create-component.md
@@ -118,7 +118,7 @@ Besides creating a component for an existing code, you could also use "starter p
 
 Starter projects are example projects developed by the community to showcase the usability of devfiles. An odo user can use these starter projects by running `odo create` command in an empty directory.
 
-### Starer projects in interactive mode
+### Starter projects in interactive mode
 
 To interactively create a Java Spring Boot component using the starter project, you can follow the below steps:
 ```shell

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -138,13 +138,13 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-          'https://github.com/redhat-developer/odo/edit/main/website/',
+          'https://github.com/redhat-developer/odo/edit/main/docs/website/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-          'https://github.com/redhat-developer/odo/edit/main/website/blog/',
+          'https://github.com/redhat-developer/odo/edit/main/docs/website/',
           blogSidebarTitle: 'All posts',
           blogSidebarCount: 'ALL',
           postsPerPage: 5,

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home(): JSX.Element {
         </div>
         <div className={clsx(styles.title, styles.titleDark)}>
           <div className={styles.titleInner}>
-            Visit our <Link to="/blog"> our blog </Link>for the newest developments on odo 🚀
+            Visit <Link to="/blog">our blog</Link> for the newest developments on odo 🚀
           </div>
         </div>
         <div className={styles.overview}>

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/flags.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/flags.md
@@ -11,7 +11,7 @@ Following are the flags commonly available with almost every odo command.
 * `--kubeconfig` - Use this flag to set path to the kubeconfig if not using the default configuration
 * `--show-log` - Use this flag to see the logs
 *  `-f`, `--force` - Use this flag to tell the command not to prompt user for confirmation
-* `-v`, `--v` - Use this flag to set the verbosity level. See (Logging in odo)[https://github.com/redhat-developer/odo/wiki/Logging-in-odo] for more information.
+* `-v`, `--v` - Use this flag to set the verbosity level. See [Logging in odo](https://github.com/redhat-developer/odo/wiki/Dev:-Logging-in-odo) for more information.
 * `-h`, `--help` - Use this flag to get help on a command
 
 **Note:** Some flags might not be available in some commands, run the command with `--help` to get a list of all the available flags.

--- a/docs/website/versioned_docs/version-3.0.0/contribution.md
+++ b/docs/website/versioned_docs/version-3.0.0/contribution.md
@@ -2,10 +2,10 @@
 title:  Contributing to odo
 sidebar_position: 50
 ---
-* [Contributing to code](https://github.com/redhat-developer/odo/wiki/Developer-Guidelines)
-* [Writing and running tests](https://github.com/redhat-developer/odo/wiki/Writing-and-running-tests)
-* [Contributing to docs](https://github.com/redhat-developer/odo/wiki/Contributing-to-Docs)
-* [Release Guideline](https://github.com/redhat-developer/odo/wiki/Release-Guideline)
-* [Reviewing PR](https://github.com/redhat-developer/odo/wiki/PR-Review)
-* [Logging in odo](https://github.com/redhat-developer/odo/wiki/Logging-in-odo)
-* [Getting involved in the community](https://github.com/redhat-developer/odo/wiki/Getting-involved-in-the-Community)
+* [Contributing to code](https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines)
+* [Writing and running tests](https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests)
+* [Contributing to docs](https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing)
+* [Release Guideline](https://github.com/redhat-developer/odo/wiki/Release:-New-version-of-odo)
+* [Reviewing PR](https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline)
+* [Logging in odo](https://github.com/redhat-developer/odo/wiki/Dev:-Logging-in-odo)
+* [Getting involved in the community](https://github.com/redhat-developer/odo/wiki/Community:-Getting-involved)

--- a/docs/website/versioned_docs/version-3.0.0/getting-started/features.md
+++ b/docs/website/versioned_docs/version-3.0.0/getting-started/features.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 By using `odo`, application developers can develop, test, debug, and deploy microservices based applications on Kubernetes without having a deep understanding of the platform.
 
-`odo` follows *create and push* workflow. As a user, when you *create*, the information (or manifest) is stored in a configuration file. When you *push* it gets created on the Kubernetes cluster. All of this gets stored in the Kubernetes API for seamless accessability and function.
+`odo` follows *create and push* workflow. As a user, when you *create*, the information (or manifest) is stored in a configuration file. When you *push* it gets created on the Kubernetes cluster. All of this gets stored in the Kubernetes API for seamless accessibility and function.
 
 `odo` uses *deploy and link* commands to link components and services together. `odo` achieves this by creating and deploying services based on [Kubernetes Operators](https://github.com/operator-framework/) in the cluster. Services can be created using any of the operators available on [OperatorHub.io](https://operatorhub.io). Upon linking this service, `odo` injects the service configuration into the service. Your application can then use this configuration to communicate with the Operator backed service.
 

--- a/docs/website/versioned_docs/version-3.0.0/intro.md
+++ b/docs/website/versioned_docs/version-3.0.0/intro.md
@@ -11,13 +11,13 @@ We abstract the complex concepts of Kubernetes so you can focus on one thing: `c
 
 Choose your favourite framework and `odo` will deploy it *fast* and *often* to your container orchestrator cluster.
 
-`odo` is focused on [inner loop](./intro#what-is-inner-loop-and-outer-loop) development as well as tooling that would helps users transition to the [outer loop](./intro#what-is-inner-loop-and-outer-loop).
+`odo` is focused on [inner loop](./intro#what-is-inner-loop-and-outer-loop) development as well as tooling that would help users transition to the [outer loop](./intro#what-is-inner-loop-and-outer-loop).
 
 Brendan Burns, one of the co-founders of Kubernetes, said in the [book Kubernetes Patterns](https://www.redhat.com/cms/managed-files/cm-oreilly-kubernetes-patterns-ebook-f19824-201910-en.pdf):
 
 > It (Kubernetes) is the foundation on which applications will be built, and it provides a large library of APIs and tools for building these applications, but it does little to provide the application or container developer with any hints or guidance for how these various pieces can be combined into a complete, reliable system that satisfies their business needs and goals.
 
-`odo` satisfies that need by making Kubernetes development *super easy* for application developers and cloud engineer.
+`odo` satisfies that need by making Kubernetes development *super easy* for application developers and cloud engineers.
 
 ### What is "inner loop" and "outer loop"?
 

--- a/docs/website/versioned_docs/version-3.0.0/using-odo/create-component.md
+++ b/docs/website/versioned_docs/version-3.0.0/using-odo/create-component.md
@@ -118,7 +118,7 @@ Besides creating a component for an existing code, you could also use "starter p
 
 Starter projects are example projects developed by the community to showcase the usability of devfiles. An odo user can use these starter projects by running `odo create` command in an empty directory.
 
-### Starer projects in interactive mode
+### Starter projects in interactive mode
 
 To interactively create a Java Spring Boot component using the starter project, you can follow the below steps:
 ```shell


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Developer-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/PR-Review

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Contributing-to-Docs
-->

**What type of PR is this:**
/kind documentation

<!--
Add one of the following kinds:
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This fixes a few minor issues I stumbled upon while playing with the `odo` tutorials on the [odo.dev](https://odo.dev/) website.
Those are fixes for both the `2.5.0` and `3.0.0` versions of the documentation.
Also, some URLs were no longer valid and used to point to a 404 page, like when clicking on the `Edit this page` links in the website. This PR also fixes this behavior.

**Which issue(s) this PR fixes:**
This was quick to fix. So I did not create a new issue.
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
I did not find any automated tests for the website. So this has to be checked manually.