### PR TITLE
Ignore PackageManifets resources when listing components

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -153,6 +153,11 @@ func ListAllClusterComponents(client kclient.ClientInterface, namespace string) 
 
 	for _, resource := range resourceList {
 
+		// ignore "PackageManifest" as they are not components, it is just a record in OpenShift catalog.
+		if resource.GetKind() == "PackageManifest" {
+			continue
+		}
+
 		var labels, annotations map[string]string
 
 		// Retrieve the labels and annotations from the unstructured resource output


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

/kind bug

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
Prevents PackageManifets to be shown as a component in `odo list` output.


before
```
▶ odo list
 ✓  Listing components from namespace 'test' [323ms]
 NAME                             PROJECT TYPE  RUNNING IN  MANAGED                         
 * devfile-nodejs-deploy          nodejs        None        odo                             
 my-nodejs-app                    nodejs        Dev         odo                             
 ibm-spectrum-scale-csi-operator  Unknown       Unknown     ibm-spectrum-scale-csi-operator 
 vfunction-operator               Unknown       Unknown     operator                        
 my-cluster-name                  Unknown       Unknown     percona-server-mongodb-operator 
 snyk-operator-marketplace        Unknown       Unknown     snyk-operator-marketplace       
```

after 
```
▶ odo list
 ✓  Listing components from namespace 'test' [314ms]
 NAME                     PROJECT TYPE  RUNNING IN  MANAGED                         
 * devfile-nodejs-deploy  nodejs        None        odo                             
 my-nodejs-app            nodejs        Dev         odo                             
 my-cluster-name          Unknown       Unknown     percona-server-mongodb-operator 
```

`PackageManifet` is not a resource that would represent something running on the cluster. It is a representation of a record in the OpenShift catalog as such it should not be considered as a valid component. 


