### PR TITLE
`odo dev --debug` + fix sync

### DIFF
--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -28,7 +28,7 @@ func NewDevClient(watchClient watch.Client) *DevClient {
 	}
 }
 
-func (o *DevClient) Start(devfileObj parser.DevfileObj, platformContext kubernetes.KubernetesContext, ignorePaths []string, path string) error {
+func (o *DevClient) Start(devfileObj parser.DevfileObj, platformContext kubernetes.KubernetesContext, ignorePaths []string, path string, debug bool) error {
 	klog.V(4).Infoln("Creating new adapter")
 	adapter, err := adapters.NewComponentAdapter(devfileObj.GetMetadataName(), path, "app", devfileObj, platformContext)
 	if err != nil {
@@ -45,6 +45,7 @@ func (o *DevClient) Start(devfileObj parser.DevfileObj, platformContext kubernet
 		DebugPort:       envSpecificInfo.GetDebugPort(),
 		Path:            path,
 		IgnoredFiles:    ignorePaths,
+		Debug:           debug,
 	}
 
 	klog.V(4).Infoln("Creating inner-loop resources for the component")
@@ -56,7 +57,7 @@ func (o *DevClient) Start(devfileObj parser.DevfileObj, platformContext kubernet
 	return nil
 }
 
-func (o *DevClient) Watch(devfileObj parser.DevfileObj, path string, ignorePaths []string, out io.Writer, h Handler, ctx context.Context) error {
+func (o *DevClient) Watch(devfileObj parser.DevfileObj, path string, ignorePaths []string, out io.Writer, h Handler, ctx context.Context, debug bool) error {
 	envSpecificInfo, err := envinfo.NewEnvSpecificInfo(path)
 	if err != nil {
 		return err
@@ -72,6 +73,8 @@ func (o *DevClient) Watch(devfileObj parser.DevfileObj, path string, ignorePaths
 		EnvSpecificInfo:     envSpecificInfo,
 		FileIgnores:         absIgnorePaths,
 		InitialDevfileObj:   devfileObj,
+		Debug:               debug,
+		DebugPort:           envSpecificInfo.GetDebugPort(),
 	}
 
 	return o.watchClient.WatchAndPush(out, watchParameters, ctx)

--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -7,7 +7,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/envinfo"
 
 	"github.com/devfile/library/pkg/devfile/parser"
-	"github.com/devfile/library/pkg/util"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes"
@@ -63,15 +62,13 @@ func (o *DevClient) Watch(devfileObj parser.DevfileObj, path string, ignorePaths
 		return err
 	}
 
-	absIgnorePaths := util.GetAbsGlobExps(path, ignorePaths)
-
 	watchParameters := watch.WatchParameters{
 		Path:                path,
 		ComponentName:       devfileObj.GetMetadataName(),
 		ApplicationName:     "app",
 		DevfileWatchHandler: h.RegenerateAdapterAndPush,
 		EnvSpecificInfo:     envSpecificInfo,
-		FileIgnores:         absIgnorePaths,
+		FileIgnores:         ignorePaths,
 		InitialDevfileObj:   devfileObj,
 		Debug:               debug,
 		DebugPort:           envSpecificInfo.GetDebugPort(),

--- a/pkg/dev/interface.go
+++ b/pkg/dev/interface.go
@@ -13,12 +13,14 @@ import (
 
 type Client interface {
 	// Start the resources in devfileObj on the platformContext. It then pushes the files in path to the container.
-	Start(devfileObj parser.DevfileObj, platformContext kubernetes.KubernetesContext, ignorePaths []string, path string) error
+	// If debug is true, executes the debug command, or the run command by default
+	Start(devfileObj parser.DevfileObj, platformContext kubernetes.KubernetesContext, ignorePaths []string, path string, debug bool) error
 
 	// Watch watches for any changes to the files under path while ignoring the files/directories in ignorePaths.
 	// It logs messages to out and uses the Handler h to perform push operation when anything changes in path.
 	// It uses devfileObj to notify user to restart odo dev if they change endpoint information in the devfile.
-	Watch(devfileObj parser.DevfileObj, path string, ignorePaths []string, out io.Writer, h Handler, ctx context.Context) error
+	// If debug is true, the debug command will be started after a sync, or the run command by default
+	Watch(devfileObj parser.DevfileObj, path string, ignorePaths []string, out io.Writer, h Handler, ctx context.Context, debug bool) error
 }
 
 type Handler interface {

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -168,8 +168,13 @@ func (o *DevOptions) Complete(cmdline cmdline.Cmdline, args []string) error {
 }
 
 func (o *DevOptions) Validate() error {
-	var err error
-	return err
+	if !o.debugFlag && !libdevfile.HasRunCommand(o.initialDevfileObj.Data) {
+		return errors.New("no command of kind Run found in the devfile")
+	}
+	if o.debugFlag && !libdevfile.HasDebugCommand(o.initialDevfileObj.Data) {
+		return errors.New("no command of kind Debug found in the devfile")
+	}
+	return nil
 }
 
 func (o *DevOptions) Run(ctx context.Context) error {
@@ -304,7 +309,7 @@ It forwards endpoints with exposure values 'public' or 'internal' to a port on l
 	}
 	devCmd.Flags().BoolVar(&o.noWatchFlag, "no-watch", false, "Do not watch for file changes")
 	devCmd.Flags().BoolVar(&o.randomPortsFlag, "random-ports", false, "Assign random ports to redirected ports")
-	devCmd.Flags().BoolVar(&o.debugFlag, "debug", false, "Execute the debug command to start the component inside container")
+	devCmd.Flags().BoolVar(&o.debugFlag, "debug", false, "Excecute the debug command within the component")
 
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT, clientset.KUBERNETES)
 	// Add a defined annotation in order to appear in the help menu

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -9,12 +9,11 @@ import (
 	"path/filepath"
 	"reflect"
 
-	scontext "github.com/redhat-developer/odo/pkg/segment/context"
+	"github.com/spf13/cobra"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/redhat-developer/odo/pkg/component"
@@ -30,6 +29,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
+	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/redhat-developer/odo/pkg/version"
 	"github.com/redhat-developer/odo/pkg/watch"
@@ -61,8 +61,9 @@ type DevOptions struct {
 	contextDir string
 
 	// Flags
-	randomPorts bool
-	noWatchFlag bool
+	noWatchFlag     bool
+	randomPortsFlag bool
+	debugFlag       bool
 }
 
 type Handler struct{}
@@ -186,7 +187,7 @@ func (o *DevOptions) Run(ctx context.Context) error {
 		"odo version: "+version.VERSION)
 
 	log.Section("Deploying to the cluster in developer mode")
-	err = o.clientset.DevClient.Start(o.Context.EnvSpecificInfo.GetDevfileObj(), platformContext, o.ignorePaths, path)
+	err = o.clientset.DevClient.Start(o.Context.EnvSpecificInfo.GetDevfileObj(), platformContext, o.ignorePaths, path, o.debugFlag)
 	if err != nil {
 		return err
 	}
@@ -200,7 +201,7 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	}
 	ceMapping := libdevfile.GetContainerEndpointMapping(containers)
 	var portPairs map[string][]string
-	if o.randomPorts {
+	if o.randomPortsFlag {
 		portPairs = randomPortPairsFromContainerEndpoints(ceMapping)
 	} else {
 		portPairs = portPairsFromContainerEndpoints(ceMapping)
@@ -240,9 +241,8 @@ func (o *DevOptions) Run(ctx context.Context) error {
 		err = o.clientset.WatchClient.Cleanup(devFileObj, log.GetStdout())
 	} else {
 		d := Handler{}
-		err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx)
+		err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx, o.debugFlag)
 	}
-
 	return err
 }
 
@@ -302,8 +302,9 @@ It forwards endpoints with exposure values 'public' or 'internal' to a port on l
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	devCmd.Flags().BoolVarP(&o.randomPorts, "random-ports", "f", false, "Assign random ports to redirected ports")
 	devCmd.Flags().BoolVar(&o.noWatchFlag, "no-watch", false, "Do not watch for file changes")
+	devCmd.Flags().BoolVar(&o.randomPortsFlag, "random-ports", false, "Assign random ports to redirected ports")
+	devCmd.Flags().BoolVar(&o.debugFlag, "debug", false, "Execute the debug command to start the component inside container")
 
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT, clientset.KUBERNETES)
 	// Add a defined annotation in order to appear in the help menu

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -147,7 +147,7 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (bool, error) {
 		changedFiles,
 		deletedFiles,
 		isForcePush,
-		dfutil.GetAbsGlobExps(pushParameters.Path, pushParameters.IgnoredFiles),
+		pushParameters.IgnoredFiles,
 		syncParameters.CompInfo,
 		ret,
 	)

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -234,7 +234,7 @@ func Test_makeTar(t *testing.T) {
 					filepath.Join(dir0, "README.txt"),
 					filepath.Join(dir0, "views"),
 					filepath.Join(dir0, "views", "view.html")},
-				globExps: []string{filepath.Join(dir0, "README.txt")},
+				globExps: []string{"README.txt"},
 				ret: util.IndexerRet{
 					NewFileMap: map[string]util.FileData{
 						"red.js": {

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -357,21 +357,8 @@ func runIndexerWithExistingFileIndex(directory string, ignoreRules []string, rem
 					fileRemoteChanged[remote] = true
 				}
 			} else {
-				// check the *absolute* path to the file for glob rules
-				fileAbsolutePath, err := dfutil.GetAbsPath(filepath.Join(directory, fileName))
-				if err != nil {
-					return ret, fmt.Errorf("unable to retrieve absolute path of file %s: %w", fileName, err)
-				}
-
 				ignoreMatcher := gitignore.CompileIgnoreLines(ignoreRules...)
-
-				rel, err := filepath.Rel(directory, fileAbsolutePath)
-				if err != nil {
-					return IndexerRet{}, err
-				}
-
-				matched := ignoreMatcher.MatchesPath(rel)
-
+				matched := ignoreMatcher.MatchesPath(fileName)
 				if matched {
 					continue
 				}

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -65,6 +65,10 @@ type WatchParameters struct {
 	DevfileDebugCmd string
 	// InitialDevfileObj is used to compare the devfile between the very first run of odo dev and subsequent ones
 	InitialDevfileObj parser.DevfileObj
+	// Debug indicates if the debug command should be started after sync, or the run command by default
+	Debug bool
+	// DebugPort indicates which debug port to use for pushing after sync
+	DebugPort int
 }
 
 // evaluateChangesFunc evaluates any file changes for the events by ignoring the files in fileIgnores slice and removes
@@ -317,8 +321,8 @@ func processEvents(changedFiles, deletedPaths []string, parameters WatchParamete
 		DevfileDebugCmd:          parameters.DevfileDebugCmd,
 		DevfileScanIndexForWatch: !hasFirstSuccessfulPushOccurred,
 		EnvSpecificInfo:          *parameters.EnvSpecificInfo,
-		Debug:                    parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
-		DebugPort:                parameters.EnvSpecificInfo.GetDebugPort(),
+		Debug:                    parameters.Debug,
+		DebugPort:                parameters.DebugPort,
 	}
 	err := parameters.DevfileWatchHandler(pushParams, parameters)
 	if err != nil {

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -87,9 +87,10 @@ type cleanupFunc func(devfileObj parser.DevfileObj, out io.Writer) error
 // and its subdirectories.  If a non-directory is specified, this call is a no-op.
 // Files matching glob pattern defined in ignores will be ignored.
 // Taken from https://github.com/openshift/origin/blob/85eb37b34f0657631592356d020cef5a58470f8e/pkg/util/fsnotification/fsnotification.go
-// path is the path of the file or the directory
+// rootPath is the root path of the file or directory,
+// path is the recursive path of the file or the directory,
 // ignores contains the glob rules for matching
-func addRecursiveWatch(watcher *fsnotify.Watcher, topPath string, path string, ignores []string) error {
+func addRecursiveWatch(watcher *fsnotify.Watcher, rootPath string, path string, ignores []string) error {
 
 	file, err := os.Stat(path)
 	if err != nil {
@@ -104,7 +105,7 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, topPath string, path string, i
 	mode := file.Mode()
 	if mode.IsRegular() {
 		var rel string
-		rel, err = filepath.Rel(topPath, path)
+		rel, err = filepath.Rel(rootPath, path)
 		if err != nil {
 			return err
 		}
@@ -138,7 +139,7 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, topPath string, path string, i
 
 		if info.IsDir() {
 			// If the current directory matches any of the ignore patterns, ignore them so that their contents are also not ignored
-			rel, err := filepath.Rel(topPath, newPath)
+			rel, err := filepath.Rel(rootPath, newPath)
 			if err != nil {
 				return err
 			}
@@ -160,7 +161,7 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, topPath string, path string, i
 	}
 	for _, folder := range folders {
 
-		rel, err := filepath.Rel(topPath, folder)
+		rel, err := filepath.Rel(rootPath, folder)
 		if err != nil {
 			return err
 		}
@@ -249,7 +250,7 @@ func eventWatcher(ctx context.Context, watcher *fsnotify.Watcher, parameters Wat
 	}
 }
 
-// evaluateFileChanges evaluates any file changes for the events. It ignores the files in fileIgnores slice and removes
+// evaluateFileChanges evaluates any file changes for the events. It ignores the files in fileIgnores slice related to path, and removes
 // any deleted paths from the watcher
 func evaluateFileChanges(events []fsnotify.Event, path string, fileIgnores []string, watcher *fsnotify.Watcher) ([]string, []string) {
 	var changedFiles []string

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-func evaluateChangesHandler(events []fsnotify.Event, fileIgnores []string, watcher *fsnotify.Watcher) ([]string, []string) {
+func evaluateChangesHandler(events []fsnotify.Event, path string, fileIgnores []string, watcher *fsnotify.Watcher) ([]string, []string) {
 	var changedFiles []string
 	var deletedPaths []string
 

--- a/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
@@ -14,6 +14,8 @@ components:
       endpoints:
         - name: "3000-tcp"
           targetPort: 3000
+        - name: "5858-tcp"
+          targetPort: 5858
       mountSources: true
 commands:
   - id: devbuild

--- a/tests/helper/helper_http.go
+++ b/tests/helper/helper_http.go
@@ -1,0 +1,49 @@
+package helper
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+)
+
+// HttpWaitForWithStatus periodically (every interval) calls GET to given url
+// ends when result response contains match string and status code, or after the maxRetry
+func HttpWaitForWithStatus(url string, match string, maxRetry int, interval int, expectedCode int) {
+	fmt.Fprintf(GinkgoWriter, "Checking %s, for %s\n", url, match)
+
+	var body []byte
+
+	for i := 0; i < maxRetry; i++ {
+		fmt.Fprintf(GinkgoWriter, "try %d of %d\n", i, maxRetry)
+
+		// #nosec
+		// gosec:G107, G402 -> This is safe since it's just used for testing.
+		transporter := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: transporter}
+		resp, err := client.Get(url)
+		if err != nil {
+			// we log the error and sleep again because this could mean the component is not up yet
+			fmt.Fprintln(GinkgoWriter, "error while requesting:", err.Error())
+			time.Sleep(time.Duration(interval) * time.Second)
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == expectedCode {
+			body, _ = ioutil.ReadAll(resp.Body)
+			if strings.Contains(string(body), match) {
+				return
+			}
+
+		}
+		time.Sleep(time.Duration(interval) * time.Second)
+	}
+	fmt.Fprintf(GinkgoWriter, "Last output from %s: %s\n", url, string(body))
+	Fail(fmt.Sprintf("Failed after %d retries. Content in %s doesn't include '%s'.", maxRetry, url, match))
+}

--- a/tests/integration/devfile/cmd_dev_debug_test.go
+++ b/tests/integration/devfile/cmd_dev_debug_test.go
@@ -1,0 +1,57 @@
+package devfile
+
+import (
+	"path/filepath"
+
+	"github.com/redhat-developer/odo/tests/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo dev debug command tests", func() {
+	var cmpName string
+	var commonVar helper.CommonVar
+
+	// This is run before every Spec (It)
+	var _ = BeforeEach(func() {
+		commonVar = helper.CommonBeforeEach()
+		cmpName = helper.RandString(6)
+		helper.Chdir(commonVar.Context)
+		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
+	})
+
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.CommonAfterEach(commonVar)
+	})
+
+	When("a component is bootstrapped", func() {
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml")).ShouldPass()
+			Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
+		})
+
+		When("running odo dev with debug flag", func() {
+			var devSession helper.DevSession
+			var ports map[string]string
+			BeforeEach(func() {
+				var err error
+				devSession, _, _, ports, err = helper.StartDevMode("--debug")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				devSession.Kill()
+				devSession.WaitEnd()
+			})
+			It("should expect a ws connection when tried to connect on default debug port locally", func() {
+				// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+				// We are just using this to validate if nodejs agent is listening on the other side
+				helper.HttpWaitForWithStatus("http://"+ports["5858"], "WebSockets request was expected", 12, 5, 400)
+			})
+		})
+	})
+
+})

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -627,7 +627,7 @@ var _ = Describe("odo dev command tests", func() {
 		waitTerminates := func(timeout time.Duration) bool {
 			done := make(chan bool)
 			go func() {
-				session.WaitSync()
+				_, _, _ = session.WaitSync()
 				done <- true
 			}()
 			select {
@@ -665,8 +665,8 @@ var _ = Describe("odo dev command tests", func() {
 				helper.ReplaceString(newFilePath2, "hello world", "hello world!!!")
 			})
 
-			It("should synchronize it", func() {
-				Expect(waitTerminates(20 * time.Second)).To(BeTrue()) // TODO fix
+			It("should not synchronize it", func() {
+				Expect(waitTerminates(20 * time.Second)).To(BeFalse())
 			})
 		})
 	})

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -609,15 +610,64 @@ var _ = Describe("odo dev command tests", func() {
 			session.WaitEnd()
 		})
 
-		It("should not sync ignored files to the container", func() {
-			podName = commonVar.CliRunner.GetRunningPodNameByComponent(devfileCmpName, commonVar.Project)
-
+		checkSyncedFiles := func(podName string) {
 			stdOut = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
 			helper.MatchAllInOutput(stdOut, []string{"testdir"})
 			helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt"})
 			stdOut = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects/testdir")
 			helper.MatchAllInOutput(stdOut, []string{"baz.txt"})
 			helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt"})
+		}
+
+		It("should not sync ignored files to the container", func() {
+			podName = commonVar.CliRunner.GetRunningPodNameByComponent(devfileCmpName, commonVar.Project)
+			checkSyncedFiles(podName)
+		})
+
+		waitTerminates := func(timeout time.Duration) bool {
+			done := make(chan bool)
+			go func() {
+				session.WaitSync()
+				done <- true
+			}()
+			select {
+			case <-time.Tick(timeout):
+				return false
+			case <-done:
+				return true
+			}
+		}
+
+		When("modifying /testdir/baz.txt file", func() {
+			BeforeEach(func() {
+				helper.ReplaceString(newFilePath3, "hello world", "hello world!!!")
+			})
+
+			It("should synchronize it only", func() {
+				Expect(waitTerminates(20 * time.Second)).To(BeTrue())
+				podName = commonVar.CliRunner.GetRunningPodNameByComponent(devfileCmpName, commonVar.Project)
+				checkSyncedFiles(podName)
+			})
+		})
+
+		When("modifying /foobar.txt file", func() {
+			BeforeEach(func() {
+				helper.ReplaceString(newFilePath1, "hello world", "hello world!!!")
+			})
+
+			It("should not synchronize it", func() {
+				Expect(waitTerminates(20 * time.Second)).To(BeFalse())
+			})
+		})
+
+		When("modifying /testdir/foobar.txt file", func() {
+			BeforeEach(func() {
+				helper.ReplaceString(newFilePath2, "hello world", "hello world!!!")
+			})
+
+			It("should synchronize it", func() {
+				Expect(waitTerminates(20 * time.Second)).To(BeTrue()) // TODO fix
+			})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

Adds the `debug` flag to the `odo dev` command

The user needs to add the debug port as an endpoint to the devfile component.

Fix ignores files during watch + sync

**Which issue(s) this PR fixes:**

Fixes #5583
Fixes #4389

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
