### PR TITLE
Wait deletion

### DIFF
--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -69,7 +69,7 @@ func (do *DeleteComponentClient) DeleteResources(resources []unstructured.Unstru
 			failed = append(failed, resource)
 			continue
 		}
-		err = do.kubeClient.DeleteDynamicResource(resource.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource, wait)
+		err = do.kubeClient.DeleteDynamicResource(resource.GetName(), gvr.Resource, wait)
 		if err != nil {
 			klog.V(3).Infof("failed to delete resource %q (%s.%s.%s): %v", resource.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource, err)
 			failed = append(failed, resource)
@@ -131,7 +131,7 @@ func (do DeleteComponentClient) ListResourcesToDeleteFromDevfile(devfileObj pars
 		}
 		// Try to fetch the resource from the cluster; if it exists, append it to the resources list
 		var cr *unstructured.Unstructured
-		cr, err = do.kubeClient.GetDynamicResource(gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource, lr.GetName())
+		cr, err = do.kubeClient.GetDynamicResource(gvr.Resource, lr.GetName())
 		if err != nil {
 			continue
 		}

--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -61,7 +61,7 @@ func (do *DeleteComponentClient) ListClusterResourcesToDelete(componentName stri
 	return result, nil
 }
 
-func (do *DeleteComponentClient) DeleteResources(resources []unstructured.Unstructured) []unstructured.Unstructured {
+func (do *DeleteComponentClient) DeleteResources(resources []unstructured.Unstructured, wait bool) []unstructured.Unstructured {
 	var failed []unstructured.Unstructured
 	for _, resource := range resources {
 		gvr, err := do.kubeClient.GetRestMappingFromUnstructured(resource)
@@ -69,7 +69,7 @@ func (do *DeleteComponentClient) DeleteResources(resources []unstructured.Unstru
 			failed = append(failed, resource)
 			continue
 		}
-		err = do.kubeClient.DeleteDynamicResource(resource.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource)
+		err = do.kubeClient.DeleteDynamicResource(resource.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource, wait)
 		if err != nil {
 			klog.V(3).Infof("failed to delete resource %q (%s.%s.%s): %v", resource.GetName(), gvr.Resource.Group, gvr.Resource.Version, gvr.Resource.Resource, err)
 			failed = append(failed, resource)

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -157,8 +157,8 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 							Resource: res2.GetKind(),
 						},
 					}, nil)
-					client.EXPECT().DeleteDynamicResource(res1.GetName(), "", "v1", res1.GetKind())
-					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind())
+					client.EXPECT().DeleteDynamicResource(res1.GetName(), "", "v1", res1.GetKind(), false)
+					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind(), false)
 					return client
 				},
 			},
@@ -180,7 +180,7 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 							Resource: res2.GetKind(),
 						},
 					}, nil)
-					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind())
+					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind(), false)
 					return client
 				},
 			},
@@ -208,8 +208,8 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 							Resource: res2.GetKind(),
 						},
 					}, nil)
-					client.EXPECT().DeleteDynamicResource(res1.GetName(), "", "v1", res1.GetKind()).Return(errors.New("some error"))
-					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind())
+					client.EXPECT().DeleteDynamicResource(res1.GetName(), "", "v1", res1.GetKind(), false).Return(errors.New("some error"))
+					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind(), false)
 					return client
 				},
 			},
@@ -226,7 +226,7 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 			do := &DeleteComponentClient{
 				kubeClient: tt.fields.kubeClient(ctrl),
 			}
-			if got := do.DeleteResources(tt.args.resources); !reflect.DeepEqual(got, tt.want) {
+			if got := do.DeleteResources(tt.args.resources, false); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DeleteComponentClient.DeleteResources() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -157,8 +157,8 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 							Resource: res2.GetKind(),
 						},
 					}, nil)
-					client.EXPECT().DeleteDynamicResource(res1.GetName(), "", "v1", res1.GetKind(), false)
-					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind(), false)
+					client.EXPECT().DeleteDynamicResource(res1.GetName(), getGVR("", "v1", res1.GetKind()), false)
+					client.EXPECT().DeleteDynamicResource(res2.GetName(), getGVR("", "v1", res2.GetKind()), false)
 					return client
 				},
 			},
@@ -180,7 +180,7 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 							Resource: res2.GetKind(),
 						},
 					}, nil)
-					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind(), false)
+					client.EXPECT().DeleteDynamicResource(res2.GetName(), getGVR("", "v1", res2.GetKind()), false)
 					return client
 				},
 			},
@@ -208,8 +208,8 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 							Resource: res2.GetKind(),
 						},
 					}, nil)
-					client.EXPECT().DeleteDynamicResource(res1.GetName(), "", "v1", res1.GetKind(), false).Return(errors.New("some error"))
-					client.EXPECT().DeleteDynamicResource(res2.GetName(), "", "v1", res2.GetKind(), false)
+					client.EXPECT().DeleteDynamicResource(res1.GetName(), getGVR("", "v1", res1.GetKind()), false).Return(errors.New("some error"))
+					client.EXPECT().DeleteDynamicResource(res2.GetName(), getGVR("", "v1", res2.GetKind()), false)
 					return client
 				},
 			},
@@ -317,7 +317,7 @@ func TestDeleteComponentClient_ListResourcesToDeleteFromDevfile(t *testing.T) {
 
 					kubeClient.EXPECT().GetRestMappingFromUnstructured(outerLoopResource).Return(&outerLoopGVR, nil)
 					kubeClient.EXPECT().
-						GetDynamicResource(outerLoopGVR.Resource.Group, outerLoopGVR.Resource.Version, outerLoopGVR.Resource.Resource, outerLoopResource.GetName()).
+						GetDynamicResource(outerLoopGVR.Resource, outerLoopResource.GetName()).
 						Return(&deployedOuterLoopResource, nil)
 
 					return kubeClient
@@ -365,7 +365,7 @@ func TestDeleteComponentClient_ListResourcesToDeleteFromDevfile(t *testing.T) {
 						Return(&appsv1.Deployment{}, kerrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "Deployments"}, innerLoopDeploymentName))
 					kubeClient.EXPECT().GetRestMappingFromUnstructured(outerLoopResource).Return(&outerLoopGVR, nil)
 					kubeClient.EXPECT().
-						GetDynamicResource(outerLoopGVR.Resource.Group, outerLoopGVR.Resource.Version, outerLoopGVR.Resource.Resource, outerLoopResource.GetName()).
+						GetDynamicResource(outerLoopGVR.Resource, outerLoopResource.GetName()).
 						Return(&deployedOuterLoopResource, nil)
 					return kubeClient
 				},
@@ -421,7 +421,7 @@ func TestDeleteComponentClient_ListResourcesToDeleteFromDevfile(t *testing.T) {
 					kubeClient.EXPECT().GetDeploymentByName(innerLoopDeploymentName).Return(deployment, nil)
 					kubeClient.EXPECT().GetRestMappingFromUnstructured(outerLoopResource).Return(&outerLoopGVR, nil)
 					kubeClient.EXPECT().
-						GetDynamicResource(outerLoopGVR.Resource.Group, outerLoopGVR.Resource.Version, outerLoopGVR.Resource.Resource, outerLoopResource.GetName()).
+						GetDynamicResource(outerLoopGVR.Resource, outerLoopResource.GetName()).
 						Return(nil, errors.New("some error"))
 					return kubeClient
 				},
@@ -608,4 +608,12 @@ func getUnstructured(name, kind, apiVersion, namespace string) (u unstructured.U
 	u.SetAPIVersion(apiVersion)
 	u.SetNamespace(namespace)
 	return
+}
+
+func getGVR(group, version, resource string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
+	}
 }

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -9,7 +9,8 @@ type Client interface {
 	// ListClusterResourcesToDelete lists Kubernetes resources from cluster in namespace for a given odo component
 	ListClusterResourcesToDelete(componentName string, namespace string) ([]unstructured.Unstructured, error)
 	// DeleteResources deletes the unstuctured resources and return the resources that failed to be deleted
-	DeleteResources([]unstructured.Unstructured, bool) []unstructured.Unstructured
+	// set wait to true to wait for all the dependencies to be deleted
+	DeleteResources(resources []unstructured.Unstructured, wait bool) []unstructured.Unstructured
 	// ExecutePreStopEvents executes preStop events if any, as a precondition to deleting a devfile component deployment
 	ExecutePreStopEvents(devfileObj parser.DevfileObj, appName string) error
 	// ListResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on the cluster that can be deleted,

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -9,7 +9,7 @@ type Client interface {
 	// ListClusterResourcesToDelete lists Kubernetes resources from cluster in namespace for a given odo component
 	ListClusterResourcesToDelete(componentName string, namespace string) ([]unstructured.Unstructured, error)
 	// DeleteResources deletes the unstuctured resources and return the resources that failed to be deleted
-	DeleteResources([]unstructured.Unstructured) []unstructured.Unstructured
+	DeleteResources([]unstructured.Unstructured, bool) []unstructured.Unstructured
 	// ExecutePreStopEvents executes preStop events if any, as a precondition to deleting a devfile component deployment
 	ExecutePreStopEvents(devfileObj parser.DevfileObj, appName string) error
 	// ListResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on the cluster that can be deleted,

--- a/pkg/component/delete/mock.go
+++ b/pkg/component/delete/mock.go
@@ -36,17 +36,17 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // DeleteResources mocks base method.
-func (m *MockClient) DeleteResources(arg0 []unstructured.Unstructured) []unstructured.Unstructured {
+func (m *MockClient) DeleteResources(arg0 []unstructured.Unstructured, arg1 bool) []unstructured.Unstructured {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteResources", arg0)
+	ret := m.ctrl.Call(m, "DeleteResources", arg0, arg1)
 	ret0, _ := ret[0].([]unstructured.Unstructured)
 	return ret0
 }
 
 // DeleteResources indicates an expected call of DeleteResources.
-func (mr *MockClientMockRecorder) DeleteResources(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteResources(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockClient)(nil).DeleteResources), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockClient)(nil).DeleteResources), arg0, arg1)
 }
 
 // ExecutePreStopEvents mocks base method.

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -8,16 +8,12 @@ import (
 	"sort"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-
 	"github.com/redhat-developer/odo/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
@@ -325,71 +321,6 @@ func (c *Client) DeleteDeployment(labels map[string]string) error {
 	klog.V(3).Info("Deleting Deployment")
 
 	return c.KubeClient.AppsV1().Deployments(c.Namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
-}
-
-// CreateDynamicResource creates a dynamic custom resource
-func (c *Client) CreateDynamicResource(resource unstructured.Unstructured, gvr *meta.RESTMapping) error {
-	klog.V(5).Infoln("Applying resource via server-side apply:")
-	klog.V(5).Infoln(resourceAsJson(resource.Object))
-	data, err := json.Marshal(resource.Object)
-	if err != nil {
-		return fmt.Errorf("unable to marshal resource: %w", err)
-	}
-
-	// Patch the dynamic resource
-	_, err = c.DynamicClient.Resource(gvr.Resource).Namespace(c.Namespace).Patch(context.TODO(), resource.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: FieldManager, Force: boolPtr(true)})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ListDynamicResource returns an unstructured list of instances of a Custom
-// Resource currently deployed in the active namespace of the cluster
-func (c *Client) ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error) {
-
-	if c.DynamicClient == nil {
-		return nil, nil
-	}
-
-	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
-
-	list, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return list, nil
-}
-
-// GetDynamicResource returns an unstructured instance of a Custom Resource currently deployed in the active namespace
-func (c *Client) GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error) {
-	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
-
-	res, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
-}
-
-// UpdateDynamicResource updates a dynamic resource
-func (c *Client) UpdateDynamicResource(group, version, resource, name string, u *unstructured.Unstructured) error {
-	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
-
-	_, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Update(context.TODO(), u, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// DeleteDynamicResource deletes an instance, specified by name, of a Custom Resource
-func (c *Client) DeleteDynamicResource(name, group, version, resource string) error {
-	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
-
-	return c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
 // Define a function that is meant to create patch based on the contents of the deployment

--- a/pkg/kclient/dynamic.go
+++ b/pkg/kclient/dynamic.go
@@ -1,0 +1,126 @@
+package kclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	apiMachineryWatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog"
+)
+
+// CreateDynamicResource creates a dynamic custom resource
+func (c *Client) CreateDynamicResource(resource unstructured.Unstructured, gvr *meta.RESTMapping) error {
+	klog.V(5).Infoln("Applying resource via server-side apply:")
+	klog.V(5).Infoln(resourceAsJson(resource.Object))
+	data, err := json.Marshal(resource.Object)
+	if err != nil {
+		return fmt.Errorf("unable to marshal resource: %w", err)
+	}
+
+	// Patch the dynamic resource
+	_, err = c.DynamicClient.Resource(gvr.Resource).Namespace(c.Namespace).Patch(context.TODO(), resource.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: FieldManager, Force: boolPtr(true)})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ListDynamicResource returns an unstructured list of instances of a Custom
+// Resource currently deployed in the active namespace of the cluster
+func (c *Client) ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error) {
+
+	if c.DynamicClient == nil {
+		return nil, nil
+	}
+
+	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	list, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return list, nil
+}
+
+// GetDynamicResource returns an unstructured instance of a Custom Resource currently deployed in the active namespace
+func (c *Client) GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error) {
+	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	res, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// UpdateDynamicResource updates a dynamic resource
+func (c *Client) UpdateDynamicResource(group, version, resource, name string, u *unstructured.Unstructured) error {
+	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	_, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Update(context.TODO(), u, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteDynamicResource deletes an instance, specified by name, of a Custom Resource
+// if wait is true, it will set the PropagationPolicy to DeletePropagationForeground
+// to wait for owned resources to be deleted (only for resources with a BlockOwnerDeletion set to true)
+func (c *Client) DeleteDynamicResource(name, group, version, resourceName string, wait bool) error {
+
+	resource := schema.GroupVersionResource{Group: group, Version: version, Resource: resourceName}
+
+	doDeleteResource := func() error {
+		return c.DynamicClient.Resource(resource).Namespace(c.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
+			PropagationPolicy: func(f metav1.DeletionPropagation) *metav1.DeletionPropagation {
+				if wait {
+					return &f
+				}
+				return nil
+			}(metav1.DeletePropagationForeground),
+		})
+	}
+
+	if !wait {
+		return doDeleteResource()
+	}
+
+	var err error
+	var watch apiMachineryWatch.Interface
+	watch, err = c.DynamicClient.Resource(resource).Namespace(c.Namespace).Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + name})
+	if err != nil {
+		return err
+	}
+	defer watch.Stop()
+
+	err = doDeleteResource()
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-time.After(time.Minute):
+			return fmt.Errorf("timeout while waiting for %q resource to be deleted", name)
+
+		case val, ok := <-watch.ResultChan():
+			if !ok {
+				return errors.New("error getting value from resultchan")
+			}
+			if val.Type == apiMachineryWatch.Deleted {
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -38,16 +38,18 @@ type ClientInterface interface {
 	UpdateDeployment(deploy appsv1.Deployment) (*appsv1.Deployment, error)
 	ApplyDeployment(deploy appsv1.Deployment) (*appsv1.Deployment, error)
 	DeleteDeployment(labels map[string]string) error
-	CreateDynamicResource(exampleCustomResource unstructured.Unstructured, gvr *meta.RESTMapping) error
-	ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error)
-	GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error)
-	UpdateDynamicResource(group, version, resource, name string, u *unstructured.Unstructured) error
-	DeleteDynamicResource(name, group, version, resource string) error
 	LinkSecret(secretName, componentName, applicationName string) error
 	UnlinkSecret(secretName, componentName, applicationName string) error
 	GetDeploymentLabelValues(label string, selector string) ([]string, error)
 	GetDeploymentAPIVersion() (metav1.GroupVersionResource, error)
 	IsDeploymentExtensionsV1Beta1() (bool, error)
+
+	// dynamic.go
+	CreateDynamicResource(exampleCustomResource unstructured.Unstructured, gvr *meta.RESTMapping) error
+	ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error)
+	GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error)
+	UpdateDynamicResource(group, version, resource, name string, u *unstructured.Unstructured) error
+	DeleteDynamicResource(name, group, version, resource string, wait bool) error
 
 	// events.go
 	CollectEvents(selector string, events map[string]corev1.Event, quit <-chan int)
@@ -87,6 +89,9 @@ type ClientInterface interface {
 	GetResourceSpecDefinition(group, version, kind string) (*spec.Schema, error)
 	GetRestMappingFromUnstructured(unstructured.Unstructured) (*meta.RESTMapping, error)
 	GetOperatorGVRList() ([]meta.RESTMapping, error)
+
+	// owner_reference.go
+	TryWithBlockOwnerDeletion(ownerReference metav1.OwnerReference, exec func(ownerReference metav1.OwnerReference) error) error
 
 	// pods.go
 	WaitAndGetPodWithEvents(selector string, desiredPhase corev1.PodPhase, pushTimeout time.Duration) (*corev1.Pod, error)

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -45,11 +46,11 @@ type ClientInterface interface {
 	IsDeploymentExtensionsV1Beta1() (bool, error)
 
 	// dynamic.go
-	CreateDynamicResource(exampleCustomResource unstructured.Unstructured, gvr *meta.RESTMapping) error
-	ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error)
-	GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error)
-	UpdateDynamicResource(group, version, resource, name string, u *unstructured.Unstructured) error
-	DeleteDynamicResource(name, group, version, resource string, wait bool) error
+	CreateDynamicResource(exampleCustomResource unstructured.Unstructured) error
+	ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
+	GetDynamicResource(gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error)
+	UpdateDynamicResource(gvr schema.GroupVersionResource, name string, u *unstructured.Unstructured) error
+	DeleteDynamicResource(name string, gvr schema.GroupVersionResource, wait bool) error
 
 	// events.go
 	CollectEvents(selector string, events map[string]corev1.Event, quit <-chan int)

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -235,17 +235,17 @@ func (mr *MockClientInterfaceMockRecorder) DeleteDeployment(labels interface{}) 
 }
 
 // DeleteDynamicResource mocks base method.
-func (m *MockClientInterface) DeleteDynamicResource(name, group, version, resource string) error {
+func (m *MockClientInterface) DeleteDynamicResource(name, group, version, resource string, wait bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDynamicResource", name, group, version, resource)
+	ret := m.ctrl.Call(m, "DeleteDynamicResource", name, group, version, resource, wait)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteDynamicResource indicates an expected call of DeleteDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) DeleteDynamicResource(name, group, version, resource interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) DeleteDynamicResource(name, group, version, resource, wait interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).DeleteDynamicResource), name, group, version, resource)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).DeleteDynamicResource), name, group, version, resource, wait)
 }
 
 // DeleteNamespace mocks base method.
@@ -1124,6 +1124,20 @@ func (m *MockClientInterface) SetupPortForwarding(pod *v11.Pod, portPairs []stri
 func (mr *MockClientInterfaceMockRecorder) SetupPortForwarding(pod, portPairs, out, errOut interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupPortForwarding", reflect.TypeOf((*MockClientInterface)(nil).SetupPortForwarding), pod, portPairs, out, errOut)
+}
+
+// TryWithBlockOwnerDeletion mocks base method.
+func (m *MockClientInterface) TryWithBlockOwnerDeletion(ownerReference v12.OwnerReference, exec func(v12.OwnerReference) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TryWithBlockOwnerDeletion", ownerReference, exec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TryWithBlockOwnerDeletion indicates an expected call of TryWithBlockOwnerDeletion.
+func (mr *MockClientInterfaceMockRecorder) TryWithBlockOwnerDeletion(ownerReference, exec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryWithBlockOwnerDeletion", reflect.TypeOf((*MockClientInterface)(nil).TryWithBlockOwnerDeletion), ownerReference, exec)
 }
 
 // UnlinkSecret mocks base method.

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -18,6 +18,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	discovery "k8s.io/client-go/discovery"
 	dynamic "k8s.io/client-go/dynamic"
 	kubernetes "k8s.io/client-go/kubernetes"
@@ -91,17 +92,17 @@ func (mr *MockClientInterfaceMockRecorder) CreateDeployment(deploy interface{}) 
 }
 
 // CreateDynamicResource mocks base method.
-func (m *MockClientInterface) CreateDynamicResource(exampleCustomResource unstructured.Unstructured, gvr *meta.RESTMapping) error {
+func (m *MockClientInterface) CreateDynamicResource(exampleCustomResource unstructured.Unstructured) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDynamicResource", exampleCustomResource, gvr)
+	ret := m.ctrl.Call(m, "CreateDynamicResource", exampleCustomResource)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateDynamicResource indicates an expected call of CreateDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) CreateDynamicResource(exampleCustomResource, gvr interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) CreateDynamicResource(exampleCustomResource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).CreateDynamicResource), exampleCustomResource, gvr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).CreateDynamicResource), exampleCustomResource)
 }
 
 // CreateNamespace mocks base method.
@@ -235,17 +236,17 @@ func (mr *MockClientInterfaceMockRecorder) DeleteDeployment(labels interface{}) 
 }
 
 // DeleteDynamicResource mocks base method.
-func (m *MockClientInterface) DeleteDynamicResource(name, group, version, resource string, wait bool) error {
+func (m *MockClientInterface) DeleteDynamicResource(name string, gvr schema.GroupVersionResource, wait bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDynamicResource", name, group, version, resource, wait)
+	ret := m.ctrl.Call(m, "DeleteDynamicResource", name, gvr, wait)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteDynamicResource indicates an expected call of DeleteDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) DeleteDynamicResource(name, group, version, resource, wait interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) DeleteDynamicResource(name, gvr, wait interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).DeleteDynamicResource), name, group, version, resource, wait)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).DeleteDynamicResource), name, gvr, wait)
 }
 
 // DeleteNamespace mocks base method.
@@ -568,18 +569,18 @@ func (mr *MockClientInterfaceMockRecorder) GetDynamicClient() *gomock.Call {
 }
 
 // GetDynamicResource mocks base method.
-func (m *MockClientInterface) GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error) {
+func (m *MockClientInterface) GetDynamicResource(gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDynamicResource", group, version, resource, name)
+	ret := m.ctrl.Call(m, "GetDynamicResource", gvr, name)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDynamicResource indicates an expected call of GetDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) GetDynamicResource(group, version, resource, name interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) GetDynamicResource(gvr, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).GetDynamicResource), group, version, resource, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).GetDynamicResource), gvr, name)
 }
 
 // GetNamespace mocks base method.
@@ -970,19 +971,19 @@ func (mr *MockClientInterfaceMockRecorder) ListDeployments(selector interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployments", reflect.TypeOf((*MockClientInterface)(nil).ListDeployments), selector)
 }
 
-// ListDynamicResource mocks base method.
-func (m *MockClientInterface) ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error) {
+// ListDynamicResources mocks base method.
+func (m *MockClientInterface) ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDynamicResource", group, version, resource)
+	ret := m.ctrl.Call(m, "ListDynamicResources", gvr)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListDynamicResource indicates an expected call of ListDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) ListDynamicResource(group, version, resource interface{}) *gomock.Call {
+// ListDynamicResources indicates an expected call of ListDynamicResources.
+func (mr *MockClientInterfaceMockRecorder) ListDynamicResources(gvr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).ListDynamicResource), group, version, resource)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDynamicResources", reflect.TypeOf((*MockClientInterface)(nil).ListDynamicResources), gvr)
 }
 
 // ListPVCNames mocks base method.
@@ -1170,17 +1171,17 @@ func (mr *MockClientInterfaceMockRecorder) UpdateDeployment(deploy interface{}) 
 }
 
 // UpdateDynamicResource mocks base method.
-func (m *MockClientInterface) UpdateDynamicResource(group, version, resource, name string, u *unstructured.Unstructured) error {
+func (m *MockClientInterface) UpdateDynamicResource(gvr schema.GroupVersionResource, name string, u *unstructured.Unstructured) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDynamicResource", group, version, resource, name, u)
+	ret := m.ctrl.Call(m, "UpdateDynamicResource", gvr, name, u)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateDynamicResource indicates an expected call of UpdateDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) UpdateDynamicResource(group, version, resource, name, u interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) UpdateDynamicResource(gvr, name, u interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).UpdateDynamicResource), group, version, resource, name, u)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).UpdateDynamicResource), gvr, name, u)
 }
 
 // UpdatePVCLabels mocks base method.

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/discovery"
@@ -205,13 +203,8 @@ func (c *Client) GetOperatorGVRList() ([]meta.RESTMapping, error) {
 	for _, c := range csvs.Items {
 		owned := c.Spec.CustomResourceDefinitions.Owned
 		for i := range owned {
-			g, v, r := GetGVRFromCR(&owned[i])
 			operatorGVRList = append(operatorGVRList, meta.RESTMapping{
-				Resource: schema.GroupVersionResource{
-					Group:    g,
-					Version:  v,
-					Resource: r,
-				},
+				Resource: GetGVRFromCR(&owned[i]),
 			})
 		}
 	}

--- a/pkg/kclient/owner_reference.go
+++ b/pkg/kclient/owner_reference.go
@@ -1,0 +1,22 @@
+package kclient
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+// TryWithBlockOwnerDeletion will execute `exec` a first time with `BlockOwnerDeletion` set to true in `ownerReference`
+// If a Forbidden errors occurs, it will call `exec` again with the original `ownerReference`
+func (c *Client) TryWithBlockOwnerDeletion(ownerReference metav1.OwnerReference, exec func(ownerReference metav1.OwnerReference) error) error {
+	blockOwnerRef := ownerReference
+	blockOwnerRef.BlockOwnerDeletion = pointer.BoolPtr(true)
+	err := exec(blockOwnerRef)
+	if err == nil {
+		return nil
+	}
+	if apierrors.IsForbidden(err) {
+		return exec(ownerReference)
+	}
+	return err
+}

--- a/pkg/kclient/owner_reference_test.go
+++ b/pkg/kclient/owner_reference_test.go
@@ -1,0 +1,110 @@
+package kclient
+
+import (
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestClient_TryWithBlockOwnerDeletion(t *testing.T) {
+	type args struct {
+		ownerReference metav1.OwnerReference
+		exec           func() func(ownerReference metav1.OwnerReference) error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "first call is ok",
+			args: args{
+				ownerReference: metav1.OwnerReference{},
+				exec: func() func(ownerReference metav1.OwnerReference) error {
+					calls := 0
+					return func(ownerReference metav1.OwnerReference) error {
+						calls++
+						if calls > 1 {
+							t.Errorf("only one call should happen")
+						}
+						return nil
+					}
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "first call fails with non forbidden error",
+			args: args{
+				ownerReference: metav1.OwnerReference{},
+				exec: func() func(ownerReference metav1.OwnerReference) error {
+					calls := 0
+					return func(ownerReference metav1.OwnerReference) error {
+						calls++
+						if calls > 1 {
+							t.Errorf("only one call should happen")
+						}
+						return errors.New("an error call 1")
+					}
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "first call fails with forbidden error, second call is ok",
+			args: args{
+				ownerReference: metav1.OwnerReference{},
+				exec: func() func(ownerReference metav1.OwnerReference) error {
+					calls := 0
+					return func(ownerReference metav1.OwnerReference) error {
+						calls++
+						switch calls {
+						case 1:
+							return apierrors.NewForbidden(schema.GroupResource{}, "aname", errors.New("an error"))
+						case 2:
+							return nil
+						default:
+							t.Errorf("only two calls should happen")
+							return nil
+						}
+					}
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "first call fails with forbidden error, second call fails with error",
+			args: args{
+				ownerReference: metav1.OwnerReference{},
+				exec: func() func(ownerReference metav1.OwnerReference) error {
+					calls := 0
+					return func(ownerReference metav1.OwnerReference) error {
+						calls++
+						switch calls {
+						case 1:
+							return apierrors.NewForbidden(schema.GroupResource{}, "aname", errors.New("an error"))
+						case 2:
+							return errors.New("an error")
+						default:
+							t.Errorf("only two calls should happen")
+							return nil
+						}
+					}
+				},
+			},
+			wantErr: true,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{}
+			if err := c.TryWithBlockOwnerDeletion(tt.args.ownerReference, tt.args.exec()); (err != nil) != tt.wantErr {
+				t.Errorf("Client.TryWithBlockOwnerDeletion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/kclient/owner_reference_test.go
+++ b/pkg/kclient/owner_reference_test.go
@@ -97,7 +97,6 @@ func TestClient_TryWithBlockOwnerDeletion(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kclient/utils.go
+++ b/pkg/kclient/utils.go
@@ -8,6 +8,7 @@ import (
 
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/olekukonko/tablewriter"
@@ -68,7 +69,7 @@ func getErrorMessageFromEvents(failedEvents map[string]corev1.Event) strings.Bui
 
 // GetGVRFromCR parses and returns the values for group, version and resource
 // for a given Custom Resource (CR).
-func GetGVRFromCR(cr *olm.CRDDescription) (string, string, string) {
+func GetGVRFromCR(cr *olm.CRDDescription) schema.GroupVersionResource {
 	var group, version, resource string
 	version = cr.Version
 
@@ -76,7 +77,11 @@ func GetGVRFromCR(cr *olm.CRDDescription) (string, string, string) {
 	resource = gr[0]
 	group = gr[1]
 
-	return group, version, resource
+	return schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
+	}
 }
 
 // ConvertK8sResourceToUnstructured converts any K8s resource to unstructured.Unstructured format

--- a/pkg/odo/cli/delete/component.go
+++ b/pkg/odo/cli/delete/component.go
@@ -41,6 +41,9 @@ type ComponentOptions struct {
 	// forceFlag forces deletion
 	forceFlag bool
 
+	// waitFlag waits for deletion of all resources
+	waitFlag bool
+
 	// Context
 	*genericclioptions.Context
 
@@ -101,7 +104,7 @@ func (o *ComponentOptions) deleteNamedComponent() error {
 	}
 	printDevfileComponents(o.name, o.namespace, list)
 	if o.forceFlag || ui.Proceed("Are you sure you want to delete these resources?") {
-		failed := o.clientset.DeleteClient.DeleteResources(list)
+		failed := o.clientset.DeleteClient.DeleteResources(list, o.waitFlag)
 		for _, fail := range failed {
 			log.Warningf("Failed to delete the %q resource: %s\n", fail.GetKind(), fail.GetName())
 		}
@@ -147,7 +150,7 @@ func (o *ComponentOptions) deleteDevfileComponent() error {
 		}
 
 		// delete all the resources
-		failed := o.clientset.DeleteClient.DeleteResources(devfileResources)
+		failed := o.clientset.DeleteClient.DeleteResources(devfileResources, o.waitFlag)
 		for _, fail := range failed {
 			log.Warningf("Failed to delete the %q resource: %s\n", fail.GetKind(), fail.GetName())
 		}
@@ -217,6 +220,7 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 	componentCmd.Flags().StringVar(&o.name, "name", "", "Name of the component to delete, optional. By default, the component described in the local devfile is deleted")
 	componentCmd.Flags().StringVar(&o.namespace, "namespace", "", "Namespace in which to find the component to delete, optional. By default, the current namespace defined in kubeconfig is used")
 	componentCmd.Flags().BoolVarP(&o.forceFlag, "force", "f", false, "Delete component without prompting")
+	componentCmd.Flags().BoolVarP(&o.waitFlag, "wait", "w", false, "Wait for deletion of all dependent resources")
 	clientset.Add(componentCmd, clientset.DELETE_COMPONENT, clientset.KUBERNETES)
 
 	return componentCmd

--- a/pkg/odo/cli/delete/component_test.go
+++ b/pkg/odo/cli/delete/component_test.go
@@ -50,7 +50,7 @@ func TestComponentOptions_deleteNamedComponent(t *testing.T) {
 				deleteComponentClient: func(ctrl *gomock.Controller) _delete.Client {
 					client := _delete.NewMockClient(ctrl)
 					client.EXPECT().ListClusterResourcesToDelete("my-component", "my-namespace").Return(nil, nil)
-					client.EXPECT().DeleteResources(gomock.Any()).Times(0)
+					client.EXPECT().DeleteResources(gomock.Any(), false).Times(0)
 					return client
 				},
 			},
@@ -73,7 +73,7 @@ func TestComponentOptions_deleteNamedComponent(t *testing.T) {
 					resources = append(resources, res1, res2)
 					client := _delete.NewMockClient(ctrl)
 					client.EXPECT().ListClusterResourcesToDelete("my-component", "my-namespace").Return(resources, nil)
-					client.EXPECT().DeleteResources([]unstructured.Unstructured{res1, res2}).Times(1)
+					client.EXPECT().DeleteResources([]unstructured.Unstructured{res1, res2}, false).Times(1)
 					return client
 				},
 			},
@@ -132,7 +132,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName).Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(compName, projectName).Return(resources, nil)
 				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any()).Return(nil)
-				deleteClient.EXPECT().DeleteResources(resources).Return([]unstructured.Unstructured{})
+				deleteClient.EXPECT().DeleteResources(resources, false).Return([]unstructured.Unstructured{})
 				return deleteClient
 			},
 			fields: fields{
@@ -147,7 +147,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName).Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(compName, projectName).Return(resources, nil)
 				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), appName).Return(errors.New("some error"))
-				deleteClient.EXPECT().DeleteResources(resources).Return(nil)
+				deleteClient.EXPECT().DeleteResources(resources, false).Return(nil)
 				return deleteClient
 			},
 			fields: fields{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -66,7 +66,7 @@ func DeleteOperatorService(client kclient.ClientInterface, serviceName string) e
 
 	group, version, resource := kclient.GetGVRFromCR(cr)
 
-	return client.DeleteDynamicResource(name, group, version, resource)
+	return client.DeleteDynamicResource(name, group, version, resource, false)
 }
 
 // ListOperatorServices lists all operator backed services.

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -344,7 +344,7 @@ func (o *WatchClient) cleanupFunc(devfileObj parser.DevfileObj, out io.Writer) e
 		}
 	}
 	// delete all the resources
-	failed := o.deleteClient.DeleteResources(resources)
+	failed := o.deleteClient.DeleteResources(resources, true)
 	for _, fail := range failed {
 		fmt.Fprintf(out, "Failed to delete the %q resource: %s\n", fail.GetKind(), fail.GetName())
 	}

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -36,4 +36,5 @@ type CliRunner interface {
 	GetEnvFromEntry(componentName string, appName string, projectName string) string
 	GetVolumeNamesFromDeployment(componentName, appName, projectName string) map[string]string
 	ScalePodToZero(componentName, appName, projectName string)
+	GetAllPodNames(namespace string) []string
 }

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"regexp"
+	"time"
 
 	"github.com/onsi/gomega/gexec"
 )
@@ -116,7 +117,7 @@ func StartDevMode(opts ...string) (DevSession, []byte, []byte, []string, error) 
 	args := []string{"dev", "--random-ports"}
 	args = append(args, opts...)
 	session := CmdRunner("odo", args...)
-	WaitForOutputToContain("Watching for changes in the current directory", 240, 10, session)
+	WaitForOutputToContain("Watching for changes in the current directory", 360, 10, session)
 	result := DevSession{
 		session: session,
 	}
@@ -142,6 +143,10 @@ func (o DevSession) Kill() {
 // Stop a Dev session cleanly (equivalent as hitting Ctrl-c)
 func (o DevSession) Stop() {
 	o.session.Interrupt()
+}
+
+func (o DevSession) WaitEnd() {
+	o.session.Wait(1 * time.Minute)
 }
 
 //  WaitSync waits for the synchronization of files to be finished

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -263,6 +263,17 @@ func (kubectl KubectlRunner) GetAllPodsInNs(namespace string) string {
 	return Cmd(kubectl.path, args...).ShouldPass().Out()
 }
 
+// GetAllPodNames gets the names of pods in given namespace
+func (kubectl KubectlRunner) GetAllPodNames(namespace string) []string {
+	session := CmdRunner(kubectl.path, "get", "pods", "--namespace", namespace, "-o", "jsonpath={.items[*].metadata.name}")
+	Eventually(session).Should(gexec.Exit(0))
+	output := string(session.Wait().Out.Contents())
+	if output == "" {
+		return []string{}
+	}
+	return strings.Split(output, " ")
+}
+
 func (kubectl KubectlRunner) PodsShouldBeRunning(project string, regex string) {
 	// now verify if the pods for the operator have started
 	pods := kubectl.GetAllPodsInNs(project)

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -397,6 +397,17 @@ func (oc OcRunner) GetAllPodsInNs(namespace string) string {
 	return Cmd(oc.path, args...).ShouldPass().Out()
 }
 
+// GetAllPodNames gets the names of pods in given namespace
+func (oc OcRunner) GetAllPodNames(namespace string) []string {
+	session := CmdRunner(oc.path, "get", "pods", "--namespace", namespace, "-o", "jsonpath={.items[*].metadata.name}")
+	Eventually(session).Should(gexec.Exit(0))
+	output := string(session.Wait().Out.Contents())
+	if output == "" {
+		return []string{}
+	}
+	return strings.Split(output, " ")
+}
+
 // StatFileInPod returns stat result of filepath in pod of given component, in a given app, in a given project.
 // It also strips access time information as it vaires accross file systems/kernel configs, and we are not interested
 // in it anyway

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -9,10 +9,9 @@ import (
 	"sort"
 	"strings"
 
-	segment "github.com/redhat-developer/odo/pkg/segment/context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	segment "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/util"
 
 	"github.com/onsi/gomega/gexec"
@@ -210,6 +209,7 @@ var _ = Describe("odo dev command tests", func() {
 					helper.EnableTelemetryDebug()
 					session, _, _, _, _ := helper.StartDevMode()
 					session.Stop()
+					session.WaitEnd()
 				})
 				AfterEach(func() {
 					helper.ResetTelemetry()

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -280,7 +280,7 @@ var _ = Describe("odo dev command tests", func() {
 					helper.Cmd("odo", "delete", "component", "--wait", "-f").ShouldPass()
 				})
 
-				It("should have deleted all resources before to return", func() {
+				It("should have deleted all resources before returning", func() {
 					By("deleting the service", func() {
 						services := commonVar.CliRunner.GetServices(commonVar.Project)
 						Expect(services).To(BeEmpty())


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

- During odo dev, when creating resources (services, pvcs) attached to the main deployment, odo first tries to set `BlockOwnerDeletion` on the ownerReference, so the call to `Delete` with `PropagationPolicy` set to `DeletePropagationForeground` is effective. Because this operation needs specific rights, if the execution fails, it is not fatal and the ownerReference is still set but without `BlockOwnerDeletion`,
- a flag `--wait` is added to the `odo delete component` command, that calls the `Delete` functions with the `wait` parameter,
- When executing `Delete`  calls on resources with `wait` set to true, set  `PropagationPolicy` is set to `DeletePropagationForeground`, so the `Delete` call returns only when owned resources with `BlockOwnerDeletion` set are completely removed
- When executing `Delete`  calls on resources with `wait` set to true, the owned without `BlockOwnerDeletion` set are collected, and odo waits for their termination
- in `pkg/kclient` package, `*Dynamic*` methods are moved to the `dynamic.go` file, and `(group, version, kind string)` parameters are changed to a single parameter `schema.GroupVersionResource`.

**Which issue(s) this PR fixes:**

Fixes #5565 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
