### PR TITLE
Remove nanoseconds from spinner

### DIFF
--- a/pkg/log/fidget/spinner.go
+++ b/pkg/log/fidget/spinner.go
@@ -145,5 +145,6 @@ func (s *Spinner) TimeSpent() string {
 		return fmt.Sprintf("%dms", timeElapsed.Nanoseconds()/int64(time.Millisecond))
 	}
 
-	return fmt.Sprintf("%dns", timeElapsed.Nanoseconds())
+	// If it's less than 1ms (nanoseconds), output none.
+	return ""
 }

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -194,17 +194,23 @@ func (s *Status) End(success bool) {
 	}
 
 	if !IsJSON() {
+
+		time := ""
+		if s.spinner.TimeSpent() != "" {
+			time = fmt.Sprintf("[%s]", s.spinner.TimeSpent())
+		}
+
 		if success {
 			// Clear the warning (unneeded now)
 			s.WarningStatus("")
 			green := color.New(color.FgGreen).SprintFunc()
-			fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%s]\n", green(getSuccessString()), s.status, s.spinner.TimeSpent())
+			fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s %s\n", green(getSuccessString()), s.status, time)
 		} else {
 			red := color.New(color.FgRed).SprintFunc()
 			if s.warningStatus != "" {
-				fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%s] [%s]\n", red(getErrString()), s.status, s.spinner.TimeSpent(), s.warningStatus)
+				fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s %s [%s]\n", red(getErrString()), s.status, time, s.warningStatus)
 			} else {
-				fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%s]\n", red(getErrString()), s.status, s.spinner.TimeSpent())
+				fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s %s\n", red(getErrString()), s.status, time)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

/kind feature

**What does this PR do / why we need it:**

When using the spinner, we shouldn't output the spinner if it is less
than 1ms (nanoseconds).

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5380

**PR acceptance criteria:**

- [X] Unit test

N/A, unable to write (function could possibly be more than 1ns)

- [X] Integration test

N/A, unable to write (function could possibly be more than 1ns)

- [X] Documentation

**How to test changes / Special notes to the reviewer:**

```
odo create nodejs foobar
odo push
```

And you should see that all nanosecond spinners are no longer shown.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>