### PR TITLE
docs: update prismjs

### DIFF
--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -28,7 +28,7 @@
     "glob-parent": "^5.1.2",
     "node-forge": "^1.0.0",
     "prism-react-renderer": "^1.2.1",
-    "prismjs": "^1.25.0",
+    "prismjs": "^1.27.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "trim": "0.0.3",

--- a/docs/website/yarn.lock
+++ b/docs/website/yarn.lock
@@ -6255,7 +6255,7 @@ prism-react-renderer@^1.2.1, prism-react-renderer@^1.3.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.3.1.tgz#88fc9d0df6bed06ca2b9097421349f8c2f24e30d"
   integrity sha512-xUeDMEz074d0zc5y6rxiMp/dlC7C+5IDDlaEUlcBOFE2wddz7hz5PNupb087mPwTt7T9BrFmewObfCBuf/LKwQ==
 
-prismjs@^1.25.0, prismjs@^1.27.0:
+prismjs@^1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==


### PR DESCRIPTION
update prismjs dependency for docs

the older version had a security issue (https://nvd.nist.gov/vuln/detail/CVE-2022-23647) 