### PR TITLE
Interactive mode — Ask all questions first

### DIFF
--- a/pkg/init/backend/alizer.go
+++ b/pkg/init/backend/alizer.go
@@ -91,6 +91,6 @@ func (o *AlizerBackend) PersonalizeName(devfile parser.DevfileObj, flags map[str
 	return devfile, nil
 }
 
-func (o *AlizerBackend) PersonalizeDevfileconfig(devfile parser.DevfileObj) error {
-	return nil
+func (o *AlizerBackend) PersonalizeDevfileConfig(devfile parser.DevfileObj) (parser.DevfileObj, error) {
+	return devfile, nil
 }

--- a/pkg/init/backend/alizer.go
+++ b/pkg/init/backend/alizer.go
@@ -87,8 +87,8 @@ func (o *AlizerBackend) SelectStarterProject(devfile parser.DevfileObj, flags ma
 	return nil, nil
 }
 
-func (o *AlizerBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
-	return devfile, nil
+func (o *AlizerBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error) {
+	return devfile.GetMetadataName(), nil
 }
 
 func (o *AlizerBackend) PersonalizeDevfileConfig(devfile parser.DevfileObj) (parser.DevfileObj, error) {

--- a/pkg/init/backend/alizer.go
+++ b/pkg/init/backend/alizer.go
@@ -87,8 +87,8 @@ func (o *AlizerBackend) SelectStarterProject(devfile parser.DevfileObj, flags ma
 	return nil, nil
 }
 
-func (o *AlizerBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
-	return nil
+func (o *AlizerBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
+	return devfile, nil
 }
 
 func (o *AlizerBackend) PersonalizeDevfileconfig(devfile parser.DevfileObj) error {

--- a/pkg/init/backend/alizer.go
+++ b/pkg/init/backend/alizer.go
@@ -87,7 +87,7 @@ func (o *AlizerBackend) SelectStarterProject(devfile parser.DevfileObj, flags ma
 	return nil, nil
 }
 
-func (o *AlizerBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error {
+func (o *AlizerBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	return nil
 }
 

--- a/pkg/init/backend/flags.go
+++ b/pkg/init/backend/flags.go
@@ -94,14 +94,11 @@ func (o *FlagsBackend) SelectStarterProject(devfile parser.DevfileObj, flags map
 	return nil, fmt.Errorf("starter project %q not found in devfile", starter)
 }
 
-func (o *FlagsBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (o *FlagsBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
 	metadata := devfile.Data.GetMetadata()
 	metadata.Name = flags[FLAG_NAME]
 	devfile.Data.SetMetadata(metadata)
-	if writeToDisk {
-		return devfile.WriteYamlDevfile()
-	}
-	return nil
+	return devfile, nil
 }
 
 func (o FlagsBackend) PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error {

--- a/pkg/init/backend/flags.go
+++ b/pkg/init/backend/flags.go
@@ -94,11 +94,8 @@ func (o *FlagsBackend) SelectStarterProject(devfile parser.DevfileObj, flags map
 	return nil, fmt.Errorf("starter project %q not found in devfile", starter)
 }
 
-func (o *FlagsBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
-	metadata := devfile.Data.GetMetadata()
-	metadata.Name = flags[FLAG_NAME]
-	devfile.Data.SetMetadata(metadata)
-	return devfile, nil
+func (o *FlagsBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error) {
+	return flags[FLAG_NAME], nil
 }
 
 func (o FlagsBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error) {

--- a/pkg/init/backend/flags.go
+++ b/pkg/init/backend/flags.go
@@ -101,6 +101,6 @@ func (o *FlagsBackend) PersonalizeName(devfile parser.DevfileObj, flags map[stri
 	return devfile, nil
 }
 
-func (o FlagsBackend) PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error {
-	return nil
+func (o FlagsBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error) {
+	return devfileobj, nil
 }

--- a/pkg/init/backend/flags.go
+++ b/pkg/init/backend/flags.go
@@ -94,8 +94,14 @@ func (o *FlagsBackend) SelectStarterProject(devfile parser.DevfileObj, flags map
 	return nil, fmt.Errorf("starter project %q not found in devfile", starter)
 }
 
-func (o *FlagsBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error {
-	return devfile.SetMetadataName(flags[FLAG_NAME])
+func (o *FlagsBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+	metadata := devfile.Data.GetMetadata()
+	metadata.Name = flags[FLAG_NAME]
+	devfile.Data.SetMetadata(metadata)
+	if writeToDisk {
+		return devfile.WriteYamlDevfile()
+	}
+	return nil
 }
 
 func (o FlagsBackend) PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error {

--- a/pkg/init/backend/flags_test.go
+++ b/pkg/init/backend/flags_test.go
@@ -429,7 +429,7 @@ func TestFlagsBackend_PersonalizeName(t *testing.T) {
 			}
 			fs := dffilesystem.NewFakeFs()
 			devfile := tt.args.devfile(fs)
-			err := o.PersonalizeName(devfile, tt.args.flags)
+			err := o.PersonalizeName(&devfile, tt.args.flags, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FlagsBackend.PersonalizeName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/init/backend/flags_test.go
+++ b/pkg/init/backend/flags_test.go
@@ -398,7 +398,7 @@ func TestFlagsBackend_PersonalizeName(t *testing.T) {
 		fields      fields
 		args        args
 		wantErr     bool
-		checkResult func(devfile parser.DevfileObj, args args) bool
+		checkResult func(newName string, args args) bool
 	}{
 		{
 			name: "name flag",
@@ -417,8 +417,8 @@ func TestFlagsBackend_PersonalizeName(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			checkResult: func(devfile parser.DevfileObj, args args) bool {
-				return devfile.GetMetadataName() == args.flags["name"]
+			checkResult: func(newName string, args args) bool {
+				return newName == args.flags["name"]
 			},
 		},
 	}
@@ -428,12 +428,12 @@ func TestFlagsBackend_PersonalizeName(t *testing.T) {
 				preferenceClient: tt.fields.preferenceClient,
 			}
 			fs := dffilesystem.NewFakeFs()
-			devfile, err := o.PersonalizeName(tt.args.devfile(fs), tt.args.flags)
+			newName, err := o.PersonalizeName(tt.args.devfile(fs), tt.args.flags)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FlagsBackend.PersonalizeName() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if tt.checkResult != nil && !tt.checkResult(devfile, tt.args) {
+			if tt.checkResult != nil && !tt.checkResult(newName, tt.args) {
 				t.Errorf("FlagsBackend.PersonalizeName(), checking result failed")
 			}
 		})

--- a/pkg/init/backend/flags_test.go
+++ b/pkg/init/backend/flags_test.go
@@ -428,8 +428,7 @@ func TestFlagsBackend_PersonalizeName(t *testing.T) {
 				preferenceClient: tt.fields.preferenceClient,
 			}
 			fs := dffilesystem.NewFakeFs()
-			devfile := tt.args.devfile(fs)
-			err := o.PersonalizeName(&devfile, tt.args.flags, false)
+			devfile, err := o.PersonalizeName(tt.args.devfile(fs), tt.args.flags)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FlagsBackend.PersonalizeName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -101,15 +101,8 @@ func (o *InteractiveBackend) SelectStarterProject(devfile parser.DevfileObj, fla
 	return &starterProjects[starter], nil
 }
 
-func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
-	name, err := o.askerClient.AskName(fmt.Sprintf("my-%s-app", devfile.Data.GetMetadata().Name))
-	if err != nil {
-		return parser.DevfileObj{}, err
-	}
-	metadata := devfile.Data.GetMetadata()
-	metadata.Name = name
-	devfile.Data.SetMetadata(metadata)
-	return devfile, nil
+func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error) {
+	return o.askerClient.AskName(fmt.Sprintf("my-%s-app", devfile.GetMetadataName()))
 }
 
 func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error) {

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -115,9 +115,9 @@ func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags ma
 func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error) {
 	// TODO: Add tests
 	config, err := getPortsAndEnvVar(devfileobj)
-	var dFile parser.DevfileObj
+	var zeroDevfile parser.DevfileObj
 	if err != nil {
-		return dFile, err
+		return zeroDevfile, err
 	}
 
 	var selectContainerAnswer string
@@ -128,7 +128,7 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 		PrintConfiguration(config)
 		selectContainerAnswer, err = o.askerClient.AskContainerName(containerOptions)
 		if err != nil {
-			return dFile, err
+			return zeroDevfile, err
 		}
 
 		selectedContainer := config[selectContainerAnswer]
@@ -140,7 +140,7 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 		for configOps.Ops != "Nothing" {
 			configOps, err = o.askerClient.AskPersonalizeConfiguration(selectedContainer)
 			if err != nil {
-				return dFile, err
+				return zeroDevfile, err
 			}
 			switch configOps.Ops {
 			case "Add":
@@ -149,12 +149,12 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 					var newPort string
 					newPort, err = o.askerClient.AskAddPort()
 					if err != nil {
-						return dFile, err
+						return zeroDevfile, err
 					}
 
 					err = devfileobj.Data.SetPorts(map[string][]string{selectContainerAnswer: {newPort}})
 					if err != nil {
-						return dFile, err
+						return zeroDevfile, err
 					}
 					selectedContainer.Ports = append(selectedContainer.Ports, newPort)
 
@@ -162,14 +162,14 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 					var newEnvNameAnswer, newEnvValueAnswer string
 					newEnvNameAnswer, newEnvValueAnswer, err = o.askerClient.AskAddEnvVar()
 					if err != nil {
-						return dFile, err
+						return zeroDevfile, err
 					}
 					err = devfileobj.Data.AddEnvVars(map[string][]v1alpha2.EnvVar{selectContainerAnswer: {{
 						Name:  newEnvNameAnswer,
 						Value: newEnvValueAnswer,
 					}}})
 					if err != nil {
-						return dFile, err
+						return zeroDevfile, err
 					}
 					selectedContainer.Envs[newEnvNameAnswer] = newEnvValueAnswer
 				}
@@ -188,7 +188,7 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 					}
 					err = devfileobj.Data.RemovePorts(map[string][]string{selectContainerAnswer: {portToDelete}})
 					if err != nil {
-						return dFile, err
+						return zeroDevfile, err
 					}
 					selectedContainer.Ports = append(selectedContainer.Ports[:indexToDelete], selectedContainer.Ports[indexToDelete+1:]...)
 
@@ -199,13 +199,13 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 					}
 					err = devfileobj.Data.RemoveEnvVars(map[string][]string{selectContainerAnswer: {envToDelete}})
 					if err != nil {
-						return dFile, err
+						return zeroDevfile, err
 					}
 					delete(selectedContainer.Envs, envToDelete)
 				}
 			case "Nothing":
 			default:
-				return dFile, fmt.Errorf("Unknown configuration selected %q", fmt.Sprintf("%v %v %v", configOps.Ops, configOps.Kind, configOps.Key))
+				return zeroDevfile, fmt.Errorf("Unknown configuration selected %q", fmt.Sprintf("%v %v %v", configOps.Ops, configOps.Kind, configOps.Key))
 			}
 			// Update the current configuration
 			config[selectContainerAnswer] = selectedContainer

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -101,12 +101,18 @@ func (o *InteractiveBackend) SelectStarterProject(devfile parser.DevfileObj, fla
 	return &starterProjects[starter], nil
 }
 
-func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error {
+func (o *InteractiveBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	name, err := o.askerClient.AskName(fmt.Sprintf("my-%s-app", devfile.Data.GetMetadata().Name))
 	if err != nil {
 		return err
 	}
-	return devfile.SetMetadataName(name)
+	metadata := devfile.Data.GetMetadata()
+	metadata.Name = name
+	devfile.Data.SetMetadata(metadata)
+	if writeToDisk {
+		return devfile.WriteYamlDevfile()
+	}
+	return nil
 }
 
 func (o *InteractiveBackend) PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error {

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -101,18 +101,15 @@ func (o *InteractiveBackend) SelectStarterProject(devfile parser.DevfileObj, fla
 	return &starterProjects[starter], nil
 }
 
-func (o *InteractiveBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
 	name, err := o.askerClient.AskName(fmt.Sprintf("my-%s-app", devfile.Data.GetMetadata().Name))
 	if err != nil {
-		return err
+		return parser.DevfileObj{}, err
 	}
 	metadata := devfile.Data.GetMetadata()
 	metadata.Name = name
 	devfile.Data.SetMetadata(metadata)
-	if writeToDisk {
-		return devfile.WriteYamlDevfile()
-	}
-	return nil
+	return devfile, nil
 }
 
 func (o *InteractiveBackend) PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error {

--- a/pkg/init/backend/interactive_test.go
+++ b/pkg/init/backend/interactive_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+
 	"github.com/redhat-developer/odo/pkg/init/asker"
 	"github.com/redhat-developer/odo/pkg/registry"
 	"github.com/redhat-developer/odo/pkg/testingutil"
@@ -13,7 +15,6 @@ import (
 	parsercontext "github.com/devfile/library/pkg/devfile/parser/context"
 	"github.com/devfile/library/pkg/devfile/parser/data"
 	"github.com/devfile/library/pkg/testingutil/filesystem"
-	"github.com/golang/mock/gomock"
 )
 
 func TestInteractiveBackend_SelectDevfile(t *testing.T) {
@@ -483,8 +484,9 @@ func TestInteractiveBackend_PersonalizeDevfileconfig(t *testing.T) {
 				askerClient:    askerClient,
 				registryClient: tt.fields.registryClient,
 			}
-			if err = o.PersonalizeDevfileconfig(devfile); (err != nil) != tt.wantErr {
-				t.Errorf("PersonalizeDevfileconfig() error = %v, wantErr %v", err, tt.wantErr)
+			devfile, err = o.PersonalizeDevfileConfig(devfile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PersonalizeDevfileConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			config, err = getPortsAndEnvVar(devfile)
 			if err != nil {

--- a/pkg/init/backend/interactive_test.go
+++ b/pkg/init/backend/interactive_test.go
@@ -211,7 +211,7 @@ func TestInteractiveBackend_PersonalizeName(t *testing.T) {
 		fields      fields
 		args        args
 		wantErr     bool
-		checkResult func(devfile parser.DevfileObj, args args) bool
+		checkResult func(newName string, args args) bool
 	}{
 		{
 			name: "no flag",
@@ -234,8 +234,8 @@ func TestInteractiveBackend_PersonalizeName(t *testing.T) {
 				flags: map[string]string{},
 			},
 			wantErr: false,
-			checkResult: func(devfile parser.DevfileObj, args args) bool {
-				return devfile.GetMetadataName() == "aname"
+			checkResult: func(newName string, args args) bool {
+				return newName == "aname"
 			},
 		}}
 	for _, tt := range tests {
@@ -250,13 +250,13 @@ func TestInteractiveBackend_PersonalizeName(t *testing.T) {
 				registryClient: tt.fields.registryClient,
 			}
 			fs := filesystem.NewFakeFs()
-			devfile, err := o.PersonalizeName(tt.args.devfile(fs), tt.args.flags)
+			newName, err := o.PersonalizeName(tt.args.devfile(fs), tt.args.flags)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InteractiveBackend.PersonalizeName() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			if tt.checkResult != nil && !tt.checkResult(devfile, tt.args) {
+			if tt.checkResult != nil && !tt.checkResult(newName, tt.args) {
 				t.Errorf("InteractiveBackend.PersonalizeName(), checking result failed")
 			}
 		})

--- a/pkg/init/backend/interactive_test.go
+++ b/pkg/init/backend/interactive_test.go
@@ -249,8 +249,7 @@ func TestInteractiveBackend_PersonalizeName(t *testing.T) {
 				registryClient: tt.fields.registryClient,
 			}
 			fs := filesystem.NewFakeFs()
-			devfile := tt.args.devfile(fs)
-			err := o.PersonalizeName(&devfile, tt.args.flags, false)
+			devfile, err := o.PersonalizeName(tt.args.devfile(fs), tt.args.flags)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InteractiveBackend.PersonalizeName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/init/backend/interactive_test.go
+++ b/pkg/init/backend/interactive_test.go
@@ -250,7 +250,7 @@ func TestInteractiveBackend_PersonalizeName(t *testing.T) {
 			}
 			fs := filesystem.NewFakeFs()
 			devfile := tt.args.devfile(fs)
-			err := o.PersonalizeName(devfile, tt.args.flags)
+			err := o.PersonalizeName(&devfile, tt.args.flags, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InteractiveBackend.PersonalizeName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/init/backend/interface.go
+++ b/pkg/init/backend/interface.go
@@ -21,8 +21,9 @@ type InitBackend interface {
 	// depending on the flags. If not starter project is selected, a nil starter is returned
 	SelectStarterProject(devfile parser.DevfileObj, flags map[string]string) (starter *v1alpha2.StarterProject, err error)
 
-	// PersonalizeName updates a devfile name, depending on the flags.
-	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error)
+	// PersonalizeName returns the customized Devfile Metadata Name.
+	// Depending on the flags, it may return a name set interactively or not.
+	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error)
 
 	// PersonalizeDevfileConfig updates the devfile config for ports and environment variables
 	PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error)

--- a/pkg/init/backend/interface.go
+++ b/pkg/init/backend/interface.go
@@ -25,5 +25,5 @@ type InitBackend interface {
 	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error)
 
 	// PersonalizeDevfileConfig updates the devfile config for ports and environment variables
-	PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error
+	PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error)
 }

--- a/pkg/init/backend/interface.go
+++ b/pkg/init/backend/interface.go
@@ -21,8 +21,9 @@ type InitBackend interface {
 	// depending on the flags. If not starter project is selected, a nil starter is returned
 	SelectStarterProject(devfile parser.DevfileObj, flags map[string]string) (starter *v1alpha2.StarterProject, err error)
 
-	// PersonalizeName updates a devfile name, depending on the flags
-	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error
+	// PersonalizeName updates a devfile name, depending on the flags.
+	// It optionally writes the resulting Devfile to disk depending on `writeToDisk`.
+	PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error
 
 	// PersonalizeDevfileConfig updates the devfile config for ports and environment variables
 	PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error

--- a/pkg/init/backend/interface.go
+++ b/pkg/init/backend/interface.go
@@ -22,8 +22,7 @@ type InitBackend interface {
 	SelectStarterProject(devfile parser.DevfileObj, flags map[string]string) (starter *v1alpha2.StarterProject, err error)
 
 	// PersonalizeName updates a devfile name, depending on the flags.
-	// It optionally writes the resulting Devfile to disk depending on `writeToDisk`.
-	PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error
+	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error)
 
 	// PersonalizeDevfileConfig updates the devfile config for ports and environment variables
 	PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error

--- a/pkg/init/backend/mock.go
+++ b/pkg/init/backend/mock.go
@@ -52,10 +52,10 @@ func (mr *MockInitBackendMockRecorder) PersonalizeDevfileConfig(devfileobj inter
 }
 
 // PersonalizeName mocks base method.
-func (m *MockInitBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
+func (m *MockInitBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags)
-	ret0, _ := ret[0].(parser.DevfileObj)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/init/backend/mock.go
+++ b/pkg/init/backend/mock.go
@@ -51,7 +51,7 @@ func (mr *MockInitBackendMockRecorder) PersonalizeDevfileconfig(devfileobj inter
 }
 
 // PersonalizeName mocks base method.
-func (m *MockInitBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (m *MockInitBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags, writeToDisk)
 	ret0, _ := ret[0].(error)

--- a/pkg/init/backend/mock.go
+++ b/pkg/init/backend/mock.go
@@ -51,17 +51,17 @@ func (mr *MockInitBackendMockRecorder) PersonalizeDevfileconfig(devfileobj inter
 }
 
 // PersonalizeName mocks base method.
-func (m *MockInitBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error {
+func (m *MockInitBackend) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags)
+	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags, writeToDisk)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PersonalizeName indicates an expected call of PersonalizeName.
-func (mr *MockInitBackendMockRecorder) PersonalizeName(devfile, flags interface{}) *gomock.Call {
+func (mr *MockInitBackendMockRecorder) PersonalizeName(devfile, flags, writeToDisk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockInitBackend)(nil).PersonalizeName), devfile, flags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockInitBackend)(nil).PersonalizeName), devfile, flags, writeToDisk)
 }
 
 // SelectDevfile mocks base method.

--- a/pkg/init/backend/mock.go
+++ b/pkg/init/backend/mock.go
@@ -36,32 +36,34 @@ func (m *MockInitBackend) EXPECT() *MockInitBackendMockRecorder {
 	return m.recorder
 }
 
-// PersonalizeDevfileconfig mocks base method.
-func (m *MockInitBackend) PersonalizeDevfileconfig(devfileobj parser.DevfileObj) error {
+// PersonalizeDevfileConfig mocks base method.
+func (m *MockInitBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersonalizeDevfileconfig", devfileobj)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "PersonalizeDevfileConfig", devfileobj)
+	ret0, _ := ret[0].(parser.DevfileObj)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// PersonalizeDevfileconfig indicates an expected call of PersonalizeDevfileconfig.
-func (mr *MockInitBackendMockRecorder) PersonalizeDevfileconfig(devfileobj interface{}) *gomock.Call {
+// PersonalizeDevfileConfig indicates an expected call of PersonalizeDevfileConfig.
+func (mr *MockInitBackendMockRecorder) PersonalizeDevfileConfig(devfileobj interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeDevfileconfig", reflect.TypeOf((*MockInitBackend)(nil).PersonalizeDevfileconfig), devfileobj)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeDevfileConfig", reflect.TypeOf((*MockInitBackend)(nil).PersonalizeDevfileConfig), devfileobj)
 }
 
 // PersonalizeName mocks base method.
-func (m *MockInitBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (m *MockInitBackend) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags, writeToDisk)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags)
+	ret0, _ := ret[0].(parser.DevfileObj)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PersonalizeName indicates an expected call of PersonalizeName.
-func (mr *MockInitBackendMockRecorder) PersonalizeName(devfile, flags, writeToDisk interface{}) *gomock.Call {
+func (mr *MockInitBackendMockRecorder) PersonalizeName(devfile, flags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockInitBackend)(nil).PersonalizeName), devfile, flags, writeToDisk)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockInitBackend)(nil).PersonalizeName), devfile, flags)
 }
 
 // SelectDevfile mocks base method.

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -261,7 +261,7 @@ func (o InitClient) SelectAndPersonalizeDevfile(flags map[string]string, context
 }
 
 func (o InitClient) InitDevfile(flags map[string]string, contextDir string,
-	preInitHandlerFunc func(interactiveMode bool), postInitHandlerFunc func(devfileObj parser.DevfileObj) error) error {
+	preInitHandlerFunc func(interactiveMode bool), newDevfileHandlerFunc func(newDevfileObj parser.DevfileObj) error) error {
 
 	containsDevfile, err := location.DirectoryContainsDevfile(o.fsys, contextDir)
 	if err != nil {
@@ -289,8 +289,8 @@ func (o InitClient) InitDevfile(flags map[string]string, contextDir string,
 	metadata.Name = name
 	devfileObj.Data.SetMetadata(metadata)
 
-	if postInitHandlerFunc != nil {
-		err = postInitHandlerFunc(devfileObj)
+	if newDevfileHandlerFunc != nil {
+		err = newDevfileHandlerFunc(devfileObj)
 	}
 
 	return err

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -210,15 +210,14 @@ func (o *InitClient) DownloadStarterProject(starter *v1alpha2.StarterProject, de
 }
 
 // PersonalizeName calls PersonalizeName methods of the adequate backend
-func (o *InitClient) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (o *InitClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
 	var backend backend.InitBackend
 	if len(flags) == 0 {
 		backend = o.interactiveBackend
 	} else {
 		backend = o.flagsBackend
 	}
-	err := backend.PersonalizeName(devfile, flags, writeToDisk)
-	return err
+	return backend.PersonalizeName(devfile, flags)
 }
 
 func (o InitClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error {

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -210,7 +210,7 @@ func (o *InitClient) DownloadStarterProject(starter *v1alpha2.StarterProject, de
 }
 
 // PersonalizeName calls PersonalizeName methods of the adequate backend
-func (o *InitClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
+func (o *InitClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error) {
 	var backend backend.InitBackend
 	if len(flags) == 0 {
 		backend = o.interactiveBackend

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -220,11 +220,11 @@ func (o *InitClient) PersonalizeName(devfile parser.DevfileObj, flags map[string
 	return backend.PersonalizeName(devfile, flags)
 }
 
-func (o InitClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error {
+func (o InitClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (parser.DevfileObj, error) {
 	var backend backend.InitBackend
 	onlyDevfile, err := location.DirContainsOnlyDevfile(fs, dir)
 	if err != nil {
-		return err
+		return parser.DevfileObj{}, err
 	}
 
 	// Interactive mode since no flags are provided
@@ -234,7 +234,7 @@ func (o InitClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags
 	} else {
 		backend = o.flagsBackend
 	}
-	return backend.PersonalizeDevfileconfig(devfileobj)
+	return backend.PersonalizeDevfileConfig(devfileobj)
 }
 
 func (o InitClient) SelectAndPersonalizeDevfile(flags map[string]string, contextDir string) (parser.DevfileObj, string, error) {
@@ -253,7 +253,7 @@ func (o InitClient) SelectAndPersonalizeDevfile(flags map[string]string, context
 		return parser.DevfileObj{}, "", fmt.Errorf("unable to parse devfile: %w", err)
 	}
 
-	err = o.PersonalizeDevfileConfig(devfileObj, flags, o.fsys, contextDir)
+	devfileObj, err = o.PersonalizeDevfileConfig(devfileObj, flags, o.fsys, contextDir)
 	if err != nil {
 		return parser.DevfileObj{}, "", fmt.Errorf("failed to configure devfile: %w", err)
 	}

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -210,14 +210,14 @@ func (o *InitClient) DownloadStarterProject(starter *v1alpha2.StarterProject, de
 }
 
 // PersonalizeName calls PersonalizeName methods of the adequate backend
-func (o *InitClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error {
+func (o *InitClient) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	var backend backend.InitBackend
 	if len(flags) == 0 {
 		backend = o.interactiveBackend
 	} else {
 		backend = o.flagsBackend
 	}
-	err := backend.PersonalizeName(devfile, flags)
+	err := backend.PersonalizeName(devfile, flags, writeToDisk)
 	return err
 }
 

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -41,8 +41,9 @@ type Client interface {
 	// WARNING: This will first remove all the content of dest.
 	DownloadStarterProject(project *v1alpha2.StarterProject, dest string) error
 
-	// PersonalizeName updates a devfile name, depending on the flags.
-	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error)
+	// PersonalizeName returns the customized Devfile Metadata Name.
+	// Depending on the flags, it may return a name set interactively or not.
+	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error)
 
 	// PersonalizeDevfileConfig updates the env vars, and URL endpoints
 	PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (parser.DevfileObj, error)

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -10,7 +10,6 @@ package init
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
-
 	"github.com/redhat-developer/odo/pkg/init/backend"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
@@ -43,8 +42,8 @@ type Client interface {
 	DownloadStarterProject(project *v1alpha2.StarterProject, dest string) error
 
 	// PersonalizeName updates a devfile name, depending on the flags.
-	// The method will modify the devfile content and save the devfile on disk
-	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error
+	// It optionally saves the devfile to disk depending on `writeToDisk`.
+	PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error
 
 	// PersonalizeDevfileConfig updates the env vars, and URL endpoints
 	PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -22,7 +22,9 @@ type Client interface {
 	// like if the directory contains no Devfile at all.
 	// `preInitHandlerFunc` allows to perform operations prior to triggering the actual Devfile
 	// initialization and personalization process.
-	InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(interactiveMode bool)) error
+	// `postInitHandlerFunc` allows to perform operations right after the Devfile has been initialized and personalized.
+	InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(interactiveMode bool),
+		postInitHandlerFunc func(devfileObj parser.DevfileObj) error) error
 
 	// SelectDevfile returns information about a devfile selected based on Alizer if the directory content,
 	// or based on the flags if the directory is empty, or

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -42,8 +42,7 @@ type Client interface {
 	DownloadStarterProject(project *v1alpha2.StarterProject, dest string) error
 
 	// PersonalizeName updates a devfile name, depending on the flags.
-	// It optionally saves the devfile to disk depending on `writeToDisk`.
-	PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error
+	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error)
 
 	// PersonalizeDevfileConfig updates the env vars, and URL endpoints
 	PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -45,7 +45,7 @@ type Client interface {
 	PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error)
 
 	// PersonalizeDevfileConfig updates the env vars, and URL endpoints
-	PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error
+	PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (parser.DevfileObj, error)
 
 	// SelectAndPersonalizeDevfile selects a devfile, then downloads, parse and personalize it
 	// Returns the devfile object and its path

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -22,9 +22,11 @@ type Client interface {
 	// like if the directory contains no Devfile at all.
 	// `preInitHandlerFunc` allows to perform operations prior to triggering the actual Devfile
 	// initialization and personalization process.
-	// `postInitHandlerFunc` allows to perform operations right after the Devfile has been initialized and personalized.
+	// `newDevfileHandlerFunc` is called only when a new Devfile object has been instantiated.
+	// It allows to perform operations right after the Devfile has been initialized and personalized.
+	// It is not called if the context directory already has a Devfile file.
 	InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(interactiveMode bool),
-		postInitHandlerFunc func(devfileObj parser.DevfileObj) error) error
+		newDevfileHandlerFunc func(newDevfileObj parser.DevfileObj) error) error
 
 	// SelectDevfile returns information about a devfile selected based on Alizer if the directory content,
 	// or based on the flags if the directory is empty, or

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -67,17 +67,17 @@ func (mr *MockClientMockRecorder) DownloadStarterProject(project, dest interface
 }
 
 // InitDevfile mocks base method.
-func (m *MockClient) InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(bool), postInitHandlerFunc func(parser.DevfileObj) error) error {
+func (m *MockClient) InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(bool), newDevfileHandlerFunc func(parser.DevfileObj) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitDevfile", flags, contextDir, preInitHandlerFunc, postInitHandlerFunc)
+	ret := m.ctrl.Call(m, "InitDevfile", flags, contextDir, preInitHandlerFunc, newDevfileHandlerFunc)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitDevfile indicates an expected call of InitDevfile.
-func (mr *MockClientMockRecorder) InitDevfile(flags, contextDir, preInitHandlerFunc, postInitHandlerFunc interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InitDevfile(flags, contextDir, preInitHandlerFunc, newDevfileHandlerFunc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitDevfile", reflect.TypeOf((*MockClient)(nil).InitDevfile), flags, contextDir, preInitHandlerFunc, postInitHandlerFunc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitDevfile", reflect.TypeOf((*MockClient)(nil).InitDevfile), flags, contextDir, preInitHandlerFunc, newDevfileHandlerFunc)
 }
 
 // PersonalizeDevfileConfig mocks base method.

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -95,17 +95,17 @@ func (mr *MockClientMockRecorder) PersonalizeDevfileConfig(devfileobj, flags, fs
 }
 
 // PersonalizeName mocks base method.
-func (m *MockClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) error {
+func (m *MockClient) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags)
+	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags, writeToDisk)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PersonalizeName indicates an expected call of PersonalizeName.
-func (mr *MockClientMockRecorder) PersonalizeName(devfile, flags interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) PersonalizeName(devfile, flags, writeToDisk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockClient)(nil).PersonalizeName), devfile, flags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockClient)(nil).PersonalizeName), devfile, flags, writeToDisk)
 }
 
 // SelectAndPersonalizeDevfile mocks base method.

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -95,7 +95,7 @@ func (mr *MockClientMockRecorder) PersonalizeDevfileConfig(devfileobj, flags, fs
 }
 
 // PersonalizeName mocks base method.
-func (m *MockClient) PersonalizeName(devfile *parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (m *MockClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags, writeToDisk)
 	ret0, _ := ret[0].(error)

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -81,11 +81,12 @@ func (mr *MockClientMockRecorder) InitDevfile(flags, contextDir, preInitHandlerF
 }
 
 // PersonalizeDevfileConfig mocks base method.
-func (m *MockClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error {
+func (m *MockClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (parser.DevfileObj, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersonalizeDevfileConfig", devfileobj, flags, fs, dir)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(parser.DevfileObj)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PersonalizeDevfileConfig indicates an expected call of PersonalizeDevfileConfig.
@@ -95,17 +96,18 @@ func (mr *MockClientMockRecorder) PersonalizeDevfileConfig(devfileobj, flags, fs
 }
 
 // PersonalizeName mocks base method.
-func (m *MockClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string, writeToDisk bool) error {
+func (m *MockClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags, writeToDisk)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags)
+	ret0, _ := ret[0].(parser.DevfileObj)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PersonalizeName indicates an expected call of PersonalizeName.
-func (mr *MockClientMockRecorder) PersonalizeName(devfile, flags, writeToDisk interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) PersonalizeName(devfile, flags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockClient)(nil).PersonalizeName), devfile, flags, writeToDisk)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersonalizeName", reflect.TypeOf((*MockClient)(nil).PersonalizeName), devfile, flags)
 }
 
 // SelectAndPersonalizeDevfile mocks base method.

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -96,10 +96,10 @@ func (mr *MockClientMockRecorder) PersonalizeDevfileConfig(devfileobj, flags, fs
 }
 
 // PersonalizeName mocks base method.
-func (m *MockClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (parser.DevfileObj, error) {
+func (m *MockClient) PersonalizeName(devfile parser.DevfileObj, flags map[string]string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersonalizeName", devfile, flags)
-	ret0, _ := ret[0].(parser.DevfileObj)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -67,17 +67,17 @@ func (mr *MockClientMockRecorder) DownloadStarterProject(project, dest interface
 }
 
 // InitDevfile mocks base method.
-func (m *MockClient) InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(bool)) error {
+func (m *MockClient) InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(bool), postInitHandlerFunc func(parser.DevfileObj) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitDevfile", flags, contextDir, preInitHandlerFunc)
+	ret := m.ctrl.Call(m, "InitDevfile", flags, contextDir, preInitHandlerFunc, postInitHandlerFunc)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitDevfile indicates an expected call of InitDevfile.
-func (mr *MockClientMockRecorder) InitDevfile(flags, contextDir, preInitHandlerFunc interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InitDevfile(flags, contextDir, preInitHandlerFunc, postInitHandlerFunc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitDevfile", reflect.TypeOf((*MockClient)(nil).InitDevfile), flags, contextDir, preInitHandlerFunc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitDevfile", reflect.TypeOf((*MockClient)(nil).InitDevfile), flags, contextDir, preInitHandlerFunc, postInitHandlerFunc)
 }
 
 // PersonalizeDevfileConfig mocks base method.

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/odo/pkg/devfile/location"
@@ -65,12 +66,16 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		return errors.New("this command cannot run in an empty directory, you need to run it in a directory containing source code")
 	}
 
-	err = o.clientset.InitClient.InitDevfile(cmdline.GetFlags(), o.contextDir, func(interactiveMode bool) {
-		if interactiveMode {
-			fmt.Println("The current directory already contains source code. " +
-				"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
-		}
-	})
+	err = o.clientset.InitClient.InitDevfile(cmdline.GetFlags(), o.contextDir,
+		func(interactiveMode bool) {
+			if interactiveMode {
+				fmt.Println("The current directory already contains source code. " +
+					"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
+			}
+		},
+		func(devfileObj parser.DevfileObj) error {
+			return devfileObj.WriteYamlDevfile()
+		})
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -73,8 +73,8 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 					"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
 			}
 		},
-		func(devfileObj parser.DevfileObj) error {
-			return devfileObj.WriteYamlDevfile()
+		func(newDevfileObj parser.DevfileObj) error {
+			return newDevfileObj.WriteYamlDevfile()
 		})
 	if err != nil {
 		return err

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -90,8 +90,8 @@ func (o *DevOptions) Complete(cmdline cmdline.Cmdline, args []string) error {
 					"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
 			}
 		},
-		func(devfileObj parser.DevfileObj) error {
-			return devfileObj.WriteYamlDevfile()
+		func(newDevfileObj parser.DevfileObj) error {
+			return newDevfileObj.WriteYamlDevfile()
 		})
 	if err != nil {
 		return err

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/devfile/location"
@@ -82,12 +83,16 @@ func (o *DevOptions) Complete(cmdline cmdline.Cmdline, args []string) error {
 		return errors.New("this command cannot run in an empty directory, you need to run it in a directory containing source code")
 	}
 
-	err = o.clientset.InitClient.InitDevfile(cmdline.GetFlags(), o.contextDir, func(interactiveMode bool) {
-		if interactiveMode {
-			fmt.Println("The current directory already contains source code. " +
-				"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
-		}
-	})
+	err = o.clientset.InitClient.InitDevfile(cmdline.GetFlags(), o.contextDir,
+		func(interactiveMode bool) {
+			if interactiveMode {
+				fmt.Println("The current directory already contains source code. " +
+					"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
+			}
+		},
+		func(devfileObj parser.DevfileObj) error {
+			return devfileObj.WriteYamlDevfile()
+		})
 	if err != nil {
 		return err
 	}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -120,6 +121,28 @@ func ExtractLines(output string) ([]string, error) {
 		lines = append(lines, scanner.Text())
 	}
 	return lines, scanner.Err()
+}
+
+// FindFirstElementIndexByPredicate returns the index of the first element in `slice` that satisfies the given `predicate`.
+func FindFirstElementIndexByPredicate(slice []string, predicate func(string) bool) (int, bool) {
+	for i, s := range slice {
+		if predicate(s) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// FindFirstElementIndexMatchingRegExp returns the index of the first element in `slice` that contains any match of
+// the given regular expression `regularExpression`.
+func FindFirstElementIndexMatchingRegExp(slice []string, regularExpression string) (int, bool) {
+	return FindFirstElementIndexByPredicate(slice, func(s string) bool {
+		matched, err := regexp.MatchString(regularExpression, s)
+		Expect(err).To(BeNil(), func() string {
+			return fmt.Sprintf("regular expression error: %v", err)
+		})
+		return matched
+	})
 }
 
 // WatchNonRetCmdStdOut runs an 'odo watch' command and stores the process' stdout output into buffer.

--- a/tests/integration/devfile/cmd_devfile_init_test.go
+++ b/tests/integration/devfile/cmd_devfile_init_test.go
@@ -170,4 +170,20 @@ var _ = Describe("odo devfile init command tests", func() {
 			}
 		})
 	})
+
+	When("source directory is empty", func() {
+		BeforeEach(func() {
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
+		})
+
+		It("name in devfile is personalized in non-interactive mode", func() {
+			helper.Cmd("odo", "init", "--name", "aname", "--devfile-path",
+				filepath.Join(helper.GetExamplePath(), "source", "devfiles", "nodejs",
+					"devfile-with-starter-with-devfile.yaml")).ShouldPass()
+
+			metadata := helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
+			Expect(metadata.Name).To(BeEquivalentTo("aname"))
+			Expect(metadata.Language).To(BeEquivalentTo("nodejs"))
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area ux

**What does this PR do / why we need it:**
To improve user experience, the goal of this PR (and linked issue) is to ask users all questions first, prior to performing actions. For the reasons discussed [here](https://github.com/redhat-developer/odo/issues/5495#issuecomment-1062984433) however, the Devfile download action cannot be delayed and still has to happen sooner.

**Which issue(s) this PR fixes:**
Fixes #5495 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
When ran interactively and a starter project selected, `odo init` should download the starter project after all interactive questions have been asked, like so (notice that the `Downloading starter project ...` action line is executed and logged after the last question):

```
~/work/tmp/empty-dir on ☁️   
❯ odo init
? Help odo improve by allowing it to collect usage data. Read about our privacy statement: https://developers.redhat.com/article/tool-data-collection. You can change your preference later by changing the ConsentTelemetry preference. Yes
The current directory is empty. odo will help you start a new project.
? Select language: dotnet
? Select project type: .NET Core 3.1
 ✓  Downloading devfile "dotnetcore31" from registry "DefaultDevfileRegistry" [2s]
? Which starter project do you want to use? s2i-example
? Enter component name: my-dotnetcore31-app
 ✓  Downloading starter project "s2i-example" [2s]

Your new component "my-dotnetcore31-app" is ready in the current directory.
To start editing your component, use "odo dev" and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.
To deploy your component to a cluster use "odo deploy".
```