### PR TITLE
Fix flaky test "should expose two endpoints on localhost"

### DIFF
--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -100,7 +100,7 @@ type ClientInterface interface {
 	// SetupPortForwarding creates port-forwarding for the pod on the port pairs provided in the
 	// ["<localhost-port>":"<remote-pod-port>"] format. errOut is used by the client-go library to output any errors
 	// encountered while the port-forwarding is running
-	SetupPortForwarding(pod *corev1.Pod, portPairs []string, errOut io.Writer) error
+	SetupPortForwarding(pod *corev1.Pod, portPairs []string, out io.Writer, errOut io.Writer) error
 
 	// projects.go
 	CreateNewProject(projectName string, wait bool) error

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -13,10 +13,10 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/project/v1"
 	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	v11 "k8s.io/api/apps/v1"
-	v12 "k8s.io/api/core/v1"
+	v10 "k8s.io/api/apps/v1"
+	v11 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
-	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	discovery "k8s.io/client-go/discovery"
 	dynamic "k8s.io/client-go/dynamic"
@@ -49,10 +49,10 @@ func (m *MockClientInterface) EXPECT() *MockClientInterfaceMockRecorder {
 }
 
 // ApplyDeployment mocks base method.
-func (m *MockClientInterface) ApplyDeployment(deploy v11.Deployment) (*v11.Deployment, error) {
+func (m *MockClientInterface) ApplyDeployment(deploy v10.Deployment) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyDeployment", deploy)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,7 +64,7 @@ func (mr *MockClientInterfaceMockRecorder) ApplyDeployment(deploy interface{}) *
 }
 
 // CollectEvents mocks base method.
-func (m *MockClientInterface) CollectEvents(selector string, events map[string]v12.Event, quit <-chan int) {
+func (m *MockClientInterface) CollectEvents(selector string, events map[string]v11.Event, quit <-chan int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CollectEvents", selector, events, quit)
 }
@@ -76,10 +76,10 @@ func (mr *MockClientInterfaceMockRecorder) CollectEvents(selector, events, quit 
 }
 
 // CreateDeployment mocks base method.
-func (m *MockClientInterface) CreateDeployment(deploy v11.Deployment) (*v11.Deployment, error) {
+func (m *MockClientInterface) CreateDeployment(deploy v10.Deployment) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDeployment", deploy)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -105,10 +105,10 @@ func (mr *MockClientInterfaceMockRecorder) CreateDynamicResource(exampleCustomRe
 }
 
 // CreateNamespace mocks base method.
-func (m *MockClientInterface) CreateNamespace(name string) (*v12.Namespace, error) {
+func (m *MockClientInterface) CreateNamespace(name string) (*v11.Namespace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNamespace", name)
-	ret0, _ := ret[0].(*v12.Namespace)
+	ret0, _ := ret[0].(*v11.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -134,10 +134,10 @@ func (mr *MockClientInterfaceMockRecorder) CreateNewProject(projectName, wait in
 }
 
 // CreatePVC mocks base method.
-func (m *MockClientInterface) CreatePVC(pvc v12.PersistentVolumeClaim) (*v12.PersistentVolumeClaim, error) {
+func (m *MockClientInterface) CreatePVC(pvc v11.PersistentVolumeClaim) (*v11.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePVC", pvc)
-	ret0, _ := ret[0].(*v12.PersistentVolumeClaim)
+	ret0, _ := ret[0].(*v11.PersistentVolumeClaim)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -149,7 +149,7 @@ func (mr *MockClientInterfaceMockRecorder) CreatePVC(pvc interface{}) *gomock.Ca
 }
 
 // CreateSecret mocks base method.
-func (m *MockClientInterface) CreateSecret(objectMeta v13.ObjectMeta, data map[string]string, ownerReference v13.OwnerReference) error {
+func (m *MockClientInterface) CreateSecret(objectMeta v12.ObjectMeta, data map[string]string, ownerReference v12.OwnerReference) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", objectMeta, data, ownerReference)
 	ret0, _ := ret[0].(error)
@@ -163,7 +163,7 @@ func (mr *MockClientInterfaceMockRecorder) CreateSecret(objectMeta, data, ownerR
 }
 
 // CreateSecrets mocks base method.
-func (m *MockClientInterface) CreateSecrets(componentName string, commonObjectMeta v13.ObjectMeta, svc *v12.Service, ownerReference v13.OwnerReference) error {
+func (m *MockClientInterface) CreateSecrets(componentName string, commonObjectMeta v12.ObjectMeta, svc *v11.Service, ownerReference v12.OwnerReference) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecrets", componentName, commonObjectMeta, svc, ownerReference)
 	ret0, _ := ret[0].(error)
@@ -177,10 +177,10 @@ func (mr *MockClientInterfaceMockRecorder) CreateSecrets(componentName, commonOb
 }
 
 // CreateService mocks base method.
-func (m *MockClientInterface) CreateService(svc v12.Service) (*v12.Service, error) {
+func (m *MockClientInterface) CreateService(svc v11.Service) (*v11.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateService", svc)
-	ret0, _ := ret[0].(*v12.Service)
+	ret0, _ := ret[0].(*v11.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -192,10 +192,10 @@ func (mr *MockClientInterfaceMockRecorder) CreateService(svc interface{}) *gomoc
 }
 
 // CreateTLSSecret mocks base method.
-func (m *MockClientInterface) CreateTLSSecret(tlsCertificate, tlsPrivKey []byte, objectMeta v13.ObjectMeta) (*v12.Secret, error) {
+func (m *MockClientInterface) CreateTLSSecret(tlsCertificate, tlsPrivKey []byte, objectMeta v12.ObjectMeta) (*v11.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTLSSecret", tlsCertificate, tlsPrivKey, objectMeta)
-	ret0, _ := ret[0].(*v12.Secret)
+	ret0, _ := ret[0].(*v11.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -376,7 +376,7 @@ func (mr *MockClientInterfaceMockRecorder) GetAllResourcesFromSelector(selector,
 }
 
 // GetAndUpdateStorageOwnerReference mocks base method.
-func (m *MockClientInterface) GetAndUpdateStorageOwnerReference(pvc *v12.PersistentVolumeClaim, ownerReference ...v13.OwnerReference) error {
+func (m *MockClientInterface) GetAndUpdateStorageOwnerReference(pvc *v11.PersistentVolumeClaim, ownerReference ...v12.OwnerReference) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{pvc}
 	for _, a := range ownerReference {
@@ -494,10 +494,10 @@ func (mr *MockClientInterfaceMockRecorder) GetCustomResourcesFromCSV(csv interfa
 }
 
 // GetDeploymentAPIVersion mocks base method.
-func (m *MockClientInterface) GetDeploymentAPIVersion() (v13.GroupVersionResource, error) {
+func (m *MockClientInterface) GetDeploymentAPIVersion() (v12.GroupVersionResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeploymentAPIVersion")
-	ret0, _ := ret[0].(v13.GroupVersionResource)
+	ret0, _ := ret[0].(v12.GroupVersionResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -509,10 +509,10 @@ func (mr *MockClientInterfaceMockRecorder) GetDeploymentAPIVersion() *gomock.Cal
 }
 
 // GetDeploymentByName mocks base method.
-func (m *MockClientInterface) GetDeploymentByName(name string) (*v11.Deployment, error) {
+func (m *MockClientInterface) GetDeploymentByName(name string) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeploymentByName", name)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -524,10 +524,10 @@ func (mr *MockClientInterfaceMockRecorder) GetDeploymentByName(name interface{})
 }
 
 // GetDeploymentFromSelector mocks base method.
-func (m *MockClientInterface) GetDeploymentFromSelector(selector string) ([]v11.Deployment, error) {
+func (m *MockClientInterface) GetDeploymentFromSelector(selector string) ([]v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeploymentFromSelector", selector)
-	ret0, _ := ret[0].([]v11.Deployment)
+	ret0, _ := ret[0].([]v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -583,10 +583,10 @@ func (mr *MockClientInterfaceMockRecorder) GetDynamicResource(group, version, re
 }
 
 // GetNamespace mocks base method.
-func (m *MockClientInterface) GetNamespace(name string) (*v12.Namespace, error) {
+func (m *MockClientInterface) GetNamespace(name string) (*v11.Namespace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespace", name)
-	ret0, _ := ret[0].(*v12.Namespace)
+	ret0, _ := ret[0].(*v11.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -598,10 +598,10 @@ func (mr *MockClientInterfaceMockRecorder) GetNamespace(name interface{}) *gomoc
 }
 
 // GetNamespaceNormal mocks base method.
-func (m *MockClientInterface) GetNamespaceNormal(name string) (*v12.Namespace, error) {
+func (m *MockClientInterface) GetNamespaceNormal(name string) (*v11.Namespace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespaceNormal", name)
-	ret0, _ := ret[0].(*v12.Namespace)
+	ret0, _ := ret[0].(*v11.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -628,10 +628,10 @@ func (mr *MockClientInterfaceMockRecorder) GetNamespaces() *gomock.Call {
 }
 
 // GetOneDeployment mocks base method.
-func (m *MockClientInterface) GetOneDeployment(componentName, appName string) (*v11.Deployment, error) {
+func (m *MockClientInterface) GetOneDeployment(componentName, appName string) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOneDeployment", componentName, appName)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -643,10 +643,10 @@ func (mr *MockClientInterfaceMockRecorder) GetOneDeployment(componentName, appNa
 }
 
 // GetOneDeploymentFromSelector mocks base method.
-func (m *MockClientInterface) GetOneDeploymentFromSelector(selector string) (*v11.Deployment, error) {
+func (m *MockClientInterface) GetOneDeploymentFromSelector(selector string) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOneDeploymentFromSelector", selector)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -658,10 +658,10 @@ func (mr *MockClientInterfaceMockRecorder) GetOneDeploymentFromSelector(selector
 }
 
 // GetOnePodFromSelector mocks base method.
-func (m *MockClientInterface) GetOnePodFromSelector(selector string) (*v12.Pod, error) {
+func (m *MockClientInterface) GetOnePodFromSelector(selector string) (*v11.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOnePodFromSelector", selector)
-	ret0, _ := ret[0].(*v12.Pod)
+	ret0, _ := ret[0].(*v11.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -673,10 +673,10 @@ func (mr *MockClientInterfaceMockRecorder) GetOnePodFromSelector(selector interf
 }
 
 // GetOneService mocks base method.
-func (m *MockClientInterface) GetOneService(componentName, appName string) (*v12.Service, error) {
+func (m *MockClientInterface) GetOneService(componentName, appName string) (*v11.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOneService", componentName, appName)
-	ret0, _ := ret[0].(*v12.Service)
+	ret0, _ := ret[0].(*v11.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -688,10 +688,10 @@ func (mr *MockClientInterfaceMockRecorder) GetOneService(componentName, appName 
 }
 
 // GetOneServiceFromSelector mocks base method.
-func (m *MockClientInterface) GetOneServiceFromSelector(selector string) (*v12.Service, error) {
+func (m *MockClientInterface) GetOneServiceFromSelector(selector string) (*v11.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOneServiceFromSelector", selector)
-	ret0, _ := ret[0].(*v12.Service)
+	ret0, _ := ret[0].(*v11.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -718,10 +718,10 @@ func (mr *MockClientInterfaceMockRecorder) GetOperatorGVRList() *gomock.Call {
 }
 
 // GetPVCFromName mocks base method.
-func (m *MockClientInterface) GetPVCFromName(pvcName string) (*v12.PersistentVolumeClaim, error) {
+func (m *MockClientInterface) GetPVCFromName(pvcName string) (*v11.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPVCFromName", pvcName)
-	ret0, _ := ret[0].(*v12.PersistentVolumeClaim)
+	ret0, _ := ret[0].(*v11.PersistentVolumeClaim)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -748,10 +748,10 @@ func (mr *MockClientInterfaceMockRecorder) GetPodLogs(podName, containerName, fo
 }
 
 // GetPodUsingComponentName mocks base method.
-func (m *MockClientInterface) GetPodUsingComponentName(componentName string) (*v12.Pod, error) {
+func (m *MockClientInterface) GetPodUsingComponentName(componentName string) (*v11.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPodUsingComponentName", componentName)
-	ret0, _ := ret[0].(*v12.Pod)
+	ret0, _ := ret[0].(*v11.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -808,10 +808,10 @@ func (mr *MockClientInterfaceMockRecorder) GetRestMappingFromUnstructured(arg0 i
 }
 
 // GetSecret mocks base method.
-func (m *MockClientInterface) GetSecret(name, namespace string) (*v12.Secret, error) {
+func (m *MockClientInterface) GetSecret(name, namespace string) (*v11.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecret", name, namespace)
-	ret0, _ := ret[0].(*v12.Secret)
+	ret0, _ := ret[0].(*v11.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -956,10 +956,10 @@ func (mr *MockClientInterfaceMockRecorder) ListClusterServiceVersions() *gomock.
 }
 
 // ListDeployments mocks base method.
-func (m *MockClientInterface) ListDeployments(selector string) (*v11.DeploymentList, error) {
+func (m *MockClientInterface) ListDeployments(selector string) (*v10.DeploymentList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDeployments", selector)
-	ret0, _ := ret[0].(*v11.DeploymentList)
+	ret0, _ := ret[0].(*v10.DeploymentList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1001,10 +1001,10 @@ func (mr *MockClientInterfaceMockRecorder) ListPVCNames(selector interface{}) *g
 }
 
 // ListPVCs mocks base method.
-func (m *MockClientInterface) ListPVCs(selector string) ([]v12.PersistentVolumeClaim, error) {
+func (m *MockClientInterface) ListPVCs(selector string) ([]v11.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPVCs", selector)
-	ret0, _ := ret[0].([]v12.PersistentVolumeClaim)
+	ret0, _ := ret[0].([]v11.PersistentVolumeClaim)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1031,10 +1031,10 @@ func (mr *MockClientInterfaceMockRecorder) ListProjectNames() *gomock.Call {
 }
 
 // ListSecrets mocks base method.
-func (m *MockClientInterface) ListSecrets(labelSelector string) ([]v12.Secret, error) {
+func (m *MockClientInterface) ListSecrets(labelSelector string) ([]v11.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecrets", labelSelector)
-	ret0, _ := ret[0].([]v12.Secret)
+	ret0, _ := ret[0].([]v11.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1046,10 +1046,10 @@ func (mr *MockClientInterfaceMockRecorder) ListSecrets(labelSelector interface{}
 }
 
 // ListServices mocks base method.
-func (m *MockClientInterface) ListServices(selector string) ([]v12.Service, error) {
+func (m *MockClientInterface) ListServices(selector string) ([]v11.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServices", selector)
-	ret0, _ := ret[0].([]v12.Service)
+	ret0, _ := ret[0].([]v11.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1113,17 +1113,17 @@ func (mr *MockClientInterfaceMockRecorder) SetNamespace(ns interface{}) *gomock.
 }
 
 // SetupPortForwarding mocks base method.
-func (m *MockClientInterface) SetupPortForwarding(pod *v12.Pod, portPairs []string, errOut io.Writer) error {
+func (m *MockClientInterface) SetupPortForwarding(pod *v11.Pod, portPairs []string, out, errOut io.Writer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupPortForwarding", pod, portPairs, errOut)
+	ret := m.ctrl.Call(m, "SetupPortForwarding", pod, portPairs, out, errOut)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupPortForwarding indicates an expected call of SetupPortForwarding.
-func (mr *MockClientInterfaceMockRecorder) SetupPortForwarding(pod, portPairs, errOut interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) SetupPortForwarding(pod, portPairs, out, errOut interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupPortForwarding", reflect.TypeOf((*MockClientInterface)(nil).SetupPortForwarding), pod, portPairs, errOut)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupPortForwarding", reflect.TypeOf((*MockClientInterface)(nil).SetupPortForwarding), pod, portPairs, out, errOut)
 }
 
 // UnlinkSecret mocks base method.
@@ -1141,10 +1141,10 @@ func (mr *MockClientInterfaceMockRecorder) UnlinkSecret(secretName, componentNam
 }
 
 // UpdateDeployment mocks base method.
-func (m *MockClientInterface) UpdateDeployment(deploy v11.Deployment) (*v11.Deployment, error) {
+func (m *MockClientInterface) UpdateDeployment(deploy v10.Deployment) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDeployment", deploy)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1170,7 +1170,7 @@ func (mr *MockClientInterfaceMockRecorder) UpdateDynamicResource(group, version,
 }
 
 // UpdatePVCLabels mocks base method.
-func (m *MockClientInterface) UpdatePVCLabels(pvc *v12.PersistentVolumeClaim, labels map[string]string) error {
+func (m *MockClientInterface) UpdatePVCLabels(pvc *v11.PersistentVolumeClaim, labels map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePVCLabels", pvc, labels)
 	ret0, _ := ret[0].(error)
@@ -1184,10 +1184,10 @@ func (mr *MockClientInterfaceMockRecorder) UpdatePVCLabels(pvc, labels interface
 }
 
 // UpdateSecret mocks base method.
-func (m *MockClientInterface) UpdateSecret(secret *v12.Secret, namespace string) (*v12.Secret, error) {
+func (m *MockClientInterface) UpdateSecret(secret *v11.Secret, namespace string) (*v11.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", secret, namespace)
-	ret0, _ := ret[0].(*v12.Secret)
+	ret0, _ := ret[0].(*v11.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1199,10 +1199,10 @@ func (mr *MockClientInterfaceMockRecorder) UpdateSecret(secret, namespace interf
 }
 
 // UpdateService mocks base method.
-func (m *MockClientInterface) UpdateService(svc v12.Service) (*v12.Service, error) {
+func (m *MockClientInterface) UpdateService(svc v11.Service) (*v11.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateService", svc)
-	ret0, _ := ret[0].(*v12.Service)
+	ret0, _ := ret[0].(*v11.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1214,7 +1214,7 @@ func (mr *MockClientInterfaceMockRecorder) UpdateService(svc interface{}) *gomoc
 }
 
 // UpdateStorageOwnerReference mocks base method.
-func (m *MockClientInterface) UpdateStorageOwnerReference(pvc *v12.PersistentVolumeClaim, ownerReference ...v13.OwnerReference) error {
+func (m *MockClientInterface) UpdateStorageOwnerReference(pvc *v11.PersistentVolumeClaim, ownerReference ...v12.OwnerReference) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{pvc}
 	for _, a := range ownerReference {
@@ -1233,10 +1233,10 @@ func (mr *MockClientInterfaceMockRecorder) UpdateStorageOwnerReference(pvc inter
 }
 
 // WaitAndGetPodWithEvents mocks base method.
-func (m *MockClientInterface) WaitAndGetPodWithEvents(selector string, desiredPhase v12.PodPhase, pushTimeout time.Duration) (*v12.Pod, error) {
+func (m *MockClientInterface) WaitAndGetPodWithEvents(selector string, desiredPhase v11.PodPhase, pushTimeout time.Duration) (*v11.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitAndGetPodWithEvents", selector, desiredPhase, pushTimeout)
-	ret0, _ := ret[0].(*v12.Pod)
+	ret0, _ := ret[0].(*v11.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1248,10 +1248,10 @@ func (mr *MockClientInterfaceMockRecorder) WaitAndGetPodWithEvents(selector, des
 }
 
 // WaitAndGetSecret mocks base method.
-func (m *MockClientInterface) WaitAndGetSecret(name, namespace string) (*v12.Secret, error) {
+func (m *MockClientInterface) WaitAndGetSecret(name, namespace string) (*v11.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitAndGetSecret", name, namespace)
-	ret0, _ := ret[0].(*v12.Secret)
+	ret0, _ := ret[0].(*v11.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1277,10 +1277,10 @@ func (mr *MockClientInterfaceMockRecorder) WaitForComponentDeletion(selector int
 }
 
 // WaitForDeploymentRollout mocks base method.
-func (m *MockClientInterface) WaitForDeploymentRollout(deploymentName string) (*v11.Deployment, error) {
+func (m *MockClientInterface) WaitForDeploymentRollout(deploymentName string) (*v10.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForDeploymentRollout", deploymentName)
-	ret0, _ := ret[0].(*v11.Deployment)
+	ret0, _ := ret[0].(*v10.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/kclient/port_forwarding.go
+++ b/pkg/kclient/port_forwarding.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 )
 
-func (c *Client) SetupPortForwarding(pod *corev1.Pod, portPairs []string, errOut io.Writer) error {
+func (c *Client) SetupPortForwarding(pod *corev1.Pod, portPairs []string, out io.Writer, errOut io.Writer) error {
 	transport, upgrader, err := spdy.RoundTripperFor(c.GetClientConfig())
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func (c *Client) SetupPortForwarding(pod *corev1.Pod, portPairs []string, errOut
 	stopChan := make(chan struct{}, 1)
 	// passing nil for readyChan because it's eventually being closed if it's not nil
 	// passing nil for out because we only care for error, not for output messages; we want to print our own messages
-	fw, err := portforward.NewOnAddresses(dialer, []string{"localhost"}, portPairs, stopChan, nil, nil, errOut)
+	fw, err := portforward.New(dialer, portPairs, stopChan, nil, out, errOut)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -277,7 +277,7 @@ It forwards endpoints with exposure values 'public' or 'internal' to a port on l
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	devCmd.Flags().BoolVarP(&o.randomPorts, "random-ports", "f", false, "Assign random ports to redirectoed ports")
+	devCmd.Flags().BoolVarP(&o.randomPorts, "random-ports", "f", false, "Assign random ports to redirected ports")
 
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT, clientset.KUBERNETES)
 	// Add a defined annotation in order to appear in the help menu

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
@@ -56,6 +55,9 @@ type DevOptions struct {
 
 	// working directory
 	contextDir string
+
+	// Flags
+	randomPorts bool
 }
 
 type Handler struct{}
@@ -183,7 +185,7 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(o.out, "\nYour application is running on cluster.\n ")
+	fmt.Fprintf(o.out, "\nYour application is running on cluster.\n\n")
 
 	// get the endpoint/port information for containers in devfile and setup port-forwarding
 	containers, err := o.Context.EnvSpecificInfo.GetDevfileObj().Data.GetComponents(parsercommon.DevfileOptions{
@@ -193,7 +195,12 @@ func (o *DevOptions) Run(ctx context.Context) error {
 		return err
 	}
 	ceMapping := libdevfile.GetContainerEndpointMapping(containers)
-	portPairs := portPairsFromContainerEndpoints(ceMapping)
+	var portPairs map[string][]string
+	if o.randomPorts {
+		portPairs = randomPortPairsFromContainerEndpoints(ceMapping)
+	} else {
+		portPairs = portPairsFromContainerEndpoints(ceMapping)
+	}
 	var portPairsSlice []string
 	for _, v1 := range portPairs {
 		portPairsSlice = append(portPairsSlice, v1...)
@@ -202,13 +209,16 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	portsBuf := NewPortWriter(os.Stdout, len(portPairsSlice))
 	go func() {
-		err = o.clientset.KubernetesClient.SetupPortForwarding(pod, portPairsSlice, o.errOut)
+		err = o.clientset.KubernetesClient.SetupPortForwarding(pod, portPairsSlice, portsBuf, o.errOut)
 		if err != nil {
 			fmt.Printf("failed to setup port-forwarding: %v\n", err)
 		}
 	}()
-	printPortForwardingInfo(portPairs, o.out)
+
+	portsBuf.Wait()
+
 	devFileObj := o.Context.EnvSpecificInfo.GetDevfileObj()
 	scontext.SetComponentType(ctx, component.GetComponentTypeFromDevfileMetadata(devFileObj.Data.GetMetadata()))
 	scontext.SetLanguage(ctx, devFileObj.Data.GetMetadata().Language)
@@ -253,20 +263,6 @@ func regenerateComponentAdapterFromWatchParams(parameters watch.WatchParameters)
 	return adapters.NewComponentAdapter(parameters.ComponentName, parameters.Path, parameters.ApplicationName, devObj, platformContext)
 }
 
-func printPortForwardingInfo(portPairs map[string][]string, out io.Writer) {
-	var portForwardURLs strings.Builder
-	for container, ports := range portPairs {
-		for _, pair := range ports {
-			split := strings.Split(pair, ":")
-			local := split[0]
-			remote := split[1]
-
-			portForwardURLs.WriteString(fmt.Sprintf("- Port %s from %q container forwarded to localhost:%s\n", remote, container, local))
-		}
-	}
-	fmt.Fprintf(out, "\n%s", portForwardURLs.String())
-}
-
 // NewCmdDev implements the odo dev command
 func NewCmdDev(name, fullName string) *cobra.Command {
 	o := NewDevOptions()
@@ -281,6 +277,7 @@ It forwards endpoints with exposure values 'public' or 'internal' to a port on l
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
+	devCmd.Flags().BoolVarP(&o.randomPorts, "random-ports", "f", false, "Assign random ports to redirectoed ports")
 
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT, clientset.KUBERNETES)
 	// Add a defined annotation in order to appear in the help menu
@@ -309,6 +306,21 @@ func portPairsFromContainerEndpoints(ceMap map[string][]int) map[string][]string
 				}
 				port++
 			}
+		}
+	}
+	return portPairs
+}
+
+// randomPortPairsFromContainerEndpoints assigns a random (empty) port on localhost to each port in the provided containerEndpoints map
+// it returns a map of the format "<container-name>":{"<local-port-1>:<remote-port-1>", "<local-port-2>:<remote-port-2>"}
+// "container1": {":3000", ":3001"}
+func randomPortPairsFromContainerEndpoints(ceMap map[string][]int) map[string][]string {
+	portPairs := make(map[string][]string)
+
+	for name, ports := range ceMap {
+		for _, p := range ports {
+			pair := fmt.Sprintf(":%d", p)
+			portPairs[name] = append(portPairs[name], pair)
 		}
 	}
 	return portPairs

--- a/pkg/odo/cli/dev/writer.go
+++ b/pkg/odo/cli/dev/writer.go
@@ -1,0 +1,39 @@
+package dev
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type PortWriter struct {
+	buffer io.Writer
+	end    chan bool
+	len    int
+}
+
+// NewPortWriter creates a writer that will write the content in buffer,
+// and Wait will return after strings "Forwarding from 127.0.0.1:" has been written "len" times
+func NewPortWriter(buffer io.Writer, len int) *PortWriter {
+	return &PortWriter{
+		buffer: buffer,
+		len:    len,
+		end:    make(chan bool),
+	}
+}
+
+func (o *PortWriter) Write(buf []byte) (n int, err error) {
+	s := string(buf)
+	if strings.HasPrefix(s, "Forwarding from 127.0.0.1") {
+		fmt.Fprintf(o.buffer, " - %s", s)
+		o.len--
+		if o.len == 0 {
+			o.end <- true
+		}
+	}
+	return len(buf), nil
+}
+
+func (o *PortWriter) Wait() {
+	<-o.end
+}

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -102,7 +102,7 @@ import (
 	The method returns the contents of std/err output since the end of the dev mode started or previous sync, and until the end of the synchronization.
 */
 
-const localhostRegexp = "localhost:[0-9]*"
+const localhostRegexp = "127.0.0.1:[0-9]*"
 
 type DevSession struct {
 	session *gexec.Session
@@ -113,7 +113,7 @@ type DevSession struct {
 // and the redirections endpoints to access ports opened by component
 // when the dev mode is completely started
 func StartDevMode(opts ...string) (DevSession, []byte, []byte, []string, error) {
-	args := []string{"dev"}
+	args := []string{"dev", "--random-ports"}
 	args = append(args, opts...)
 	session := CmdRunner("odo", args...)
 	WaitForOutputToContain("Watching for changes in the current directory", 240, 10, session)

--- a/tests/integration/devfile/cmd_delete_test.go
+++ b/tests/integration/devfile/cmd_delete_test.go
@@ -198,7 +198,7 @@ ComponentSettings:
 			var projectName string
 			BeforeEach(func() {
 				// deploy the component to the cluster
-				session := helper.CmdRunner("odo", "dev")
+				session := helper.CmdRunner("odo", "dev", "--random-ports")
 				defer session.Kill()
 				helper.WaitForOutputToContain("Press Ctrl+c to exit", 180, 10, session)
 				Expect(string(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents())).To(ContainSubstring(cmpName))
@@ -238,7 +238,7 @@ ComponentSettings:
 			cmpName = "nodejs"
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml")).ShouldPass()
-			session := helper.CmdRunner("odo", "dev")
+			session := helper.CmdRunner("odo", "dev", "--random-ports")
 			defer session.Kill()
 			helper.WaitForOutputToContain("Press Ctrl+c to exit", 180, 10, session)
 			// Ensure that the pod is in running state

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -44,7 +44,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should error", func() {
-			output := helper.Cmd("odo", "dev").ShouldFail().Err()
+			output := helper.Cmd("odo", "dev", "--random-ports").ShouldFail().Err()
 			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
 
 		})
@@ -776,7 +776,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should throw a validation error for composite run commands", func() {
-			output := helper.Cmd("odo", "dev").ShouldFail().Err()
+			output := helper.Cmd("odo", "dev", "--random-ports").ShouldFail().Err()
 			Expect(output).To(ContainSubstring("not supported currently"))
 		})
 	})
@@ -787,7 +787,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should not correctly execute PreStart commands", func() {
-			output := helper.Cmd("odo", "dev").ShouldFail().Err()
+			output := helper.Cmd("odo", "dev", "--random-ports").ShouldFail().Err()
 			// This is expected to fail for now.
 			// see https://github.com/redhat-developer/odo/issues/4187 for more info
 			helper.MatchAllInOutput(output, []string{"myprestart should either map to an apply command or a composite command with apply commands\n"})

--- a/tests/interactive/cmd_dev_test.go
+++ b/tests/interactive/cmd_dev_test.go
@@ -72,7 +72,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 		It("should run alizer to download devfile", func() {
 
 			language := "python"
-			_, _ = helper.RunInteractive([]string{"odo", "dev"},
+			_, _ = helper.RunInteractive([]string{"odo", "dev", "--random-ports"},
 				nil,
 				func(ctx helper.InteractiveContext) {
 					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
@@ -103,7 +103,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 		It("should display welcoming messages first", func() {
 
 			language := "python"
-			output, _ := helper.RunInteractive([]string{"odo", "dev"},
+			output, _ := helper.RunInteractive([]string{"odo", "dev", "--random-ports"},
 				// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
 				// message displayed to the end user. So we do not want any potential debug lines to be printed first.
 				// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513

--- a/tests/interactive/cmd_dev_test.go
+++ b/tests/interactive/cmd_dev_test.go
@@ -41,7 +41,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 		It("should run alizer to download devfile successfully even with -v flag", func() {
 
 			language := "python"
-			_, _ = helper.RunInteractive([]string{"odo", "dev", "-v", "4"},
+			_, _ = helper.RunInteractive([]string{"odo", "dev", "--random-ports", "-v", "4"},
 				nil,
 				func(ctx helper.InteractiveContext) {
 					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")


### PR DESCRIPTION
**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**

This PR adds a `random-ports` flag to `odo dev`, that calls the port-forward library with a destination port set to zero, this way a port is automatically chosen by the system atomically.

```
func net.Listen(network string, address string) (net.Listener, error)
[net.Listen on pkg.go.dev]()

Listen announces on the local network address.

The network must be "tcp", "tcp4", "tcp6", "unix" or "unixpacket".
[...]
If the port in the address parameter is empty or "0", as in "127.0.0.1:" or "[::1]:0", a port number is automatically chosen.
[...]
```


**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5603

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

Using Decorators with integration tests as discussed during Cabal is not possible as they are compatible with Ginkgo 2 and we are still using v1