### PR TITLE
[Hotfix] Always ignore `command` and `args` defined in Devfile container components

### DIFF
--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -236,9 +236,11 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					},
 				},
 			},
-			componentType:           devfilev1.ContainerComponentType,
-			expectRunCommand:        command,
-			isSupervisordEntrypoint: false,
+			componentType:    devfilev1.ContainerComponentType,
+			expectRunCommand: command,
+			//TODO(#5620): Hotfix by ignoring Component Command and Args.
+			// A proper fix will need to be implemented later on.
+			isSupervisordEntrypoint: true,
 			wantErr:                 false,
 		},
 		{
@@ -269,9 +271,11 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					},
 				},
 			},
-			componentType:           devfilev1.ContainerComponentType,
-			expectRunCommand:        command,
-			isSupervisordEntrypoint: false,
+			componentType:    devfilev1.ContainerComponentType,
+			expectRunCommand: command,
+			//TODO(#5620): Hotfix by ignoring Component Command and Args.
+			// A proper fix will need to be implemented later on.
+			isSupervisordEntrypoint: true,
 			wantErr:                 false,
 		},
 		{

--- a/tests/examples/source/devfiles/nodejs/issue-5620-devfile-with-container-command-args.yaml
+++ b/tests/examples/source/devfiles/nodejs/issue-5620-devfile-with-container-command-args.yaml
@@ -1,0 +1,59 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  version: 1.0.1
+  displayName: Node.js Runtime
+  description: Stack with Node.js 14
+  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+  tags: ['NodeJS', 'Express', 'ubi8']
+  projectType: 'nodejs'
+  language: 'javascript'
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-14:latest
+      command: ["tail"]
+      args: ["-f", "/dev/null"]
+      memoryLimit: 1024Mi
+      mountSources: true
+      endpoints:
+        - name: http-3000
+          targetPort: 3000
+commands:
+  - id: install
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: runtime
+      commandLine: npm run debug
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: debug
+        isDefault: true
+  - id: test
+    exec:
+      component: runtime
+      commandLine: npm test
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: test
+        isDefault: true


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/kind hotfix

**What does this PR do / why we need it:**
Before this fix, running `odo dev` would not succeed if the Devfile defines a container component with `command` or `args`. 

**Which issue(s) this PR fixes:**
Fixes #5620

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
