### PR TITLE
Fix potential issue with `image.TestSelectBackend` unit tests when `PODMAN_CMD` env var is set

### DIFF
--- a/pkg/devfile/image/image.go
+++ b/pkg/devfile/image/image.go
@@ -24,6 +24,7 @@ type Backend interface {
 }
 
 var lookPathCmd = exec.LookPath
+var getEnvFunc = os.Getenv
 
 // BuildPushImages build all images defined in the devfile with the detected backend
 // If push is true, also push the images to their registries
@@ -89,7 +90,7 @@ func buildPushImage(backend Backend, image *devfile.ImageComponent, devfilePath 
 // or return an error if none are present locally
 func selectBackend() (Backend, error) {
 
-	podmanCmd := os.Getenv("PODMAN_CMD")
+	podmanCmd := getEnvFunc("PODMAN_CMD")
 	if podmanCmd == "" {
 		podmanCmd = "podman"
 	}
@@ -97,7 +98,7 @@ func selectBackend() (Backend, error) {
 		return NewDockerCompatibleBackend(podmanCmd), nil
 	}
 
-	dockerCmd := os.Getenv("DOCKER_CMD")
+	dockerCmd := getEnvFunc("DOCKER_CMD")
 	if dockerCmd == "" {
 		dockerCmd = "docker"
 	}


### PR DESCRIPTION
**What type of PR is this:**
/kind tests

**Which issue(s) this PR fixes:**
For some valid reasons, we could want `odo` to use Docker as backend when building images.
One way of doing so is to set the `PODMAN_CMD` system environment variable to a command we know does not exist.
This is what I did a few days ago on my system.
Now the `image` unit tests will not pass, because they rely on the system environment variables.

```
~/w/p/odo on  main [$] via 🐹 v1.16.15 on ☁️   
❯ PODMAN_CMD=a-command-not-found-should-make-odo-use-docker go test -race github.com/redhat-developer/odo/pkg/devfile/image

↪ Building & Pushing Container: a name

↪ Building & Pushing Container: a name

↪ Building & Pushing Container: a name

↪ Building & Pushing Container: a name
--- FAIL: TestSelectBackend (0.00s)
    --- FAIL: TestSelectBackend/all_backends_are_present (0.00s)
        image_test.go:172: all backends are present: Error backend wanted podman, got a-command-not-found-should-make-odo-use-docker
    --- FAIL: TestSelectBackend/only_podman_is_present (0.00s)
        image_test.go:168: only podman is present: Error result wanted false, got true
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1e9caf3]

goroutine 69 [running]:
testing.tRunner.func1.2(0x1fb62c0, 0x2e503b0)
        /home/asoro/.asdf/installs/golang/1.16.15/go/src/testing/testing.go:1153 +0x49f
testing.tRunner.func1(0xc0005b0180)
        /home/asoro/.asdf/installs/golang/1.16.15/go/src/testing/testing.go:1156 +0x695
panic(0x1fb62c0, 0x2e503b0)
        /home/asoro/.asdf/installs/golang/1.16.15/go/src/runtime/panic.go:971 +0x499
github.com/redhat-developer/odo/pkg/devfile/image.TestSelectBackend.func5(0xc0005b0180)
        /home/asoro/work/projects/odo/pkg/devfile/image/image_test.go:171 +0x173
testing.tRunner(0xc0005b0180, 0xc000692960)
        /home/asoro/.asdf/installs/golang/1.16.15/go/src/testing/testing.go:1203 +0x203
created by testing.(*T).Run
        /home/asoro/.asdf/installs/golang/1.16.15/go/src/testing/testing.go:1248 +0x5d8
FAIL    github.com/redhat-developer/odo/pkg/devfile/image       0.047s
FAIL
```

A workaround is to unset the `PODMAN_CMD` system environment variable prior to running the unit tests, but I found it cleaner to adapt the unit tests, so they run in a controlled environment.

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
The unit tests should pass regardless of the value of `PODMAN_CMD`:
```shell
~/w/p/odo on  fix_image_unit_test_if_PODMAN_CMD_envvar_set [$] via 🐹 v1.16.15 on ☁️   
❯ PODMAN_CMD=a-command-not-found-should-make-odo-use-docker go test -race github.com/redhat-developer/odo/pkg/devfile/image
ok      github.com/redhat-developer/odo/pkg/devfile/image
```