### PR TITLE
[#5330] Make `odo build-images` return an error if no Image component found in Devfile

### DIFF
--- a/pkg/devfile/image/image.go
+++ b/pkg/devfile/image/image.go
@@ -9,6 +9,7 @@ import (
 	devfile "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"github.com/redhat-developer/odo/pkg/log"
 )
 
@@ -38,6 +39,9 @@ func BuildPushImages(devfileObj parser.DevfileObj, path string, push bool) error
 	})
 	if err != nil {
 		return err
+	}
+	if len(components) == 0 {
+		return libdevfile.NewComponentTypeNotFoundError(devfile.ImageComponentType)
 	}
 
 	for _, component := range components {

--- a/pkg/libdevfile/errors.go
+++ b/pkg/libdevfile/errors.go
@@ -83,3 +83,18 @@ func NewNotAContainerError() NotAContainerError {
 func (e NotAContainerError) Error() string {
 	return "component not a container"
 }
+
+// ComponentTypeNotFoundError is returned when no component with the specified type has been found in Devfile
+type ComponentTypeNotFoundError struct {
+	componentType v1alpha2.ComponentType
+}
+
+func NewComponentTypeNotFoundError(componentType v1alpha2.ComponentType) ComponentTypeNotFoundError {
+	return ComponentTypeNotFoundError{
+		componentType: componentType,
+	}
+}
+
+func (e ComponentTypeNotFoundError) Error() string {
+	return fmt.Sprintf("no component with type %q found in Devfile", e.componentType)
+}

--- a/tests/integration/devfile/cmd_devfile_build_images_test.go
+++ b/tests/integration/devfile/cmd_devfile_build_images_test.go
@@ -43,6 +43,24 @@ var _ = Describe("odo devfile build-images command tests", func() {
 		})
 	})
 
+	When("using a devfile.yaml with no Image component", func() {
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.Cmd("odo", "init", "--name", "aname",
+				"--devfile-path",
+				helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml")).ShouldPass()
+			helper.CreateLocalEnv(commonVar.Context, "aname", commonVar.Project)
+		})
+		It("should not be able to run odo build-images", func() {
+			stdout, stderr := helper.Cmd("odo", "build-images").AddEnv("PODMAN_CMD=echo").ShouldFail().OutAndErr()
+			// Make sure no "{podman,docker} build -t ..." command gets executed
+			imageBuildCmd := "build -t "
+			Expect(stdout).ShouldNot(ContainSubstring(imageBuildCmd))
+			Expect(stderr).ShouldNot(ContainSubstring(imageBuildCmd))
+			Expect(stderr).To(ContainSubstring("no component with type \"Image\" found in Devfile"))
+		})
+	})
+
 	When("using a devfile.yaml containing an Image component with Dockerfile args", func() {
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
See #5330 for more context.

**Which issue(s) this PR fixes:**
Fixes #5330 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
When running `odo build-images` with a Devfile that has no `Image` component in it, the command should not succeed and should output an error message on the standard error instead, like so:
```
asoro in work-laptop in /tmp/no-image-in-devfile on ☁️   
❯ odo build-images            
 ✗  no component with type "Image" found in Devfile
```