### PR TITLE
Fix potential issue with odo binary being outdated when running tests directly with Ginkgo

### DIFF
--- a/.ibm/pipelines/kubernetes-tests.sh
+++ b/.ibm/pipelines/kubernetes-tests.sh
@@ -13,6 +13,7 @@ cleanup_namespaces
 (
     set -e
     make install
+    export ODO_BINARY_PATH="$(go env GOPATH)/bin/odo"
     make test-integration-devfile
     make test-interactive
     make test-e2e-devfile

--- a/.ibm/pipelines/openshift-tests.sh
+++ b/.ibm/pipelines/openshift-tests.sh
@@ -14,6 +14,7 @@ cleanup_namespaces
 (
     set -e
     make install
+    export ODO_BINARY_PATH="$(go env GOPATH)/bin/odo"
     make test-integration
     make test-interactive
     make test-integration-devfile

--- a/Makefile
+++ b/Makefile
@@ -160,119 +160,119 @@ test-windows:
 	go test $(UNIT_TEST_ARGS)  $(PKGS)
 
 .PHONY: test-generic
-test-generic: install ## Run generic integration tests
+test-generic: ## Run generic integration tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo generic" tests/integration/
 
 .PHONY: test-cmd-login-logout
-test-cmd-login-logout: install ## Run odo login and logout tests
+test-cmd-login-logout: ## Run odo login and logout tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS_SERIAL) -focus="odo login and logout command tests" tests/integration/loginlogout/
 
 .PHONY: test-cmd-link-unlink-4-cluster
-test-cmd-link-unlink-4-cluster: install ## Run link and unlink commnad tests against 4.x cluster
+test-cmd-link-unlink-4-cluster: ## Run link and unlink commnad tests against 4.x cluster
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo link and unlink commnad tests" tests/integration/
 
 .PHONY: test-cmd-project
-test-cmd-project: install ## Run odo project command tests
+test-cmd-project: ## Run odo project command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo project command tests" tests/integration/project/
 
 .PHONY: test-cmd-pref-config
-test-cmd-pref-config: install ## Run odo preference and config command tests
+test-cmd-pref-config: ## Run odo preference and config command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo preference and config command tests" tests/integration/
 
 .PHONY: test-plugin-handler
-test-plugin-handler: install ## Run odo plugin handler tests
+test-plugin-handler: ## Run odo plugin handler tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo plugin functionality" tests/integration/
 
 .PHONY: test-cmd-devfile-list
-test-cmd-devfile-list: install ## Run odo list devfile command tests
+test-cmd-devfile-list: ## Run odo list devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo list with devfile" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-init
-test-cmd-devfile-init: install ## Run odo init devfile command tests
+test-cmd-devfile-init: ## Run odo init devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile init command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-push
-test-cmd-devfile-push: install ## Run odo push devfile command tests
+test-cmd-devfile-push: ## Run odo push devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile push command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-exec
-test-cmd-devfile-exec: install ## Run odo exec devfile command tests
+test-cmd-devfile-exec: ## Run odo exec devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile exec command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-status
-test-cmd-devfile-status: install ## Run odo status devfile command tests
+test-cmd-devfile-status: ## Run odo status devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile status command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-watch
-test-cmd-devfile-watch: install ## Run odo devfile watch command tests
+test-cmd-devfile-watch: ## Run odo devfile watch command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile watch command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-app
-test-cmd-devfile-app: install ## Run odo devfile app command tests
+test-cmd-devfile-app: ## Run odo devfile app command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile app command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-delete
-test-cmd-delete: install ## Run odo delete command tests
+test-cmd-delete: ## Run odo delete command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo delete command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-registry
-test-cmd-devfile-registry: install ## Run odo devfile registry command tests
+test-cmd-devfile-registry: ## Run odo devfile registry command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile registry command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-test
-test-cmd-devfile-test: install ## Run odo devfile test command tests
+test-cmd-devfile-test: ## Run odo devfile test command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile test command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-debug
-test-cmd-devfile-debug: install ## Run odo debug devfile command tests
+test-cmd-devfile-debug: ## Run odo debug devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile debug command tests" tests/integration/devfile/
 	$(RUN_GINKGO) $(GINKGO_FLAGS_SERIAL) -focus="odo devfile debug command serial tests" tests/integration/devfile/debug/
 
 .PHONY: test-cmd-devfile-storage
-test-cmd-devfile-storage: install ## Run odo storage devfile command tests
+test-cmd-devfile-storage: ## Run odo storage devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile storage command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-log
-test-cmd-devfile-log: install ## Run odo log devfile command tests
+test-cmd-devfile-log: ## Run odo log devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile log command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-env
-test-cmd-devfile-env: install ## Run odo env devfile command tests
+test-cmd-devfile-env: ## Run odo env devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile env command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-devfile-config
-test-cmd-devfile-config: install ## Run odo config devfile command tests
+test-cmd-devfile-config: ## Run odo config devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile config command tests" tests/integration/devfile/
 
 .PHONY: test-cmd-watch
-test-cmd-watch: install ## Run odo watch command tests
+test-cmd-watch: ## Run odo watch command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo watch command tests" tests/integration/
 
 .PHONY: test-cmd-debug
-test-cmd-debug: install ## Run odo debug command tests
+test-cmd-debug: ## Run odo debug command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo debug command tests" tests/integration/
 	$(RUN_GINKGO) $(GINKGO_FLAGS_SERIAL) -focus="odo debug command serial tests" tests/integration/debug/
 
 # Service, link and login/logout command tests are not the part of this test run
 .PHONY: test-integration
-test-integration: install ## Run command's integration tests irrespective of service catalog status in the cluster.
+test-integration: ## Run command's integration tests irrespective of service catalog status in the cluster.
 	$(RUN_GINKGO) $(GINKGO_FLAGS) tests/integration/
 
 .PHONY: test-interactive
-test-interactive: install ## Run integration interactive tests
+test-interactive: ## Run integration interactive tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) tests/interactive/
 
 .PHONY: test-integration-devfile
-test-integration-devfile: install ## Run devfile integration tests
+test-integration-devfile: ## Run devfile integration tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) tests/integration/devfile/
 	$(RUN_GINKGO) $(GINKGO_FLAGS_SERIAL) tests/integration/devfile/debug/
 
 .PHONY: test-e2e-devfile
-test-e2e-devfile: install ## Run devfile e2e tests: odo devfile supported tests
+test-e2e-devfile: ## Run devfile e2e tests: odo devfile supported tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile supported tests" tests/e2escenarios/
 
 .PHONY: test-e2e-all
-test-e2e-all: install ## Run all e2e test scenarios
+test-e2e-all: ## Run all e2e test scenarios
 	$(RUN_GINKGO) $(GINKGO_FLAGS) tests/e2escenarios/
 
 # run make cross before this!
@@ -294,5 +294,5 @@ openshiftci-presubmit-unittests:
 	./scripts/openshiftci-presubmit-unittests.sh
 
 .PHONY: test-cmd-devfile-describe
-test-cmd-devfile-describe: install
+test-cmd-devfile-describe:
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile describe command tests" tests/integration/devfile/

--- a/tests/e2escenarios/e2escenarios_suite_test.go
+++ b/tests/e2escenarios/e2escenarios_suite_test.go
@@ -3,8 +3,11 @@ package e2escenarios
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestE2eScenarios(t *testing.T) {
 	helper.RunTestSpecs(t, "odo e2e scenarios")

--- a/tests/helper/helper_cmd_wrapper.go
+++ b/tests/helper/helper_cmd_wrapper.go
@@ -27,7 +27,12 @@ type CmdWrapper struct {
 	pass            bool
 }
 
-func Cmd(program string, args ...string) *CmdWrapper {
+func Cmd(prog string, args ...string) *CmdWrapper {
+	program := prog
+	if prog == "odo" {
+		// Make sure to use the version built (or the one explicitly defined by callers)
+		program = os.Getenv(EnvOdoBinaryPath)
+	}
 	prefix := fmt.Sprintf("[%s] ", filepath.Base(program))
 	prefixWriter := gexec.NewPrefixedWriter(prefix, GinkgoWriter)
 	command := exec.Command(program, args...)

--- a/tests/helper/helper_interactive.go
+++ b/tests/helper/helper_interactive.go
@@ -48,6 +48,11 @@ type Tester func(InteractiveContext)
 // If there are duplicate environment keys, only the last value in the slice for each duplicate key is used.
 func RunInteractive(command []string, env []string, tester Tester) (string, error) {
 
+	if len(command) != 0 && command[0] == "odo" {
+		// Make sure to use the version built (or the one explicitly defined by callers)
+		command[0] = os.Getenv(EnvOdoBinaryPath)
+	}
+
 	fmt.Fprintln(GinkgoWriter, "running command", command, "with env", env)
 
 	ptm, pts, err := pty.Open()

--- a/tests/helper/helper_run.go
+++ b/tests/helper/helper_run.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,12 @@ func runningCmd(cmd *exec.Cmd) string {
 	return fmt.Sprintf("Running %s with args %v", prog, cmd.Args)
 }
 
-func CmdRunner(program string, args ...string) *gexec.Session {
+func CmdRunner(prog string, args ...string) *gexec.Session {
+	program := prog
+	if prog == "odo" {
+		// Make sure to use the version built (or the one explicitly defined by callers)
+		program = os.Getenv(EnvOdoBinaryPath)
+	}
 	// prefix ginkgo verbose output with program name
 	prefix := fmt.Sprintf("[%s] ", filepath.Base(program))
 	prefixWriter := gexec.NewPrefixedWriter(prefix, GinkgoWriter)

--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -3,8 +3,11 @@ package debug
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestDebug(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Debug Suite")

--- a/tests/integration/devfile/devfile_suite_test.go
+++ b/tests/integration/devfile/devfile_suite_test.go
@@ -3,8 +3,11 @@ package devfile
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestDevfiles(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Suite")

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -6,8 +6,11 @@ package integration
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestIntegration(t *testing.T) {
 	helper.RunTestSpecs(t, "Integration Suite")

--- a/tests/integration/loginlogout/loginlogout_suite_test.go
+++ b/tests/integration/loginlogout/loginlogout_suite_test.go
@@ -3,8 +3,11 @@ package integration
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestLoginlogout(t *testing.T) {
 	helper.RunTestSpecs(t, "Login Logout Suite")

--- a/tests/integration/project/project_suite_test.go
+++ b/tests/integration/project/project_suite_test.go
@@ -3,8 +3,11 @@ package project
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestProject(t *testing.T) {
 	helper.RunTestSpecs(t, "Project Suite")

--- a/tests/interactive/interactive_suit_test.go
+++ b/tests/interactive/interactive_suit_test.go
@@ -7,8 +7,11 @@ package interactive
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestInteractive(t *testing.T) {
 	helper.RunTestSpecs(t, "Interactive Suite")

--- a/tests/template/template_suite_test.go
+++ b/tests/template/template_suite_test.go
@@ -3,8 +3,11 @@ package template
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/redhat-developer/odo/tests/helper"
 )
+
+var _ = SynchronizedBeforeSuite(helper.TestSuiteBeforeAllSpecsFunc, helper.TestSuiteBeforeEachSpecFunc)
 
 func TestTemplate(t *testing.T) {
 	helper.RunTestSpecs(t, "TestTemplate Suite")


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**

#5538 made both integration and E2E tests `Makefile` targets depend on the `install` one. This is fine when running the tests with `make`, but I noticed we could still run into the same issue when running them using the `ginkgo` CLI (as I often do when iterating on the code): the `odo` binary might be outdated and not match the current version of the code being tested, if one forgot to run `make install` before or make sure to add the relevant binary for `odo` to their `PATH`.

The approach I'm suggesting here is to:

1. Let Ginkgo build `odo` using the `make bin` target, prior to running the tests specs. To avoid building in parallel because of parallel tests specs, we could leverage Ginkgo's [`SynchronizedBeforeSuite/SynchronizedAfterSuite`](https://onsi.github.io/ginkgo/#parallel-suite-setup-and-cleanup-synchronizedbeforesuite-and-synchronizedaftersuite) to build the project only once. And this should not have an impact on performance thanks to the Go build cache.
2. Use the path to that built binary everywhere a test tries to run `odo`
3. Let developers/testers choose a different binary path if they wish to do so, e.g., via an environment variable (aptly named `ODO_BINARY_PATH`). If this environment variable is set, we would not build `odo`, but we would use that path instead everywhere a test runs `odo`. I'm thinking of @kadel 's comment here: https://github.com/redhat-developer/odo/pull/5538#issuecomment-1064989123

This is somehow inspired by how integration tests are written in Rust CLI apps: https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
