### PR TITLE
Remove information about resource cleanup from odo dev exit message

### DIFF
--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -42,7 +42,7 @@ type WatchParameters struct {
 	// List/Slice of files/folders in component source, the updates to which need not be pushed to component deployed pod
 	FileIgnores []string
 	// Custom function that can be used to push detected changes to remote pod. For more info about what each of the parameters to this function, please refer, pkg/component/component.go#PushLocal
-	//WatchHandler func(kclient.ClientInterface, string, string, string, io.Writer, []string, []string, bool, []string, bool) error
+	// WatchHandler func(kclient.ClientInterface, string, string, string, io.Writer, []string, []string, bool, []string, bool) error
 	// Custom function that can be used to push detected changes to remote devfile pod. For more info about what each of the parameters to this function, please refer, pkg/devfile/adapters/interface.go#PlatformAdapter
 	DevfileWatchHandler func(common.PushParameters, WatchParameters) error
 	// This is a channel added to signal readiness of the watch command to the external channel listeners
@@ -299,7 +299,8 @@ func (o *WatchClient) WatchAndPush(out io.Writer, parameters WatchParameters) er
 			if parameters.EnvSpecificInfo != nil && parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug {
 				fmt.Fprintf(out, "Component is running in debug mode\nPlease start port-forwarding in a different terminal\n")
 			}
-			fmt.Fprintf(out, "\nWaiting for something to change in %s\n\nPress Ctrl+c to exit and clean up resources from cluster.\n", parameters.Path)
+			// TODO: append "and clean up resources from cluster." to the message, once cleanup is implemented
+			fmt.Fprintf(out, "\nWaiting for something to change in %s\n\nPress Ctrl+c to exit.\n", parameters.Path)
 			showWaitingMessage = false
 		}
 		// if a change happened more than 'delay' seconds ago, sync it now.


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR removes message about resource cleanup from the `odo dev` exit message. Cleanup has not been implemented yet, the message should be added once it is done.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```sh
➜  odo dev
Using devfile.yaml from the current directory.
Starting your application on cluster in developer mode
 ✓  Waiting for Kubernetes resources [11s]
 ✓  Syncing files into the container [143ms]
 ✓  Building your application in container on cluster [508ms]
 ✓  Executing the application [1s]

Your application is running on cluster.
 
Waiting for something to change in /tmp/101

Press Ctrl+c to exit.
```