### PR TITLE
Set list command in main help section

### DIFF
--- a/pkg/odo/cli/list/list.go
+++ b/pkg/odo/cli/list/list.go
@@ -166,7 +166,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 		Long:        "List all components in the current namespace.",
 		Example:     fmt.Sprintf(listExample, fullName),
 		Args:        cobra.NoArgs,
-		Annotations: map[string]string{"machineoutput": "json", "command": "component"},
+		Annotations: map[string]string{"machineoutput": "json", "command": "main"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR moves the `list` command into the `main` help section, so it is displayed when running `odo help`

