### PR TITLE
Implement `odo delete namespace/project`

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/delete-component.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/delete-component.md
@@ -1,5 +1,5 @@
 ---
-title: odo delete
+title: odo delete component
 sidebar_position: 3
 ---
 

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/delete-namespace.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/delete-namespace.md
@@ -1,0 +1,39 @@
+---
+title: odo delete namespace
+sidebar_position: 3
+---
+
+`odo delete namespace` lets you delete a namespace/project on your cluster. If you are on a Kubernetes cluster, running the command will delete a Namespace resource for you, and for an OpenShift cluster, it will delete a Project resource.
+
+To delete a namespace you can run `odo delete namespace <name>`:
+```shell
+odo delete namespace mynamespace
+```
+
+Example:
+```shell
+odo delete namespace mynamespace
+ ✓  Namespace "mynamespace" deleted
+```
+
+Optionally, you can also use `project` as an alias to `namespace`.
+
+To delete a project you can run `odo delete project <name>`:
+```shell
+odo delete project myproject
+```
+
+Example:
+```shell
+odo delete project myproject    
+  ✓  Project "myproject" deleted
+```
+
+:::note
+This command is smart enough to detect the resources supported by your cluster and make an informed decision on the type of resource that should be deleted, using either of the aliases.
+So you can run `odo delete project` on a Kubernetes cluster, and it will delete a Namespace resource, and you can run `odo delete namespace` on an OpenShift cluster, it will delete a Project resource.
+:::
+
+## Available Flags
+* `-f`, `--force` - Use this flag to avoid being prompted for confirmation.
+* `--wait` - Use this flag to wait until the namespace no longer exists

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -1,4 +1,4 @@
-package delete
+package component
 
 import (
 	"context"

--- a/pkg/odo/cli/delete/component/component_test.go
+++ b/pkg/odo/cli/delete/component/component_test.go
@@ -1,4 +1,4 @@
-package delete
+package component
 
 import (
 	"errors"

--- a/pkg/odo/cli/delete/delete.go
+++ b/pkg/odo/cli/delete/delete.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/redhat-developer/odo/pkg/odo/cli/delete/component"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,8 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 		Short: "Delete resources",
 	}
 
-	componentCmd := NewCmdComponent(ComponentRecommendedCommandName, util.GetFullName(fullName, ComponentRecommendedCommandName))
+	componentCmd := component.NewCmdComponent(component.ComponentRecommendedCommandName,
+		util.GetFullName(fullName, component.ComponentRecommendedCommandName))
 	deleteCmd.AddCommand(componentCmd)
 	deleteCmd.Annotations = map[string]string{"command": "main"}
 	deleteCmd.SetUsageTemplate(util.CmdUsageTemplate)

--- a/pkg/odo/cli/delete/delete.go
+++ b/pkg/odo/cli/delete/delete.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"github.com/redhat-developer/odo/pkg/odo/cli/delete/component"
+	"github.com/redhat-developer/odo/pkg/odo/cli/delete/namespace"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 )
@@ -12,14 +13,19 @@ const RecommendedCommandName = "delete"
 // NewCmdDelete implements the delete odo command
 func NewCmdDelete(name, fullName string) *cobra.Command {
 	var deleteCmd = &cobra.Command{
-		Use:   name,
-		Short: "Delete resources",
+		Use:         name,
+		Short:       "Delete resources",
+		Annotations: map[string]string{"command": "main"},
 	}
 
 	componentCmd := component.NewCmdComponent(component.ComponentRecommendedCommandName,
 		util.GetFullName(fullName, component.ComponentRecommendedCommandName))
 	deleteCmd.AddCommand(componentCmd)
-	deleteCmd.Annotations = map[string]string{"command": "main"}
+
+	namespaceDeleteCmd := namespace.NewCmdNamespaceDelete(namespace.RecommendedCommandName,
+		util.GetFullName(fullName, namespace.RecommendedCommandName))
+	deleteCmd.AddCommand(namespaceDeleteCmd)
+
 	deleteCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return deleteCmd

--- a/pkg/odo/cli/delete/namespace/namespace.go
+++ b/pkg/odo/cli/delete/namespace/namespace.go
@@ -1,0 +1,138 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
+	scontext "github.com/redhat-developer/odo/pkg/segment/context"
+	"github.com/spf13/cobra"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+	"os"
+	"strings"
+
+	"github.com/redhat-developer/odo/pkg/odo/cmdline"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+)
+
+const RecommendedCommandName = "namespace"
+
+var (
+	deleteExample = ktemplates.Examples(`
+	# Delete a namespace
+    %[1]s my-namespace`)
+
+	deleteLongDesc = ktemplates.LongDesc(`
+	Delete the specified namespace
+	`)
+
+	deleteShortDesc = `Delete a namespace`
+)
+
+// DeleteOptions encapsulates the options for the 'odo delete namespace' command
+type DeleteOptions struct {
+	// Context
+	*genericclioptions.Context
+
+	// Clients
+	clientset *clientset.Clientset
+
+	// Parameters
+	namespaceName string
+
+	// Flags
+	waitFlag bool
+
+	// forceFlag forces deletion
+	forceFlag bool
+
+	// value can be either 'project' or 'namespace', depending on what command is called
+	commandName string
+}
+
+// NewDeleteOptions creates a new DeleteOptions instance
+func NewDeleteOptions() *DeleteOptions {
+	return &DeleteOptions{}
+}
+
+func (do *DeleteOptions) SetClientset(clientset *clientset.Clientset) {
+	do.clientset = clientset
+}
+
+// Complete completes DeleteOptions after they've been created
+func (do *DeleteOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
+	do.namespaceName = args[0]
+	do.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
+	if err != nil {
+		return err
+	}
+	if scontext.GetTelemetryStatus(cmdline.Context()) {
+		scontext.SetClusterType(cmdline.Context(), do.KClient)
+	}
+	return nil
+}
+
+// Validate validates the DeleteOptions based on completed values
+func (do *DeleteOptions) Validate() (err error) {
+	return nil
+}
+
+// Run contains the logic for the 'odo delete namespace' command
+func (do *DeleteOptions) Run(ctx context.Context) error {
+	if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete namespace %q?", do.namespaceName)) {
+		// Create the "spinner"
+		s := &log.Status{}
+
+		// If the --wait parameter has been passed, we add a spinner..
+		if do.waitFlag {
+			s = log.Spinnerf("Waiting for %s %q to be deleted", do.commandName, do.namespaceName)
+			defer s.End(false)
+		}
+
+		err := do.clientset.ProjectClient.Delete(do.namespaceName, do.waitFlag)
+		if err != nil {
+			return err
+		}
+		s.End(true)
+
+		successMessage := fmt.Sprintf(`%s %q deleted`,
+			strings.Title(do.commandName), do.namespaceName)
+		log.Successf(successMessage)
+
+		return nil
+	}
+	log.Error("Aborting namespace deletion")
+	return nil
+}
+
+// NewCmdNamespaceDelete implements the 'odo delete namespace' command.
+func NewCmdNamespaceDelete(name, fullName string) *cobra.Command {
+	do := NewDeleteOptions()
+	// To help the UI messages deal better with namespace vs project
+	do.commandName = name
+	if len(os.Args) > 2 {
+		do.commandName = os.Args[2]
+	}
+	namespaceDeleteCmd := &cobra.Command{
+		Use:     name,
+		Short:   deleteShortDesc,
+		Long:    deleteLongDesc,
+		Example: fmt.Sprintf(deleteExample, fullName),
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(do, cmd, args)
+		},
+		Annotations: map[string]string{"command": "main"},
+		Aliases:     []string{"project"},
+	}
+
+	namespaceDeleteCmd.Flags().BoolVarP(&do.forceFlag, "force", "f", false, "Delete namespace without prompting")
+	namespaceDeleteCmd.Flags().BoolVarP(
+		&do.waitFlag,
+		"wait", "w", false,
+		"Wait until the namespace no longer exists")
+
+	clientset.Add(namespaceDeleteCmd, clientset.PROJECT)
+	return namespaceDeleteCmd
+}

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -18,6 +18,7 @@ type CliRunner interface {
 	SetProject(namespace string) string
 	DeleteNamespaceProject(projectName string)
 	DeletePod(podName string, projectName string)
+	GetAllNamespaceProjects() []string
 	GetNamespaceProject() string
 	CheckNamespaceProjectExists(name string) bool
 	GetActiveNamespace() string

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -390,3 +390,11 @@ func (kubectl KubectlRunner) CheckNamespaceProjectExists(name string) bool {
 func (kubectl KubectlRunner) GetActiveNamespace() string {
 	return Cmd(kubectl.path, "config", "view", "--minify", "-ojsonpath={..namespace}").ShouldPass().Out()
 }
+
+func (kubectl KubectlRunner) GetAllNamespaceProjects() []string {
+	output := Cmd(kubectl.path, "get", "namespaces",
+		"-o", "custom-columns=NAME:.metadata.name").ShouldPass().Out()
+	result, err := ExtractLines(output)
+	Expect(err).ShouldNot(HaveOccurred())
+	return result
+}

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -393,7 +393,8 @@ func (kubectl KubectlRunner) GetActiveNamespace() string {
 
 func (kubectl KubectlRunner) GetAllNamespaceProjects() []string {
 	output := Cmd(kubectl.path, "get", "namespaces",
-		"-o", "custom-columns=NAME:.metadata.name").ShouldPass().Out()
+		"-o", "custom-columns=NAME:.metadata.name",
+		"--no-headers").ShouldPass().Out()
 	result, err := ExtractLines(output)
 	Expect(err).ShouldNot(HaveOccurred())
 	return result

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -582,3 +582,11 @@ func (oc OcRunner) CheckNamespaceProjectExists(name string) bool {
 func (oc OcRunner) GetActiveNamespace() string {
 	return Cmd(oc.path, "config", "view", "--minify", "-ojsonpath={..namespace}").ShouldPass().Out()
 }
+
+func (oc OcRunner) GetAllNamespaceProjects() []string {
+	output := Cmd(oc.path, "get", "projects",
+		"-o", "custom-columns=NAME:.metadata.name").ShouldPass().Out()
+	result, err := ExtractLines(output)
+	Expect(err).ShouldNot(HaveOccurred())
+	return result
+}

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -585,7 +585,8 @@ func (oc OcRunner) GetActiveNamespace() string {
 
 func (oc OcRunner) GetAllNamespaceProjects() []string {
 	output := Cmd(oc.path, "get", "projects",
-		"-o", "custom-columns=NAME:.metadata.name").ShouldPass().Out()
+		"-o", "custom-columns=NAME:.metadata.name",
+		"--no-headers").ShouldPass().Out()
 	result, err := ExtractLines(output)
 	Expect(err).ShouldNot(HaveOccurred())
 	return result


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This PR continues the work started by @valaparthvi by implementing the missing `odo delete namespace/project` command.

**Which issue(s) this PR fixes:**
Relates to #5525

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
```
❯ odo help delete namespace
Delete the specified namespace

Usage:
  odo delete namespace [flags]

Aliases:
  namespace, project

Examples:
  # Delete a namespace
  odo delete namespace my-namespace

Flags:
  -f, --force   Delete namespace without prompting
  -h, --help    Help for namespace
  -w, --wait    Wait until the namespace no longer exists

Additional Flags:
      --kubeconfig string    Paths to a kubeconfig. Only required if out-of-cluster.
  -v, --v Level              Number for the log level verbosity. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec   Comma-separated list of pattern=N settings for file-filtered logging
```