### PR TITLE
Fix panic with odo init when non-existent devfile path is provided

### DIFF
--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -134,7 +134,9 @@ func (o *InitOptions) Run() (err error) {
 	}
 
 	devfileObj, devfilePath, err := o.clientset.InitClient.SelectAndPersonalizeDevfile(o.flags, o.contextDir)
-
+	if err != nil {
+		return err
+	}
 	scontext.SetComponentType(o.ctx, component.GetComponentTypeFromDevfileMetadata(devfileObj.Data.GetMetadata()))
 
 	starterInfo, err := o.clientset.InitClient.SelectStarterProject(devfileObj, o.flags, o.clientset.FS, o.contextDir)

--- a/tests/integration/devfile/cmd_devfile_init_test.go
+++ b/tests/integration/devfile/cmd_devfile_init_test.go
@@ -2,6 +2,7 @@ package devfile
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -35,13 +36,21 @@ var _ = Describe("odo devfile init command tests", func() {
 		})
 		By("running odo init in a directory containing a devfile.yaml", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			defer os.Remove(filepath.Join(commonVar.Context, "devfile.yaml"))
 			err := helper.Cmd("odo", "init").ShouldFail().Err()
 			Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))
 		})
+
 		By("running odo init in a directory containing a .devfile.yaml", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), filepath.Join(commonVar.Context, ".devfile.yaml"))
+			defer os.Remove(filepath.Join(commonVar.Context, ".devfile.yaml"))
 			err := helper.Cmd("odo", "init").ShouldFail().Err()
 			Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))
+		})
+
+		By("running odo init with wrong path given to --devfile-path", func() {
+			err := helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", "/some/path/devfile.yaml").ShouldFail().Err()
+			Expect(err).To(ContainSubstring("no such file or directory"))
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_init_test.go
+++ b/tests/integration/devfile/cmd_devfile_init_test.go
@@ -48,9 +48,13 @@ var _ = Describe("odo devfile init command tests", func() {
 			Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))
 		})
 
-		By("running odo init with wrong path given to --devfile-path", func() {
+		By("running odo init with wrong local file path given to --devfile-path", func() {
 			err := helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", "/some/path/devfile.yaml").ShouldFail().Err()
 			Expect(err).To(ContainSubstring("no such file or directory"))
+		})
+		By("running odo init with wrong URL path given to --devfile-path", func() {
+			err := helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", "https://github.com/path/to/devfile.yaml").ShouldFail().Err()
+			Expect(err).To(ContainSubstring("unable to download devfile: failed to retrieve"))
 		})
 	})
 
@@ -65,7 +69,7 @@ var _ = Describe("odo devfile init command tests", func() {
 				Expect(files).To(Equal([]string{"devfile.yaml"}))
 			})
 		})
-		When("using --devfile-path flag", func() {
+		When("using --devfile-path flag with a local devfile", func() {
 			var newContext string
 			BeforeEach(func() {
 				newContext = helper.CreateNewContext()
@@ -80,8 +84,17 @@ var _ = Describe("odo devfile init command tests", func() {
 				files := helper.ListFilesInDir(commonVar.Context)
 				Expect(files).To(Equal([]string{"devfile.yaml"}))
 			})
-
 		})
+		When("using --devfile-path flag with a URL", func() {
+			BeforeEach(func() {
+				helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/devfile.yaml").ShouldPass()
+			})
+			It("should copy the devfile.yaml file", func() {
+				files := helper.ListFilesInDir(commonVar.Context)
+				Expect(files).To(Equal([]string{"devfile.yaml"}))
+			})
+		})
+
 	})
 
 	When("running odo init from a directory with sources", func() {

--- a/tests/integration/devfile/cmd_devfile_init_test.go
+++ b/tests/integration/devfile/cmd_devfile_init_test.go
@@ -54,14 +54,33 @@ var _ = Describe("odo devfile init command tests", func() {
 		})
 	})
 
-	When("running odo init with valid flags", func() {
-		BeforeEach(func() {
-			helper.Cmd("odo", "init", "--name", "aname", "--devfile", "go").ShouldPass()
-		})
+	Context("running odo init with valid flags", func() {
+		When("using --devfile flag", func() {
+			BeforeEach(func() {
+				helper.Cmd("odo", "init", "--name", "aname", "--devfile", "go").ShouldPass().Out()
+			})
 
-		It("should download a devfile.yaml file", func() {
-			files := helper.ListFilesInDir(commonVar.Context)
-			Expect(files).To(Equal([]string{"devfile.yaml"}))
+			It("should download a devfile.yaml file", func() {
+				files := helper.ListFilesInDir(commonVar.Context)
+				Expect(files).To(Equal([]string{"devfile.yaml"}))
+			})
+		})
+		When("using --devfile-path flag", func() {
+			var newContext string
+			BeforeEach(func() {
+				newContext = helper.CreateNewContext()
+				newDevfilePath := filepath.Join(newContext, "devfile.yaml")
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), newDevfilePath)
+				helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", newDevfilePath).ShouldPass()
+			})
+			AfterEach(func() {
+				helper.DeleteDir(newContext)
+			})
+			It("should copy the devfile.yaml file", func() {
+				files := helper.ListFilesInDir(commonVar.Context)
+				Expect(files).To(Equal([]string{"devfile.yaml"}))
+			})
+
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR fixes panic when a non-existent devfile path is provided to odo init.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5540


**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```sh
➜  odo init --name aname --devfile-path /tmp/devfile.go
 ✗  Copying devfile from "/tmp/devfile.go" [42631ns]
 ✗  unable to download devfile: open /tmp/devfile.go: no such file or directory
the command failed, the devfile has been removed from current directory
```