### PR TITLE
Adds `odo dev --no-watch`

### DIFF
--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -234,10 +234,8 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	if o.noWatchFlag {
 		log.Finfof(log.GetStdout(), "\n"+watch.CtrlCMessage)
 		for {
-			select {
-			case <-o.ctx.Done():
-				return o.clientset.WatchClient.CleanupFunc(devFileObj, log.GetStdout())
-			}
+			<-o.ctx.Done()
+			return o.clientset.WatchClient.CleanupFunc(devFileObj, log.GetStdout())
 		}
 	} else {
 		d := Handler{}

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -15,7 +15,7 @@ import (
 	"github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/templates"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	ododevfile "github.com/redhat-developer/odo/pkg/devfile"
@@ -74,9 +74,12 @@ func NewDevOptions() *DevOptions {
 	}
 }
 
-var devExample = templates.Examples(`
+var devExample = ktemplates.Examples(`
 	# Deploy component to the development cluster
 	%[1]s
+
+	# Deploy component to the development cluster without automatically syncing the code upon any file changes
+	%[1]s --no-watch
 `)
 
 func (o *DevOptions) SetClientset(clientset *clientset.Clientset) {

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -235,7 +235,7 @@ func (o *DevOptions) Run(ctx context.Context) error {
 		log.Finfof(log.GetStdout(), "\n"+watch.CtrlCMessage)
 		for {
 			<-o.ctx.Done()
-			return o.clientset.WatchClient.CleanupFunc(devFileObj, log.GetStdout())
+			return o.clientset.WatchClient.Cleanup(devFileObj, log.GetStdout())
 		}
 	} else {
 		d := Handler{}

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -62,6 +62,7 @@ type DevOptions struct {
 
 	// Flags
 	randomPorts bool
+	noWatchFlag bool
 }
 
 type Handler struct{}
@@ -230,8 +231,18 @@ func (o *DevOptions) Run(ctx context.Context) error {
 	scontext.SetProjectType(ctx, devFileObj.Data.GetMetadata().ProjectType)
 	scontext.SetDevfileName(ctx, devFileObj.GetMetadataName())
 
-	d := Handler{}
-	err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx)
+	if o.noWatchFlag {
+		log.Finfof(log.GetStdout(), "\n"+watch.CtrlCMessage)
+		for {
+			select {
+			case <-o.ctx.Done():
+				return o.clientset.WatchClient.CleanupFunc(devFileObj, log.GetStdout())
+			}
+		}
+	} else {
+		d := Handler{}
+		err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx)
+	}
 
 	return err
 }
@@ -293,6 +304,7 @@ It forwards endpoints with exposure values 'public' or 'internal' to a port on l
 		},
 	}
 	devCmd.Flags().BoolVarP(&o.randomPorts, "random-ports", "f", false, "Assign random ports to redirected ports")
+	devCmd.Flags().BoolVar(&o.noWatchFlag, "no-watch", false, "Do not watch for file changes")
 
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT, clientset.KUBERNETES)
 	// Add a defined annotation in order to appear in the help menu

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -236,10 +236,8 @@ func (o *DevOptions) Run(ctx context.Context) error {
 
 	if o.noWatchFlag {
 		log.Finfof(log.GetStdout(), "\n"+watch.CtrlCMessage)
-		for {
-			<-o.ctx.Done()
-			return o.clientset.WatchClient.Cleanup(devFileObj, log.GetStdout())
-		}
+		<-o.ctx.Done()
+		err = o.clientset.WatchClient.Cleanup(devFileObj, log.GetStdout())
 	} else {
 		d := Handler{}
 		err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx)

--- a/pkg/watch/interface.go
+++ b/pkg/watch/interface.go
@@ -11,6 +11,6 @@ type Client interface {
 	// WatchAndPush watches the component under the context directory and triggers Push if there are any changes
 	// It also listens on ctx's Done channel to trigger cleanup when indicated to do so
 	WatchAndPush(out io.Writer, parameters WatchParameters, ctx context.Context) error
-	// CleanupFunc deletes the component created using the devfileObj and writes any outputs to out
-	CleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error
+	// Cleanup deletes the component created using the devfileObj and writes any outputs to out
+	Cleanup(devfileObj parser.DevfileObj, out io.Writer) error
 }

--- a/pkg/watch/interface.go
+++ b/pkg/watch/interface.go
@@ -3,10 +3,14 @@ package watch
 import (
 	"context"
 	"io"
+
+	"github.com/devfile/library/pkg/devfile/parser"
 )
 
 type Client interface {
 	// WatchAndPush watches the component under the context directory and triggers Push if there are any changes
 	// It also listens on ctx's Done channel to trigger cleanup when indicated to do so
 	WatchAndPush(out io.Writer, parameters WatchParameters, ctx context.Context) error
+	// CleanupFunc deletes the component created using the devfileObj and writes any outputs to out
+	CleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error
 }

--- a/pkg/watch/mock.go
+++ b/pkg/watch/mock.go
@@ -9,6 +9,7 @@ import (
 	io "io"
 	reflect "reflect"
 
+	parser "github.com/devfile/library/pkg/devfile/parser"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -33,6 +34,20 @@ func NewMockClient(ctrl *gomock.Controller) *MockClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
+}
+
+// CleanupFunc mocks base method.
+func (m *MockClient) CleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupFunc", devfileObj, out)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupFunc indicates an expected call of CleanupFunc.
+func (mr *MockClientMockRecorder) CleanupFunc(devfileObj, out interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupFunc", reflect.TypeOf((*MockClient)(nil).CleanupFunc), devfileObj, out)
 }
 
 // WatchAndPush mocks base method.

--- a/pkg/watch/mock.go
+++ b/pkg/watch/mock.go
@@ -36,18 +36,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CleanupFunc mocks base method.
-func (m *MockClient) CleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error {
+// Cleanup mocks base method.
+func (m *MockClient) Cleanup(devfileObj parser.DevfileObj, out io.Writer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupFunc", devfileObj, out)
+	ret := m.ctrl.Call(m, "Cleanup", devfileObj, out)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CleanupFunc indicates an expected call of CleanupFunc.
-func (mr *MockClientMockRecorder) CleanupFunc(devfileObj, out interface{}) *gomock.Call {
+// Cleanup indicates an expected call of Cleanup.
+func (mr *MockClientMockRecorder) Cleanup(devfileObj, out interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupFunc", reflect.TypeOf((*MockClient)(nil).CleanupFunc), devfileObj, out)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockClient)(nil).Cleanup), devfileObj, out)
 }
 
 // WatchAndPush mocks base method.

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -26,6 +26,7 @@ import (
 const (
 	// PushErrorString is the string that is printed when an error occurs during watch's Push operation
 	PushErrorString = "Error occurred on Push"
+	CtrlCMessage    = "Press Ctrl+c to exit `odo dev` and delete resources from the cluster"
 )
 
 type WatchClient struct {
@@ -187,7 +188,7 @@ func (o *WatchClient) WatchAndPush(out io.Writer, parameters WatchParameters, ct
 
 	printInfoMessage(out, parameters.Path)
 
-	return eventWatcher(ctx, watcher, parameters, out, evaluateFileChanges, processEvents, o.cleanupFunc)
+	return eventWatcher(ctx, watcher, parameters, out, evaluateFileChanges, processEvents, o.CleanupFunc)
 }
 
 // eventWatcher loops till the context's Done channel indicates it to stop looping, at which point it performs cleanup.
@@ -330,7 +331,7 @@ func processEvents(changedFiles, deletedPaths []string, parameters WatchParamete
 	}
 }
 
-func (o *WatchClient) cleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error {
+func (o *WatchClient) CleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error {
 	isInnerLoopDeployed, resources, err := o.deleteClient.ListResourcesToDeleteFromDevfile(devfileObj, "app")
 	if err != nil {
 		fmt.Fprintf(out, "failed to delete inner loop resources: %v", err)
@@ -393,6 +394,5 @@ func removeDuplicates(input []string) []string {
 }
 
 func printInfoMessage(out io.Writer, path string) {
-	log.Finfof(out, "\nWatching for changes in the current directory %s\n"+
-		"Press Ctrl+c to exit `odo dev` and delete resources from the cluster\n", path)
+	log.Finfof(out, "\nWatching for changes in the current directory %s\n"+CtrlCMessage+"\n", path)
 }

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -188,7 +188,7 @@ func (o *WatchClient) WatchAndPush(out io.Writer, parameters WatchParameters, ct
 
 	printInfoMessage(out, parameters.Path)
 
-	return eventWatcher(ctx, watcher, parameters, out, evaluateFileChanges, processEvents, o.CleanupFunc)
+	return eventWatcher(ctx, watcher, parameters, out, evaluateFileChanges, processEvents, o.Cleanup)
 }
 
 // eventWatcher loops till the context's Done channel indicates it to stop looping, at which point it performs cleanup.
@@ -331,7 +331,7 @@ func processEvents(changedFiles, deletedPaths []string, parameters WatchParamete
 	}
 }
 
-func (o *WatchClient) CleanupFunc(devfileObj parser.DevfileObj, out io.Writer) error {
+func (o *WatchClient) Cleanup(devfileObj parser.DevfileObj, out io.Writer) error {
 	isInnerLoopDeployed, resources, err := o.deleteClient.ListResourcesToDeleteFromDevfile(devfileObj, "app")
 	if err != nil {
 		fmt.Fprintf(out, "failed to delete inner loop resources: %v", err)

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -118,7 +118,7 @@ func StartDevMode(opts ...string) (DevSession, []byte, []byte, []string, error) 
 	args := []string{"dev", "--random-ports"}
 	args = append(args, opts...)
 	session := CmdRunner("odo", args...)
-	WaitForOutputToContain("Watching for changes in the current directory", 360, 10, session)
+	WaitForOutputToContain("Press Ctrl+c to exit `odo dev` and delete resources from the cluster", 360, 10, session)
 	result := DevSession{
 		session: session,
 	}

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -348,7 +348,7 @@ var _ = Describe("odo dev command tests", func() {
 				It("should not trigger a push", func() {
 					helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "App started", "App is super started")
 					podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-					execResult := commonVar.CliRunner.Exec(podName, commonVar.Project, "cat", "/projects/"+filepath.Base("server.js"))
+					execResult := commonVar.CliRunner.Exec(podName, commonVar.Project, "cat", "/projects/server.js")
 					Expect(execResult).To(ContainSubstring("App started"))
 					Expect(execResult).ToNot(ContainSubstring("App is super started"))
 


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**
Need this to allow users to avoid syncing the code too fast

**Which issue(s) this PR fixes:**
Fixes #5631

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. Execute `odo dev --no-watch`; modify a file in the component directory.
2. odo should not trigger a sync for the file change
3. Hitting `Ctrl+c` should correctly delete the resources from the cluster