### PR TITLE
Fix some flaky tests

### DIFF
--- a/tests/integration/devfile/cmd_delete_test.go
+++ b/tests/integration/devfile/cmd_delete_test.go
@@ -97,10 +97,12 @@ ComponentSettings:
 						// wait until the resources are deleted from the first delete
 						Eventually(string(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents()), 60, 3).ShouldNot(ContainSubstring(deploymentName))
 						Eventually(string(commonVar.CliRunner.Run(getSVCArgs...).Out.Contents()), 60, 3).ShouldNot(ContainSubstring(serviceName))
-						stdOut = helper.Cmd("odo", "delete", "component", "--name", cmpName, "--namespace", commonVar.Project, "-f").ShouldPass().Out()
 					})
 					It("should output that there are no resources to be deleted", func() {
-						Expect(stdOut).To(ContainSubstring("No resource found for component %q in namespace %q", cmpName, commonVar.Project))
+						Eventually(func() string {
+							stdOut = helper.Cmd("odo", "delete", "component", "--name", cmpName, "--namespace", commonVar.Project, "-f").ShouldPass().Out()
+							return stdOut
+						}, 60, 3).Should(ContainSubstring("No resource found for component %q in namespace %q", cmpName, commonVar.Project))
 					})
 				})
 			})

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -180,6 +180,10 @@ var _ = Describe("odo dev command tests", func() {
 					output := commonVar.CliRunner.Run("get", "deployment", "-n", commonVar.Project).Err.Contents()
 					Expect(string(output)).To(ContainSubstring("No resources found in " + commonVar.Project + " namespace."))
 
+					Eventually(func() string {
+						return string(commonVar.CliRunner.Run("get", "pods", "-n", commonVar.Project).Err.Contents())
+					}).Should(ContainSubstring("No resources found"))
+
 					otherNS = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 				})
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -700,7 +700,8 @@ var _ = Describe("odo devfile push command tests", func() {
 				podName,
 				"runtime",
 				commonVar.Project,
-				[]string{"ps", "-ef"},
+				// [s] to not match the current command: https://unix.stackexchange.com/questions/74185/how-can-i-prevent-grep-from-showing-up-in-ps-results
+				[]string{"bash", "-c", "grep [s]pring-boot:run /proc/*/cmdline"},
 				func(cmdOp string, err error) bool {
 					cmdOutput = cmdOp
 					statErr = err
@@ -708,7 +709,7 @@ var _ = Describe("odo devfile push command tests", func() {
 				},
 			)
 			Expect(statErr).ToNot(HaveOccurred())
-			Expect(cmdOutput).To(ContainSubstring("spring-boot:run"))
+			Expect(cmdOutput).To(MatchRegexp("Binary file .* matches"))
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**

```
odo delete command tests
/go/src/github.com/redhat-developer/odo/tests/integration/devfile/cmd_delete_test.go:13
  when a component is bootstrapped
  /go/src/github.com/redhat-developer/odo/tests/integration/devfile/cmd_delete_test.go:32
    when the component is deployed in DEV mode and dev mode stopped
    /go/src/github.com/redhat-developer/odo/tests/integration/devfile/cmd_delete_test.go:68
      when the component is deleted using its name and namespace from another directory
      /go/src/github.com/redhat-developer/odo/tests/integration/devfile/cmd_delete_test.go:76
        when odo delete command is run again with nothing deployed on the cluster
        /go/src/github.com/redhat-developer/odo/tests/integration/devfile/cmd_delete_test.go:94
          should output that there are no resources to be deleted [It]
          /go/src/github.com/redhat-developer/odo/tests/integration/devfile/cmd_delete_test.go:102
          Expected
              
              <string>: Searching resources to delete, please wait...
              This will delete "mynodejs" from the namespace "cmd-delete-test102goj".
               •  The component contains the following resources that will get deleted:
              	- PodMetrics: mynodejs-app-6d84cf9975-jw4pv
              The component "mynodejs" is successfully deleted from namespace "cmd-delete-test102goj"
              
          to contain substring
              <string>: No resource found for component "mynodejs" in namespace "cmd-delete-test102goj"
```

+ Fixes #5568 

- Bug ps -ef receiving SIGURG: replacing ps with a grep on `proc/*/cmdline` as Docker seems to send SIGURG signals from time to time (https://github.com/flatcar-linux/Flatcar/issues/315)
 
**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
