### PR TITLE
Error when running odo list and there are no components deployed

### DIFF
--- a/pkg/odo/cli/list/list.go
+++ b/pkg/odo/cli/list/list.go
@@ -180,7 +180,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 
 func (lo *ListOptions) HumanReadableOutput(components []component.OdoComponent) {
 	if len(components) == 0 {
-		log.Info("There are no components deployed.")
+		log.Error("There are no components deployed.")
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind bug

**What does this PR do / why we need it:**

When there are no components shown, we should exit with an error 0,
rather than a info / warning.

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

N/A

**PR acceptance criteria:**

- [X] Unit test

- [X] Integration test

- [X] Documentation

N/A

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>