### PR TITLE
Update help usage to a working example / updated commands

### DIFF
--- a/pkg/odo/cli/build_images/build_images.go
+++ b/pkg/odo/cli/build_images/build_images.go
@@ -79,7 +79,7 @@ func NewCmdBuildImages(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	buildImagesCmd.Annotations = map[string]string{"command": "utility"}
+	buildImagesCmd.Annotations = map[string]string{"command": "main"}
 	buildImagesCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	buildImagesCmd.Flags().BoolVar(&o.pushFlag, "push", false, "If true, build and push the images")
 	util.AddContextFlag(buildImagesCmd, &o.contextFlag)

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/redhat-developer/odo/pkg/odo/cli/dev"
-
 	"github.com/redhat-developer/odo/pkg/odo/cli/build_images"
 	"github.com/redhat-developer/odo/pkg/odo/cli/component"
 	_delete "github.com/redhat-developer/odo/pkg/odo/cli/delete"

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/redhat-developer/odo/pkg/odo/cli/dev"
+
 	"github.com/redhat-developer/odo/pkg/odo/cli/build_images"
 	"github.com/redhat-developer/odo/pkg/odo/cli/component"
 	_delete "github.com/redhat-developer/odo/pkg/odo/cli/delete"
@@ -40,13 +42,16 @@ var (
  /  \__/    Find more information at https://odo.dev
  \__/`
 
-	odoExample = ktemplates.Examples(`  # Creating and deploying a Node.js project
-  git clone https://github.com/odo-devfiles/nodejs-ex && cd nodejs-ex
-  %[1]s create nodejs
-  %[1]s push
+	odoExample = ktemplates.Examples(`Initialize and take your pick from multiple languages or frameworks:
+  %[1]s init
 
-  # Accessing your Node.js component
-  %[1]s url create`)
+	After creating your initial application, start development with:
+  %[1]s dev
+
+	Want to deploy to production? See it live with:
+  %[1]s deploy
+
+	`)
 
 	rootUsageTemplate = `Usage:{{if .Runnable}}
   {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
@@ -58,14 +63,14 @@ Aliases:
 Examples:
 {{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
 
-Commands:{{range .Commands}}{{if eq .Annotations.command "main"}}
+Main Commands:{{range .Commands}}{{if eq .Annotations.command "main"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+
+OpenShift Commands:{{range .Commands}}{{if eq .Annotations.command "cluster"}}
+  {{rpad .Name .NamePadding }} {{.Short}} {{end}}{{end}}{{end}}
 
 Utility Commands:{{range .Commands}}{{if or (eq .Annotations.command "utility") (eq .Name "help") }}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
-
-Component Shortcuts:{{range .Commands}}{{if eq .Annotations.command "component"}}
-  {{rpad .Name .NamePadding }} {{.Short}} {{end}}{{end}}{{end}}
 
 Flags:
 {{CapitalizeFlagDescriptions .LocalFlags | trimRightSpace }}{{end}}{{ if .HasAvailableInheritedFlags}}

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -41,15 +41,13 @@ var (
  \__/`
 
 	odoExample = ktemplates.Examples(`Initializing your component by taking your pick from multiple languages or frameworks:
-  %[1]s init
+  odo init
 
 	After creating your initial component, start development with:
-  %[1]s dev
+  odo dev
 
 	Want to deploy after development? See it live with:
-  %[1]s deploy
-
-	`)
+  odo deploy`)
 
 	rootUsageTemplate = `Usage:{{if .Runnable}}
   {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
@@ -82,32 +80,9 @@ Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
 
-	rootDefaultHelp = odoLong + `
+	rootDefaultHelp = fmt.Sprintf("%s\n\nUsage:\n%s\n\n%s", odoLong, odoExample, rootHelpMessage)
 
-Get started by creating a new application:
-
- git clone https://github.com/odo-devfiles/nodejs-ex && cd nodejs-ex
- odo create nodejs
- odo push
-
-Your Node.JS application has now been deployed to Kubernetes. odo has pushed the source code, built the application and deployed it.
-
-You can now edit your code in real time and watch as odo automatically deploys your application.
-
- odo watch
-
-To access your application, create a URL:
-
- odo url create myurl
- odo push
-
-More information such as logs or what components you've deployed can be accessed with these commands:
-
- odo describe
- odo list
- odo log
-
-To see a full list of commands, run 'odo --help'`
+	rootHelpMessage = "To see a full list of commands, run 'odo --help'"
 )
 
 const pluginPrefix = "odo"
@@ -139,7 +114,7 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 		Short:   "odo",
 		Long:    odoLong,
 		RunE:    ShowHelp,
-		Example: fmt.Sprintf(odoExample, fullName),
+		Example: odoExample,
 	}
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -42,13 +42,13 @@ var (
  /  \__/    Find more information at https://odo.dev
  \__/`
 
-	odoExample = ktemplates.Examples(`Initialize and take your pick from multiple languages or frameworks:
+	odoExample = ktemplates.Examples(`Initializing your component by taking your pick from multiple languages or frameworks:
   %[1]s init
 
-	After creating your initial application, start development with:
+	After creating your initial component, start development with:
   %[1]s dev
 
-	Want to deploy to production? See it live with:
+	Want to deploy after development? See it live with:
   %[1]s deploy
 
 	`)
@@ -66,7 +66,7 @@ Examples:
 Main Commands:{{range .Commands}}{{if eq .Annotations.command "main"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 
-OpenShift Commands:{{range .Commands}}{{if eq .Annotations.command "cluster"}}
+OpenShift Commands:{{range .Commands}}{{if eq .Annotations.command "openshift"}}
   {{rpad .Name .NamePadding }} {{.Short}} {{end}}{{end}}{{end}}
 
 Utility Commands:{{range .Commands}}{{if or (eq .Annotations.command "utility") (eq .Name "help") }}

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -60,7 +60,6 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 	componentCmd.AddCommand(componentGetCmd, createCmd, listCmd, pushCmd)
 
 	// Add a defined annotation in order to appear in the help menu
-	componentCmd.Annotations = map[string]string{"command": "main"}
 	componentCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return componentCmd

--- a/pkg/odo/cli/delete/delete.go
+++ b/pkg/odo/cli/delete/delete.go
@@ -17,6 +17,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 
 	componentCmd := NewCmdComponent(ComponentRecommendedCommandName, util.GetFullName(fullName, ComponentRecommendedCommandName))
 	deleteCmd.AddCommand(componentCmd)
+	deleteCmd.Annotations = map[string]string{"command": "main"}
 	deleteCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return deleteCmd

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -151,7 +151,7 @@ func NewCmdDeploy(name, fullName string) *cobra.Command {
 	clientset.Add(deployCmd, clientset.INIT, clientset.DEPLOY)
 
 	// Add a defined annotation in order to appear in the help menu
-	deployCmd.Annotations["command"] = "utility"
+	deployCmd.Annotations["command"] = "main"
 	deployCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	return deployCmd
 }

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -215,7 +215,7 @@ func NewCmdDev(name, fullName string) *cobra.Command {
 
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT)
 	// Add a defined annotation in order to appear in the help menu
-	devCmd.Annotations["command"] = "utility"
+	devCmd.Annotations["command"] = "main"
 	devCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return devCmd

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 
@@ -211,6 +212,7 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().String(backend.FLAG_DEVFILE_PATH, "", "path to a devfile. This is an alternative to using devfile from Devfile registry. It can be local filesystem path or http(s) URL")
 
 	// Add a defined annotation in order to appear in the help menu
+	initCmd.Annotations["command"] = "main"
 	initCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	return initCmd
 }

--- a/pkg/odo/cli/login/login.go
+++ b/pkg/odo/cli/login/login.go
@@ -103,7 +103,7 @@ func NewCmdLogin(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	loginCmd.Annotations = map[string]string{"command": "cluster"}
+	loginCmd.Annotations = map[string]string{"command": "openshift"}
 	loginCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	loginCmd.Flags().StringVarP(&o.userNameFlag, "username", "u", "", "username, will prompt if not provided")
 	loginCmd.Flags().StringVarP(&o.passwordFlag, "password", "p", "", "password, will prompt if not provided")

--- a/pkg/odo/cli/login/login.go
+++ b/pkg/odo/cli/login/login.go
@@ -103,7 +103,7 @@ func NewCmdLogin(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	loginCmd.Annotations = map[string]string{"command": "utility"}
+	loginCmd.Annotations = map[string]string{"command": "cluster"}
 	loginCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	loginCmd.Flags().StringVarP(&o.userNameFlag, "username", "u", "", "username, will prompt if not provided")
 	loginCmd.Flags().StringVarP(&o.passwordFlag, "password", "p", "", "password, will prompt if not provided")

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -54,8 +54,8 @@ func NewCmdLogout(name, fullName string) *cobra.Command {
 	o := NewLogoutOptions()
 	logoutCmd := &cobra.Command{
 		Use:     name,
-		Short:   "Log out of the current OpenShift session",
-		Long:    "Log out of the current OpenShift session",
+		Short:   "Logout of the cluster",
+		Long:    "Logout of the cluster.",
 		Example: fmt.Sprintf(example, fullName),
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -64,7 +64,7 @@ func NewCmdLogout(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	logoutCmd.Annotations = map[string]string{"command": "utility"}
+	logoutCmd.Annotations = map[string]string{"command": "cluster"}
 	logoutCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return logoutCmd

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -64,7 +64,7 @@ func NewCmdLogout(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	logoutCmd.Annotations = map[string]string{"command": "cluster"}
+	logoutCmd.Annotations = map[string]string{"command": "openshift"}
 	logoutCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return logoutCmd

--- a/pkg/odo/cli/preference/preference.go
+++ b/pkg/odo/cli/preference/preference.go
@@ -46,7 +46,7 @@ func NewCmdPreference(name, fullName string) *cobra.Command {
 	preferenceCmd.AddCommand(preferenceUnsetCmd)
 	preferenceCmd.AddCommand(registryCmd)
 	preferenceCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	preferenceCmd.Annotations = map[string]string{"command": "main"}
+	preferenceCmd.Annotations = map[string]string{"command": "utility"}
 
 	return preferenceCmd
 }

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -49,7 +49,6 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 	projectCmd.AddCommand(projectListCmd)
 
 	// Add a defined annotation in order to appear in the help menu
-	projectCmd.Annotations = map[string]string{"command": "main"}
 	projectCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	completion.RegisterCommandHandler(projectSetCmd, completion.ProjectNameCompletionHandler)

--- a/pkg/odo/cli/url/url.go
+++ b/pkg/odo/cli/url/url.go
@@ -36,7 +36,6 @@ func NewCmdURL(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	urlCmd.Annotations = map[string]string{"command": "main"}
 	urlCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	urlCmd.AddCommand(urlCreateCmd, urlDeleteCmd, urlListCmd)
 

--- a/tests/integration/loginlogout/cmd_login_logout_test.go
+++ b/tests/integration/loginlogout/cmd_login_logout_test.go
@@ -34,7 +34,7 @@ var _ = Describe("odo login and logout command tests", func() {
 	Context("when running help for logout command", func() {
 		It("should display the help", func() {
 			appHelp := helper.Cmd("odo", "logout", "-h").ShouldPass().Out()
-			Expect(appHelp).To(ContainSubstring("Log out of the current OpenShift session"))
+			Expect(appHelp).To(ContainSubstring("Logout of the cluster"))
 		})
 	})
 


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

/kind cleanup

**What does this PR do / why we need it:**

This updates the help usage so it outputs a working example, as well as
reorganizes commands to the appropriate places.

```sh
▶ odo -h
  __
 /  \__     odo is a CLI tool for fast iterative application development
 \__/  \    deployed immediately to your kubernetes cluster.
 /  \__/    Find more information at https://odo.dev
 \__/

Usage:
  odo [flags]
  odo [command]

Examples:
  Initialize and take your pick from multiple languages or frameworks:
  odo init

  After creating your initial application, start development with:
  odo dev

  Want to deploy to production? See it live with:
  odo deploy

Main Commands:
  build-images Build images
  deploy       Deploy components
  dev          Deploy component to development cluster
  init         Init bootstraps a new project
  v2delete     Delete component

OpenShift Commands:
  login        Login to cluster
  logout       Logout of the cluster

Utility Commands:
  preference   Modifies preference settings (registry, set, unset, view)
  utils        Utilities for terminal commands and modifying odo configurations (terminal)
  version      Print the client version information

Flags:
      --complete             Install completion for odo command
      --kubeconfig string    Paths to a kubeconfig. Only required if out-of-cluster.
      --uncomplete           Uninstall completion for odo command
  -v, --v Level              Number for the log level verbosity. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec   Comma-separated list of pattern=N settings for file-filtered logging
  -y, --y                    Don't prompt user for typing 'yes'

Use "odo [command] --help" for more information about a command.
```

**Which issue(s) this PR fixes:**

Part of: https://github.com/redhat-developer/odo/issues/5521

**PR acceptance criteria:**

- [X] Unit test

- [X] Integration test

- [X] Documentation

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>