### PR TITLE
[#5322] Add `PROJECT_SOURCE` to the container image build command environment

### DIFF
--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -37,7 +37,11 @@ func (o *DockerCompatibleBackend) Build(image *devfile.ImageComponent, devfilePa
 	shell := getShellCommand(o.name, image, devfilePath)
 
 	cmd := exec.Command("bash", "-c", shell)
-	cmd.Env = append(os.Environ(), "PROJECTS_ROOT="+devfilePath)
+	cmdEnv := []string{
+		"PROJECTS_ROOT=" + devfilePath,
+		"PROJECT_SOURCE=" + devfilePath,
+	}
+	cmd.Env = append(os.Environ(), cmdEnv...)
 	cmd.Stdout = log.GetStdout()
 	cmd.Stderr = log.GetStderr()
 

--- a/tests/examples/source/devfiles/nodejs/devfile-outerloop-project_source-in-docker-build-context.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-outerloop-project_source-in-docker-build-context.yaml
@@ -1,0 +1,98 @@
+# Source: https://github.com/kadel/devfile-nodejs-deploy/blob/main/devfile.yaml
+schemaVersion: 2.2.0
+metadata:
+  language: javascript
+  name: devfile-nodejs-deploy
+  projectType: nodejs
+variables:
+  CONTAINER_IMAGE: localhost:5000/devfile-nodejs-deploy:0.1.0
+commands:
+  - id: install
+    exec:
+      commandLine: npm install
+      component: runtime
+      group:
+        isDefault: true
+        kind: build
+      workingDir: $PROJECT_SOURCE
+  - id: run
+    exec:
+      commandLine: npm start
+      component: runtime
+      group:
+        isDefault: true
+        kind: run
+      workingDir: $PROJECT_SOURCE
+  - id: build-image
+    apply:
+      component: prod-image
+  - id: deploy-deployment
+    apply:
+      component: outerloop-deploy
+  - id: deploy-service
+    apply:
+      component: outerloop-service
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deploy-deployment
+        - deploy-service
+      group:
+        kind: deploy
+        isDefault: true
+components:
+  - container:
+      endpoints:
+        - name: http-3000
+          targetPort: 3000
+      image: registry.access.redhat.com/ubi8/nodejs-14:latest
+      memoryLimit: 1024Mi
+      mountSources: true
+    name: runtime
+  - name: prod-image
+    image:
+      imageName: "{{CONTAINER_IMAGE}}"
+      dockerfile:
+        uri: ./Dockerfile
+        buildContext: ${PROJECT_SOURCE}
+  - name: outerloop-deploy
+    kubernetes:
+      inlined: |
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: devfile-nodejs-deploy
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: devfile-nodejs-deploy
+          template:
+            metadata:
+              labels:
+                app: devfile-nodejs-deploy
+            spec:
+              containers:
+                - name: main
+                  image: "{{CONTAINER_IMAGE}}"
+                  resources: {}
+  - name: outerloop-service
+    kubernetes:
+      inlined: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          labels:
+            app: devfile-nodejs-deploy
+          name: devfile-nodejs-deploy
+        spec:
+          ports:
+          - name: http-3000
+            port: 3000
+            protocol: TCP
+            targetPort: 3000
+          selector:
+            app: devfile-nodejs-deploy
+          type: LoadBalancer
+


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
Fixes #5322

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Run the reproduction steps depicted in #5322:

```shell
$ git clone https://github.com/kadel/devfile-nodejs-deploy && cd devfile-nodejs-deploy
$ sed -i "s/tkral/<quay-username>/" devfile.yaml
$ # Force odo to use Docker for building images
$ export PODMAN_CMD=a-command-not-found-should-make-odo-use-docker 
$ # Both odo deploy and odo build-images should now be able to build the container images
$ odo deploy
$ odo build-images
```

To run the integration tests related to this issue:
```shell
ginkgo -v -focus 'using a devfile.yaml containing an Image component with a build context' tests/integration/devfile
```