### PR TITLE
Updates the odo dev output for logging

### DIFF
--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -186,7 +186,6 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(o.out, "\nYour application is running on cluster.\n\n")
 
 	// get the endpoint/port information for containers in devfile and setup port-forwarding
 	containers, err := o.Context.EnvSpecificInfo.GetDevfileObj().Data.GetComponents(parsercommon.DevfileOptions{
@@ -210,7 +209,11 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	portsBuf := NewPortWriter(os.Stdout, len(portPairsSlice))
+
+	// Output that the application is running, and then show the port-forwarding information
+	log.Info("\nYour application is now running on the cluster")
+
+	portsBuf := NewPortWriter(log.GetStdout(), len(portPairsSlice))
 	go func() {
 		err = o.clientset.KubernetesClient.SetupPortForwarding(pod, portPairsSlice, portsBuf, o.errOut)
 		if err != nil {

--- a/pkg/odo/cli/dev/writer.go
+++ b/pkg/odo/cli/dev/writer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 type PortWriter struct {
@@ -23,6 +25,12 @@ func NewPortWriter(buffer io.Writer, len int) *PortWriter {
 }
 
 func (o *PortWriter) Write(buf []byte) (n int, err error) {
+
+	// Set the colours to green (to indicate that the port is OPEN)
+	// as well as bold. So it stands our that the application is currently
+	// being port forwarded.
+	color.Set(color.FgGreen, color.Bold)
+	defer color.Unset() // Use it in your function
 	s := string(buf)
 	if strings.HasPrefix(s, "Forwarding from 127.0.0.1") {
 		fmt.Fprintf(o.buffer, " - %s", s)

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -927,7 +927,7 @@ var _ = Describe("odo dev command tests", func() {
 
 		It("should error out with some log", func() {
 			helper.MatchAllInOutput(string(initErr), []string{
-				"exited with error status within 1 sec",
+				"exited with an error status in 1 sec",
 				"Did you mean one of these?",
 			})
 		})


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

/kind cleanup

**What does this PR do / why we need it:**

This PR does the following:
- Removes the references to `odo log`
- Changes the output to last 100 lines and puts the number in a constant
- Reworks the output of `odo dev` a bit to be bolded / more consise with
  out outputs.

See below for the changes:
```sh
▶ copy-odo && devfiles && cd deploy-no-knative && odo dev
go build -mod=vendor -ldflags="-X github.com/redhat-developer/odo/pkg/version.GITCOMMIT=4669bc9dc" cmd/odo/odo.go
  __
 /  \__     Developing using the deploy-no-knative Devfile
 \__/  \    Namespace: default
 /  \__/    odo version: v2.5.0
 \__/

↪ Deploying to the cluster in developer mode
 ✓  Waiting for Kubernetes resources [360ms]
 ✓  Syncing files into the container [1ms]
 ✓  Building your application in container on cluster [1s]
 ✓  Executing the application [1s]
 ⚠  Devfile command "run" exited with an error status in 1 seconds
 ⚠  Last 100 lines of log:
time="2022-03-30T16:47:25Z" level=info msg="try to start program" program=devrun
time="2022-03-30T16:47:25Z" level=info msg="success to start program" program=devrun
ODO_COMMAND_RUN is npm start
Changing directory to /project
Executing command cd /project && npm start
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /project/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/project/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
...
time="2022-03-30T16:50:30Z" level=info msg="Don't start the stopped program because its retry times 0 is greater than start retries 0" program=devrun
Your application is now running on the cluster.

- Port 3000 from "runtime" container forwarded to localhost:40001

Watching for changes in the current directory /Users/cdrage/syncthing/dev/k8s/devfiles/deploy-no-knative

Press Ctrl+c to exit.
```

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5606

**PR acceptance criteria:**

- [X] Unit test

- [X] Integration test

- [X] Documentation

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>