### PR TITLE
Adds warning for running podman on Apple Silicon

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -484,6 +484,11 @@ func IsDebug() bool {
 	return false
 }
 
+// IsAppleSilicon returns true if we are on a Mac M1 / Apple Silicon natively
+func IsAppleSilicon() bool {
+	return runtime.GOOS == "darwin" && (strings.HasPrefix(runtime.GOARCH, "arm") || strings.HasPrefix(runtime.GOARCH, "arm64"))
+}
+
 // GetStdout gets the appropriate stdout from the OS. If it's Linux, it will use
 // the go-colorable library in order to fix any and all color ASCII issues.
 // TODO: Test needs to be added once we get Windows testing available on TravisCI / CI platform.


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

/kind feature

**What does this PR do / why we need it:**

Warns the user if we are trying to run Podman on Mac M1. As we are
unable to build x86 images natively unless using the workaround.

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5597

**PR acceptance criteria:**

- [X] Unit test

- [X] Integration test

- [X] Documentation

**How to test changes / Special notes to the reviewer:**

Run it on a M1 mac :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>