### PR TITLE
move alizer command from gui to utility group

### DIFF
--- a/pkg/odo/cli/alizer/alizer.go
+++ b/pkg/odo/cli/alizer/alizer.go
@@ -72,6 +72,6 @@ func NewCmdAlizer(name, fullName string) *cobra.Command {
 	clientset.Add(alizerCmd, clientset.ALIZER)
 	machineoutput.UsedByCommand(alizerCmd)
 	alizerCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
-	alizerCmd.Annotations["command"] = "gui"
+	alizerCmd.Annotations["command"] = "utility"
 	return alizerCmd
 }

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -74,9 +74,6 @@ OpenShift Commands:{{range .Commands}}{{if eq .Annotations.command "openshift"}}
 Utility Commands:{{range .Commands}}{{if eq .Annotations.command "utility" }}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 
-GUI Commands:{{range .Commands}}{{if or (eq .Annotations.command "gui") }}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
-
 Flags:
 {{CapitalizeFlagDescriptions .LocalFlags | trimRightSpace }}{{end}}{{ if .HasAvailableInheritedFlags}}
 

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -72,7 +72,7 @@ OpenShift Commands:{{range .Commands}}{{if eq .Annotations.command "openshift"}}
   {{rpad .Name .NamePadding }} {{.Short}} {{end}}{{end}}
 
 Utility Commands:{{range .Commands}}{{if eq .Annotations.command "utility" }}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 
 Flags:
 {{CapitalizeFlagDescriptions .LocalFlags | trimRightSpace }}{{end}}{{ if .HasAvailableInheritedFlags}}


### PR DESCRIPTION
`alizer` command looked a little bit weird in "GUI Commands" section.
It made it look like the command itself has some kind of GUI.


For now, I moved it into the utility section. Later we might consider some other placement. 