### PR TITLE
Favor use of "allowlist" and "denylist" in `wwhrd` license check config

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -1,9 +1,9 @@
 ---
-blacklist:
+denylist:
   # https://www.apache.org/licenses/GPL-compatibility.html
   - GPL-2.0
 
-whitelist:
+allowlist:
   - Apache-2.0
   - MIT
   - NewBSD


### PR DESCRIPTION
**What does this PR do / why we need it:**
Stumbled upon this while working on #5567

This changes the terminology used in `.wwhrd.yml`, as this is the recommended way of configuring [wwhrd](https://github.com/frapposelli/wwhrd) [1].
Also, those are more inclusive terms in line with Red Hat recommendations [2].

[1] https://github.com/frapposelli/wwhrd#configuration-file
[2] https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language

**Which issue(s) this PR fixes:**
No related issue, as this was very quick to update.

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Both `make validate-vendor-licenses` and `make validate` should pass.