### PR TITLE
Remove github.com/pkg/errors dependency

### DIFF
--- a/cmd/cli-doc/cli-doc.go
+++ b/cmd/cli-doc/cli-doc.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/odo/cli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -185,7 +185,15 @@ func main() {
 
 	err := clidoc.Execute()
 	if err != nil {
-		fmt.Println(errors.Cause(err))
+		for {
+			e := errors.Unwrap(err)
+			if e != nil {
+				err = e
+			} else {
+				break
+			}
+		}
+		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/operator-framework/api v0.3.20
 	github.com/operator-framework/operator-lifecycle-manager v0.17.0
 	github.com/pborman/uuid v1.2.0
-	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.1.1
 	github.com/redhat-developer/alizer/go v0.0.0-20220215154256-33df7feef4ae
 	github.com/redhat-developer/service-binding-operator v1.0.1-0.20211222115357-5b7bbba3bfb3

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -189,7 +189,7 @@ func getRegistryDevfiles(preferenceClient preference.Client, registry Registry) 
 	// Github-based registry
 	URL, err := convertURL(registry.URL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to convert URL %s", registry.URL)
+		return nil, fmt.Errorf("unable to convert URL %s: %w", registry.URL, err)
 	}
 	registry.URL = URL
 	indexLink := registry.URL + indexPath
@@ -208,7 +208,7 @@ func getRegistryDevfiles(preferenceClient preference.Client, registry Registry) 
 
 	jsonBytes, err := dfutil.HTTPGetRequest(request, preferenceClient.GetRegistryCacheTime())
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to download the devfile index.json from %s", indexLink)
+		return nil, fmt.Errorf("unable to download the devfile index.json from %s: %w", indexLink, err)
 	}
 
 	var devfileIndex []indexSchema.Schema
@@ -220,12 +220,12 @@ func getRegistryDevfiles(preferenceClient preference.Client, registry Registry) 
 		// we try once again
 		jsonBytes, err := dfutil.HTTPGetRequest(request, preferenceClient.GetRegistryCacheTime())
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to download the devfile index.json from %s", indexLink)
+			return nil, fmt.Errorf("unable to download the devfile index.json from %s: %w", indexLink, err)
 		}
 
 		err = json.Unmarshal(jsonBytes, &devfileIndex)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to unmarshal the devfile index.json from %s", indexLink)
+			return nil, fmt.Errorf("unable to unmarshal the devfile index.json from %s: %w", indexLink, err)
 		}
 	}
 	return createRegistryDevfiles(registry, devfileIndex)

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/zalando/go-keyring"
 
 	dfutil "github.com/devfile/library/pkg/util"
@@ -127,7 +126,7 @@ func (o *CatalogClient) SearchComponent(client kclient.ClientInterface, name str
 	//var result []string
 	//componentList, err := ListDevfileComponents(client)
 	//if err != nil {
-	//	return nil, errors.Wrap(err, "unable to list components")
+	//	return nil, fmt.Errorf("unable to list components: %w", err)
 	//}
 	//
 	//// do a partial search in all the components
@@ -201,7 +200,7 @@ func getRegistryDevfiles(preferenceClient preference.Client, registry Registry) 
 	if secure {
 		token, e := keyring.Get(fmt.Sprintf("%s%s", dfutil.CredentialPrefix, registry.Name), registryUtil.RegistryUser)
 		if e != nil {
-			return nil, errors.Wrap(e, "unable to get secure registry credential from keyring")
+			return nil, fmt.Errorf("unable to get secure registry credential from keyring: %w", e)
 		}
 		request.Token = token
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -55,7 +55,7 @@ func GetComponentDir(path string) (string, error) {
 	} else {
 		currDir, err := os.Getwd()
 		if err != nil {
-			return "", errors.Wrapf(err, "unable to generate a random name as getting current directory failed")
+			return "", fmt.Errorf("unable to generate a random name as getting current directory failed: %w", err)
 		}
 		retVal = filepath.Base(currDir)
 	}
@@ -135,7 +135,7 @@ func ListDevfileComponents(client kclient.ClientInterface, selector string) (Com
 	// retrieve all the deployments that are associated with this application
 	deploymentList, err := client.GetDeploymentFromSelector(selector)
 	if err != nil {
-		return ComponentList{}, errors.Wrapf(err, "unable to list components")
+		return ComponentList{}, fmt.Errorf("unable to list components: %w", err)
 	}
 
 	// create a list of object metadata based on the component and application name (extracted from Deployment labels)
@@ -319,7 +319,7 @@ func ListDevfileComponentsInPath(client kclient.ClientInterface, paths []string)
 func Exists(client kclient.ClientInterface, componentName, applicationName string) (bool, error) {
 	deploymentName, err := dfutil.NamespaceOpenShiftObject(componentName, applicationName)
 	if err != nil {
-		return false, errors.Wrapf(err, "unable to create namespaced name")
+		return false, fmt.Errorf("unable to create namespaced name: %w", err)
 	}
 	deployment, _ := client.GetDeploymentByName(deploymentName)
 	if deployment != nil {
@@ -349,7 +349,7 @@ func GetComponent(client kclient.ClientInterface, componentName string, applicat
 func getRemoteComponentMetadata(client kclient.ClientInterface, componentName string, applicationName string, getUrls, getStorage bool) (Component, error) {
 	fromCluster, err := GetPushedComponent(client, componentName, applicationName)
 	if err != nil || fromCluster == nil {
-		return Component{}, errors.Wrapf(err, "unable to get remote metadata for %s component", componentName)
+		return Component{}, fmt.Errorf("unable to get remote metadata for %s component: %w", componentName, err)
 	}
 
 	// Component Type
@@ -565,7 +565,7 @@ func Delete(kubeClient kclient.ClientInterface, devfileObj parser.DevfileObj, co
 		log.Warningf("%v", e)
 		return nil
 	} else if err != nil {
-		return errors.Wrapf(err, "unable to determine if component %s exists", componentName)
+		return fmt.Errorf("unable to determine if component %s exists: %w", componentName, err)
 	}
 
 	podSpinner.End(true)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -79,7 +79,7 @@ func GetDefaultComponentName(cfg preference.Client, componentPath string, compon
 	// Create a random generated name for the component to use within Kubernetes
 	prefix, err = GetComponentDir(componentPath)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to generate random component name")
+		return "", fmt.Errorf("unable to generate random component name: %w", err)
 	}
 	prefix = util.TruncateString(prefix, componentRandomNamePartsMaxLen)
 
@@ -91,7 +91,7 @@ func GetDefaultComponentName(cfg preference.Client, componentPath string, compon
 		componentNameMaxRetries,
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to generate random component name")
+		return "", fmt.Errorf("unable to generate random component name: %w", err)
 	}
 
 	return util.GetDNS1123Name(componentName), nil
@@ -142,7 +142,7 @@ func ListDevfileComponents(client kclient.ClientInterface, selector string) (Com
 	for _, elem := range deploymentList {
 		component, err := GetComponent(client, elem.Labels[componentlabels.KubernetesInstanceLabel], elem.Labels[applabels.ApplicationLabel], client.GetCurrentNamespace())
 		if err != nil {
-			return ComponentList{}, errors.Wrap(err, "Unable to get component")
+			return ComponentList{}, fmt.Errorf("Unable to get component: %w", err)
 		}
 
 		if !reflect.ValueOf(component).IsZero() {
@@ -355,7 +355,7 @@ func getRemoteComponentMetadata(client kclient.ClientInterface, componentName st
 	// Component Type
 	componentType, err := fromCluster.GetType()
 	if err != nil {
-		return Component{}, errors.Wrap(err, "unable to get source type")
+		return Component{}, fmt.Errorf("unable to get source type: %w", err)
 	}
 
 	// init component
@@ -382,7 +382,7 @@ func getRemoteComponentMetadata(client kclient.ClientInterface, componentName st
 	if getStorage {
 		appStore, e := fromCluster.GetStorage()
 		if e != nil {
-			return Component{}, errors.Wrap(e, "unable to get storage list")
+			return Component{}, fmt.Errorf("unable to get storage list: %w", e)
 		}
 
 		component.Spec.StorageSpec = appStore

--- a/pkg/component/exec_handler.go
+++ b/pkg/component/exec_handler.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
@@ -114,7 +113,7 @@ func executeCommand(client kclient.ClientInterface, containerName string, podNam
 		// It is safe to read from cmdOutput here, as the goroutines are guaranteed to have terminated at this point.
 		klog.V(2).Infof("ExecuteCommand returned an an err: %v. for command '%v'. output: %v", err, command, cmdOutput)
 
-		return errors.Wrapf(err, "unable to exec command %v: \n%v", command, cmdOutput)
+		return fmt.Errorf("unable to exec command %v: \n%v: %w", command, cmdOutput, err)
 	}
 
 	return

--- a/pkg/component/pushed_component.go
+++ b/pkg/component/pushed_component.go
@@ -1,9 +1,9 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/storage"
@@ -195,10 +195,15 @@ func GetPushedComponent(c kclient.ClientInterface, componentName, applicationNam
 }
 
 func isIgnorableError(err error) bool {
-	e := errors.Cause(err)
-	if e != nil {
-		err = e
+	for {
+		e := errors.Unwrap(err)
+		if e != nil {
+			err = e
+		} else {
+			break
+		}
 	}
+
 	if _, ok := err.(*kclient.DeploymentNotFoundError); ok {
 		return true
 	}

--- a/pkg/component/starter_project.go
+++ b/pkg/component/starter_project.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -82,7 +83,7 @@ func DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedT
 	if contextDir == "" {
 		path, err = os.Getwd()
 		if err != nil {
-			return errors.Wrapf(err, "Could not get the current working directory.")
+			return fmt.Errorf("Could not get the current working directory: %w", err)
 		}
 	} else {
 		path = contextDir
@@ -133,7 +134,7 @@ func DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedT
 func downloadGitProject(starterProject *devfilev1.StarterProject, starterToken, path string, verbose bool) error {
 	remoteName, remoteUrl, revision, err := parsercommon.GetDefaultSource(starterProject.Git.GitLikeProjectSource)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get default project source for starter project %s", starterProject.Name)
+		return fmt.Errorf("unable to get default project source for starter project %s: %w", starterProject.Name, err)
 	}
 
 	// convert revision to referenceName type, ref name could be a branch or tag

--- a/pkg/component/starter_project.go
+++ b/pkg/component/starter_project.go
@@ -32,7 +32,7 @@ func checkoutProject(subDir, zipURL, path, starterToken string) error {
 	}
 	err := util.GetAndExtractZip(zipURL, path, subDir, starterToken)
 	if err != nil {
-		return errors.Wrap(err, "failed to download and extract project zip folder")
+		return fmt.Errorf("failed to download and extract project zip folder: %w", err)
 	}
 	return nil
 }

--- a/pkg/component/starter_project.go
+++ b/pkg/component/starter_project.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,8 +18,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/log"
 	registryUtil "github.com/redhat-developer/odo/pkg/odo/cli/preference/registry/util"
 	"github.com/redhat-developer/odo/pkg/util"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -43,7 +42,7 @@ func GetStarterProject(projects []devfilev1.StarterProject, projectPassed string
 	nOfProjects := len(projects)
 
 	if nOfProjects == 0 {
-		return nil, errors.Errorf("no starter project found in devfile.")
+		return nil, fmt.Errorf("no starter project found in devfile.")
 	}
 
 	// Determine what project to be used
@@ -66,7 +65,7 @@ func GetStarterProject(projects []devfilev1.StarterProject, projectPassed string
 
 		if !projectFound {
 			availableNamesString := strings.Join(availableNames, ",")
-			return nil, errors.Errorf("the project: %s specified in --starter does not exist, available projects: %s", projectPassed, availableNamesString)
+			return nil, fmt.Errorf("the project: %s specified in --starter does not exist, available projects: %s", projectPassed, availableNamesString)
 		}
 	}
 
@@ -124,7 +123,7 @@ func DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedT
 			downloadSpinner.End(true)
 		}
 	} else {
-		return errors.Errorf("Project type not supported")
+		return errors.New("Project type not supported")
 	}
 
 	return nil

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -85,7 +86,7 @@ func (o *deployHandler) ApplyKubernetes(kubernetes v1alpha2.Component) error {
 	log.Infof("\nDeploying Kubernetes %s: %s", u.GetKind(), u.GetName())
 	isOperatorBackedService, err := service.PushKubernetesResource(o.kubeClient, u, labels, annotations)
 	if err != nil {
-		return errors.Wrap(err, "failed to create service(s) associated with the component")
+		return fmt.Errorf("failed to create service(s) associated with the component: %w", err)
 	}
 
 	if isOperatorBackedService {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -8,8 +9,6 @@ import (
 	"github.com/devfile/library/pkg/devfile/parser"
 	devfilefs "github.com/devfile/library/pkg/testingutil/filesystem"
 	"k8s.io/klog"
-
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -29,7 +29,7 @@ func New(devfile devfilev1.Command, knowCommands map[string]devfilev1.Command, e
 			if devfileCommand, ok := knowCommands[strings.ToLower(cmd)]; ok {
 				c, err := New(devfileCommand, knowCommands, executor)
 				if err != nil {
-					return nil, errors.Wrapf(err, "couldn't create command %s", cmd)
+					return nil, fmt.Errorf("couldn't create command %s: %w", cmd, err)
 				}
 				components = append(components, c)
 			} else {

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -8,7 +9,6 @@ import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/util"
 	"k8s.io/klog"
 )

--- a/pkg/devfile/adapters/common/command_parallel_composite.go
+++ b/pkg/devfile/adapters/common/command_parallel_composite.go
@@ -1,7 +1,8 @@
 package common
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/redhat-developer/odo/pkg/util"
 )
 
@@ -32,7 +33,7 @@ func (p parallelCompositeCommand) Execute(show bool) error {
 
 	err := commandExecs.Run()
 	if err != nil {
-		return errors.Wrap(err, "parallel command execution failed")
+		return fmt.Errorf("parallel command execution failed: %w", err)
 	}
 	return nil
 }
@@ -52,7 +53,7 @@ func (p parallelCompositeCommand) UnExecute() error {
 
 	err := commandExecs.Run()
 	if err != nil {
-		return errors.Wrap(err, "parallel command execution failed")
+		return fmt.Errorf("parallel command execution failed: %w", err)
 	}
 	return nil
 }

--- a/pkg/devfile/adapters/common/command_simple.go
+++ b/pkg/devfile/adapters/common/command_simple.go
@@ -2,8 +2,8 @@ package common
 
 import (
 	"fmt"
+
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
 	"github.com/redhat-developer/odo/pkg/util"
@@ -107,7 +107,7 @@ func (s execCommand) Execute(show bool) error {
 	logger.DevFileCommandExecutionComplete(s.id, s.component, s.originalCmd, s.group, machineoutput.TimestampNow(), err)
 
 	if err != nil {
-		return errors.Wrapf(err, "unable to execute the run command")
+		return fmt.Errorf("unable to execute the run command: %w", err)
 	}
 
 	if showSpinner {

--- a/pkg/devfile/adapters/common/exec.go
+++ b/pkg/devfile/adapters/common/exec.go
@@ -8,7 +8,6 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/log"
 )
 
@@ -42,7 +41,7 @@ func ExecuteCommand(client ExecClient, compInfo ComponentInfo, command []string,
 		// It is safe to read from cmdOutput here, as the goroutines are guaranteed to have terminated at this point.
 		klog.V(2).Infof("ExecuteCommand returned an an err: %v. for command '%v'. output: %v", err, command, cmdOutput)
 
-		return errors.Wrapf(err, "unable to exec command %v: \n%v", command, cmdOutput)
+		return fmt.Errorf("unable to exec command %v: \n%v: %w", command, cmdOutput, err)
 	}
 
 	return

--- a/pkg/devfile/adapters/common/generic.go
+++ b/pkg/devfile/adapters/common/generic.go
@@ -1,11 +1,11 @@
 package common
 
 import (
+	"errors"
 	"io"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
 	"github.com/redhat-developer/odo/pkg/util"
 	"k8s.io/klog"

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -1,11 +1,12 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/preference"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes/component"
 )
@@ -34,7 +35,7 @@ func (k Adapter) Push(parameters common.PushParameters) error {
 
 	err := k.componentAdapter.Push(parameters)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create the component")
+		return fmt.Errorf("Failed to create the component: %w", err)
 	}
 
 	return nil
@@ -44,7 +45,7 @@ func (k Adapter) Push(parameters common.PushParameters) error {
 func (k Adapter) CheckSupervisordCommandStatus(command devfilev1.Command) error {
 	err := k.componentAdapter.CheckSupervisordCommandStatus(command)
 	if err != nil {
-		return errors.Wrap(err, "Failed to check the status")
+		return fmt.Errorf("Failed to check the status: %w", err)
 	}
 
 	return nil

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/devfile/library/pkg/devfile/generator"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/preference"
@@ -365,7 +365,7 @@ func TestDoesComponentExist(t *testing.T) {
 				deployment := odoTestingUtil.CreateFakeDeployment(tt.getComponentName)
 
 				if tt.wantErr {
-					return true, &v1.DeploymentList{Items: []v1.Deployment{*emptyDeployment}}, errors.Errorf("deployment get error")
+					return true, &v1.DeploymentList{Items: []v1.Deployment{*emptyDeployment}}, errors.New("deployment get error")
 				} else if tt.getComponentName == tt.componentName {
 					return true, &v1.DeploymentList{Items: []v1.Deployment{*deployment}}, nil
 				}

--- a/pkg/devfile/adapters/kubernetes/component/status.go
+++ b/pkg/devfile/adapters/kubernetes/component/status.go
@@ -1,9 +1,8 @@
 package component
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
@@ -32,7 +31,7 @@ func getSupervisordStatusInContainer(podName string, containerName string, a Ada
 	consoleStderrResult := <-stderrOutputChannel
 
 	if err != nil {
-		a.Logger().ReportError(errors.Wrapf(err, "unable to execute command on %s within container %s, %v, output: %v %v", podName, containerName, err, consoleResult, consoleStderrResult), machineoutput.TimestampNow())
+		a.Logger().ReportError(fmt.Errorf("unable to execute command on %s within container %s, %v, output: %v %v: %w", podName, containerName, err, consoleResult, consoleStderrResult, err), machineoutput.TimestampNow())
 		return nil
 	}
 

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/devfile/library/pkg/devfile/generator"
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
@@ -41,7 +39,7 @@ func GetVolumeInfos(pvcs []corev1.PersistentVolumeClaim) (odoSourcePVCName strin
 
 		generatedVolumeName, e := generateVolumeNameFromPVC(pvc.Name)
 		if e != nil {
-			return "", nil, errors.Wrapf(e, "Unable to generate volume name from pvc name")
+			return "", nil, fmt.Errorf("Unable to generate volume name from pvc name: %w", e)
 		}
 
 		if pvc.Labels[storagelabels.StorageLabel] == storagepkg.OdoSourceVolume {

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"reflect"
 	"strconv"
 	"testing"
@@ -12,7 +13,6 @@ import (
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
-	"github.com/pkg/errors"
 	adaptersCommon "github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	odoTestingUtil "github.com/redhat-developer/odo/pkg/testingutil"
@@ -72,7 +72,7 @@ func TestComponentExists(t *testing.T) {
 						Items: []appsv1.Deployment{
 							*emptyDeployment,
 						},
-					}, errors.Errorf("deployment get error")
+					}, errors.New("deployment get error")
 				} else if tt.getComponentName == tt.componentName {
 					return true, &appsv1.DeploymentList{
 						Items: []appsv1.Deployment{

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -2,6 +2,7 @@
 package envinfo
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -96,7 +97,7 @@ func newEnvSpecificInfo(envDir string, fs filesystem.Filesystem) (*EnvSpecificIn
 	// Get the path of the environment file
 	envInfoFile, devfilePath, err := getEnvInfoFile(envDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get the path of the environment file")
+		return nil, fmt.Errorf("failed to get the path of the environment file: %w", err)
 	}
 
 	// Organize that information into a struct
@@ -158,7 +159,7 @@ func (esi *EnvSpecificInfo) SetConfiguration(parameter string, value interface{}
 		case "debugport":
 			val, err := strconv.Atoi(value.(string))
 			if err != nil {
-				return errors.Wrap(err, "failed to set debug port")
+				return fmt.Errorf("failed to set debug port: %w", err)
 			}
 			esi.componentSettings.DebugPort = &val
 		case "url":

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	dfutil "github.com/devfile/library/pkg/util"
@@ -173,7 +171,7 @@ func (esi *EnvSpecificInfo) SetConfiguration(parameter string, value interface{}
 
 		return esi.writeToFile()
 	}
-	return errors.Errorf("unknown parameter: %q is not a parameter in the odo environment file, please refer `odo env set --help` to see valid parameters", parameter)
+	return fmt.Errorf("unknown parameter: %q is not a parameter in the odo environment file, please refer `odo env set --help` to see valid parameters", parameter)
 
 }
 
@@ -232,7 +230,7 @@ var (
 func (esi *EnvSpecificInfo) DeleteConfiguration(parameter string) error {
 	for _, manParam := range manParams {
 		if parameter == manParam {
-			return errors.Errorf("failed to unset %q: %q is mandatory parameter", parameter, parameter)
+			return fmt.Errorf("failed to unset %q: %q is mandatory parameter", parameter, parameter)
 		}
 	}
 
@@ -242,7 +240,7 @@ func (esi *EnvSpecificInfo) DeleteConfiguration(parameter string) error {
 		}
 		return esi.writeToFile()
 	}
-	return errors.Errorf("unknown parameter: %q is not a parameter in the odo environment file, please refer `odo env unset --help` to unset a valid parameter", parameter)
+	return fmt.Errorf("unknown parameter: %q is not a parameter in the odo environment file, please refer `odo env unset --help` to unset a valid parameter", parameter)
 
 }
 

--- a/pkg/envinfo/url.go
+++ b/pkg/envinfo/url.go
@@ -9,7 +9,6 @@ import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
 	"github.com/redhat-developer/odo/pkg/odo/util/validation"
 	"github.com/redhat-developer/odo/pkg/util"
@@ -382,7 +381,7 @@ func (ei *EnvInfo) ListURLs() ([]localConfigProvider.LocalURL, error) {
 func (esi *EnvSpecificInfo) DeleteURL(name string) error {
 	err := removeEndpointInDevfile(esi.devfileObj, name)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete URL")
+		return fmt.Errorf("failed to delete URL: %w", err)
 	}
 
 	if esi.componentSettings.URL == nil {

--- a/pkg/envinfo/url.go
+++ b/pkg/envinfo/url.go
@@ -302,7 +302,7 @@ func (esi *EnvSpecificInfo) CreateURL(url localConfigProvider.LocalURL) error {
 
 		err := addEndpointInDevfile(esi.devfileObj, newEndpointEntry, url.Container)
 		if err != nil {
-			return errors.Wrapf(err, "failed to write endpoints information into devfile")
+			return fmt.Errorf("failed to write endpoints information into devfile: %w", err)
 		}
 	} else {
 		err := updateEndpointInDevfile(esi.devfileObj, url)
@@ -313,7 +313,7 @@ func (esi *EnvSpecificInfo) CreateURL(url localConfigProvider.LocalURL) error {
 
 	err := esi.SetConfiguration("url", localConfigProvider.LocalURL{Name: url.Name, Host: url.Host, TLSSecret: url.TLSSecret, Kind: url.Kind})
 	if err != nil {
-		return errors.Wrapf(err, "failed to persist the component settings to env file")
+		return fmt.Errorf("failed to persist the component settings to env file: %w", err)
 	}
 	return nil
 }

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -3,13 +3,13 @@ package kclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -221,10 +221,10 @@ func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deploy
 See below for a list of failed events that occured more than %d times during deployment:
 %s`, failedEventCount, tableString.String())
 
-			return nil, errors.Errorf(errorMessage)
+			return nil, fmt.Errorf(errorMessage)
 		}
 
-		return nil, errors.Errorf("timeout while waiting for %s deployment roll out", deploymentName)
+		return nil, fmt.Errorf("timeout while waiting for %s deployment roll out", deploymentName)
 	}
 }
 
@@ -453,7 +453,7 @@ func (c *Client) jsonPatchDeployment(deploymentSelector string, deploymentPatchP
 			return fmt.Errorf("Deployment not patched %s: %w", deployment.Name, e)
 		}
 	} else {
-		return fmt.Errorf("deploymentPatch was not properly set: %w", err)
+		return errors.New("deploymentPatch was not properly set")
 	}
 
 	return nil

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -96,7 +96,7 @@ func (c *Client) GetDeploymentFromSelector(selector string) ([]appsv1.Deployment
 		})
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list Deployments")
+		return nil, fmt.Errorf("unable to list Deployments: %w", err)
 	}
 	return deploymentList.Items, nil
 }
@@ -444,7 +444,7 @@ func (c *Client) jsonPatchDeployment(deploymentSelector string, deploymentPatchP
 	if deploymentPatchProvider != nil {
 		patch, e := deploymentPatchProvider(deployment)
 		if e != nil {
-			return errors.Wrap(e, "Unable to create a patch for the Deployment")
+			return fmt.Errorf("Unable to create a patch for the Deployment: %w", e)
 		}
 
 		// patch the Deployment with the secret
@@ -466,7 +466,7 @@ func (c *Client) GetDeploymentLabelValues(label string, selector string) ([]stri
 	// List Deployment according to selectors
 	deploymentList, err := c.appsClient.Deployments(c.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list DeploymentConfigs")
+		return nil, fmt.Errorf("unable to list DeploymentConfigs: %w", err)
 	}
 
 	// Grab all the matched strings

--- a/pkg/kclient/deployments_test.go
+++ b/pkg/kclient/deployments_test.go
@@ -1,10 +1,10 @@
 package kclient
 
 import (
+	"errors"
+	"fmt"
 	reflect "reflect"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/generator"
@@ -54,7 +54,7 @@ func createFakeDeployment(fkclient *Client, fkclientset *FakeClientset, podName 
 	deploy, _ := generator.GetDeployment(devObj, deploymentParams)
 	fkclientset.Kubernetes.PrependReactor("patch", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
 		if podName == "" {
-			return true, nil, errors.Errorf("deployment name is empty")
+			return true, nil, errors.New("deployment name is empty")
 		}
 		deployment := appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
@@ -167,7 +167,7 @@ func TestGetDeploymentByName(t *testing.T) {
 					deployment := odoTestingUtil.CreateFakeDeployment(tt.deploymentName)
 					return true, deployment, nil
 				} else {
-					return true, nil, errors.Errorf("deployment get error")
+					return true, nil, errors.New("deployment get error")
 				}
 
 			})
@@ -236,7 +236,7 @@ func TestUpdateDeployment(t *testing.T) {
 			deploy, _ := generator.GetDeployment(devObj, deploymentParams)
 			fkclientset.Kubernetes.PrependReactor("patch", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if tt.deploymentName == "" {
-					return true, nil, errors.Errorf("deployment name is empty")
+					return true, nil, errors.New("deployment name is empty")
 				}
 				deployment := appsv1.Deployment{
 					TypeMeta: metav1.TypeMeta{
@@ -303,7 +303,7 @@ func TestDeleteDeployment(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("delete-collection", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if util.ConvertLabelsToSelector(tt.args.labels) != action.(ktesting.DeleteCollectionAction).GetListRestrictions().Labels.String() {
-					return true, nil, errors.Errorf("collection labels are not matching, wanted: %v, got: %v", util.ConvertLabelsToSelector(tt.args.labels), action.(ktesting.DeleteCollectionAction).GetListRestrictions().Labels.String())
+					return true, nil, fmt.Errorf("collection labels are not matching, wanted: %v, got: %v", util.ConvertLabelsToSelector(tt.args.labels), action.(ktesting.DeleteCollectionAction).GetListRestrictions().Labels.String())
 				}
 				return true, nil, nil
 			})

--- a/pkg/kclient/ingress_test.go
+++ b/pkg/kclient/ingress_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/kclient/unions"
 
 	"github.com/devfile/library/pkg/devfile/generator"
-	"github.com/pkg/errors"
 	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -209,7 +208,7 @@ func TestListIngresses(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("list", "ingresses", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if tt.labelSelector != action.(ktesting.ListAction).GetListRestrictions().Labels.String() {
-					return true, nil, errors.Errorf("selectors are different")
+					return true, nil, fmt.Errorf("selectors are different")
 				}
 				if action.GetResource().GroupVersion().Group == "networking.k8s.io" {
 					return true, tt.wantIngress.GetNetworkingV1IngressList(true), nil
@@ -347,7 +346,7 @@ func TestGetIngresses(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("get", "ingresses", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if tt.ingressName == "" {
-					return true, nil, errors.Errorf("ingress name is empty")
+					return true, nil, fmt.Errorf("ingress name is empty")
 				}
 				if action.GetResource().Group == "networking.k8s.io" {
 					ingress := networkingv1.Ingress{

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -2,12 +2,12 @@ package kclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/util"
 

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -37,7 +37,8 @@ const (
 	// errorMsg is the message for user when invalid configuration error occurs
 	errorMsg = `
 Please ensure you have an active kubernetes context to your cluster. 
-Consult your Kubernetes distribution's documentation for more details
+Consult your Kubernetes distribution's documentation for more details.
+Error: %w
 `
 	waitForComponentDeletionTimeout = 120 * time.Second
 
@@ -110,7 +111,7 @@ func NewForConfig(config clientcmd.ClientConfig) (client *Client, err error) {
 
 	client.KubeClientConfig, err = client.KubeConfig.ClientConfig()
 	if err != nil {
-		return nil, errors.Wrapf(err, errorMsg)
+		return nil, fmt.Errorf(errorMsg, err)
 	}
 
 	// For the rest CLIENT, we set the QPS and Burst to high values so

--- a/pkg/kclient/kclient_test.go
+++ b/pkg/kclient/kclient_test.go
@@ -1,11 +1,11 @@
 package kclient
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"testing"
 
-	"github.com/pkg/errors"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery/fake"

--- a/pkg/kclient/namespace.go
+++ b/pkg/kclient/namespace.go
@@ -27,7 +27,7 @@ const (
 func (c *Client) GetNamespaces() ([]string, error) {
 	namespaces, err := c.KubeClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list namespaces")
+		return nil, fmt.Errorf("unable to list namespaces: %w", err)
 	}
 
 	var names []string

--- a/pkg/kclient/namespace.go
+++ b/pkg/kclient/namespace.go
@@ -2,10 +2,10 @@ package kclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,7 +105,7 @@ func (c *Client) DeleteNamespace(name string, wait bool) error {
 			for {
 				val, ok := <-watcher.ResultChan()
 				if !ok {
-					watchErrorChannel <- errors.Errorf("watch channel was closed unexpectedly: %+v", val)
+					watchErrorChannel <- fmt.Errorf("watch channel was closed unexpectedly: %+v", val)
 					break
 				}
 				klog.V(3).Infof("Watch event.Type '%s'.", val.Type)
@@ -117,7 +117,7 @@ func (c *Client) DeleteNamespace(name string, wait bool) error {
 						break
 					}
 					if val.Type == watch.Error {
-						watchErrorChannel <- errors.Errorf("failed watching the deletion of namespace %s", name)
+						watchErrorChannel <- fmt.Errorf("failed watching the deletion of namespace %s", name)
 						break
 					}
 
@@ -135,7 +135,7 @@ func (c *Client) DeleteNamespace(name string, wait bool) error {
 		case err := <-watchErrorChannel:
 			return err
 		case <-time.After(waitForNamespaceDeletionTimeOut):
-			return errors.Errorf("waited %s but couldn't delete namespace %s in time", waitForNamespaceDeletionTimeOut, name)
+			return fmt.Errorf("waited %s but couldn't delete namespace %s in time", waitForNamespaceDeletionTimeOut, name)
 		}
 
 	}

--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -25,7 +25,7 @@ func isServerUp(server string, timeout time.Duration) bool {
 	klog.V(3).Infof("Trying to connect to server %s", address)
 	_, connectionError := net.DialTimeout("tcp", address, timeout)
 	if connectionError != nil {
-		klog.V(3).Info(errors.Wrap(connectionError, "unable to connect to server"))
+		klog.V(3).Info(fmt.Errorf("unable to connect to server: %w", connectionError))
 		return false
 	}
 

--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -3,13 +3,13 @@ package kclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"time"
 
 	dfutil "github.com/devfile/library/pkg/util"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog"

--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -3,6 +3,7 @@ package kclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"time"
 
@@ -48,7 +49,7 @@ func (c *Client) GetServerVersion(timeout time.Duration) (*ServerInfo, error) {
 	// This will fetch the information about Server Address
 	config, err := c.KubeConfig.ClientConfig()
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get server's address")
+		return nil, fmt.Errorf("unable to get server's address: %w", err)
 	}
 	info.Address = config.Host
 
@@ -72,7 +73,7 @@ func (c *Client) GetServerVersion(timeout time.Duration) (*ServerInfo, error) {
 	} else {
 		var openShiftVersion version.Info
 		if e := json.Unmarshal(rawOpenShiftVersion, &openShiftVersion); e != nil {
-			return nil, errors.Wrapf(e, "unable to unmarshal OpenShift version %v", string(rawOpenShiftVersion))
+			return nil, fmt.Errorf("unable to unmarshal OpenShift version %v: %w", string(rawOpenShiftVersion), e)
 		}
 		info.OpenShiftVersion = openShiftVersion.GitVersion
 	}
@@ -80,11 +81,11 @@ func (c *Client) GetServerVersion(timeout time.Duration) (*ServerInfo, error) {
 	// This will fetch the information about Kubernetes Version
 	rawKubernetesVersion, err := coreGet.AbsPath("/version").Do(context.TODO()).Raw()
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get Kubernetes Version")
+		return nil, fmt.Errorf("unable to get Kubernetes Version: %w", err)
 	}
 	var kubernetesVersion version.Info
 	if err := json.Unmarshal(rawKubernetesVersion, &kubernetesVersion); err != nil {
-		return nil, errors.Wrapf(err, "unable to unmarshal Kubernetes Version: %v", string(rawKubernetesVersion))
+		return nil, fmt.Errorf("unable to unmarshal Kubernetes Version: %v: %w", string(rawKubernetesVersion), err)
 	}
 	info.KubernetesVersion = kubernetesVersion.GitVersion
 

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -57,7 +57,7 @@ func (c *Client) GetCustomResourcesFromCSV(csv *olm.ClusterServiceVersion) *[]ol
 func (c *Client) GetCSVWithCR(name string) (*olm.ClusterServiceVersion, error) {
 	csvs, err := c.ListClusterServiceVersions()
 	if err != nil {
-		return &olm.ClusterServiceVersion{}, errors.Wrap(err, "unable to list services")
+		return &olm.ClusterServiceVersion{}, fmt.Errorf("unable to list services: %w", err)
 	}
 
 	for _, csv := range csvs.Items {

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -3,6 +3,7 @@ package kclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,7 +17,6 @@ import (
 
 	"github.com/go-openapi/spec"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/log"
 	"k8s.io/klog"
 
@@ -72,7 +72,7 @@ func (c *Client) WaitAndGetPodWithEvents(selector string, desiredPhase corev1.Po
 					podChannel <- e
 					break loop
 				case corev1.PodFailed, corev1.PodUnknown:
-					watchErrorChannel <- errors.Errorf("pod %s status %s", e.Name, e.Status.Phase)
+					watchErrorChannel <- fmt.Errorf("pod %s status %s", e.Name, e.Status.Phase)
 					break loop
 				default:
 					// we start in a phase different from the desired one, let's wait
@@ -113,7 +113,7 @@ See below for a list of failed events that occured more than %d times during dep
 %s`, pushTimeout, selector, failedEventCount, tableString.String())
 		}
 
-		return nil, errors.Errorf(errorMessage)
+		return nil, fmt.Errorf(errorMessage)
 	}
 }
 

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -38,7 +38,7 @@ func (c *Client) WaitAndGetPodWithEvents(selector string, desiredPhase corev1.Po
 		LabelSelector: selector,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to watch pod")
+		return nil, fmt.Errorf("unable to watch pod: %w", err)
 	}
 	defer w.Stop()
 
@@ -142,13 +142,13 @@ func (c *Client) ExecCMDInContainer(containerName, podName string, cmd []string,
 
 	config, err := c.KubeConfig.ClientConfig()
 	if err != nil {
-		return errors.Wrapf(err, "unable to get Kubernetes client config")
+		return fmt.Errorf("unable to get Kubernetes client config: %w", err)
 	}
 
 	// Connect to url (constructed from req) using SPDY (HTTP/2) protocol which allows bidirectional streams.
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if err != nil {
-		return errors.Wrapf(err, "unable execute command via SPDY")
+		return fmt.Errorf("unable execute command via SPDY: %w", err)
 	}
 	// initialize the transport of the standard shell streams
 	err = exec.Stream(remotecommand.StreamOptions{
@@ -158,7 +158,7 @@ func (c *Client) ExecCMDInContainer(containerName, podName string, cmd []string,
 		Tty:    tty,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "error while streaming command")
+		return fmt.Errorf("error while streaming command: %w", err)
 	}
 
 	return nil

--- a/pkg/kclient/projects.go
+++ b/pkg/kclient/projects.go
@@ -81,7 +81,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 			FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
 		})
 		if err != nil {
-			return errors.Wrapf(err, "unable to watch project")
+			return fmt.Errorf("unable to watch project: %w", err)
 		}
 		defer watcher.Stop()
 	}
@@ -170,7 +170,7 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 			FieldSelector: fields.Set{"metadata.name": projectName}.AsSelector().String(),
 		})
 		if err != nil {
-			return errors.Wrapf(err, "unable to watch new project %s creation", projectName)
+			return fmt.Errorf("unable to watch new project %s creation: %w", projectName, err)
 		}
 		defer watcher.Stop()
 	}
@@ -182,7 +182,7 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 	}
 	_, err = c.projectClient.ProjectRequests().Create(context.TODO(), projectRequest, metav1.CreateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return errors.Wrapf(err, "unable to create new project %s", projectName)
+		return fmt.Errorf("unable to create new project %s: %w", projectName, err)
 	}
 
 	if watcher != nil {

--- a/pkg/kclient/projects.go
+++ b/pkg/kclient/projects.go
@@ -89,7 +89,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 	// Delete the project
 	err = c.projectClient.Projects().Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrap(err, "unable to delete project")
+		return fmt.Errorf("unable to delete project: %w", err)
 	}
 
 	// If watcher has been created (wait was passed) we will create a go routine and actually **wait**

--- a/pkg/kclient/projects.go
+++ b/pkg/kclient/projects.go
@@ -2,11 +2,11 @@ package kclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	projectv1 "github.com/openshift/api/project/v1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +110,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 				val, ok := <-watcher.ResultChan()
 				if !ok {
 					//return fmt.Errorf("received unexpected signal %+v on project watch channel", val)
-					watchErrorChannel <- errors.Errorf("watch channel was closed unexpectedly: %+v", val)
+					watchErrorChannel <- fmt.Errorf("watch channel was closed unexpectedly: %+v", val)
 					break
 				}
 
@@ -127,7 +127,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 							break
 						}
 						if val.Type == watch.Error {
-							watchErrorChannel <- errors.Errorf("failed watching the deletion of project %s", name)
+							watchErrorChannel <- fmt.Errorf("failed watching the deletion of project %s", name)
 							break
 						}
 					}
@@ -149,7 +149,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 		case err := <-watchErrorChannel:
 			return err
 		case <-time.After(waitForProjectDeletionTimeOut):
-			return errors.Errorf("waited %s but couldn't delete project %s in time", waitForProjectDeletionTimeOut, name)
+			return fmt.Errorf("waited %s but couldn't delete project %s in time", waitForProjectDeletionTimeOut, name)
 		}
 
 	}

--- a/pkg/kclient/routes.go
+++ b/pkg/kclient/routes.go
@@ -7,7 +7,6 @@ import (
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/generator"
 	routev1 "github.com/openshift/api/route/v1"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"
@@ -46,7 +45,7 @@ func (c *Client) CreateRoute(name string, serviceName string, portNumber intstr.
 
 	r, err := c.routeClient.Routes(c.Namespace).Create(context.TODO(), route, metav1.CreateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating route")
+		return nil, fmt.Errorf("error creating route: %w", err)
 	}
 	return r, nil
 }
@@ -55,7 +54,7 @@ func (c *Client) CreateRoute(name string, serviceName string, portNumber intstr.
 func (c *Client) DeleteRoute(name string) error {
 	err := c.routeClient.Routes(c.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrap(err, "unable to delete route")
+		return fmt.Errorf("unable to delete route: %w", err)
 	}
 	return nil
 }
@@ -67,7 +66,7 @@ func (c *Client) ListRoutes(labelSelector string) ([]routev1.Route, error) {
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get route list")
+		return nil, fmt.Errorf("unable to get route list: %w", err)
 	}
 
 	return routeList.Items, nil

--- a/pkg/kclient/secrets.go
+++ b/pkg/kclient/secrets.go
@@ -60,7 +60,7 @@ func GenerateSelfSignedCertificate(host string) (SelfSignedCertificate, error) {
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return SelfSignedCertificate{}, errors.Wrap(err, "unable to generate rsa key")
+		return SelfSignedCertificate{}, fmt.Errorf("unable to generate rsa key: %w", err)
 	}
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(time.Now().Unix()),
@@ -77,12 +77,12 @@ func GenerateSelfSignedCertificate(host string) (SelfSignedCertificate, error) {
 
 	certificateDerEncoding, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
-		return SelfSignedCertificate{}, errors.Wrap(err, "unable to create certificate")
+		return SelfSignedCertificate{}, fmt.Errorf("unable to create certificate: %w", err)
 	}
 	out := &bytes.Buffer{}
 	err = pem.Encode(out, &pem.Block{Type: "CERTIFICATE", Bytes: certificateDerEncoding})
 	if err != nil {
-		return SelfSignedCertificate{}, errors.Wrap(err, "unable to encode certificate")
+		return SelfSignedCertificate{}, fmt.Errorf("unable to encode certificate: %w", err)
 	}
 	certPemEncode := out.String()
 	certPemByteArr := []byte(certPemEncode)
@@ -90,7 +90,7 @@ func GenerateSelfSignedCertificate(host string) (SelfSignedCertificate, error) {
 	tlsPrivKeyEncoding := x509.MarshalPKCS1PrivateKey(privateKey)
 	err = pem.Encode(out, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: tlsPrivKeyEncoding})
 	if err != nil {
-		return SelfSignedCertificate{}, errors.Wrap(err, "unable to encode rsa private key")
+		return SelfSignedCertificate{}, fmt.Errorf("unable to encode rsa private key: %w", err)
 	}
 	keyPemEncode := out.String()
 	keyPemByteArr := []byte(keyPemEncode)
@@ -190,7 +190,7 @@ func (c *Client) ListSecrets(labelSelector string) ([]corev1.Secret, error) {
 
 	secretList, err := c.KubeClient.CoreV1().Secrets(c.Namespace).List(context.TODO(), listOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get secret list")
+		return nil, fmt.Errorf("unable to get secret list: %w", err)
 	}
 
 	return secretList.Items, nil

--- a/pkg/kclient/secrets.go
+++ b/pkg/kclient/secrets.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/klog"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -217,7 +216,7 @@ func (c *Client) WaitAndGetSecret(name string, namespace string) (*corev1.Secret
 			return e, nil
 		}
 	}
-	return nil, errors.Errorf("unknown error while waiting for secret '%s'", name)
+	return nil, fmt.Errorf("unknown error while waiting for secret '%s'", name)
 }
 
 func secretKeyName(componentName, baseKeyName string) string {

--- a/pkg/kclient/secrets.go
+++ b/pkg/kclient/secrets.go
@@ -42,7 +42,7 @@ func (c *Client) CreateTLSSecret(tlsCertificate []byte, tlsPrivKey []byte, objec
 
 	secret, err := c.KubeClient.CoreV1().Secrets(c.Namespace).Create(context.TODO(), &secretTemplate, metav1.CreateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to create secret %s", objectMeta.Name)
+		return nil, fmt.Errorf("unable to create secret %s: %w", objectMeta.Name, err)
 	}
 	return secret, nil
 }
@@ -102,7 +102,7 @@ func GenerateSelfSignedCertificate(host string) (SelfSignedCertificate, error) {
 func (c *Client) GetSecret(name, namespace string) (*corev1.Secret, error) {
 	secret, err := c.KubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get the secret %s", secret)
+		return nil, fmt.Errorf("unable to get the secret %s: %w", secret, err)
 	}
 	return secret, nil
 }
@@ -111,7 +111,7 @@ func (c *Client) GetSecret(name, namespace string) (*corev1.Secret, error) {
 func (c *Client) UpdateSecret(secret *corev1.Secret, namespace string) (*corev1.Secret, error) {
 	secret, err := c.KubeClient.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to update the secret %s", secret)
+		return nil, fmt.Errorf("unable to update the secret %s: %w", secret, err)
 	}
 	return secret, nil
 }
@@ -120,7 +120,7 @@ func (c *Client) UpdateSecret(secret *corev1.Secret, namespace string) (*corev1.
 func (c *Client) DeleteSecret(secretName, namespace string) error {
 	err := c.KubeClient.CoreV1().Secrets(namespace).Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "unable to delete the secret %s", secretName)
+		return fmt.Errorf("unable to delete the secret %s: %w", secretName, err)
 	}
 	return nil
 }
@@ -137,7 +137,7 @@ func (c *Client) CreateSecret(objectMeta metav1.ObjectMeta, data map[string]stri
 	secret.SetOwnerReferences(append(secret.GetOwnerReferences(), ownerReference))
 	_, err := c.KubeClient.CoreV1().Secrets(c.Namespace).Create(context.TODO(), &secret, metav1.CreateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return errors.Wrapf(err, "unable to create secret for %s", objectMeta.Name)
+		return fmt.Errorf("unable to create secret for %s: %w", objectMeta.Name, err)
 	}
 	return nil
 }
@@ -168,7 +168,7 @@ func (c *Client) CreateSecrets(componentName string, commonObjectMeta metav1.Obj
 			ownerReference)
 
 		if err != nil {
-			return errors.Wrapf(err, "unable to create Secret for %s", commonObjectMeta.Name)
+			return fmt.Errorf("unable to create Secret for %s: %w", commonObjectMeta.Name, err)
 		}
 	}
 
@@ -204,7 +204,7 @@ func (c *Client) WaitAndGetSecret(name string, namespace string) (*corev1.Secret
 		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to watch secret")
+		return nil, fmt.Errorf("unable to watch secret: %w", err)
 	}
 	defer w.Stop()
 	for {

--- a/pkg/kclient/services.go
+++ b/pkg/kclient/services.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +35,7 @@ func (c *Client) ListServices(selector string) ([]corev1.Service, error) {
 		LabelSelector: selector,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list Services")
+		return nil, fmt.Errorf("unable to list Services: %w", err)
 	}
 	return serviceList.Items, nil
 }

--- a/pkg/kclient/services.go
+++ b/pkg/kclient/services.go
@@ -15,7 +15,7 @@ import (
 func (c *Client) CreateService(svc corev1.Service) (*corev1.Service, error) {
 	service, err := c.KubeClient.CoreV1().Services(c.Namespace).Create(context.TODO(), &svc, metav1.CreateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to create Service for %s", svc.Name)
+		return nil, fmt.Errorf("unable to create Service for %s: %w", svc.Name, err)
 	}
 	return service, err
 }
@@ -24,7 +24,7 @@ func (c *Client) CreateService(svc corev1.Service) (*corev1.Service, error) {
 func (c *Client) UpdateService(svc corev1.Service) (*corev1.Service, error) {
 	service, err := c.KubeClient.CoreV1().Services(c.Namespace).Update(context.TODO(), &svc, metav1.UpdateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to update Service for %s", svc.Name)
+		return nil, fmt.Errorf("unable to update Service for %s: %w", svc.Name, err)
 	}
 	return service, err
 }

--- a/pkg/kclient/services_test.go
+++ b/pkg/kclient/services_test.go
@@ -1,6 +1,7 @@
 package kclient
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	"github.com/devfile/library/pkg/testingutil"
-	"github.com/pkg/errors"
 	componentlabels "github.com/redhat-developer/odo/pkg/component/labels"
 	odoTestingUtil "github.com/redhat-developer/odo/pkg/testingutil"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +67,7 @@ func TestCreateService(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("create", "services", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if tt.componentName == "" {
-					return true, nil, errors.Errorf("component name is empty")
+					return true, nil, fmt.Errorf("component name is empty")
 				}
 				service := corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +154,7 @@ func TestUpdateService(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("update", "services", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if tt.componentName == "" {
-					return true, nil, errors.Errorf("component name is empty")
+					return true, nil, fmt.Errorf("component name is empty")
 				}
 				service := corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kclient/utils.go
+++ b/pkg/kclient/utils.go
@@ -1,15 +1,16 @@
 package kclient
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/json"
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -27,7 +28,7 @@ func GetInputEnvVarsFromStrings(envVars []string) ([]corev1.EnvVar, error) {
 		}
 		_, ok := keys[splits[0]]
 		if ok {
-			return nil, errors.Errorf("multiple values found for VariableName: %s", splits[0])
+			return nil, fmt.Errorf("multiple values found for VariableName: %s", splits[0])
 		}
 
 		keys[splits[0]] = 1

--- a/pkg/kclient/volumes.go
+++ b/pkg/kclient/volumes.go
@@ -20,7 +20,7 @@ const (
 func (c *Client) CreatePVC(pvc corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
 	createdPvc, err := c.KubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).Create(context.TODO(), &pvc, metav1.CreateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create PVC")
+		return nil, fmt.Errorf("unable to create PVC: %w", err)
 	}
 	return createdPvc, nil
 }
@@ -46,7 +46,7 @@ func (c *Client) ListPVCs(selector string) ([]corev1.PersistentVolumeClaim, erro
 func (c *Client) ListPVCNames(selector string) ([]string, error) {
 	pvcs, err := c.ListPVCs(selector)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get PVCs from selector")
+		return nil, fmt.Errorf("unable to get PVCs from selector: %w", err)
 	}
 
 	var names []string
@@ -67,7 +67,7 @@ func (c *Client) UpdatePVCLabels(pvc *corev1.PersistentVolumeClaim, labels map[s
 	pvc.Labels = labels
 	_, err := c.KubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{FieldManager: FieldManager})
 	if err != nil {
-		return errors.Wrap(err, "unable to remove storage label from PVC")
+		return fmt.Errorf("unable to remove storage label from PVC: %w", err)
 	}
 	return nil
 }

--- a/pkg/kclient/volumes.go
+++ b/pkg/kclient/volumes.go
@@ -2,6 +2,7 @@ package kclient
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/devfile/library/pkg/devfile/generator"
 	"github.com/pkg/errors"
@@ -35,7 +36,7 @@ func (c *Client) ListPVCs(selector string) ([]corev1.PersistentVolumeClaim, erro
 		LabelSelector: selector,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get PVCs for selector: %v", selector)
+		return nil, fmt.Errorf("unable to get PVCs for selector: %v: %w", selector, err)
 	}
 
 	return pvcList.Items, nil

--- a/pkg/kclient/volumes.go
+++ b/pkg/kclient/volumes.go
@@ -2,10 +2,10 @@ package kclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/devfile/library/pkg/devfile/generator"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/kclient/volumes_test.go
+++ b/pkg/kclient/volumes_test.go
@@ -1,13 +1,12 @@
 package kclient
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/redhat-developer/odo/pkg/testingutil"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +78,7 @@ func TestCreatePVC(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("create", "persistentvolumeclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
 				if tt.pvcName == "" {
-					return true, nil, errors.Errorf("pvc name is empty")
+					return true, nil, errors.New("pvc name is empty")
 				}
 				pvc := corev1.PersistentVolumeClaim{
 					TypeMeta: metav1.TypeMeta{

--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
@@ -88,7 +87,7 @@ func (o *DescribeComponentOptions) Complete(cmdline cmdline.Cmdline, args []stri
 // Validate validates the DescribeComponentOptions based on completed values
 func (o *DescribeComponentOptions) Validate() (err error) {
 	if len(o.devfileComponents) == 0 {
-		return errors.Wrapf(err, "No components with the name \"%s\" found", o.componentName)
+		return fmt.Errorf("No components with the name \"%s\" found: %w", o.componentName, err)
 	}
 
 	return nil
@@ -196,15 +195,15 @@ func GetDevfile(devfileComponent catalog.DevfileComponentType) (parser.DevfileOb
 func getDevFileNoValidation(devfileComponent catalog.DevfileComponentType) (parser.DevfileObj, error) {
 	if strings.Contains(devfileComponent.Registry.URL, "github") {
 		devObj, err := devfile.ParseAndValidateFromURL(devfileComponent.Registry.URL + devfileComponent.Link)
-		return devObj, errors.Wrapf(err, "Failed to download devfile.yaml from Github-based registry for devfile component: %s", devfileComponent.Name)
+		return devObj, fmt.Errorf("Failed to download devfile.yaml from Github-based registry for devfile component: %s: %w", devfileComponent.Name, err)
 	}
 	registryURL, err := url.Parse(devfileComponent.Registry.URL)
 	if err != nil {
-		return parser.DevfileObj{}, errors.Wrapf(err, "Failed to parse registry URL for devfile component: %s", devfileComponent.Name)
+		return parser.DevfileObj{}, fmt.Errorf("Failed to parse registry URL for devfile component: %s: %w", devfileComponent.Name, err)
 	}
 	registryURL.Path = path.Join(registryURL.Path, "devfiles", devfileComponent.Name)
 	devObj, err := devfile.ParseAndValidateFromURL(registryURL.String())
-	return devObj, errors.Wrapf(err, "Failed to download devfile.yaml from OCI-based registry for devfile component: %s", devfileComponent.Name)
+	return devObj, fmt.Errorf("Failed to download devfile.yaml from OCI-based registry for devfile component: %s: %w", devfileComponent.Name, err)
 }
 
 // PrintDevfileStarterProjects prints all the starter projects in a devfile
@@ -215,7 +214,7 @@ func (o *DescribeComponentOptions) PrintDevfileStarterProjects(w *tabwriter.Writ
 		for _, project := range projects {
 			yamlData, err := yaml.Marshal(project)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to marshal devfile object into yaml")
+				return fmt.Errorf("Failed to marshal devfile object into yaml: %w", err)
 			}
 			fmt.Printf("---\n%s", string(yamlData))
 		}
@@ -223,7 +222,7 @@ func (o *DescribeComponentOptions) PrintDevfileStarterProjects(w *tabwriter.Writ
 		fmt.Fprintln(w, "The Odo devfile component \""+o.componentName+"\" has no starter projects.")
 		yamlData, err := yaml.Marshal(devObj)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to marshal devfile object into yaml")
+			return fmt.Errorf("Failed to marshal devfile object into yaml: %w", err)
 		}
 		fmt.Printf("---\n%s", string(yamlData))
 	}

--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -87,7 +87,7 @@ func (o *DescribeComponentOptions) Complete(cmdline cmdline.Cmdline, args []stri
 // Validate validates the DescribeComponentOptions based on completed values
 func (o *DescribeComponentOptions) Validate() (err error) {
 	if len(o.devfileComponents) == 0 {
-		return fmt.Errorf("No components with the name \"%s\" found: %w", o.componentName, err)
+		return fmt.Errorf("No components with the name \"%s\" found", o.componentName)
 	}
 
 	return nil
@@ -195,7 +195,10 @@ func GetDevfile(devfileComponent catalog.DevfileComponentType) (parser.DevfileOb
 func getDevFileNoValidation(devfileComponent catalog.DevfileComponentType) (parser.DevfileObj, error) {
 	if strings.Contains(devfileComponent.Registry.URL, "github") {
 		devObj, err := devfile.ParseAndValidateFromURL(devfileComponent.Registry.URL + devfileComponent.Link)
-		return devObj, fmt.Errorf("Failed to download devfile.yaml from Github-based registry for devfile component: %s: %w", devfileComponent.Name, err)
+		if err != nil {
+			return devObj, fmt.Errorf("Failed to download devfile.yaml from Github-based registry for devfile component: %s: %w", devfileComponent.Name, err)
+		}
+		return devObj, nil
 	}
 	registryURL, err := url.Parse(devfileComponent.Registry.URL)
 	if err != nil {
@@ -203,7 +206,10 @@ func getDevFileNoValidation(devfileComponent catalog.DevfileComponentType) (pars
 	}
 	registryURL.Path = path.Join(registryURL.Path, "devfiles", devfileComponent.Name)
 	devObj, err := devfile.ParseAndValidateFromURL(registryURL.String())
-	return devObj, fmt.Errorf("Failed to download devfile.yaml from OCI-based registry for devfile component: %s: %w", devfileComponent.Name, err)
+	if err != nil {
+		return devObj, fmt.Errorf("Failed to download devfile.yaml from OCI-based registry for devfile component: %s: %w", devfileComponent.Name, err)
+	}
+	return devObj, nil
 }
 
 // PrintDevfileStarterProjects prints all the starter projects in a devfile

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -76,15 +77,14 @@ func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 	// check if project exist
 	isPrjExists, err := cpo.clientset.ProjectClient.Exists(prjName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to check if project with name %s exists", prjName)
+		return fmt.Errorf("failed to check if project with name %s exists: %w", prjName, err)
 	}
 	if !isPrjExists {
 		err = cpo.clientset.ProjectClient.Create(prjName, true)
 		if err != nil {
-			return errors.Wrapf(
-				err,
-				"project %s does not exist. Failed creating it. Please try after creating project using `odo project create <project_name>`",
-				prjName,
+			return fmt.Errorf(
+				"project %s does not exist. Failed creating it. Please try after creating project using `odo project create <project_name>`: %w",
+				prjName, err,
 			)
 		}
 	}

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/devfile/library/pkg/devfile/parser"
@@ -142,7 +141,7 @@ func GatherName(devObj parser.DevfileObj, devfilePath string) (string, error) {
 	// 2. Use the folder name as a last resort if nothing else exists
 	sourcePath, err := dfutil.GetAbsPath(devfilePath)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to get source path")
+		return "", fmt.Errorf("unable to get source path: %w", err)
 	}
 	klog.V(4).Infof("Source path: %s", sourcePath)
 	klog.V(4).Infof("devfile dir: %s", filepath.Dir(sourcePath))

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -1,12 +1,12 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 
@@ -184,7 +184,7 @@ func (co *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err e
 		fileErr := dfutil.ValidateFile(co.devfileMetadata.devfilePath.value)
 		urlErr := util.ValidateURL(co.devfileMetadata.devfilePath.value)
 		if fileErr != nil && urlErr != nil {
-			return errors.Errorf("the devfile path you specify is invalid with either file error %q or url error %q", fileErr, urlErr)
+			return fmt.Errorf("the devfile path you specify is invalid with either file error %q or url error %q", fileErr, urlErr)
 		} else if fileErr == nil {
 			co.createMethod = FileCreateMethod{}
 		} else if urlErr == nil {

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -218,7 +218,7 @@ func (co *CreateOptions) Complete(cmdline cmdline.Cmdline, args []string) (err e
 			var token string
 			token, err = keyring.Get(fmt.Sprintf("%s%s", dfutil.CredentialPrefix, co.devfileMetadata.devfileRegistry.Name), registryUtil.RegistryUser)
 			if err != nil {
-				return errors.Wrap(err, "unable to get secure registry credential from keyring")
+				return fmt.Errorf("unable to get secure registry credential from keyring: %w", err)
 			}
 			co.devfileMetadata.starterToken = token
 		}
@@ -282,7 +282,7 @@ func (co *CreateOptions) Run() (err error) {
 	// WARN: Starter Project uses go-git that overrides the directory content, there by deleting the existing devfile.
 	err = decideAndDownloadStarterProject(devObj, co.devfileMetadata.starter, co.devfileMetadata.starterToken, co.interactive, co.contextFlag)
 	if err != nil {
-		return errors.Wrap(err, "failed to download project for devfile component")
+		return fmt.Errorf("failed to download project for devfile component: %w", err)
 	}
 
 	//Check if the directory already contains a devfile when starter project is downloaded
@@ -316,13 +316,13 @@ func (co *CreateOptions) Run() (err error) {
 		UserCreatedDevfile: co.devfileMetadata.userCreatedDevfile,
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to create env file for devfile component")
+		return fmt.Errorf("failed to create env file for devfile component: %w", err)
 	}
 
 	// Prepare .gitignore file
 	sourcePath, err := dfutil.GetAbsPath(co.contextFlag)
 	if err != nil {
-		return errors.Wrap(err, "unable to get source path")
+		return fmt.Errorf("unable to get source path: %w", err)
 	}
 
 	ignoreFile, err := util.TouchGitIgnoreFile(sourcePath)

--- a/pkg/odo/cli/component/create_methods.go
+++ b/pkg/odo/cli/component/create_methods.go
@@ -1,12 +1,12 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/zalando/go-keyring"
 
 	"github.com/redhat-developer/odo/pkg/catalog"
@@ -279,7 +279,7 @@ func validateAndFetchRegistry(registryName string) (catalog.DevfileComponentType
 			return catalog.DevfileComponentTypeList{}, fmt.Errorf("failed to get registry: %w", e)
 		}
 		if len(registryList) == 0 {
-			return catalog.DevfileComponentTypeList{}, errors.Errorf("registry %s doesn't exist, please specify a valid registry via --registry", registryName)
+			return catalog.DevfileComponentTypeList{}, fmt.Errorf("registry %s doesn't exist, please specify a valid registry via --registry", registryName)
 		}
 		registryExistSpinner.End(true)
 	}
@@ -292,7 +292,7 @@ func validateAndFetchRegistry(registryName string) (catalog.DevfileComponentType
 	}
 
 	if registryName != "" && catalogDevfileList.Items == nil {
-		return catalog.DevfileComponentTypeList{}, errors.Errorf("can't create devfile component from registry %s", registryName)
+		return catalog.DevfileComponentTypeList{}, fmt.Errorf("can't create devfile component from registry %s", registryName)
 	}
 
 	if len(catalogDevfileList.DevfileRegistries) == 0 {

--- a/pkg/odo/cli/component/create_methods.go
+++ b/pkg/odo/cli/component/create_methods.go
@@ -193,11 +193,11 @@ func (hcm HTTPCreateMethod) FetchDevfileAndCreateComponent(co *CreateOptions, cm
 	}
 	devfileData, err := util.DownloadFileInMemory(params)
 	if err != nil {
-		return errors.Wrapf(err, "failed to download devfile for devfile component from %s", co.devfileMetadata.devfilePath.value)
+		return fmt.Errorf("failed to download devfile for devfile component from %s: %w", co.devfileMetadata.devfilePath.value, err)
 	}
 	err = ioutil.WriteFile(co.DevfilePath, devfileData, 0644) // #nosec G306
 	if err != nil {
-		return errors.Wrapf(err, "unable to save devfile to %s", co.DevfilePath)
+		return fmt.Errorf("unable to save devfile to %s: %w", co.DevfilePath, err)
 	}
 	devfileSpinner.End(true)
 
@@ -228,11 +228,11 @@ func (fcm FileCreateMethod) FetchDevfileAndCreateComponent(co *CreateOptions, cm
 	defer devfileSpinner.End(false)
 	devfileData, err := ioutil.ReadFile(co.devfileMetadata.devfilePath.value)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read devfile from %s", co.devfileMetadata.devfilePath)
+		return fmt.Errorf("failed to read devfile from %s: %w", co.devfileMetadata.devfilePath, err)
 	}
 	err = ioutil.WriteFile(co.DevfilePath, devfileData, 0644) // #nosec G306
 	if err != nil {
-		return errors.Wrapf(err, "unable to save devfile to %s", co.DevfilePath)
+		return fmt.Errorf("unable to save devfile to %s: %w", co.DevfilePath, (err)
 	}
 	devfileSpinner.End(true)
 

--- a/pkg/odo/cli/component/create_methods.go
+++ b/pkg/odo/cli/component/create_methods.go
@@ -232,7 +232,7 @@ func (fcm FileCreateMethod) FetchDevfileAndCreateComponent(co *CreateOptions, cm
 	}
 	err = ioutil.WriteFile(co.DevfilePath, devfileData, 0644) // #nosec G306
 	if err != nil {
-		return fmt.Errorf("unable to save devfile to %s: %w", co.DevfilePath, (err)
+		return fmt.Errorf("unable to save devfile to %s: %w", co.DevfilePath, err)
 	}
 	devfileSpinner.End(true)
 
@@ -276,7 +276,7 @@ func validateAndFetchRegistry(registryName string) (catalog.DevfileComponentType
 		defer registryExistSpinner.End(false)
 		registryList, e := catalogClient.GetDevfileRegistries(registryName)
 		if e != nil {
-			return catalog.DevfileComponentTypeList{}, errors.Wrap(e, "failed to get registry")
+			return catalog.DevfileComponentTypeList{}, fmt.Errorf("failed to get registry: %w", e)
 		}
 		if len(registryList) == 0 {
 			return catalog.DevfileComponentTypeList{}, errors.Errorf("registry %s doesn't exist, please specify a valid registry via --registry", registryName)
@@ -338,7 +338,7 @@ func fetchDevfileFromRegistry(registry catalog.Registry, devfileLink, devfilePat
 			var token string
 			token, err = keyring.Get(fmt.Sprintf("%s%s", dfutil.CredentialPrefix, registry.Name), registryUtil.RegistryUser)
 			if err != nil {
-				return errors.Wrap(err, "unable to get secure registry credential from keyring")
+				return fmt.Errorf("unable to get secure registry credential from keyring: %w", err)
 			}
 			params.Token = token
 		}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -1,12 +1,11 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilefs "github.com/devfile/library/pkg/testingutil/filesystem"
@@ -107,7 +106,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	// Start or update the component
 	err = devfileHandler.Push(pushParams)
 	if err != nil {
-		err = errors.Errorf("Failed to start component with name %q. Error: %v",
+		err = fmt.Errorf("Failed to start component with name %q. Error: %w",
 			componentName,
 			err,
 		)

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,13 +66,13 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	// Set the source path to either the context or current working directory (if context not set)
 	po.sourcePath, err = dfutil.GetAbsPath(po.componentContext)
 	if err != nil {
-		return errors.Wrap(err, "unable to get source path")
+		return fmt.Errorf("unable to get source path: %w", err)
 	}
 
 	// Apply ignore information
 	err = genericclioptions.ApplyIgnore(&po.ignoreFlag, po.sourcePath)
 	if err != nil {
-		return errors.Wrap(err, "unable to apply ignore information")
+		return fmt.Errorf("unable to apply ignore information: %w", err)
 	}
 
 	var platformContext interface{}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -1,13 +1,13 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
@@ -124,7 +124,7 @@ func (lo *ListOptions) Validate() (err error) {
 
 // ThrowContextError prints a context error if application/project is not found
 func throwContextError() error {
-	return errors.Errorf(`Please specify the application name and project name
+	return errors.New(`Please specify the application name and project name
 Or use the command from inside a directory containing an odo component.`)
 }
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -105,7 +105,7 @@ func (po *PushOptions) Complete(cmdline cmdline.Cmdline, args []string) (err err
 
 	po.Devfile, err = devfile.ParseAndValidateFromFile(po.DevfilePath)
 	if err != nil {
-		return errors.Wrap(err, "unable to parse devfile")
+		return fmt.Errorf("unable to parse devfile: %w", err)
 	}
 	err = validate.ValidateDevfileData(po.Devfile.Data)
 	if err != nil {
@@ -115,7 +115,7 @@ func (po *PushOptions) Complete(cmdline cmdline.Cmdline, args []string) (err err
 	// We retrieve the configuration information. If this does not exist, then BLANK is returned (important!).
 	envFileInfo, err := envinfo.NewEnvSpecificInfo(po.componentContext)
 	if err != nil {
-		return errors.Wrap(err, "unable to retrieve configuration information")
+		return fmt.Errorf("unable to retrieve configuration information: %w", err)
 	}
 
 	err = po.setupEnvFile(envFileInfo, cmdline, args)
@@ -157,7 +157,7 @@ func (po *PushOptions) setupEnvFile(envFileInfo *envinfo.EnvSpecificInfo, cmdlin
 		// either cmd commands or the current default kubernetes namespace
 		namespace, err := retrieveCmdNamespace(cmdline)
 		if err != nil {
-			return errors.Wrap(err, "unable to determine target namespace for the component")
+			return fmt.Errorf("unable to determine target namespace for the component: %w", err)
 		}
 
 		if err = checkDefaultProject(kc, namespace); err != nil {
@@ -175,14 +175,14 @@ func (po *PushOptions) setupEnvFile(envFileInfo *envinfo.EnvSpecificInfo, cmdlin
 		} else {
 			name, err = GatherName(po.Devfile, po.DevfilePath)
 			if err != nil {
-				return errors.Wrap(err, "unable to gather a name to apply to the env.yaml file")
+				return fmt.Errorf("unable to gather a name to apply to the env.yaml file: %w", err)
 			}
 		}
 
 		// Create the environment file. This will actually *create* the env.yaml file in your context directory.
 		err = envFileInfo.SetComponentSettings(envinfo.ComponentSettings{Name: name, Project: namespace, AppName: "app"})
 		if err != nil {
-			return errors.Wrap(err, "failed to create env.yaml for devfile component")
+			return fmt.Errorf("failed to create env.yaml for devfile component: %w", err)
 		}
 
 	} else if envFileInfo.GetNamespace() == "" {
@@ -191,7 +191,7 @@ func (po *PushOptions) setupEnvFile(envFileInfo *envinfo.EnvSpecificInfo, cmdlin
 		// and write it to the env.yaml
 		namespace, err := retrieveCmdNamespace(cmdline)
 		if err != nil {
-			return errors.Wrap(err, "unable to determine target namespace for devfile")
+			return fmt.Errorf("unable to determine target namespace for devfile: %w", err)
 		}
 		if err = checkDefaultProject(kc, namespace); err != nil {
 			return err
@@ -199,7 +199,7 @@ func (po *PushOptions) setupEnvFile(envFileInfo *envinfo.EnvSpecificInfo, cmdlin
 
 		err = envFileInfo.SetConfiguration("project", namespace)
 		if err != nil {
-			return errors.Wrap(err, "failed to write the project to the env.yaml for devfile component")
+			return fmt.Errorf("failed to write the project to the env.yaml for devfile component: %w", err)
 		}
 	} else if envFileInfo.GetNamespace() == "default" {
 		if err := checkDefaultProject(kc, envFileInfo.GetNamespace()); err != nil {
@@ -210,7 +210,7 @@ func (po *PushOptions) setupEnvFile(envFileInfo *envinfo.EnvSpecificInfo, cmdlin
 	if envFileInfo.GetApplication() == "" {
 		err := envFileInfo.SetConfiguration("app", "")
 		if err != nil {
-			return errors.Wrap(err, "failed to write the app to the env.yaml for devfile component")
+			return fmt.Errorf("failed to write the app to the env.yaml for devfile component: %w", err)
 		}
 	}
 	return nil
@@ -272,7 +272,7 @@ func checkDefaultProject(client kclient.ClientInterface, name string) error {
 	projectSupported, err := client.IsProjectSupported()
 
 	if err != nil {
-		return errors.Wrap(err, "resource project validation check failed.")
+		return fmt.Errorf("resource project validation check failed.: %w", err)
 	}
 
 	if projectSupported && name == "default" {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -14,7 +15,6 @@ import (
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/devfile/library/pkg/devfile/parser"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/devfile"
 	projectCmd "github.com/redhat-developer/odo/pkg/odo/cli/project"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -1,11 +1,11 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/odo/pkg/devfile/location"

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -79,23 +79,23 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 
 	envFileInfo, err := envinfo.NewEnvSpecificInfo(o.contextDir)
 	if err != nil {
-		return errors.Wrap(err, "unable to retrieve configuration information")
+		return fmt.Errorf("unable to retrieve configuration information: %w", err)
 	}
 	if !envFileInfo.Exists() {
 		var cmpName string
 		cmpName, err = component.GatherName(o.EnvSpecificInfo.GetDevfileObj(), o.GetDevfilePath())
 		if err != nil {
-			return errors.Wrap(err, "unable to retrieve component name")
+			return fmt.Errorf("unable to retrieve component name: %w", err)
 		}
 		err = envFileInfo.SetComponentSettings(envinfo.ComponentSettings{Name: cmpName, Project: o.GetProject(), AppName: "app"})
 		if err != nil {
-			return errors.Wrap(err, "failed to write new env.yaml file")
+			return fmt.Errorf("failed to write new env.yaml file: %w", err)
 		}
 
 	} else if envFileInfo.GetComponentSettings().Project != o.GetProject() {
 		err = envFileInfo.SetConfiguration("project", o.GetProject())
 		if err != nil {
-			return errors.Wrap(err, "failed to update project in env.yaml file")
+			return fmt.Errorf("failed to update project in env.yaml file: %w", err)
 		}
 	}
 

--- a/pkg/odo/cli/preference/registry/add.go
+++ b/pkg/odo/cli/preference/registry/add.go
@@ -6,7 +6,6 @@ import (
 
 	// Third-party packages
 	dfutil "github.com/devfile/library/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -94,7 +93,7 @@ func (o *AddOptions) Run() (err error) {
 	if o.tokenFlag != "" {
 		err = keyring.Set(dfutil.CredentialPrefix+o.registryName, o.user, o.tokenFlag)
 		if err != nil {
-			return errors.Wrap(err, "unable to store registry credential to keyring")
+			return fmt.Errorf("unable to store registry credential to keyring: %w", err)
 		}
 	}
 

--- a/pkg/odo/cli/preference/registry/delete.go
+++ b/pkg/odo/cli/preference/registry/delete.go
@@ -6,7 +6,6 @@ import (
 
 	// Third-party packages
 	dfutil "github.com/devfile/library/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -79,7 +78,7 @@ func (o *DeleteOptions) Run() (err error) {
 	if isSecure {
 		err = keyring.Delete(dfutil.CredentialPrefix+o.registryName, o.user)
 		if err != nil {
-			return errors.Wrap(err, "unable to delete registry credential from keyring")
+			return fmt.Errorf("unable to delete registry credential from keyring: %w", err)
 		}
 	}
 

--- a/pkg/odo/cli/preference/registry/update.go
+++ b/pkg/odo/cli/preference/registry/update.go
@@ -6,7 +6,6 @@ import (
 
 	// Third-party packages
 	dfutil "github.com/devfile/library/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -99,12 +98,12 @@ func (o *UpdateOptions) Run() (err error) {
 	if secureAfterUpdate {
 		err = keyring.Set(dfutil.CredentialPrefix+o.registryName, o.user, o.tokenFlag)
 		if err != nil {
-			return errors.Wrap(err, "unable to store registry credential to keyring")
+			return fmt.Errorf("unable to store registry credential to keyring: %w", err)
 		}
 	} else if secureBeforeUpdate && !secureAfterUpdate {
 		err = keyring.Delete(dfutil.CredentialPrefix+o.registryName, o.user)
 		if err != nil {
-			return errors.Wrap(err, "unable to delete registry credential from keyring")
+			return fmt.Errorf("unable to delete registry credential from keyring: %w", err)
 		}
 	}
 

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -1,6 +1,7 @@
 package preference
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/preference"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -179,7 +178,7 @@ func (o *CreateOptions) Run() (err error) {
 		o.EnvSpecificInfo = o.Context.EnvSpecificInfo
 		err = o.DevfilePush()
 		if err != nil {
-			return errors.Wrap(err, "failed to push changes")
+			return fmt.Errorf("failed to push changes: %w", err)
 		}
 	} else {
 		log.Italic("\nTo apply the URL configuration changes, please use `odo push`")

--- a/pkg/odo/cli/version/notify.go
+++ b/pkg/odo/cli/version/notify.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 
 	dfutil "github.com/devfile/library/pkg/util"
 )
@@ -26,7 +25,7 @@ func getLatestReleaseTag() (string, error) {
 	// Make request and cache response for 60 minutes
 	body, err := dfutil.HTTPGetRequest(request, 60)
 	if err != nil {
-		return "", errors.Wrap(err, "error getting latest release")
+		return "", fmt.Errorf("error getting latest release: %w", err)
 	}
 
 	return strings.TrimSuffix(string(body), "\n"), nil
@@ -42,7 +41,7 @@ func checkLatestReleaseTag(currentVersion string) (string, error) {
 
 	latestTag, err := getLatestReleaseTag()
 	if err != nil {
-		return "", errors.Wrap(err, "unable to get latest release tag")
+		return "", fmt.Errorf("unable to get latest release tag: %w", err)
 	}
 
 	latestSemver, err := semver.Make(strings.TrimPrefix(latestTag, "v"))

--- a/pkg/odo/cli/version/notify.go
+++ b/pkg/odo/cli/version/notify.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/blang/semver"
@@ -36,7 +37,7 @@ func getLatestReleaseTag() (string, error) {
 func checkLatestReleaseTag(currentVersion string) (string, error) {
 	currentSemver, err := semver.Make(strings.TrimPrefix(currentVersion, "v"))
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to make semver from the current version: %v", currentVersion)
+		return "", fmt.Errorf("unable to make semver from the current version: %v: %w", currentVersion, err)
 	}
 
 	latestTag, err := getLatestReleaseTag()
@@ -46,7 +47,7 @@ func checkLatestReleaseTag(currentVersion string) (string, error) {
 
 	latestSemver, err := semver.Make(strings.TrimPrefix(latestTag, "v"))
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to make semver from the latest release tag: %v", latestTag)
+		return "", fmt.Errorf("unable to make semver from the latest release tag: %v: %w", latestTag, err)
 	}
 
 	if currentSemver.LT(latestSemver) {

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	commonutil "github.com/redhat-developer/odo/pkg/util"
@@ -74,7 +73,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	captureSignals := []os.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}
 	go commonutil.StartSignalWatcher(captureSignals, func(receivedSignal os.Signal) {
 		scontext.SetSignal(cmd.Context(), receivedSignal)
-		startTelemetry(cmd, errors.Wrapf(terminal.InterruptErr, "user interrupted the command execution"), startTime)
+		startTelemetry(cmd, fmt.Errorf("user interrupted the command execution: %w", terminal.InterruptErr), startTime)
 	})
 
 	// CheckMachineReadableOutput

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -8,14 +8,13 @@ import (
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // LogErrorAndExit prints the cause of the given error and exits the code with an
 // exit code of 1.
 // If the context is provided, then that is printed, if not, then the cause is
-// detected using errors.Cause(err)
+// displayed
 // *If* we are using the global json parameter, we instead output the json output
 func LogErrorAndExit(err error, context string, a ...interface{}) {
 
@@ -38,7 +37,7 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 
 		} else {
 			if context == "" {
-				log.Error(errors.Cause(err))
+				log.Error(err)
 			} else {
 				printstring := fmt.Sprintf("%s%s", strings.Title(context), "\nError: %v")
 				log.Errorf(printstring, err)

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -11,10 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// LogErrorAndExit prints the cause of the given error and exits the code with an
-// exit code of 1.
-// If the context is provided, then that is printed, if not, then the cause is
-// displayed
+// LogErrorAndExit prints the given error and exits the code with an exit code of 1.
+// If the context is provided, then that is printed alongside the error.
 // *If* we are using the global json parameter, we instead output the json output
 func LogErrorAndExit(err error, context string, a ...interface{}) {
 

--- a/pkg/preference/implem.go
+++ b/pkg/preference/implem.go
@@ -1,14 +1,13 @@
 package preference
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
@@ -187,7 +186,7 @@ func (c *preferenceInfo) RegistryHandler(operation string, registryName string, 
 	c.OdoSettings.RegistryList = &registryList
 	err = util.WriteToFile(&c.Preference, c.Filename)
 	if err != nil {
-		return errors.Errorf("unable to write the configuration of %q operation to preference file", operation)
+		return fmt.Errorf("unable to write the configuration of %q operation to preference file", operation)
 	}
 
 	return nil
@@ -205,7 +204,7 @@ func handleWithoutRegistryExist(registryList []Registry, operation string, regis
 		registryList = append(registryList, registry)
 
 	case "update", "delete":
-		return nil, errors.Errorf("failed to %v registry: registry %q doesn't exist", operation, registryName)
+		return nil, fmt.Errorf("failed to %v registry: registry %q doesn't exist", operation, registryName)
 	}
 
 	return registryList, nil
@@ -215,7 +214,7 @@ func handleWithRegistryExist(index int, registryList []Registry, operation strin
 	switch operation {
 
 	case "add":
-		return nil, errors.Errorf("failed to add registry: registry %q already exists", registryName)
+		return nil, fmt.Errorf("failed to add registry: registry %q already exists", registryName)
 
 	case "update":
 		if !forceFlag {
@@ -256,61 +255,61 @@ func (c *preferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "timeout":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %q to %q", parameter, value)
+				return fmt.Errorf("unable to set %q to %q", parameter, value)
 			}
 			if typedval < 0 {
-				return errors.Errorf("cannot set timeout to less than 0")
+				return errors.New("cannot set timeout to less than 0")
 			}
 			c.OdoSettings.Timeout = &typedval
 
 		case "pushtimeout":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
+				return fmt.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
 			}
 			if typedval < 0 {
-				return errors.Errorf("cannot set timeout to less than 0")
+				return errors.New("cannot set timeout to less than 0")
 			}
 			c.OdoSettings.PushTimeout = &typedval
 
 		case "registrycachetime":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
+				return fmt.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
 			}
 			if typedval < 0 {
-				return errors.Errorf("cannot set timeout to less than 0")
+				return errors.New("cannot set timeout to less than 0")
 			}
 			c.OdoSettings.RegistryCacheTime = &typedval
 
 		case "updatenotification":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
+				return fmt.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.UpdateNotification = &val
 
 		case "ephemeral":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
+				return fmt.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.Ephemeral = &val
 
 		case "consenttelemetry":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
+				return fmt.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.ConsentTelemetry = &val
 		}
 	} else {
-		return errors.Errorf("unknown parameter : %q is not a parameter in odo preference, run `odo preference -h` to see list of available parameters", parameter)
+		return fmt.Errorf("unknown parameter : %q is not a parameter in odo preference, run `odo preference -h` to see list of available parameters", parameter)
 	}
 
 	err := util.WriteToFile(&c.Preference, c.Filename)
 	if err != nil {
-		return errors.Errorf("unable to set %q, something is wrong with odo, kindly raise an issue at https://github.com/redhat-developer/odo/issues/new?template=Bug.md", parameter)
+		return fmt.Errorf("unable to set %q, something is wrong with odo, kindly raise an issue at https://github.com/redhat-developer/odo/issues/new?template=Bug.md", parameter)
 	}
 	return nil
 }
@@ -324,12 +323,12 @@ func (c *preferenceInfo) DeleteConfiguration(parameter string) error {
 			return err
 		}
 	} else {
-		return errors.Errorf("unknown parameter :%q is not a parameter in the odo preference", parameter)
+		return fmt.Errorf("unknown parameter :%q is not a parameter in the odo preference", parameter)
 	}
 
 	err := util.WriteToFile(&c.Preference, c.Filename)
 	if err != nil {
-		return errors.Errorf("unable to set %q, something is wrong with odo, kindly raise an issue at https://github.com/redhat-developer/odo/issues/new?template=Bug.md", parameter)
+		return fmt.Errorf("unable to set %q, something is wrong with odo, kindly raise an issue at https://github.com/redhat-developer/odo/issues/new?template=Bug.md", parameter)
 	}
 	return nil
 }

--- a/pkg/project/kubernetes.go
+++ b/pkg/project/kubernetes.go
@@ -1,9 +1,8 @@
 package project
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
 )
@@ -22,7 +21,7 @@ func NewClient(client kclient.ClientInterface) Client {
 func (o kubernetesClient) SetCurrent(projectName string) error {
 	err := o.client.SetCurrentNamespace(projectName)
 	if err != nil {
-		return errors.Wrap(err, "unable to set current project to"+projectName)
+		return fmt.Errorf("unable to set current project to %s: %w", projectName, err)
 	}
 	return nil
 }
@@ -34,7 +33,7 @@ func (o kubernetesClient) SetCurrent(projectName string) error {
 // to be created in the namespace before returning
 func (o kubernetesClient) Create(projectName string, wait bool) error {
 	if projectName == "" {
-		return errors.Errorf("no project name given")
+		return errors.New("no project name given")
 	}
 
 	projectSupport, err := o.client.IsProjectSupported()
@@ -65,7 +64,7 @@ func (o kubernetesClient) Create(projectName string, wait bool) error {
 // with the name projectName and returns an error if any
 func (o kubernetesClient) Delete(projectName string, wait bool) error {
 	if projectName == "" {
-		return errors.Errorf("no project name given")
+		return errors.New("no project name given")
 	}
 
 	projectSupport, err := o.client.IsProjectSupported()

--- a/pkg/project/kubernetes.go
+++ b/pkg/project/kubernetes.go
@@ -39,7 +39,7 @@ func (o kubernetesClient) Create(projectName string, wait bool) error {
 
 	projectSupport, err := o.client.IsProjectSupported()
 	if err != nil {
-		return errors.Wrap(err, "unable to detect project support")
+		return fmt.Errorf("unable to detect project support: %w", err)
 	}
 
 	if projectSupport {
@@ -49,13 +49,13 @@ func (o kubernetesClient) Create(projectName string, wait bool) error {
 		_, err = o.client.CreateNamespace(projectName)
 	}
 	if err != nil {
-		return errors.Wrap(err, "unable to create new project")
+		return fmt.Errorf("unable to create new project: %w", err)
 	}
 
 	if wait {
 		err = o.client.WaitForServiceAccountInNamespace(projectName, "default")
 		if err != nil {
-			return errors.Wrap(err, "unable to wait for service account")
+			return fmt.Errorf("unable to wait for service account: %w", err)
 		}
 	}
 	return nil
@@ -70,7 +70,7 @@ func (o kubernetesClient) Delete(projectName string, wait bool) error {
 
 	projectSupport, err := o.client.IsProjectSupported()
 	if err != nil {
-		return errors.Wrap(err, "unable to detect project support")
+		return fmt.Errorf("unable to detect project support: %w", err)
 	}
 
 	if projectSupport {
@@ -90,7 +90,7 @@ func (o kubernetesClient) List() (ProjectList, error) {
 
 	projectSupport, err := o.client.IsProjectSupported()
 	if err != nil {
-		return ProjectList{}, errors.Wrap(err, "unable to detect project support")
+		return ProjectList{}, fmt.Errorf("unable to detect project support: %w", err)
 	}
 
 	var allProjects []string
@@ -100,7 +100,7 @@ func (o kubernetesClient) List() (ProjectList, error) {
 		allProjects, err = o.client.GetNamespaces()
 	}
 	if err != nil {
-		return ProjectList{}, errors.Wrap(err, "cannot get all the projects")
+		return ProjectList{}, fmt.Errorf("cannot get all the projects: %w", err)
 	}
 
 	projects := make([]Project, len(allProjects))
@@ -116,7 +116,7 @@ func (o kubernetesClient) List() (ProjectList, error) {
 func (o kubernetesClient) Exists(projectName string) (bool, error) {
 	projectSupport, err := o.client.IsProjectSupported()
 	if err != nil {
-		return false, errors.Wrap(err, "unable to detect project support")
+		return false, fmt.Errorf("unable to detect project support: %w", err)
 	}
 
 	if projectSupport {

--- a/pkg/project/kubernetes.go
+++ b/pkg/project/kubernetes.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
@@ -77,7 +79,7 @@ func (o kubernetesClient) Delete(projectName string, wait bool) error {
 		err = o.client.DeleteNamespace(projectName, wait)
 	}
 	if err != nil {
-		return errors.Wrapf(err, "unable to delete project %q", projectName)
+		return fmt.Errorf("unable to delete project %q: %w", projectName, err)
 	}
 	return nil
 }

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -2,10 +2,9 @@ package context
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
 
@@ -62,7 +61,7 @@ func SetClusterType(ctx context.Context, client kclient.ClientInterface) {
 		// it sometimes fails to retrieve the data if user is using minishift or plain oc cluster
 		isOC, err := client.IsProjectSupported()
 		if err != nil {
-			klog.V(3).Info(errors.Wrap(err, "unable to detect project support"))
+			klog.V(3).Info(fmt.Errorf("unable to detect project support: %w", err))
 			value = NOTFOUND
 		} else {
 			if isOC {

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -18,7 +19,6 @@ import (
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 
 	"github.com/pborman/uuid"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/preference"
 	"golang.org/x/term"
 	"gopkg.in/segmentio/analytics-go.v3"

--- a/pkg/service/crd_builder.go
+++ b/pkg/service/crd_builder.go
@@ -1,11 +1,11 @@
 package service
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
 	"github.com/go-openapi/spec"
-	"github.com/pkg/errors"
 )
 
 // BuildCRDFromParams iterates over the parameter maps provided by the user and builds the CRD

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -78,7 +78,7 @@ func ListOperatorServices(client kclient.ClientInterface) ([]unstructured.Unstru
 	}
 
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Unable to list operator backed services")
+		return nil, nil, fmt.Errorf("Unable to list operator backed services: %w", err)
 	}
 
 	var allCRInstances []unstructured.Unstructured

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"k8s.io/klog"
 
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/pkg/errors"
 	servicebinding "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 )
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -38,7 +38,7 @@ const ServiceKind = "app.kubernetes.io/service-kind"
 func DeleteOperatorService(client kclient.ClientInterface, serviceName string) error {
 	kind, name, err := SplitServiceKindName(serviceName)
 	if err != nil {
-		return errors.Wrapf(err, "Refer %q to see list of running services", serviceName)
+		return fmt.Errorf("Refer %q to see list of running services: %w", serviceName, err)
 	}
 
 	csv, err := client.GetCSVWithCR(kind)

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/devfile/library/pkg/devfile/generator"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	storagelabels "github.com/redhat-developer/odo/pkg/storage/labels"
 	v1 "k8s.io/api/apps/v1"
@@ -66,7 +65,7 @@ func (k kubernetesClient) Create(storage Storage) error {
 	klog.V(2).Infof("Creating a PVC with name %v and labels %v", pvcName, labels)
 	_, err = k.client.CreatePVC(*pvc)
 	if err != nil {
-		return errors.Wrap(err, "unable to create PVC")
+		return fmt.Errorf("unable to create PVC: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -53,7 +53,7 @@ func (k kubernetesClient) Create(storage Storage) error {
 
 	quantity, err := resource.ParseQuantity(storage.Spec.Size)
 	if err != nil {
-		return errors.Wrapf(err, "unable to parse size: %v", storage.Spec.Size)
+		return fmt.Errorf("unable to parse size: %v: %w", storage.Spec.Size, err)
 	}
 
 	pvcParams := generator.PVCParams{
@@ -81,7 +81,7 @@ func (k kubernetesClient) Delete(name string) error {
 	// delete the associated PVC with the component
 	err = k.client.DeletePVC(pvcName)
 	if err != nil {
-		return errors.Wrapf(err, "unable to delete PVC %v", pvcName)
+		return fmt.Errorf("unable to delete PVC %v: %w", pvcName, err)
 	}
 
 	return nil
@@ -146,7 +146,7 @@ func (k kubernetesClient) ListFromCluster() (StorageList, error) {
 
 	pvcs, err := k.client.ListPVCs(selector)
 	if err != nil {
-		return StorageList{}, errors.Wrapf(err, "unable to get PVC using selector %v", storagelabels.StorageLabel)
+		return StorageList{}, fmt.Errorf("unable to get PVC using selector %v: %w", storagelabels.StorageLabel, err)
 	}
 
 	// to track volume mounts used by a PVC

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,7 +1,8 @@
 package storage
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	applabels "github.com/redhat-developer/odo/pkg/application/labels"
 	"github.com/redhat-developer/odo/pkg/component/labels"
 	"github.com/redhat-developer/odo/pkg/kclient"
@@ -110,7 +111,7 @@ func Push(client Client, configProvider localConfigProvider.LocalConfigProvider)
 			continue
 		} else if storage.Name == val.Name {
 			if val.Spec.Size != storage.Spec.Size {
-				return nil, errors.Errorf("config mismatch for storage with the same name %s", storage.Name)
+				return nil, fmt.Errorf("config mismatch for storage with the same name %s", storage.Name)
 			}
 		}
 	}

--- a/pkg/storage/utils.go
+++ b/pkg/storage/utils.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/localConfigProvider"
 	storagelabels "github.com/redhat-developer/odo/pkg/storage/labels"
@@ -18,7 +17,7 @@ func getPVCNameFromStorageName(client kclient.ClientInterface, storageName strin
 	selector := util.ConvertLabelsToSelector(labels)
 	pvcs, err := client.ListPVCNames(selector)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to get PVC names for selector %v", selector)
+		return "", fmt.Errorf("unable to get PVC names for selector %v: %w", selector, err)
 	}
 	numPVCs := len(pvcs)
 	if numPVCs != 1 {
@@ -32,12 +31,12 @@ func generatePVCName(volName, componentName, appName string) (string, error) {
 
 	pvcName, err := util.NamespaceKubernetesObject(volName, componentName)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to create namespaced name")
+		return "", fmt.Errorf("unable to create namespaced name: %w", err)
 	}
 
 	pvcName, err = util.NamespaceKubernetesObject(pvcName, appName)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to create namespaced name")
+		return "", fmt.Errorf("unable to create namespaced name: %w", err)
 	}
 
 	return pvcName, nil

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -83,7 +83,7 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (bool, error) {
 		deletedFiles = pushParameters.WatchDeletedFiles
 		deletedFiles, err = dfutil.RemoveRelativePathFromFiles(deletedFiles, pushParameters.Path)
 		if err != nil {
-			return false, errors.Wrap(err, "unable to remove relative path from list of changed/deleted files")
+			return false, fmt.Errorf("unable to remove relative path from list of changed/deleted files: %w", err)
 		}
 		indexRegeneratedByWatch = true
 
@@ -100,7 +100,7 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (bool, error) {
 		if _, err := os.Stat(odoFolder); os.IsNotExist(err) {
 			err = os.Mkdir(odoFolder, 0750)
 			if err != nil {
-				return false, errors.Wrap(err, "unable to create directory")
+				return false, fmt.Errorf("unable to create directory: %w", err)
 			}
 		}
 
@@ -110,7 +110,7 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (bool, error) {
 		if syncParameters.PodChanged || !syncParameters.ComponentExists {
 			err := util.DeleteIndexFile(pushParameters.Path)
 			if err != nil {
-				return false, errors.Wrap(err, "unable to reset the index file")
+				return false, fmt.Errorf("unable to reset the index file: %w", err)
 			}
 		}
 
@@ -119,7 +119,7 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (bool, error) {
 		ret, err = util.RunIndexerWithRemote(pushParameters.Path, absIgnoreRules, pushParameters.IgnoredFiles, syncParameters.Files)
 
 		if err != nil {
-			return false, errors.Wrap(err, "unable to run indexer")
+			return false, fmt.Errorf("unable to run indexer: %w", err)
 		}
 
 		if len(ret.FilesChanged) > 0 || len(ret.FilesDeleted) > 0 {
@@ -211,7 +211,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 		klog.V(4).Infof("Copying files %s to pod", strings.Join(files, " "))
 		err = CopyFile(a.Client, path, compInfo, syncFolder, files, globExps, ret)
 		if err != nil {
-			return errors.Wrap(err, "unable push files to pod")
+			return fmt.Errorf("unable push files to pod: %w", err)
 		}
 	}
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -154,12 +154,12 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (bool, error) {
 		ret,
 	)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to sync to component with name %s", a.ComponentName)
+		return false, fmt.Errorf("failed to sync to component with name %s: %w", a.ComponentName, err)
 	}
 	if forceWrite {
 		err = util.WriteFile(ret.NewFileMap, ret.ResolvedPath)
 		if err != nil {
-			return false, errors.Wrapf(err, "Failed to write file")
+			return false, fmt.Errorf("Failed to write file: %w", err)
 		}
 	}
 
@@ -173,7 +173,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	// Edge case: check to see that the path is NOT empty.
 	emptyDir, err := dfutil.IsEmpty(path)
 	if err != nil {
-		return errors.Wrapf(err, "unable to check directory: %s", path)
+		return fmt.Errorf("unable to check directory: %s: %w", path, err)
 	} else if emptyDir {
 		return errors.New(fmt.Sprintf("directory/file %s is empty", path))
 	}
@@ -224,7 +224,7 @@ func updateIndexWithWatchChanges(pushParameters common.PushParameters) error {
 	indexFilePath, err := util.ResolveIndexFilePath(pushParameters.Path)
 
 	if err != nil {
-		return errors.Wrapf(err, "unable to resolve path: %s", pushParameters.Path)
+		return fmt.Errorf("unable to resolve path: %s: %w", pushParameters.Path, err)
 	}
 
 	// Check that the path exists
@@ -236,13 +236,13 @@ func updateIndexWithWatchChanges(pushParameters common.PushParameters) error {
 		//
 		// If you see this error it means somehow watch's SyncFiles was called without the index being first generated (likely because the
 		// above mentioned pushParam wasn't set). See SyncFiles(...) for details.
-		return errors.Wrapf(err, "resolved path doesn't exist: %s", indexFilePath)
+		return fmt.Errorf("resolved path doesn't exist: %s: %w", indexFilePath, err)
 	}
 
 	// Parse the existing index
 	fileIndex, err := util.ReadFileIndex(indexFilePath)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to read index from path: %s", indexFilePath)
+		return fmt.Errorf("Unable to read index from path: %s: %w", indexFilePath, err)
 	}
 
 	rootDir := pushParameters.Path

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/devfile/library/pkg/devfile/generator"
 	dfutil "github.com/devfile/library/pkg/util"
 
@@ -175,7 +173,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	if err != nil {
 		return fmt.Errorf("unable to check directory: %s: %w", path, err)
 	} else if emptyDir {
-		return errors.New(fmt.Sprintf("directory/file %s is empty", path))
+		return fmt.Errorf("directory/file %s is empty", path)
 	}
 
 	// Sync the files to the pod

--- a/pkg/testingutil/fileutils.go
+++ b/pkg/testingutil/fileutils.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // TempMkdir creates a temporary directory
@@ -14,7 +12,7 @@ func TempMkdir(parentDir string, newDirPrefix string) (string, error) {
 	parentDir = filepath.FromSlash(parentDir)
 	dir, err := ioutil.TempDir(parentDir, newDirPrefix)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create dir with prefix %s in directory %s", newDirPrefix, parentDir)
+		return "", fmt.Errorf("failed to create dir with prefix %s in directory %s: %w", newDirPrefix, parentDir, err)
 	}
 	return dir, nil
 }
@@ -24,7 +22,7 @@ func TempMkFile(dir string, fileName string) (string, error) {
 	dir = filepath.FromSlash(dir)
 	f, err := ioutil.TempFile(dir, fileName)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create test file %s in dir %s", fileName, dir)
+		return "", fmt.Errorf("failed to create test file %s in dir %s: %w", fileName, dir, err)
 	}
 	if err := f.Close(); err != nil {
 		return "", err

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -48,14 +48,14 @@ func (k kubernetesClient) ListFromCluster() (URLList, error) {
 	klog.V(4).Infof("Listing ingresses with label selector: %v", labelSelector)
 	ingresses, err := k.client.ListIngresses(labelSelector)
 	if err != nil {
-		return URLList{}, errors.Wrap(err, "unable to list ingress")
+		return URLList{}, fmt.Errorf("unable to list ingress: %w", err)
 	}
 
 	var routes []routev1.Route
 	if k.isRouteSupported {
 		routes, err = k.client.ListRoutes(labelSelector)
 		if err != nil {
-			return URLList{}, errors.Wrap(err, "unable to list routes")
+			return URLList{}, fmt.Errorf("unable to list routes: %w", err)
 		}
 	}
 
@@ -82,7 +82,7 @@ func (k kubernetesClient) List() (URLList, error) {
 	if k.client != nil {
 		clusterURLs, err = k.ListFromCluster()
 		if err != nil {
-			return URLList{}, errors.Wrap(err, "unable to list routes")
+			return URLList{}, fmt.Errorf("unable to list routes: %w", err)
 		}
 	}
 
@@ -251,7 +251,7 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 				}
 				secret, e := k.client.CreateTLSSecret(selfSignedCert.CertPem, selfSignedCert.KeyPem, objectMeta)
 				if e != nil {
-					return "", errors.Wrap(e, "unable to create tls secret")
+					return "", fmt.Errorf("unable to create tls secret: %w", e)
 				}
 				url.Spec.TLSSecret = secret.Name
 			} else if err != nil {
@@ -325,7 +325,7 @@ func (k kubernetesClient) createRoute(url URL, labels map[string]string) (string
 		if kerrors.IsAlreadyExists(err) {
 			return "", fmt.Errorf("url named %q already exists in the same app named %q", url.Name, k.appName)
 		}
-		return "", errors.Wrap(err, "unable to create route")
+		return "", fmt.Errorf("unable to create route: %w", err)
 	}
 	return GetURLString(GetProtocol(*route, iextensionsv1.Ingress{}), route.Spec.Host, ""), nil
 }

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -303,7 +303,7 @@ func (k kubernetesClient) createRoute(url URL, labels map[string]string) (string
 	suffix := util.GetAdler32Value(url.Name + k.appName + k.componentName)
 	routeName, err := dfutil.NamespaceOpenShiftObject(url.Name, suffix)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to create namespaced name")
+		return "", fmt.Errorf("unable to create namespaced name: %w", err)
 	}
 
 	if k.deployment == nil {

--- a/pkg/util/config_util.go
+++ b/pkg/util/config_util.go
@@ -39,7 +39,7 @@ func CreateIfNotExists(configFile string) error {
 func GetFromFile(c interface{}, filename string) error {
 	configData, err := filesystem.Get().ReadFile(filename)
 	if err != nil {
-		return errors.Wrapf(err, "unable to read file %v", filename)
+		return fmt.Errorf("unable to read file %v: %w", filename, err)
 	}
 
 	err = yaml.Unmarshal(configData, c)
@@ -62,7 +62,7 @@ func WriteToFile(c interface{}, filename string) error {
 	}
 	err = ioutil.WriteFile(filename, data, 0600)
 	if err != nil {
-		return errors.Wrapf(err, "unable to write config to file %v", c)
+		return fmt.Errorf("unable to write config to file %v: %w", c, err)
 	}
 
 	return nil

--- a/pkg/util/config_util.go
+++ b/pkg/util/config_util.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 	"gopkg.in/yaml.v2"
 )
@@ -19,7 +18,7 @@ func CreateIfNotExists(configFile string) error {
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(filepath.Dir(configFile), 0750)
 		if err != nil {
-			return errors.Wrap(err, "unable to create directory")
+			return fmt.Errorf("unable to create directory: %w", err)
 		}
 	}
 	// Check whether config file is present or not
@@ -27,7 +26,7 @@ func CreateIfNotExists(configFile string) error {
 	if os.IsNotExist(err) {
 		file, err := os.Create(configFile)
 		if err != nil {
-			return errors.Wrap(err, "unable to create config file")
+			return fmt.Errorf("unable to create config file: %w", err)
 		}
 		defer file.Close() // #nosec G307
 	}
@@ -44,7 +43,7 @@ func GetFromFile(c interface{}, filename string) error {
 
 	err = yaml.Unmarshal(configData, c)
 	if err != nil {
-		return errors.Wrap(err, "unable to unmarshal odo config file")
+		return fmt.Errorf("unable to unmarshal odo config file: %w", err)
 	}
 
 	return nil
@@ -54,7 +53,7 @@ func GetFromFile(c interface{}, filename string) error {
 func WriteToFile(c interface{}, filename string) error {
 	data, err := yaml.Marshal(c)
 	if err != nil {
-		return errors.Wrap(err, "unable to marshal odo config data")
+		return fmt.Errorf("unable to marshal odo config data: %w", err)
 	}
 
 	if err = CreateIfNotExists(filename); err != nil {

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	dfutil "github.com/devfile/library/pkg/util"
 
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
@@ -125,7 +123,7 @@ func touchGitIgnoreFile(directory string, fs filesystem.Filesystem) (string, err
 	if _, err := fs.Stat(gitIgnoreFile); os.IsNotExist(err) {
 		file, err := fs.OpenFile(gitIgnoreFile, os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {
-			return gitIgnoreFile, errors.Wrap(err, "failed to create .gitignore file")
+			return gitIgnoreFile, fmt.Errorf("failed to create .gitignore file: %w", err)
 		}
 		file.Close()
 	}

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -363,7 +363,7 @@ func runIndexerWithExistingFileIndex(directory string, ignoreRules []string, rem
 				// check the *absolute* path to the file for glob rules
 				fileAbsolutePath, err := dfutil.GetAbsPath(filepath.Join(directory, fileName))
 				if err != nil {
-					return ret, errors.Wrapf(err, "unable to retrieve absolute path of file %s", fileName)
+					return ret, fmt.Errorf("unable to retrieve absolute path of file %s: %w", fileName, err)
 				}
 
 				ignoreMatcher := gitignore.CompileIgnoreLines(ignoreRules...)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	devfilefs "github.com/devfile/library/pkg/testingutil/filesystem"
 	"hash/adler32"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/go-git/go-git/v5"
-	"github.com/pkg/errors"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	dfutil "github.com/devfile/library/pkg/util"
@@ -204,7 +204,7 @@ func IsValidProjectDir(path string, devfilePath string) error {
 				return nil
 			}
 		}
-		return errors.Errorf("Folder %s doesn't contain the devfile used.", path)
+		return fmt.Errorf("Folder %s doesn't contain the devfile used.", path)
 	}
 
 	return nil
@@ -216,7 +216,7 @@ func IsValidProjectDir(path string, devfilePath string) error {
 // TODO(feloy) sync with devfile library?
 func GetAndExtractZip(zipURL string, destination string, pathToUnzip string, starterToken string) error {
 	if zipURL == "" {
-		return errors.Errorf("Empty zip url: %s", zipURL)
+		return fmt.Errorf("Empty zip url: %s", zipURL)
 	}
 
 	var pathToZip string
@@ -249,7 +249,7 @@ func GetAndExtractZip(zipURL string, destination string, pathToUnzip string, sta
 			}
 		}()
 	} else {
-		return errors.Errorf("Invalid Zip URL: %s . Should either be prefixed with file://, http:// or https://", zipURL)
+		return fmt.Errorf("Invalid Zip URL: %s . Should either be prefixed with file://, http:// or https://", zipURL)
 	}
 
 	filenames, err := Unzip(pathToZip, destination, pathToUnzip)
@@ -451,7 +451,7 @@ func addFileToIgnoreFile(gitIgnoreFile, filename string, fs filesystem.Filesyste
 	defer file.Close()
 
 	if data, err = fs.ReadFile(gitIgnoreFile); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed reading data from %v file", gitIgnoreFile))
+		return fmt.Errorf("failed reading data from %v file: %w", gitIgnoreFile, err)
 	}
 	// check whether .odo/odo-file-index.json is already in the .gitignore file
 	if !strings.Contains(string(data), filename) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -456,7 +456,7 @@ func addFileToIgnoreFile(gitIgnoreFile, filename string, fs filesystem.Filesyste
 	// check whether .odo/odo-file-index.json is already in the .gitignore file
 	if !strings.Contains(string(data), filename) {
 		if _, err := file.WriteString("\n" + filename); err != nil {
-			return errors.Wrapf(err, "failed to add %v to %v file", filepath.Base(filename), gitIgnoreFile)
+			return fmt.Errorf("failed to add %v to %v file: %w", filepath.Base(filename), gitIgnoreFile, err)
 		}
 	}
 	return nil
@@ -486,7 +486,7 @@ func DisplayLog(followLog bool, rd io.ReadCloser, writer io.Writer, compName str
 		}()
 
 		if _, err = io.Copy(writer, rd); err != nil {
-			return errors.Wrapf(err, "error followLoging logs for %s", compName)
+			return fmt.Errorf("error followLoging logs for %s: %w", compName, err)
 		}
 
 	} else if numberOfLastLines == -1 {
@@ -494,12 +494,12 @@ func DisplayLog(followLog bool, rd io.ReadCloser, writer io.Writer, compName str
 		buf := new(bytes.Buffer)
 		_, err = io.Copy(buf, rd)
 		if err != nil {
-			return errors.Wrapf(err, "unable to copy followLog to buffer")
+			return fmt.Errorf("unable to copy followLog to buffer: %w", err)
 		}
 
 		// Copy to stdout
 		if _, err = io.Copy(writer, buf); err != nil {
-			return errors.Wrapf(err, "error copying logs to stdout")
+			return fmt.Errorf("error copying logs to stdout: %w", err)
 		}
 	} else {
 		reader := bufio.NewReader(rd)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -446,7 +446,7 @@ func addFileToIgnoreFile(gitIgnoreFile, filename string, fs filesystem.Filesyste
 	var data []byte
 	file, err := fs.OpenFile(gitIgnoreFile, os.O_APPEND|os.O_RDWR, dfutil.ModeReadWriteFile)
 	if err != nil {
-		return errors.Wrap(err, "failed to open .gitignore file")
+		return fmt.Errorf("failed to open .gitignore file: %w", err)
 	}
 	defer file.Close()
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
-	"github.com/pkg/errors"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	dfutil "github.com/devfile/library/pkg/util"
@@ -492,12 +491,12 @@ func TestGetHostWithPort(t *testing.T) {
 func MakeFileWithContent(dir string, fileName string, content string) error {
 	file, err := os.Create(dir + string(os.PathSeparator) + fileName)
 	if err != nil {
-		return errors.Wrapf(err, "error while creating file")
+		return fmt.Errorf("error while creating file: %w", err)
 	}
 	defer file.Close()
 	_, err = file.WriteString(content)
 	if err != nil {
-		return errors.Wrapf(err, "error while writing to file")
+		return fmt.Errorf("error while writing to file: %w", err)
 	}
 	return nil
 }

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -83,7 +83,7 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, path string, ignores []string)
 	if mode.IsRegular() {
 		matched, e := dfutil.IsGlobExpMatch(path, ignores)
 		if e != nil {
-			return errors.Wrapf(e, "unable to watcher on %s", path)
+			return fmt.Errorf("unable to watcher on %s: %w", path, e)
 		}
 		if !matched {
 			klog.V(4).Infof("adding watch on path %s", path)
@@ -109,14 +109,14 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, path string, ignores []string)
 				klog.V(4).Infof("Walk func received an error for path %s, but the path doesn't exist so this is likely not an error. err: %v", path, err)
 				return nil
 			}
-			return errors.Wrapf(err, "unable to walk path: %s", newPath)
+			return fmt.Errorf("unable to walk path: %s: %w", newPath, err)
 		}
 
 		if info.IsDir() {
 			// If the current directory matches any of the ignore patterns, ignore them so that their contents are also not ignored
 			matched, err := dfutil.IsGlobExpMatch(newPath, ignores)
 			if err != nil {
-				return errors.Wrapf(err, "unable to addRecursiveWatch on %s", newPath)
+				return fmt.Errorf("unable to addRecursiveWatch on %s: %w", newPath, err)
 			}
 			if matched {
 				klog.V(4).Infof("ignoring watch on path %s", newPath)
@@ -319,7 +319,7 @@ func (o *WatchClient) WatchAndPush(out io.Writer, parameters WatchParameters) er
 				fmt.Fprintf(out, "Pushing files...\n")
 				fileInfo, err := os.Stat(parameters.Path)
 				if err != nil {
-					return errors.Wrapf(err, "%s: file doesn't exist", parameters.Path)
+					return fmt.Errorf("%s: file doesn't exist: %w", parameters.Path, err)
 				}
 				if fileInfo.IsDir() {
 					klog.V(4).Infof("Copying files %s to pod", changedFiles)

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/pkg/errors"
 
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/envinfo"
@@ -223,7 +222,7 @@ func (o *WatchClient) WatchAndPush(out io.Writer, parameters WatchParameters) er
 				matched, globErr := dfutil.IsGlobExpMatch(event.Name, parameters.FileIgnores)
 				klog.V(4).Infof("Matching %s with %s. Matched %v, err: %v", event.Name, parameters.FileIgnores, matched, globErr)
 				if globErr != nil {
-					watchError = errors.Wrap(globErr, "unable to watch changes")
+					watchError = fmt.Errorf("unable to watch changes: %w", globErr)
 				}
 				if !alreadyInChangedFiles && !matched && !isIgnoreEvent {
 					// Append the new file change event to changedFiles if and only if the event is not a file remove event
@@ -396,12 +395,12 @@ func shouldIgnoreEvent(event fsnotify.Event) (ignoreEvent bool) {
 		stat, err := os.Lstat(event.Name)
 		if err != nil {
 			// Some of the editors like vim and gedit, generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
-			// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
-			// which will terminate the watch
+			// So, its better to log the error rather than feeding it to error handler via `watchError = fmt.Errorf("unable to watch changes: %w", err)`,
+			// which will terminate the watchfmt.Errorf("unable to watch changes: %w", err)
 			klog.V(4).Infof("Failed getting details of the changed file %s. Ignoring the change", event.Name)
 		}
 		// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
-		// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
+		// So, its better to log the error rather than feeding it to error handler via `watchError = fmt.Errorf("unable to watch changes: %w", err)`,
 		// which will terminate the watch
 		if stat == nil {
 			klog.V(4).Infof("Ignoring event for file %s as details about the file couldn't be fetched", event.Name)

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -396,7 +396,7 @@ func shouldIgnoreEvent(event fsnotify.Event) (ignoreEvent bool) {
 		if err != nil {
 			// Some of the editors like vim and gedit, generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 			// So, its better to log the error rather than feeding it to error handler via `watchError = fmt.Errorf("unable to watch changes: %w", err)`,
-			// which will terminate the watchfmt.Errorf("unable to watch changes: %w", err)
+			// which will terminate the watch
 			klog.V(4).Infof("Failed getting details of the changed file %s. Ignoring the change", event.Name)
 		}
 		// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -5,7 +5,6 @@ package watch
 
 import (
 	"fmt"
-	"github.com/golang/mock/gomock"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -16,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/golang/mock/gomock"
 
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/envinfo"
@@ -46,7 +45,7 @@ func setUpF8AnalyticsComponentSrc(componentName string, requiredFilePaths []test
 	// Create temporary directory for mock component source code
 	srcPath, err := testingutil.TempMkdir(basePath, componentName)
 	if err != nil {
-		return "", retVal, errors.Wrapf(err, "failed to create dir %s under %s", componentName, basePath)
+		return "", retVal, fmt.Errorf("failed to create dir %s under %s: %w", componentName, basePath, err)
 	}
 	dirTreeMappings[componentName] = srcPath
 
@@ -70,7 +69,7 @@ func setUpF8AnalyticsComponentSrc(componentName string, requiredFilePaths []test
 		newPath, err := testingutil.SimulateFileModifications(srcPath, fileProperties)
 		dirTreeMappings[relativePath] = newPath
 		if err != nil {
-			return "", retVal, errors.Wrapf(err, "unable to setup test env")
+			return "", retVal, fmt.Errorf("unable to setup test env: %w", err)
 		}
 
 		fileProperties.FilePath = filepath.Base(newPath)

--- a/tests/integration/devfile/cmd_devfile_init_test.go
+++ b/tests/integration/devfile/cmd_devfile_init_test.go
@@ -51,11 +51,11 @@ var _ = Describe("odo devfile init command tests", func() {
 
 		By("running odo init with wrong local file path given to --devfile-path", func() {
 			err := helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", "/some/path/devfile.yaml").ShouldFail().Err()
-			Expect(err).To(ContainSubstring("no such file or directory"))
+			Expect(err).To(ContainSubstring("unable to download devfile"))
 		})
 		By("running odo init with wrong URL path given to --devfile-path", func() {
 			err := helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", "https://github.com/path/to/devfile.yaml").ShouldFail().Err()
-			Expect(err).To(ContainSubstring("unable to download devfile: failed to retrieve"))
+			Expect(err).To(ContainSubstring("unable to download devfile"))
 		})
 	})
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -491,7 +491,6 @@ github.com/pborman/uuid
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR:
- [x] replaces the use of `errors.Wrap[f]` with `fmt.Errorf`
- [x] replaces the use of package `github.com/pkg/errors` with stdlib package `errors` for calls to `errors.New`
- [x] replaces the use of `errors.Cause` and `errors.Unwrap`

The goal is to completely remove the dependency on `github.com/pkg/errors` as this package is deprecated since go.1.13: https://go.dev/blog/go1.13-errors
