### PR TITLE
Make `odo dev` and `odo deploy` display welcoming messages too before running Alizer detection, just like `odo init`

### DIFF
--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -263,3 +263,27 @@ func (o InitClient) SelectAndPersonalizeDevfile(flags map[string]string, context
 	}
 	return devfileObj, devfilePath, nil
 }
+
+func (o InitClient) InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(interactiveMode bool)) error {
+	containsDevfile, err := location.DirectoryContainsDevfile(o.fsys, contextDir)
+	if err != nil {
+		return err
+	}
+	if containsDevfile {
+		return nil
+	}
+
+	preInitHandlerFunc(len(flags) == 0)
+
+	devfileObj, _, err := o.SelectAndPersonalizeDevfile(map[string]string{}, contextDir)
+	if err != nil {
+		return err
+	}
+
+	// Set the name in the devfile and writes the devfile back to the disk
+	err = o.PersonalizeName(devfileObj, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("failed to update the devfile's name: %w", err)
+	}
+	return nil
+}

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -19,6 +19,12 @@ type Client interface {
 	// Validate checks for each backend if flags are valid
 	Validate(flags map[string]string, fs filesystem.Filesystem, dir string) error
 
+	// InitDevfile allows to initialize a Devfile in cases where this operation is needed as a prerequisite,
+	// like if the directory contains no Devfile at all.
+	// `preInitHandlerFunc` allows to perform operations prior to triggering the actual Devfile
+	// initialization and personalization process.
+	InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(interactiveMode bool)) error
+
 	// SelectDevfile returns information about a devfile selected based on Alizer if the directory content,
 	// or based on the flags if the directory is empty, or
 	// interactively if flags is empty

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -66,6 +66,20 @@ func (mr *MockClientMockRecorder) DownloadStarterProject(project, dest interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadStarterProject", reflect.TypeOf((*MockClient)(nil).DownloadStarterProject), project, dest)
 }
 
+// InitDevfile mocks base method.
+func (m *MockClient) InitDevfile(flags map[string]string, contextDir string, preInitHandlerFunc func(bool)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitDevfile", flags, contextDir, preInitHandlerFunc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitDevfile indicates an expected call of InitDevfile.
+func (mr *MockClientMockRecorder) InitDevfile(flags, contextDir, preInitHandlerFunc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitDevfile", reflect.TypeOf((*MockClient)(nil).InitDevfile), flags, contextDir, preInitHandlerFunc)
+}
+
 // PersonalizeDevfileConfig mocks base method.
 func (m *MockClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) error {
 	m.ctrl.T.Helper()

--- a/tests/interactive/cmd_deploy_test.go
+++ b/tests/interactive/cmd_deploy_test.go
@@ -69,5 +69,44 @@ var _ = Describe("odo deploy interactive command tests", func() {
 			Expect(output).To(ContainSubstring("no deploy command found in devfile"))
 			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 		})
+
+		It("should display welcoming messages first", func() {
+
+			language := "python"
+			output, err := helper.RunInteractive([]string{"odo", "deploy"},
+				// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
+				// message displayed to the end user. So we do not want any potential debug lines to be printed first.
+				// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513
+				[]string{"ODO_LOG_LEVEL=0"},
+				func(ctx helper.InteractiveContext) {
+					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", language))
+
+					helper.ExpectString(ctx,
+						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", language))
+
+					helper.ExpectString(ctx, "Is this correct")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Select container for which you want to change configuration")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Enter component name")
+					helper.SendLine(ctx, "my-app")
+
+					helper.ExpectString(ctx, "no deploy command found in devfile")
+				})
+
+			Expect(err).To(Not(BeNil()))
+			// Make sure it also displays welcoming messages first
+			lines, err := helper.ExtractLines(output)
+			Expect(err).To(BeNil())
+			Expect(lines).To(Not(BeEmpty()))
+			Expect(lines[0]).To(Equal("The current directory already contains source code. " +
+				"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project."))
+		})
 	})
 })

--- a/tests/interactive/cmd_dev_test.go
+++ b/tests/interactive/cmd_dev_test.go
@@ -68,5 +68,43 @@ var _ = Describe("odo dev interactive command tests", func() {
 
 			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 		})
+
+		It("should display welcoming messages first", func() {
+
+			language := "python"
+			output, _ := helper.RunInteractive([]string{"odo", "dev"},
+				// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
+				// message displayed to the end user. So we do not want any potential debug lines to be printed first.
+				// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513
+				[]string{"ODO_LOG_LEVEL=0"},
+				func(ctx helper.InteractiveContext) {
+					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", language))
+
+					helper.ExpectString(ctx,
+						fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", language))
+
+					helper.ExpectString(ctx, "Is this correct")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Select container for which you want to change configuration")
+					helper.SendLine(ctx, "\n")
+
+					helper.ExpectString(ctx, "Enter component name")
+					helper.SendLine(ctx, "my-app")
+
+					helper.ExpectString(ctx, "Press Ctrl+c to exit")
+					ctx.StopCommand()
+				})
+
+			lines, err := helper.ExtractLines(output)
+			Expect(err).To(BeNil())
+			Expect(lines).To(Not(BeEmpty()))
+			Expect(lines[0]).To(Equal("The current directory already contains source code. " +
+				"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project."))
+		})
 	})
 })


### PR DESCRIPTION

**What type of PR is this:**
/kind feature
/area ux

**What does this PR do / why we need it:**
This relates to #5494, because users might have similar symptoms (few seconds before any output) when running either `odo dev` or `odo deploy` in a source code directory with no Devfile, and those commands try to do an `Alizer` analysis first.

**Which issue(s) this PR fixes:**
Relates to #5494

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Run either `odo dev` or `odo deploy` from a source code directory with no Devfile. A welcoming message should be displayed before the Alizer detection messages are showed.