### PR TITLE
Rename alizer command to analyze

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/json-output.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/json-output.md
@@ -16,15 +16,15 @@ When used with the `-o json` flags, a command:
 
 The structures used to return information using JSON output are defined in [the `pkg/api` package](https://github.com/redhat-developer/odo/tree/main/pkg/api).
 
-## odo alizer -o json
+## odo analyze -o json
 
-The `alizer` command analyzes the files in the current directory to select the best devfile to use,
+The `analyze` command analyzes the files in the current directory to select the best devfile to use,
 from the devfiles in the registries defined in the list of preferred registries with the command `odo preference registry`.
 
 The output of this command contains a devfile name and a registry name:
 
 ```bash
-$ odo alizer -o json
+$ odo analyze -o json
 {
     "devfile": "nodejs",
     "devfileRegistry": "DefaultDevfileRegistry"
@@ -36,7 +36,7 @@ $ echo $?
 If the command is executed in an empty directory, it will return an error in the standard error stream and terminate with a non-zero exit status:
 
 ```bash
-$ odo alizer -o json
+$ odo analyze -o json
 {
 	"message": "No valid devfile found for project in /home/user/my/empty/directory"
 }

--- a/pkg/odo/cli/alizer/alizer.go
+++ b/pkg/odo/cli/alizer/alizer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const RecommendedCommandName = "alizer"
+const RecommendedCommandName = "analyze"
 
 type AlizerOptions struct {
 	clientset *clientset.Clientset

--- a/tests/integration/devfile/cmd_analyze_test.go
+++ b/tests/integration/devfile/cmd_analyze_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo alizer command tests", func() {
+var _ = Describe("odo analyze command tests", func() {
 	var commonVar helper.CommonVar
 
 	// This is run before every Spec (It)
@@ -28,8 +28,8 @@ var _ = Describe("odo alizer command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 		})
 
-		It("alizer should return correct value", func() {
-			res := helper.Cmd("odo", "alizer", "-o", "json").ShouldPass()
+		It("analyze should return correct value", func() {
+			res := helper.Cmd("odo", "analyze", "-o", "json").ShouldPass()
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stderr).To(BeEmpty())
 			Expect(helper.IsJSON(stdout)).To(BeTrue())
@@ -38,16 +38,16 @@ var _ = Describe("odo alizer command tests", func() {
 		})
 	})
 
-	It("alizer should fail in an empty directory", func() {
-		res := helper.Cmd("odo", "alizer", "-o", "json").ShouldFail()
+	It("analyze should fail in an empty directory", func() {
+		res := helper.Cmd("odo", "analyze", "-o", "json").ShouldFail()
 		stdout, stderr := res.Out(), res.Err()
 		Expect(stdout).To(BeEmpty())
 		Expect(helper.IsJSON(stderr)).To(BeTrue())
 		helper.JsonPathContentContain(stderr, "message", "No valid devfile found for project in")
 	})
 
-	It("alizer should fail without json output", func() {
-		stderr := helper.Cmd("odo", "alizer").ShouldFail().Err()
+	It("analyze should fail without json output", func() {
+		stderr := helper.Cmd("odo", "analyze").ShouldFail().Err()
 		Expect(stderr).To(ContainSubstring("this command can be run with json output only"))
 	})
 })


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

Thos PR renames the `alizer` command to `analyze`

The internal name of the process is still referenced as `alizer`, as it is the name of the library we are using.

**Which issue(s) this PR fixes:**

Related to #5642

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
