### PR TITLE
Fix issue with `build-images` and `deploy` not working with Docker if optional `buildContext` field is not set in Devfile (#5600)

### DIFF
--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -61,6 +61,9 @@ func getShellCommand(cmdName string, image *devfile.ImageComponent, devfilePath 
 	imageName := image.ImageName
 	dockerfile := filepath.Join(devfilePath, image.Dockerfile.Uri)
 	buildpath := image.Dockerfile.BuildContext
+	if buildpath == "" {
+		buildpath = devfilePath
+	}
 	args := image.Dockerfile.Args
 
 	shell := fmt.Sprintf(`%s build -t "%s" -f "%s" %s`, cmdName, imageName, dockerfile, buildpath)

--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -66,7 +66,7 @@ func getShellCommand(cmdName string, image *devfile.ImageComponent, devfilePath 
 	}
 	args := image.Dockerfile.Args
 
-	shell := fmt.Sprintf(`%s build -t "%s" -f "%s" %s`, cmdName, imageName, dockerfile, buildpath)
+	shell := fmt.Sprintf(`%s build -t "%s" -f "%s" "%s"`, cmdName, imageName, dockerfile, buildpath)
 	if len(args) > 0 {
 		shell = shell + " " + strings.Join(args, " ")
 	}

--- a/pkg/devfile/image/docker_compatible_test.go
+++ b/pkg/devfile/image/docker_compatible_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 )
 
 func TestGetShellCommand(t *testing.T) {
+	devfilePath := filepath.Join("home", "user", "project1")
 	tests := []struct {
 		name        string
 		cmdName     string
@@ -33,8 +35,9 @@ func TestGetShellCommand(t *testing.T) {
 					},
 				},
 			},
-			devfilePath: filepath.Join("home", "user", "project1"),
-			want:        `cli build -t "registry.io/myimagename:tag" -f "` + filepath.Join("home", "user", "project1", "Dockerfile") + `" ${PROJECTS_ROOT}`,
+			devfilePath: devfilePath,
+			want: fmt.Sprintf(`cli build -t "registry.io/myimagename:tag" -f "%s" "${PROJECTS_ROOT}"`,
+				filepath.Join(devfilePath, "Dockerfile")),
 		},
 		{
 			name:    "test 2",
@@ -54,8 +57,9 @@ func TestGetShellCommand(t *testing.T) {
 					},
 				},
 			},
-			devfilePath: filepath.Join("home", "user", "project1"),
-			want:        `cli build -t "registry.io/myimagename:tag" -f "` + filepath.Join("home", "user", "project1", "Dockerfile") + `" ${PROJECTS_ROOT}`,
+			devfilePath: devfilePath,
+			want: fmt.Sprintf(`cli build -t "registry.io/myimagename:tag" -f "%s" "${PROJECTS_ROOT}"`,
+				filepath.Join(devfilePath, "Dockerfile")),
 		},
 		{
 			name:    "test with args",
@@ -76,8 +80,28 @@ func TestGetShellCommand(t *testing.T) {
 					},
 				},
 			},
-			devfilePath: filepath.Join("home", "user", "project1"),
-			want:        `cli build -t "registry.io/myimagename:tag" -f "` + filepath.Join("home", "user", "project1", "Dockerfile") + `" ${PROJECTS_ROOT} --flag value`,
+			devfilePath: devfilePath,
+			want: fmt.Sprintf(`cli build -t "registry.io/myimagename:tag" -f "%s" "${PROJECTS_ROOT}" --flag value`,
+				filepath.Join(devfilePath, "Dockerfile")),
+		},
+		{
+			name:    "test with no build context in Devfile",
+			cmdName: "cli",
+			image: &devfile.ImageComponent{
+				Image: devfile.Image{
+					ImageName: "registry.io/myimagename:tag",
+					ImageUnion: devfile.ImageUnion{
+						Dockerfile: &devfile.DockerfileImage{
+							DockerfileSrc: devfile.DockerfileSrc{
+								Uri: "Dockerfile.rhel",
+							},
+						},
+					},
+				},
+			},
+			devfilePath: devfilePath,
+			want: fmt.Sprintf(`cli build -t "registry.io/myimagename:tag" -f "%s" "%s"`,
+				filepath.Join(devfilePath, "Dockerfile.rhel"), devfilePath),
 		},
 	}
 

--- a/tests/examples/source/devfiles/nodejs/issue-5600-devfile-with-image-component-and-no-buildContext.yaml
+++ b/tests/examples/source/devfiles/nodejs/issue-5600-devfile-with-image-component-and-no-buildContext.yaml
@@ -1,0 +1,95 @@
+commands:
+- exec:
+    commandLine: npm install
+    component: runtime
+    group:
+      isDefault: true
+      kind: build
+    workingDir: $PROJECT_SOURCE
+  id: install
+- exec:
+    commandLine: npm start
+    component: runtime
+    group:
+      isDefault: true
+      kind: run
+    workingDir: $PROJECT_SOURCE
+  id: run
+- apply:
+    component: prod-image
+  id: build-image
+- apply:
+    component: outerloop-deploy
+  id: deploy-deployment
+- apply:
+    component: outerloop-service
+  id: deploy-service
+- composite:
+    commands:
+    - build-image
+    - deploy-deployment
+    - deploy-service
+    group:
+      isDefault: true
+      kind: deploy
+  id: deploy
+components:
+- container:
+    endpoints:
+    - name: http-3000
+      targetPort: 3000
+    image: registry.access.redhat.com/ubi8/nodejs-14:0.1.0
+    memoryLimit: 1024Mi
+    mountSources: true
+  name: runtime
+- image:
+    dockerfile:
+      uri: ./Dockerfile
+    imageName: localhost:5000/devfile-nodejs-deploy:0.1.0
+  name: prod-image
+- kubernetes:
+    inlined: |
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: devfile-nodejs-deploy
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: devfile-nodejs-deploy
+        template:
+          metadata:
+            labels:
+              app: devfile-nodejs-deploy
+          spec:
+            containers:
+              - name: main
+                image: "localhost:5000/devfile-nodejs-deploy:0.1.0"
+                resources: {}
+  name: outerloop-deploy
+- kubernetes:
+    inlined: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app: devfile-nodejs-deploy
+        name: devfile-nodejs-deploy
+      spec:
+        ports:
+        - name: http-3000
+          port: 3000
+          protocol: TCP
+          targetPort: 3000
+        selector:
+          app: devfile-nodejs-deploy
+        type: LoadBalancer
+  name: outerloop-service
+metadata:
+  language: javascript
+  name: my-nodejs-without-buildctx
+  projectType: nodejs
+schemaVersion: 2.2.0
+variables:
+  CONTAINER_IMAGE: localhost:5000/devfile-nodejs-deploy:0.1.0

--- a/tests/integration/devfile/cmd_devfile_build_images_test.go
+++ b/tests/integration/devfile/cmd_devfile_build_images_test.go
@@ -116,4 +116,46 @@ var _ = Describe("odo devfile build-images command tests", func() {
 			})
 		}
 	})
+
+	When("using a devfile.yaml containing an Image component with no build context", func() {
+
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs",
+					"issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
+				filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.CreateLocalEnv(commonVar.Context, "aname", commonVar.Project)
+		})
+
+		for _, scope := range []struct {
+			name    string
+			envvars []string
+		}{
+			{
+				name:    "Podman",
+				envvars: []string{"PODMAN_CMD=echo"},
+			},
+			{
+				name: "Docker",
+				envvars: []string{
+					"PODMAN_CMD=a-command-not-found-for-podman-should-make-odo-fallback-to-docker",
+					"DOCKER_CMD=echo",
+				},
+			},
+		} {
+			It(fmt.Sprintf("should build image via %s by defaulting build context to devfile path", scope.name), func() {
+				stdout := helper.Cmd("odo", "build-images").AddEnv(scope.envvars...).ShouldPass().Out()
+				lines, err := helper.ExtractLines(stdout)
+				Expect(err).ShouldNot(HaveOccurred())
+				nbLines := len(lines)
+				Expect(nbLines).To(BeNumerically(">", 2))
+				containerImage := "localhost:5000/devfile-nodejs-deploy:0.1.0" // from Devfile yaml file
+				dockerfilePath := filepath.Join(commonVar.Context, "Dockerfile")
+				buildCtx := commonVar.Context
+				Expect(lines[nbLines-2]).To(BeEquivalentTo(
+					fmt.Sprintf("build -t %s -f %s %s", containerImage, dockerfilePath, buildCtx)))
+			})
+		}
+	})
 })


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
This makes the build context directory for Docker (and Podman) default to the Devfile parent directory, if not set.

**Which issue(s) this PR fixes:**
Fixes #5600

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
See reproduction steps detailed in https://github.com/redhat-developer/odo/issues/5600#issue-1184803587