### PR TITLE
odo delete component - show warning that something was not deleted

### DIFF
--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -30,9 +30,9 @@ func NewDeleteComponentClient(kubeClient kclient.ClientInterface) *DeleteCompone
 	}
 }
 
-// ListResourcesToDelete lists Kubernetes resources from cluster in namespace for a given odo component
+// ListClusterResourcesToDelete lists Kubernetes resources from cluster in namespace for a given odo component
 // It only returns resources not owned by another resource of the component, letting the garbage collector do its job
-func (do *DeleteComponentClient) ListResourcesToDelete(componentName string, namespace string) ([]unstructured.Unstructured, error) {
+func (do *DeleteComponentClient) ListClusterResourcesToDelete(componentName string, namespace string) ([]unstructured.Unstructured, error) {
 	var result []unstructured.Unstructured
 	labels := componentlabels.GetLabels(componentName, "app", false)
 	labels[applabels.ManagedBy] = "odo"

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/util"
 )
 
-func TestDeleteComponentClient_ListResourcesToDelete(t *testing.T) {
+func TestDeleteComponentClient_ListClusterResourcesToDelete(t *testing.T) {
 	res1 := getUnstructured("dep1", "deployment", "v1", "")
 	res2 := getUnstructured("svc1", "service", "v1", "")
 
@@ -110,7 +110,7 @@ func TestDeleteComponentClient_ListResourcesToDelete(t *testing.T) {
 			do := &DeleteComponentClient{
 				kubeClient: tt.fields.kubeClient(ctrl),
 			}
-			got, err := do.ListResourcesToDelete(tt.args.componentName, tt.args.namespace)
+			got, err := do.ListClusterResourcesToDelete(tt.args.componentName, tt.args.namespace)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DeleteComponentClient.ListResourcesToDelete() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Client interface {
-	// ListResourcesToDelete lists Kubernetes resources from cluster in namespace for a given odo component
-	ListResourcesToDelete(componentName string, namespace string) ([]unstructured.Unstructured, error)
+	// ListClusterResourcesToDelete lists Kubernetes resources from cluster in namespace for a given odo component
+	ListClusterResourcesToDelete(componentName string, namespace string) ([]unstructured.Unstructured, error)
 	// DeleteResources deletes the unstuctured resources and return the resources that failed to be deleted
 	DeleteResources([]unstructured.Unstructured) []unstructured.Unstructured
 	// ExecutePreStopEvents executes preStop events if any, as a precondition to deleting a devfile component deployment

--- a/pkg/component/delete/mock.go
+++ b/pkg/component/delete/mock.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// ListClusterResourcesToDelete mocks base method
+func (m *MockClient) ListClusterResourcesToDelete(componentName, namespace string) ([]unstructured.Unstructured, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterResourcesToDelete", componentName, namespace)
+	ret0, _ := ret[0].([]unstructured.Unstructured)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterResourcesToDelete indicates an expected call of ListClusterResourcesToDelete
+func (mr *MockClientMockRecorder) ListClusterResourcesToDelete(componentName, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterResourcesToDelete", reflect.TypeOf((*MockClient)(nil).ListClusterResourcesToDelete), componentName, namespace)
+}
+
 // DeleteResources mocks base method.
 func (m *MockClient) DeleteResources(arg0 []unstructured.Unstructured) []unstructured.Unstructured {
 	m.ctrl.T.Helper()
@@ -61,21 +76,6 @@ func (m *MockClient) ExecutePreStopEvents(devfileObj parser.DevfileObj, appName 
 func (mr *MockClientMockRecorder) ExecutePreStopEvents(devfileObj, appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePreStopEvents", reflect.TypeOf((*MockClient)(nil).ExecutePreStopEvents), devfileObj, appName)
-}
-
-// ListResourcesToDelete mocks base method.
-func (m *MockClient) ListResourcesToDelete(componentName, namespace string) ([]unstructured.Unstructured, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResourcesToDelete", componentName, namespace)
-	ret0, _ := ret[0].([]unstructured.Unstructured)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListResourcesToDelete indicates an expected call of ListResourcesToDelete.
-func (mr *MockClientMockRecorder) ListResourcesToDelete(componentName, namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourcesToDelete", reflect.TypeOf((*MockClient)(nil).ListResourcesToDelete), componentName, namespace)
 }
 
 // ListResourcesToDeleteFromDevfile mocks base method.

--- a/tests/integration/devfile/cmd_delete_test.go
+++ b/tests/integration/devfile/cmd_delete_test.go
@@ -168,6 +168,24 @@ ComponentSettings:
 					})
 				})
 			})
+			When("a resource is changed in the devfile and the component is deleted while having access to the devfile.yaml", func() {
+				var changedServiceName, stdout string
+				BeforeEach(func() {
+					changedServiceName = "my-changed-cs"
+					helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), fmt.Sprintf("name: %s", serviceName), fmt.Sprintf("name: %s", changedServiceName))
+
+					stdout = helper.Cmd("odo", "delete", "component", "-f").ShouldPass().Out()
+				})
+				It("should show warning about undeleted service belonging to the component", func() {
+					Expect(stdout).To(SatisfyAll(
+						ContainSubstring("There are still resources left in the cluster that might be belonging to the deleted component"),
+						Not(ContainSubstring(changedServiceName)),
+						ContainSubstring(serviceName),
+						ContainSubstring("odo delete component --name %s --namespace %s", cmpName, commonVar.Project),
+					))
+				})
+
+			})
 			When("the component is deleted while having access to the devfile.yaml", func() {
 				var stdOut string
 				BeforeEach(func() {


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR adds information about not deleted component resources because devfile.yaml was changed.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5555 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `mkdir /tmp/101; cd /tmp/101`
2. `cp $ODOPATH/tests/examples/source/devfiles/nodejs/devfile-deploy-with-multiple-resources.yaml devfile.yaml`
3. `cp -r $ODOPATH/tests/examples/source/nodejs/* . `
4. `export PODMAN_CMD=echo`
5. `odo deploy`
6. `odo dev`
7. Replace `my-cs` service name to `my-changed-cs` in devfile.yaml
8. `odo delete component`

Output will be similar to:
```sh
➜  odo delete component                                                                                                                                                  
Searching resources to delete, please wait...                                                                                                                                
This will delete "mynodejs" from the namespace "default".                                                                                                                    
 •  The component contains the following resources that will get deleted:                                                                                                    
        - Deployment: mynodejs-app                                                                                                                                           
? Are you sure you want to delete "mynodejs" and all its resources? Yes                                                                                                      
The component "mynodejs" is successfully deleted from namespace "default"                                                                                                    
 •  There are still resources left in the cluster that might be belonging to the deleted component.
        - Service: my-cs
        - Deployment: my-component
        - Endpoints: my-cs
If you want to delete those, execute `odo delete component --name mynodejs --namespace default`
```