### PR TITLE
odo dev store information about currently forwarded ports

### DIFF
--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -14,9 +14,7 @@ RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and associated home directory
-RUN useradd -u 2001 tester
-RUN mkdir /home/tester
-RUN chown tester:tester /home/tester
+RUN useradd -u 2001 --create-home tester
 # Change to non-root privilege
 USER tester
 

--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -1,8 +1,6 @@
 FROM golang:1.17
 
 RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
-    ibmcloud plugin install -f cloud-object-storage && \
-    ibmcloud plugin install -f kubernetes-service && \
     curl -sLO https://github.com/cli/cli/releases/download/v2.1.0/gh_2.1.0_linux_amd64.deb && \
     apt install ./gh_2.1.0_linux_amd64.deb && \
     curl -sLO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
@@ -15,4 +13,13 @@ RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
     apt-get install -y sshpass && \
     rm -rf /var/lib/apt/lists/*
 
-RUN go get github.com/kadel/odo-robot@965ea0dd848856691bfc76e6824a8b787b950045
+# Create non-root user and associated home directory
+RUN useradd -u 2001 tester
+RUN mkdir /home/tester
+RUN chown tester:tester /home/tester
+# Change to non-root privilege
+USER tester
+
+RUN go get github.com/kadel/odo-robot@965ea0dd848856691bfc76e6824a8b787b950045 && \
+    ibmcloud plugin install -f cloud-object-storage && \
+    ibmcloud plugin install -f kubernetes-service

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
@@ -231,8 +231,7 @@ components:
 
 When the command `odo dev` is executed, the state of the command is saved in the file `./.odo/devstate.json`. 
 
-This state file contains the PID of the `odo dev` running process (`0` if no command is running), the timestamp 
-at which the state has been last saved, and the currently forwarded ports.
+This state file contains the currently forwarded ports.
 
 ```
 {

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
@@ -229,7 +229,7 @@ components:
 
 ### State file
 
-When the command `odo dev` is executed, the state of the command isa saved in the file `./.odo/state.json`. 
+When the command `odo dev` is executed, the state of the command is saved in the file `./.odo/state.json`. 
 
 This state file contains the PID of the `odo dev` running process (`0` if no command is running), the timestamp 
 at which the state has been last saved, and the currently forwarded ports.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
@@ -229,7 +229,7 @@ components:
 
 ### State file
 
-When the command `odo dev` is executed, the state of the command is saved in the file `./.odo/state.json`. 
+When the command `odo dev` is executed, the state of the command is saved in the file `./.odo/devstate.json`. 
 
 This state file contains the PID of the `odo dev` running process (`0` if no command is running), the timestamp 
 at which the state has been last saved, and the currently forwarded ports.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
@@ -226,3 +226,25 @@ components:
     memoryLimit: 1024Mi
     mountSources: true
 ```
+
+### State file
+
+When the command `odo dev` is executed, the state of the command isa saved in the file `./.odo/state.json`. 
+
+This state file contains the PID of the `odo dev` running process (`0` if no command is running), the timestamp 
+at which the state has been last saved, and the currently forwarded ports.
+
+```
+{
+ "timestamp": 1651247240,
+ "pid": 154474,
+ "forwardedPorts": [
+  {
+   "containerName": "runtime",
+   "localAddress": "127.0.0.1",
+   "localPort": 40001,
+   "containerPort": 3000
+  }
+ ]
+}
+```

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
@@ -236,8 +236,6 @@ at which the state has been last saved, and the currently forwarded ports.
 
 ```
 {
- "timestamp": 1651247240,
- "pid": 154474,
  "forwardedPorts": [
   {
    "containerName": "runtime",

--- a/pkg/api/component.go
+++ b/pkg/api/component.go
@@ -19,6 +19,7 @@ type Component struct {
 
 type ForwardedPort struct {
 	ContainerName string `json:"containerName"`
+	LocalAddress  string `json:"localAddress"`
 	LocalPort     int    `json:"localPort"`
 	ContainerPort int    `json:"containerPort"`
 }

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -241,7 +241,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 	}()
 
 	portsBuf.Wait()
-	err = o.clientset.StateClient.SetForwardedPorts(portsBuf.GetForwaredPorts())
+	err = o.clientset.StateClient.SetForwardedPorts(portsBuf.GetForwardedPorts())
 	if err != nil {
 		return fmt.Errorf("unable to save forwarded ports to state file: %v", err)
 	}

--- a/pkg/odo/cli/dev/writer.go
+++ b/pkg/odo/cli/dev/writer.go
@@ -65,7 +65,7 @@ func (o *PortWriter) Wait() {
 	<-o.end
 }
 
-func (o *PortWriter) GetForwaredPorts() []api.ForwardedPort {
+func (o *PortWriter) GetForwardedPorts() []api.ForwardedPort {
 	return o.fwPorts
 }
 

--- a/pkg/odo/cli/dev/writer.go
+++ b/pkg/odo/cli/dev/writer.go
@@ -1,26 +1,37 @@
 package dev
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
+
+	"github.com/redhat-developer/odo/pkg/api"
+
+	"k8s.io/klog"
 )
 
 type PortWriter struct {
 	buffer io.Writer
 	end    chan bool
 	len    int
+	// mapping indicates the list of ports open by containers (ex: mapping["runtime"] = {3000, 3030})
+	mapping map[string][]int
+	fwPorts []api.ForwardedPort
 }
 
 // NewPortWriter creates a writer that will write the content in buffer,
 // and Wait will return after strings "Forwarding from 127.0.0.1:" has been written "len" times
-func NewPortWriter(buffer io.Writer, len int) *PortWriter {
+func NewPortWriter(buffer io.Writer, len int, mapping map[string][]int) *PortWriter {
 	return &PortWriter{
-		buffer: buffer,
-		len:    len,
-		end:    make(chan bool),
+		buffer:  buffer,
+		len:     len,
+		end:     make(chan bool),
+		mapping: mapping,
 	}
 }
 
@@ -33,6 +44,14 @@ func (o *PortWriter) Write(buf []byte) (n int, err error) {
 	defer color.Unset() // Use it in your function
 	s := string(buf)
 	if strings.HasPrefix(s, "Forwarding from 127.0.0.1") {
+
+		fwPort, err := getForwardedPort(o.mapping, s)
+		if err == nil {
+			o.fwPorts = append(o.fwPorts, fwPort)
+		} else {
+			klog.V(4).Infof("unable to get forwarded port: %v", err)
+		}
+
 		fmt.Fprintf(o.buffer, " - %s", s)
 		o.len--
 		if o.len == 0 {
@@ -44,4 +63,39 @@ func (o *PortWriter) Write(buf []byte) (n int, err error) {
 
 func (o *PortWriter) Wait() {
 	<-o.end
+}
+
+func (o *PortWriter) GetForwaredPorts() []api.ForwardedPort {
+	return o.fwPorts
+}
+
+func getForwardedPort(mapping map[string][]int, s string) (api.ForwardedPort, error) {
+	regex := regexp.MustCompile(`Forwarding from 127.0.0.1:([0-9]+) -> ([0-9]+)`)
+	matches := regex.FindStringSubmatch(s)
+	if len(matches) < 3 {
+		return api.ForwardedPort{}, errors.New("unable to analyze port forwarding string")
+	}
+	localPort, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return api.ForwardedPort{}, err
+	}
+	remotePort, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return api.ForwardedPort{}, err
+	}
+	containerName := ""
+	for container, ports := range mapping {
+		for _, port := range ports {
+			if port == remotePort {
+				containerName = container
+				break
+			}
+		}
+	}
+	return api.ForwardedPort{
+		ContainerName: containerName,
+		LocalAddress:  "127.0.0.1",
+		LocalPort:     localPort,
+		ContainerPort: remotePort,
+	}, nil
 }

--- a/pkg/odo/cli/dev/writer_test.go
+++ b/pkg/odo/cli/dev/writer_test.go
@@ -1,0 +1,63 @@
+package dev
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/redhat-developer/odo/pkg/api"
+)
+
+func Test_getForwardedPort(t *testing.T) {
+	type args struct {
+		mapping map[string][]int
+		s       string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    api.ForwardedPort
+		wantErr bool
+	}{
+		{
+			name: "find port in container",
+			args: args{
+				mapping: map[string][]int{
+					"container1": {3000, 4200},
+					"container2": {80, 8080},
+				},
+				s: "Forwarding from 127.0.0.1:40407 -> 3000",
+			},
+			want: api.ForwardedPort{
+				ContainerName: "container1",
+				LocalAddress:  "127.0.0.1",
+				LocalPort:     40407,
+				ContainerPort: 3000,
+			},
+			wantErr: false,
+		},
+		{
+			name: "string error",
+			args: args{
+				mapping: map[string][]int{
+					"container1": {3000, 4200},
+					"container2": {80, 8080},
+				},
+				s: "Forwarding from 127.0.0.1:40407 => 3000",
+			},
+			want:    api.ForwardedPort{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getForwardedPort(tt.args.mapping, tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getForwardedPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getForwardedPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -14,6 +14,7 @@ package clientset
 import (
 	"github.com/redhat-developer/odo/pkg/alizer"
 	"github.com/redhat-developer/odo/pkg/dev"
+	"github.com/redhat-developer/odo/pkg/state"
 	"github.com/spf13/cobra"
 
 	_delete "github.com/redhat-developer/odo/pkg/component/delete"
@@ -50,6 +51,8 @@ const (
 	PROJECT = "DEP_PROJECT"
 	// REGISTRY instantiates client for pkg/registry
 	REGISTRY = "DEP_REGISTRY"
+	// STATE instantiates client for pkg/state
+	STATE = "DEP_STATE"
 	// WATCH instantiates client for pkg/watch
 	WATCH = "DEP_WATCH"
 
@@ -66,7 +69,8 @@ var subdeps map[string][]string = map[string][]string{
 	INIT:             {ALIZER, FILESYSTEM, PREFERENCE, REGISTRY},
 	PROJECT:          {KUBERNETES_NULLABLE},
 	REGISTRY:         {FILESYSTEM, PREFERENCE},
-	WATCH:            {DELETE_COMPONENT},
+	STATE:            {FILESYSTEM},
+	WATCH:            {DELETE_COMPONENT, STATE},
 	/* Add sub-dependencies here, if any */
 }
 
@@ -81,6 +85,7 @@ type Clientset struct {
 	PreferenceClient preference.Client
 	ProjectClient    project.Client
 	RegistryClient   registry.Client
+	StateClient      state.Client
 	WatchClient      watch.Client
 	/* Add client here */
 }
@@ -144,8 +149,11 @@ func Fetch(command *cobra.Command) (*Clientset, error) {
 	if isDefined(command, PROJECT) {
 		dep.ProjectClient = project.NewClient(dep.KubernetesClient)
 	}
+	if isDefined(command, STATE) {
+		dep.StateClient = state.NewStateClient(dep.FS)
+	}
 	if isDefined(command, WATCH) {
-		dep.WatchClient = watch.NewWatchClient(dep.DeleteClient)
+		dep.WatchClient = watch.NewWatchClient(dep.DeleteClient, dep.StateClient)
 	}
 	if isDefined(command, DEV) {
 		dep.DevClient = dev.NewDevClient(dep.WatchClient)

--- a/pkg/state/const.go
+++ b/pkg/state/const.go
@@ -1,3 +1,3 @@
 package state
 
-const _filepath = "./.odo/state.json"
+const _filepath = "./.odo/devstate.json"

--- a/pkg/state/const.go
+++ b/pkg/state/const.go
@@ -1,0 +1,3 @@
+package state
+
+const _filepath = "./.odo/state.json"

--- a/pkg/state/doc.go
+++ b/pkg/state/doc.go
@@ -1,0 +1,2 @@
+// Package state gives access to the state of the odo process stored in a local file
+package state

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -1,0 +1,11 @@
+package state
+
+import "github.com/redhat-developer/odo/pkg/api"
+
+type Client interface {
+	// SetForwardedPorts sets the forwarded ports in the state file and saves it to the file, updating the metadata
+	SetForwardedPorts(fwPorts []api.ForwardedPort) error
+
+	// SaveExit resets the state file to indicate odo is not running
+	SaveExit() error
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,0 +1,59 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/redhat-developer/odo/pkg/api"
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+)
+
+type State struct {
+	content             Content
+	fs                  filesystem.Filesystem
+	getSecondsFromEpoch func() int64
+	getpid              func() int
+}
+
+func NewStateClient(fs filesystem.Filesystem) *State {
+	return &State{
+		fs:                  fs,
+		getSecondsFromEpoch: getSecondsFromEpoch,
+		getpid:              os.Getpid,
+	}
+}
+
+func (o *State) SetForwardedPorts(fwPorts []api.ForwardedPort) error {
+	// TODO(feloy) When other data is persisted into the state file, it will be needed to read the file first
+	o.content.ForwardedPorts = fwPorts
+	o.setMetadata()
+	return o.save()
+}
+
+func (o *State) SaveExit() error {
+	o.content.ForwardedPorts = nil
+	o.content.PID = 0
+	o.content.Timestamp = o.getSecondsFromEpoch()
+	return o.save()
+}
+
+// setMetadata sets the metadata in the state with current PID and epoch
+func (o *State) setMetadata() {
+	o.content.PID = o.getpid()
+	o.content.Timestamp = o.getSecondsFromEpoch()
+}
+
+// save writes the content structure in json format in file
+func (o *State) save() error {
+	jsonContent, err := json.MarshalIndent(o.content, "", " ")
+	if err != nil {
+		return err
+	}
+	// .odo directory is supposed to exist, don't create it
+	return o.fs.WriteFile(_filepath, jsonContent, 0644)
+}
+
+func getSecondsFromEpoch() int64 {
+	return time.Now().Unix()
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2,46 +2,31 @@ package state
 
 import (
 	"encoding/json"
-	"os"
-	"time"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 type State struct {
-	content             Content
-	fs                  filesystem.Filesystem
-	getSecondsFromEpoch func() int64
-	getpid              func() int
+	content Content
+	fs      filesystem.Filesystem
 }
 
 func NewStateClient(fs filesystem.Filesystem) *State {
 	return &State{
-		fs:                  fs,
-		getSecondsFromEpoch: getSecondsFromEpoch,
-		getpid:              os.Getpid,
+		fs: fs,
 	}
 }
 
 func (o *State) SetForwardedPorts(fwPorts []api.ForwardedPort) error {
 	// TODO(feloy) When other data is persisted into the state file, it will be needed to read the file first
 	o.content.ForwardedPorts = fwPorts
-	o.setMetadata()
 	return o.save()
 }
 
 func (o *State) SaveExit() error {
 	o.content.ForwardedPorts = nil
-	o.content.PID = 0
-	o.content.Timestamp = o.getSecondsFromEpoch()
 	return o.save()
-}
-
-// setMetadata sets the metadata in the state with current PID and epoch
-func (o *State) setMetadata() {
-	o.content.PID = o.getpid()
-	o.content.Timestamp = o.getSecondsFromEpoch()
 }
 
 // save writes the content structure in json format in file
@@ -52,8 +37,4 @@ func (o *State) save() error {
 	}
 	// .odo directory is supposed to exist, don't create it
 	return o.fs.WriteFile(_filepath, jsonContent, 0644)
-}
-
-func getSecondsFromEpoch() int64 {
-	return time.Now().Unix()
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -62,12 +62,6 @@ func TestState_SetForwardedPorts(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if content.Timestamp != 13000 {
-					return fmt.Errorf("timestamp is %d, should be 13000", content.Timestamp)
-				}
-				if content.PID != 100 {
-					return fmt.Errorf("PID is %d, should be 100", content.PID)
-				}
 				expected := []api.ForwardedPort{forwardedPort1}
 				if !reflect.DeepEqual(content.ForwardedPorts, expected) {
 					return fmt.Errorf("Forwarded ports is %+v, should be %+v", content.ForwardedPorts, expected)
@@ -80,9 +74,7 @@ func TestState_SetForwardedPorts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := tt.fields.fs()
 			o := State{
-				fs:                  fs,
-				getSecondsFromEpoch: tt.fields.getSecondsFromEpoch,
-				getpid:              tt.fields.getpid,
+				fs: fs,
 			}
 			if err := o.SetForwardedPorts(tt.args.fwPorts); (err != nil) != tt.wantErr {
 				t.Errorf("State.SetForwardedPorts() error = %v, wantErr %v", err, tt.wantErr)
@@ -130,12 +122,6 @@ func TestState_SaveExit(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if content.Timestamp != 13000 {
-					return fmt.Errorf("timestamp is %d, should be 13000", content.Timestamp)
-				}
-				if content.PID != 0 {
-					return fmt.Errorf("PID is %d, should be 0", content.PID)
-				}
 				if len(content.ForwardedPorts) != 0 {
 					return fmt.Errorf("Forwarded ports is %+v, should be empty", content.ForwardedPorts)
 				}
@@ -147,9 +133,7 @@ func TestState_SaveExit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := tt.fields.fs()
 			o := State{
-				fs:                  fs,
-				getSecondsFromEpoch: tt.fields.getSecondsFromEpoch,
-				getpid:              tt.fields.getpid,
+				fs: fs,
 			}
 			if err := o.SaveExit(); (err != nil) != tt.wantErr {
 				t.Errorf("State.SaveExit() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1,0 +1,162 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/redhat-developer/odo/pkg/api"
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+)
+
+func TestState_SetForwardedPorts(t *testing.T) {
+
+	forwardedPort1 := api.ForwardedPort{
+		ContainerName: "acontainer",
+		LocalAddress:  "localhost",
+		LocalPort:     40001,
+		ContainerPort: 3000,
+	}
+
+	type fields struct {
+		fs                  func() filesystem.Filesystem
+		getSecondsFromEpoch func() int64
+		getpid              func() int
+	}
+	type args struct {
+		fwPorts []api.ForwardedPort
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantErr    bool
+		checkState func(fs filesystem.Filesystem) error
+	}{
+		// TODO: Add test cases.
+		{
+			name: "set forwarded ports",
+			fields: fields{
+				fs: func() filesystem.Filesystem {
+					return filesystem.NewFakeFs()
+				},
+				getSecondsFromEpoch: func() int64 {
+					return 13000
+				},
+				getpid: func() int {
+					return 100
+				},
+			},
+			args: args{
+				fwPorts: []api.ForwardedPort{forwardedPort1},
+			},
+			wantErr: false,
+			checkState: func(fs filesystem.Filesystem) error {
+				jsonContent, err := fs.ReadFile(_filepath)
+				if err != nil {
+					return err
+				}
+				var content Content
+				err = json.Unmarshal(jsonContent, &content)
+				if err != nil {
+					return err
+				}
+				if content.Timestamp != 13000 {
+					return fmt.Errorf("timestamp is %d, should be 13000", content.Timestamp)
+				}
+				if content.PID != 100 {
+					return fmt.Errorf("PID is %d, should be 100", content.PID)
+				}
+				expected := []api.ForwardedPort{forwardedPort1}
+				if !reflect.DeepEqual(content.ForwardedPorts, expected) {
+					return fmt.Errorf("Forwarded ports is %+v, should be %+v", content.ForwardedPorts, expected)
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := tt.fields.fs()
+			o := State{
+				fs:                  fs,
+				getSecondsFromEpoch: tt.fields.getSecondsFromEpoch,
+				getpid:              tt.fields.getpid,
+			}
+			if err := o.SetForwardedPorts(tt.args.fwPorts); (err != nil) != tt.wantErr {
+				t.Errorf("State.SetForwardedPorts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if check := tt.checkState(fs); check != nil {
+				t.Error(check)
+			}
+		})
+	}
+}
+
+func TestState_SaveExit(t *testing.T) {
+	type fields struct {
+		fs                  func() filesystem.Filesystem
+		getSecondsFromEpoch func() int64
+		getpid              func() int
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		wantErr    bool
+		checkState func(fs filesystem.Filesystem) error
+	}{
+		{
+			name: "save exit",
+			fields: fields{
+				fs: func() filesystem.Filesystem {
+					return filesystem.NewFakeFs()
+				},
+				getSecondsFromEpoch: func() int64 {
+					return 13000
+				},
+				getpid: func() int {
+					return 100
+				},
+			},
+			wantErr: false,
+			checkState: func(fs filesystem.Filesystem) error {
+				jsonContent, err := fs.ReadFile(_filepath)
+				if err != nil {
+					return err
+				}
+				var content Content
+				err = json.Unmarshal(jsonContent, &content)
+				if err != nil {
+					return err
+				}
+				if content.Timestamp != 13000 {
+					return fmt.Errorf("timestamp is %d, should be 13000", content.Timestamp)
+				}
+				if content.PID != 0 {
+					return fmt.Errorf("PID is %d, should be 0", content.PID)
+				}
+				if len(content.ForwardedPorts) != 0 {
+					return fmt.Errorf("Forwarded ports is %+v, should be empty", content.ForwardedPorts)
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := tt.fields.fs()
+			o := State{
+				fs:                  fs,
+				getSecondsFromEpoch: tt.fields.getSecondsFromEpoch,
+				getpid:              tt.fields.getpid,
+			}
+			if err := o.SaveExit(); (err != nil) != tt.wantErr {
+				t.Errorf("State.SaveExit() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if check := tt.checkState(fs); check != nil {
+				t.Error(check)
+			}
+		})
+	}
+}

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -5,10 +5,6 @@ import (
 )
 
 type Content struct {
-	// Timestamp is the number of seconds from epoch at which the state were saved
-	Timestamp int64 `json:"timestamp"`
-	// PID is the pid of the running odo process, 0 if odo is not running
-	PID int `json:"pid"`
 	// ForwardedPorts are the ports forwarded during odo dev session
 	ForwardedPorts []api.ForwardedPort `json:"forwardedPorts"`
 }

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -1,0 +1,14 @@
+package state
+
+import (
+	"github.com/redhat-developer/odo/pkg/api"
+)
+
+type Content struct {
+	// Timestamp is the number of seconds from epoch at which the state were saved
+	Timestamp int64 `json:"timestamp"`
+	// PID is the pid of the running odo process, 0 if odo is not running
+	PID int `json:"pid"`
+	// ForwardedPorts are the ports forwarded during odo dev session
+	ForwardedPorts []api.ForwardedPort `json:"forwardedPorts"`
+}

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -359,6 +359,7 @@ func processEvents(changedFiles, deletedPaths []string, parameters WatchParamete
 }
 
 func (o *WatchClient) Cleanup(devfileObj parser.DevfileObj, out io.Writer) error {
+	fmt.Fprintln(out, "Cleaning resources, please wait")
 	isInnerLoopDeployed, resources, err := o.deleteClient.ListResourcesToDeleteFromDevfile(devfileObj, "app")
 	if err != nil {
 		fmt.Fprintf(out, "failed to delete inner loop resources: %v", err)

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/devfile/library/pkg/devfile/parser"
 	_delete "github.com/redhat-developer/odo/pkg/component/delete"
+	"github.com/redhat-developer/odo/pkg/state"
 
 	"github.com/fsnotify/fsnotify"
 	gitignore "github.com/sabhiram/go-gitignore"
@@ -32,11 +33,13 @@ const (
 
 type WatchClient struct {
 	deleteClient _delete.Client
+	stateClient  state.Client
 }
 
-func NewWatchClient(deleteClient _delete.Client) *WatchClient {
+func NewWatchClient(deleteClient _delete.Client, stateClient state.Client) *WatchClient {
 	return &WatchClient{
 		deleteClient: deleteClient,
+		stateClient:  stateClient,
 	}
 }
 
@@ -373,7 +376,8 @@ func (o *WatchClient) Cleanup(devfileObj parser.DevfileObj, out io.Writer) error
 	for _, fail := range failed {
 		fmt.Fprintf(out, "Failed to delete the %q resource: %s\n", fail.GetKind(), fail.GetName())
 	}
-	return nil
+
+	return o.stateClient.SaveExit()
 }
 
 func shouldIgnoreEvent(event fsnotify.Event) (ignoreEvent bool) {

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -258,23 +258,25 @@ func CommonAfterEach(commonVar CommonVar) {
 }
 
 // JsonPathContentIs expects that the content of the path to equal value
-func JsonPathContentIs(json string, path string, value string) bool {
+func JsonPathContentIs(json string, path string, value string) {
 	result := gjson.Get(json, path)
 	Expect(result.String()).To(Equal(value), fmt.Sprintf("content of path %q should be %q but is %q", path, value, result.String()))
-	return true
 }
 
 // JsonPathContentContain expects that the content of the path to contain value
-func JsonPathContentContain(json string, path string, value string) bool {
+func JsonPathContentContain(json string, path string, value string) {
 	result := gjson.Get(json, path)
 	Expect(result.String()).To(ContainSubstring(value), fmt.Sprintf("content of path %q should contain %q but is %q", path, value, result.String()))
-	return true
 }
 
-func JsonPathContentMatch(json string, path string, regexp string) bool {
+func JsonPathContentIsValidUserPort(json string, path string) {
 	result := gjson.Get(json, path)
-	Expect(result.String()).To(MatchRegexp(regexp), fmt.Sprintf("content of path %q should match %q but is %q", path, regexp, result.String()))
-	return true
+	intVal, err := strconv.Atoi(result.String())
+	Expect(err).ToNot(HaveOccurred())
+	Expect(intVal).To(SatisfyAll(
+		BeNumerically(">=", 1024),
+		BeNumerically("<=", 65535),
+	))
 }
 
 // SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -271,6 +271,12 @@ func JsonPathContentContain(json string, path string, value string) bool {
 	return true
 }
 
+func JsonPathContentMatch(json string, path string, regexp string) bool {
+	result := gjson.Get(json, path)
+	Expect(result.String()).To(MatchRegexp(regexp), fmt.Sprintf("content of path %q should match %q but is %q", path, regexp, result.String()))
+	return true
+}
+
 // SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
 func SetProjectName() string {
 	// Get current test filename and remove file path, file extension and replace undescores with hyphens

--- a/tests/integration/devfile/cmd_alizer_test.go
+++ b/tests/integration/devfile/cmd_alizer_test.go
@@ -33,8 +33,8 @@ var _ = Describe("odo alizer command tests", func() {
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stderr).To(BeEmpty())
 			Expect(helper.IsJSON(stdout)).To(BeTrue())
-			Expect(helper.JsonPathContentIs(stdout, "devfile", "nodejs"))
-			Expect(helper.JsonPathContentIs(stdout, "devfileRegistry", "DefaultDevfileRegistry"))
+			helper.JsonPathContentIs(stdout, "devfile", "nodejs")
+			helper.JsonPathContentIs(stdout, "devfileRegistry", "DefaultDevfileRegistry")
 		})
 	})
 
@@ -43,7 +43,7 @@ var _ = Describe("odo alizer command tests", func() {
 		stdout, stderr := res.Out(), res.Err()
 		Expect(stdout).To(BeEmpty())
 		Expect(helper.IsJSON(stderr)).To(BeTrue())
-		Expect(helper.JsonPathContentContain(stderr, "message", "No valid devfile found for project in"))
+		helper.JsonPathContentContain(stderr, "message", "No valid devfile found for project in")
 	})
 
 	It("alizer should fail without json output", func() {

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -1445,6 +1445,8 @@ var _ = Describe("odo dev command tests", func() {
 			helper.JsonPathContentIs(string(contentJSON), "forwardedPorts.1.localAddress", "127.0.0.1")
 			helper.JsonPathContentIs(string(contentJSON), "forwardedPorts.0.containerPort", "3000")
 			helper.JsonPathContentIs(string(contentJSON), "forwardedPorts.1.containerPort", "4567")
+			helper.JsonPathContentMatch(string(contentJSON), "forwardedPorts.0.localPort", "[0-9]+")
+			helper.JsonPathContentMatch(string(contentJSON), "forwardedPorts.1.localPort", "[0-9]+")
 		})
 
 		When("odo dev is stopped", func() {

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -172,7 +172,7 @@ var _ = Describe("odo dev command tests", func() {
 				stateFile := filepath.Join(commonVar.Context, ".odo", "devstate.json")
 				helper.MakeDir(filepath.Dir(stateFile))
 				Expect(helper.CreateFileWithContent(stateFile, "")).ToNot(HaveOccurred())
-				Expect(os.Chmod(stateFile, 0000)).ToNot(HaveOccurred())
+				Expect(os.Chmod(stateFile, 0400)).ToNot(HaveOccurred())
 			})
 			It("should fail running odo dev", func() {
 				res := helper.Cmd("odo", "dev", "--random-ports").ShouldFail()

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -167,6 +167,22 @@ var _ = Describe("odo dev command tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		When("a state file is not writable", func() {
+			BeforeEach(func() {
+				stateFile := filepath.Join(commonVar.Context, ".odo", "state.json")
+				helper.MakeDir(filepath.Dir(stateFile))
+				Expect(helper.CreateFileWithContent(stateFile, "")).ToNot(HaveOccurred())
+				Expect(os.Chmod(stateFile, 0400)).ToNot(HaveOccurred())
+			})
+			It("should fail running odo dev", func() {
+				res := helper.Cmd("odo", "dev", "--random-ports").ShouldFail()
+				stdout := res.Out()
+				stderr := res.Err()
+				Expect(stdout).To(ContainSubstring("Cleaning"))
+				Expect(stderr).To(ContainSubstring("unable to save forwarded ports to state file"))
+			})
+		})
+
 		When("odo dev is executed", func() {
 
 			BeforeEach(func() {

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -1445,8 +1445,8 @@ var _ = Describe("odo dev command tests", func() {
 			helper.JsonPathContentIs(string(contentJSON), "forwardedPorts.1.localAddress", "127.0.0.1")
 			helper.JsonPathContentIs(string(contentJSON), "forwardedPorts.0.containerPort", "3000")
 			helper.JsonPathContentIs(string(contentJSON), "forwardedPorts.1.containerPort", "4567")
-			helper.JsonPathContentMatch(string(contentJSON), "forwardedPorts.0.localPort", "[0-9]+")
-			helper.JsonPathContentMatch(string(contentJSON), "forwardedPorts.1.localPort", "[0-9]+")
+			helper.JsonPathContentIsValidUserPort(string(contentJSON), "forwardedPorts.0.localPort")
+			helper.JsonPathContentIsValidUserPort(string(contentJSON), "forwardedPorts.1.localPort")
 		})
 
 		When("odo dev is stopped", func() {

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -169,10 +169,10 @@ var _ = Describe("odo dev command tests", func() {
 
 		When("a state file is not writable", func() {
 			BeforeEach(func() {
-				stateFile := filepath.Join(commonVar.Context, ".odo", "state.json")
+				stateFile := filepath.Join(commonVar.Context, ".odo", "devstate.json")
 				helper.MakeDir(filepath.Dir(stateFile))
 				Expect(helper.CreateFileWithContent(stateFile, "")).ToNot(HaveOccurred())
-				Expect(os.Chmod(stateFile, 0400)).ToNot(HaveOccurred())
+				Expect(os.Chmod(stateFile, 0000)).ToNot(HaveOccurred())
 			})
 			It("should fail running odo dev", func() {
 				res := helper.Cmd("odo", "dev", "--random-ports").ShouldFail()
@@ -1417,13 +1417,13 @@ var _ = Describe("odo dev command tests", func() {
 	})
 
 	When("a component with multiple endpoints is run", func() {
-		stateFile := ".odo/state.json"
+		stateFile := ".odo/devstate.json"
 		var devSession helper.DevSession
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project-with-multiple-endpoints"), commonVar.Context)
 			helper.Cmd("odo", "project", "set", commonVar.Project).ShouldPass()
 			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-multiple-endpoints.yaml")).ShouldPass()
-			Expect(helper.VerifyFileExists(".odo/state.json")).To(BeFalse())
+			Expect(helper.VerifyFileExists(".odo/devstate.json")).To(BeFalse())
 			var err error
 			devSession, _, _, _, err = helper.StartDevMode()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/integration/devfile/cmd_devfile_init_test.go
+++ b/tests/integration/devfile/cmd_devfile_init_test.go
@@ -40,7 +40,7 @@ var _ = Describe("odo devfile init command tests", func() {
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stdout).To(BeEmpty())
 			Expect(helper.IsJSON(stderr)).To(BeTrue())
-			Expect(helper.JsonPathContentIs(stderr, "message", "parameters are expected to select a devfile"))
+			helper.JsonPathContentIs(stderr, "message", "parameters are expected to select a devfile")
 		})
 
 		By("running odo init with incomplete flags and JSON output", func() {
@@ -48,7 +48,7 @@ var _ = Describe("odo devfile init command tests", func() {
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stdout).To(BeEmpty())
 			Expect(helper.IsJSON(stderr)).To(BeTrue())
-			Expect(helper.JsonPathContentContain(stderr, "message", "either --devfile or --devfile-path parameter should be specified"))
+			helper.JsonPathContentContain(stderr, "message", "either --devfile or --devfile-path parameter should be specified")
 		})
 
 		By("keeping an empty directory when running odo init with wrong starter name", func() {
@@ -124,12 +124,12 @@ var _ = Describe("odo devfile init command tests", func() {
 				stdout, stderr := res.Out(), res.Err()
 				Expect(stderr).To(BeEmpty())
 				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				Expect(helper.JsonPathContentIs(stdout, "devfilePath", filepath.Join(commonVar.Context, "devfile.yaml")))
-				Expect(helper.JsonPathContentIs(stdout, "devfileData.devfile.schemaVersion", "2.0.0"))
-				Expect(helper.JsonPathContentIs(stdout, "devfileData.supportedOdoFeatures.dev", "true"))
-				Expect(helper.JsonPathContentIs(stdout, "devfileData.supportedOdoFeatures.debug", "false"))
-				Expect(helper.JsonPathContentIs(stdout, "devfileData.supportedOdoFeatures.deploy", "false"))
-				Expect(helper.JsonPathContentIs(stdout, "managedBy", "odo"))
+				helper.JsonPathContentIs(stdout, "devfilePath", filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.JsonPathContentIs(stdout, "devfileData.devfile.schemaVersion", "2.0.0")
+				helper.JsonPathContentIs(stdout, "devfileData.supportedOdoFeatures.dev", "true")
+				helper.JsonPathContentIs(stdout, "devfileData.supportedOdoFeatures.debug", "false")
+				helper.JsonPathContentIs(stdout, "devfileData.supportedOdoFeatures.deploy", "false")
+				helper.JsonPathContentIs(stdout, "managedBy", "odo")
 			})
 		})
 		When("using --devfile-path flag with a local devfile", func() {


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

See issue.

The PR updates the image used to run tests on IBM Cloud to be able to run tests as non-root user, to make a new test relying on user rights pass.

**Which issue(s) this PR fixes:**

Fixes #5676 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] Documentation

**How to test changes / Special notes to the reviewer:**

The values for the forwarded ports are obtained through the `PortWriter`, from the text written by the low level port forwarder. This is because we need to get the information of the local port when we are using random ports (with --random-ports flag).
