### PR TITLE
Fix error when opening file in windows OS

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -228,7 +229,9 @@ func CommonAfterEach(commonVar CommonVar) {
 	testDate := strings.Split(time.Now().Format(time.RFC3339), "T")[0]
 	resultsRow = prNum + "," + testDate + "," + clusterType + "," + commonVar.testFileName + "," + commonVar.testCase + "," + passedOrFailed + "," + strconv.FormatFloat(commonVar.testDuration, 'E', -1, 64) + "\n"
 	testResultsFile := filepath.Join("/", "tmp", "testResults.txt")
-
+	if runtime.GOOS == "windows" {
+		testResultsFile = filepath.Join("c:\\", "tmp", "testResults.txt")
+	}
 	f, err := os.OpenFile(testResultsFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		fmt.Println("Error when opening file: ", err)

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -230,7 +230,7 @@ func CommonAfterEach(commonVar CommonVar) {
 	resultsRow = prNum + "," + testDate + "," + clusterType + "," + commonVar.testFileName + "," + commonVar.testCase + "," + passedOrFailed + "," + strconv.FormatFloat(commonVar.testDuration, 'E', -1, 64) + "\n"
 	testResultsFile := filepath.Join("/", "tmp", "testResults.txt")
 	if runtime.GOOS == "windows" {
-		testResultsFile = filepath.Join("c:\\", "tmp", "testResults.txt")
+		testResultsFile = filepath.Join(os.Getenv("TEMP"), "testResults.txt")
 	}
 	f, err := os.OpenFile(testResultsFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this:**
/kind tests

**What does this PR do / why we need it:**
Fixes `+Error when opening file:  open \tmp\testResults.txt: The system cannot find the path specified.` when running tests on Windows

**Which issue(s) this PR fixes:**
Fixes #5681 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

**How to test changes / Special notes to the reviewer:**
Run any test on windows platform and should not fail with `+Error when opening file:  open \tmp\testResults.txt: The system cannot find the path specified.`