### PR TITLE
[Hotfix][v2] Always ignore `command` and `args` defined in Devfile container components

### DIFF
--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -100,9 +100,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 		// Check if the container belongs to a run command component
 		if container.Name == runCommand.Exec.Component {
 			// If the run component container has no entrypoint and arguments, override the entrypoint with supervisord
-			if len(container.Command) == 0 && len(container.Args) == 0 {
-				overrideContainerArgs(container)
-			}
+			overrideContainerArgs(container)
 
 			// Always mount the supervisord volume in the run component container
 			klog.V(2).Infof("Updating container %v with supervisord volume mounts", container.Name)
@@ -144,9 +142,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 		// Check if the container belongs to a debug command component
 		if debugCommand.Exec != nil && container.Name == debugCommand.Exec.Component {
 			// If the debug component container has no entrypoint and arguments, override the entrypoint with supervisord
-			if len(container.Command) == 0 && len(container.Args) == 0 {
-				overrideContainerArgs(container)
-			}
+			overrideContainerArgs(container)
 
 			foundMountPath := false
 			for _, mounts := range container.VolumeMounts {
@@ -222,6 +218,16 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 // overrideContainerArgs overrides the container's entrypoint with supervisord
 func overrideContainerArgs(container *corev1.Container) {
 	klog.V(2).Infof("Updating container %v entrypoint with supervisord", container.Name)
-	container.Command = append(container.Command, adaptersCommon.SupervisordBinaryPath)
-	container.Args = append(container.Args, "-c", adaptersCommon.SupervisordConfFile)
+	//TODO(#5620): overriding command and args, irrespective of whether the container had Command or Args defined in it.
+	//   This is a hacky hotfix for https://github.com/redhat-developer/odo/issues/5620. Otherwise,
+	//   odo does not work at all if Devfile container component defines a Command or an Args.
+	//   As suggested in the issue, a proper fix will need to be implemented later on,
+	//   for example by keeping using supervisord as pid1, and executing the command with args "on the side"
+	//   as a separate process.
+	if len(container.Command) != 0 || len(container.Args) != 0 {
+		klog.V(4).Infof("original command and args for container %v intentionally ignored due to issue #5620",
+			container.Name)
+	}
+	container.Command = []string{adaptersCommon.SupervisordBinaryPath}
+	container.Args = []string{"-c", adaptersCommon.SupervisordConfFile}
 }

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -235,9 +235,11 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					},
 				},
 			},
-			componentType:           devfilev1.ContainerComponentType,
-			expectRunCommand:        command,
-			isSupervisordEntrypoint: false,
+			componentType:    devfilev1.ContainerComponentType,
+			expectRunCommand: command,
+			//TODO(#5620): Hotfix by ignoring Component Command and Args.
+			// A proper fix will need to be implemented later on.
+			isSupervisordEntrypoint: true,
 			wantErr:                 false,
 		},
 		{
@@ -268,9 +270,11 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					},
 				},
 			},
-			componentType:           devfilev1.ContainerComponentType,
-			expectRunCommand:        command,
-			isSupervisordEntrypoint: false,
+			componentType:    devfilev1.ContainerComponentType,
+			expectRunCommand: command,
+			//TODO(#5620): Hotfix by ignoring Component Command and Args.
+			// A proper fix will need to be implemented later on.
+			isSupervisordEntrypoint: true,
 			wantErr:                 false,
 		},
 		{

--- a/tests/examples/source/devfiles/nodejs/issue-5620-devfile-with-container-command-args.yaml
+++ b/tests/examples/source/devfiles/nodejs/issue-5620-devfile-with-container-command-args.yaml
@@ -1,0 +1,59 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  version: 1.0.1
+  displayName: Node.js Runtime
+  description: Stack with Node.js 14
+  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+  tags: ['NodeJS', 'Express', 'ubi8']
+  projectType: 'nodejs'
+  language: 'javascript'
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-14:latest
+      command: ["tail"]
+      args: ["-f", "/dev/null"]
+      memoryLimit: 1024Mi
+      mountSources: true
+      endpoints:
+        - name: http-3000
+          targetPort: 3000
+commands:
+  - id: install
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: runtime
+      commandLine: npm run debug
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: debug
+        isDefault: true
+  - id: test
+    exec:
+      component: runtime
+      commandLine: npm test
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: test
+        isDefault: true


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/kind hotfix

**What does this PR do / why we need it:**
This backports the hotfix done in #5639 to `v2`.
I am manually creating a separate PR because the test cases are different for `v2` and `main` branches, so I cannot rely on openshift-bot to cherry-pick commits and create a new PR automatically.
This adapts the tests by using `odo push` instead of `odo dev`.

Before this fix, running `odo push` would not succeed if the Devfile defines a container component with `command` or `args`. 

**Which issue(s) this PR fixes:**
Fixes #5620

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
