### PR TITLE
Initialize devfile on odo dev/deploy without devfile

### DIFF
--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -42,4 +42,8 @@ type Client interface {
 
 	// PersonalizeDevfileConfig updates the env vars, and URL endpoints
 	PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error
+
+	// SelectAndPersonalizeDevfile selects a devfile, then downloads, parse and personalize it
+	// Returns the devfile object and its path
+	SelectAndPersonalizeDevfile(flags map[string]string, contextDir string) (parser.DevfileObj, string, error)
 }

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -94,6 +94,22 @@ func (mr *MockClientMockRecorder) PersonalizeName(devfile, flags interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockClient)(nil).PersonalizeName), devfile, flags)
 }
 
+// SelectAndPersonalizeDevfile mocks base method.
+func (m *MockClient) SelectAndPersonalizeDevfile(flags map[string]string, contextDir string) (parser.DevfileObj, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectAndPersonalizeDevfile", flags, contextDir)
+	ret0, _ := ret[0].(parser.DevfileObj)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SelectAndPersonalizeDevfile indicates an expected call of SelectAndPersonalizeDevfile.
+func (mr *MockClientMockRecorder) SelectAndPersonalizeDevfile(flags, contextDir interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAndPersonalizeDevfile", reflect.TypeOf((*MockClient)(nil).SelectAndPersonalizeDevfile), flags, contextDir)
+}
+
 // SelectDevfile mocks base method.
 func (m *MockClient) SelectDevfile(flags map[string]string, fs filesystem.Filesystem, dir string) (*backend.DevfileLocation, error) {
 	m.ctrl.T.Helper()

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -34,9 +34,6 @@ type DeployOptions struct {
 
 	// Clients
 	clientset *clientset.Clientset
-
-	// Flags
-	contextFlag string
 }
 
 var deployExample = templates.Examples(`
@@ -80,6 +77,11 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 			return fmt.Errorf("unable to download devfile: %w", err2)
 		}
 
+		err = o.clientset.InitClient.PersonalizeDevfileConfig(devfileObj, map[string]string{}, o.clientset.FS, cwd)
+		if err != nil {
+			return fmt.Errorf("failed to configure devfile: %w", err)
+		}
+
 		// Set the name in the devfile and writes the devfile back to the disk
 		err = o.clientset.InitClient.PersonalizeName(devfileObj, map[string]string{})
 		if err != nil {
@@ -87,12 +89,12 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		}
 
 	}
-	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextFlag))
+	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(cwd))
 	if err != nil {
 		return err
 	}
 
-	envFileInfo, err := envinfo.NewEnvSpecificInfo(o.contextFlag)
+	envFileInfo, err := envinfo.NewEnvSpecificInfo(cwd)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve configuration information")
 	}

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -57,6 +57,15 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 	if err != nil {
 		return err
 	}
+
+	isEmptyDir, err := location.DirIsEmpty(o.clientset.FS, cwd)
+	if err != nil {
+		return err
+	}
+	if isEmptyDir {
+		return errors.New("this command cannot run in an empty directory, you need to run it in a directory containing source code")
+	}
+
 	containsDevfile, err := location.DirectoryContainsDevfile(filesystem.DefaultFs{}, cwd)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -8,9 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/devfile/library/pkg/devfile"
-	"github.com/devfile/library/pkg/devfile/parser"
-
 	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/odo/cli/component"
@@ -21,7 +18,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 
 	"k8s.io/kubectl/pkg/util/templates"
-	"k8s.io/utils/pointer"
 )
 
 // RecommendedCommandName is the recommended command name
@@ -34,6 +30,9 @@ type DeployOptions struct {
 
 	// Clients
 	clientset *clientset.Clientset
+
+	// working directory
+	contextDir string
 }
 
 var deployExample = templates.Examples(`
@@ -52,13 +51,12 @@ func (o *DeployOptions) SetClientset(clientset *clientset.Clientset) {
 
 // Complete DeployOptions after they've been created
 func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
-
-	cwd, err := os.Getwd()
+	o.contextDir, err = os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	isEmptyDir, err := location.DirIsEmpty(o.clientset.FS, cwd)
+	isEmptyDir, err := location.DirIsEmpty(o.clientset.FS, o.contextDir)
 	if err != nil {
 		return err
 	}
@@ -66,44 +64,17 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		return errors.New("this command cannot run in an empty directory, you need to run it in a directory containing source code")
 	}
 
-	containsDevfile, err := location.DirectoryContainsDevfile(filesystem.DefaultFs{}, cwd)
-	if err != nil {
-		return err
-	}
-	if !containsDevfile {
-		devfileLocation, err2 := o.clientset.InitClient.SelectDevfile(map[string]string{}, o.clientset.FS, cwd)
-		if err2 != nil {
-			return err2
-		}
-
-		devfilePath, err2 := o.clientset.InitClient.DownloadDevfile(devfileLocation, cwd)
-		if err2 != nil {
-			return fmt.Errorf("unable to download devfile: %w", err2)
-		}
-
-		devfileObj, _, err2 := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: devfilePath, FlattenedDevfile: pointer.BoolPtr(false)})
-		if err2 != nil {
-			return fmt.Errorf("unable to download devfile: %w", err2)
-		}
-
-		err = o.clientset.InitClient.PersonalizeDevfileConfig(devfileObj, map[string]string{}, o.clientset.FS, cwd)
-		if err != nil {
-			return fmt.Errorf("failed to configure devfile: %w", err)
-		}
-
-		// Set the name in the devfile and writes the devfile back to the disk
-		err = o.clientset.InitClient.PersonalizeName(devfileObj, map[string]string{})
-		if err != nil {
-			return fmt.Errorf("failed to update the devfile's name: %w", err)
-		}
-
-	}
-	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(cwd))
+	err = o.initDevfile()
 	if err != nil {
 		return err
 	}
 
-	envFileInfo, err := envinfo.NewEnvSpecificInfo(cwd)
+	o.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline).NeedDevfile(o.contextDir))
+	if err != nil {
+		return err
+	}
+
+	envFileInfo, err := envinfo.NewEnvSpecificInfo(o.contextDir)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve configuration information")
 	}
@@ -129,6 +100,27 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 
 // Validate validates the DeployOptions based on completed values
 func (o *DeployOptions) Validate() error {
+	return nil
+}
+
+func (o *DeployOptions) initDevfile() error {
+	containsDevfile, err := location.DirectoryContainsDevfile(filesystem.DefaultFs{}, o.contextDir)
+	if err != nil {
+		return err
+	}
+	if containsDevfile {
+		return nil
+	}
+	devfileObj, _, err := o.clientset.InitClient.SelectAndPersonalizeDevfile(map[string]string{}, o.contextDir)
+	if err != nil {
+		return err
+	}
+
+	// Set the name in the devfile and writes the devfile back to the disk
+	err = o.clientset.InitClient.PersonalizeName(devfileObj, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("failed to update the devfile's name: %w", err)
+	}
 	return nil
 }
 

--- a/tests/helper/helper_interactive.go
+++ b/tests/helper/helper_interactive.go
@@ -31,6 +31,9 @@ type InteractiveContext struct {
 	// Its content will get updated as long as there are interactions with the console, like sending lines or
 	// expecting lines.
 	buffer *bytes.Buffer
+
+	// A function yto call to stop the process
+	StopCommand func()
 }
 
 // Tester represents the function that contains all steps to test the given interactive command.
@@ -79,6 +82,9 @@ func RunInteractive(command []string, env []string, tester Tester) (string, erro
 		Command: command,
 		console: c,
 		buffer:  buf,
+		StopCommand: func() {
+			_ = cmd.Process.Kill()
+		},
 	}
 	tester(ctx)
 

--- a/tests/helper/helper_interactive.go
+++ b/tests/helper/helper_interactive.go
@@ -81,10 +81,9 @@ func RunInteractive(command []string, env []string, tester Tester) (string, erro
 		buffer:  buf,
 	}
 	tester(ctx)
+
 	err = cmd.Wait()
-	if err != nil {
-		log.Fatal(err)
-	}
+
 	// Close the slave end of the pty, and read the remaining bytes from the master end.
 	c.Tty().Close()
 

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -30,6 +30,19 @@ var _ = Describe("odo dev command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
+	When("directory is empty", func() {
+
+		BeforeEach(func() {
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
+		})
+
+		It("should error", func() {
+			output := helper.Cmd("odo", "dev").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
+
+		})
+	})
+
 	When("a component is bootstrapped and pushed", func() {
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)

--- a/tests/integration/devfile/cmd_devfile_deploy_test.go
+++ b/tests/integration/devfile/cmd_devfile_deploy_test.go
@@ -23,6 +23,19 @@ var _ = Describe("odo devfile deploy command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
+	When("directory is empty", func() {
+
+		BeforeEach(func() {
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
+		})
+
+		It("should error", func() {
+			output := helper.Cmd("odo", "deploy").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
+
+		})
+	})
+
 	When("using a devfile.yaml containing a deploy command", func() {
 
 		BeforeEach(func() {

--- a/tests/integration/interactive/cmd_deploy_test.go
+++ b/tests/integration/interactive/cmd_deploy_test.go
@@ -28,19 +28,6 @@ var _ = Describe("odo deploy interactive command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("directory is empty", func() {
-
-		BeforeEach(func() {
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
-		})
-
-		It("should error", func() {
-			output := helper.Cmd("odo", "deploy").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
-
-		})
-	})
-
 	When("directory is not empty", func() {
 
 		BeforeEach(func() {

--- a/tests/integration/interactive/cmd_deploy_test.go
+++ b/tests/integration/interactive/cmd_deploy_test.go
@@ -1,0 +1,86 @@
+//go:build linux || darwin || dragonfly || solaris || openbsd || netbsd || freebsd
+// +build linux darwin dragonfly solaris openbsd netbsd freebsd
+
+package interactive
+
+import (
+	"fmt"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/odo/tests/helper"
+)
+
+var _ = Describe("odo deploy interactive command tests", func() {
+
+	var commonVar helper.CommonVar
+
+	// This is run before every Spec (It)
+	var _ = BeforeEach(func() {
+		commonVar = helper.CommonBeforeEach()
+		helper.Chdir(commonVar.Context)
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.CommonAfterEach(commonVar)
+	})
+
+	When("directory is empty", func() {
+
+		BeforeEach(func() {
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
+		})
+
+		It("should error", func() {
+			output := helper.Cmd("odo", "deploy").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
+
+		})
+	})
+
+	When("directory is not empty", func() {
+
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "python"), commonVar.Context)
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(
+				SatisfyAll(
+					HaveLen(2),
+					ContainElements("requirements.txt", "wsgi.py")))
+		})
+
+		It("should run alizer to download devfile", func() {
+
+			language := "python"
+			output, err := helper.RunInteractive([]string{"odo", "deploy"},
+				nil,
+				func(ctx helper.InteractiveContext) {
+					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", language))
+
+					helper.ExpectString(ctx,
+						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", language))
+
+					helper.ExpectString(ctx, "Is this correct")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Select container for which you want to change configuration")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Enter component name")
+					helper.SendLine(ctx, "my-app")
+
+					helper.ExpectString(ctx, "no deploy command found in devfile")
+				})
+
+			Expect(err).To(Not(BeNil()))
+			Expect(output).To(ContainSubstring("no deploy command found in devfile"))
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+		})
+	})
+})

--- a/tests/integration/interactive/cmd_dev_test.go
+++ b/tests/integration/interactive/cmd_dev_test.go
@@ -28,19 +28,6 @@ var _ = Describe("odo dev interactive command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("directory is empty", func() {
-
-		BeforeEach(func() {
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
-		})
-
-		It("should error", func() {
-			output := helper.Cmd("odo", "dev").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
-
-		})
-	})
-
 	When("directory is not empty", func() {
 
 		BeforeEach(func() {
@@ -64,7 +51,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", language))
 
 					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", language))
+						fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", language))
 
 					helper.ExpectString(ctx, "Is this correct")
 					helper.SendLine(ctx, "\n")

--- a/tests/integration/interactive/cmd_dev_test.go
+++ b/tests/integration/interactive/cmd_dev_test.go
@@ -1,0 +1,85 @@
+//go:build linux || darwin || dragonfly || solaris || openbsd || netbsd || freebsd
+// +build linux darwin dragonfly solaris openbsd netbsd freebsd
+
+package interactive
+
+import (
+	"fmt"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/odo/tests/helper"
+)
+
+var _ = Describe("odo dev interactive command tests", func() {
+
+	var commonVar helper.CommonVar
+
+	// This is run before every Spec (It)
+	var _ = BeforeEach(func() {
+		commonVar = helper.CommonBeforeEach()
+		helper.Chdir(commonVar.Context)
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.CommonAfterEach(commonVar)
+	})
+
+	When("directory is empty", func() {
+
+		BeforeEach(func() {
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
+		})
+
+		It("should error", func() {
+			output := helper.Cmd("odo", "dev").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
+
+		})
+	})
+
+	When("directory is not empty", func() {
+
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "python"), commonVar.Context)
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(
+				SatisfyAll(
+					HaveLen(2),
+					ContainElements("requirements.txt", "wsgi.py")))
+		})
+
+		It("should run alizer to download devfile", func() {
+
+			language := "python"
+			_, _ = helper.RunInteractive([]string{"odo", "dev"},
+				nil,
+				func(ctx helper.InteractiveContext) {
+					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", language))
+
+					helper.ExpectString(ctx,
+						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", language))
+
+					helper.ExpectString(ctx, "Is this correct")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Select container for which you want to change configuration")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Enter component name")
+					helper.SendLine(ctx, "my-app")
+
+					helper.ExpectString(ctx, "Press Ctrl+c to exit")
+					ctx.StopCommand()
+				})
+
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+		})
+	})
+})

--- a/tests/integration/interactive/cmd_init_test.go
+++ b/tests/integration/interactive/cmd_init_test.go
@@ -5,11 +5,12 @@ package interactive
 
 import (
 	"fmt"
+	"log"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/odo/tests/helper"
-	"log"
-	"path/filepath"
 )
 
 var _ = Describe("odo init interactive command tests", func() {


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

odo Initializes a devfile interactively when `odo dev` and `odo deploy` are executed from a directory without a devfile.

**Which issue(s) this PR fixes:**

Fixes #5476, #5477, #5491

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
