### PR TITLE
Remove v2delete reference from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,9 @@ test-cmd-devfile-watch: install ## Run odo devfile watch command tests
 test-cmd-devfile-app: install ## Run odo devfile app command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile app command tests" tests/integration/devfile/
 
-.PHONY: test-cmd-devfile-delete
-test-cmd-devfile-delete: install ## Run odo devfile delete command tests
-	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile delete command tests" tests/integration/devfile/
+.PHONY: test-cmd-delete
+test-cmd-delete: install ## Run odo delete command tests
+	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo delete command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-registry
 test-cmd-devfile-registry: install ## Run odo devfile registry command tests


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind code-refactoring
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR removes reference of the old delete test file from Makefile and replaces it with the new one.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5559 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Run `make test-cmd-delete` and check if it runs the desired set of tests, ie tests/integration/devfile/cmd_delete_test.go