### PR TITLE
Implement `odo set namespace/project`

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/set-namespace.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/set-namespace.md
@@ -1,0 +1,37 @@
+---
+title: odo set namespace
+sidebar_position: 3
+---
+
+`odo set namespace` lets you set a namespace/project as the current active one in your local `kubeconfig` configuration.
+
+Executing this command inside a component directory will not update the namespace or project of the existing component.
+
+To set the current active namespace you can run `odo set namespace <name>`:
+```shell
+odo set namespace mynamespace
+```
+
+Example:
+```shell
+odo set namespace mynamespace
+ ✓  Current active namespace set to "mynamespace"
+```
+
+Optionally, you can also use `project` as an alias to `namespace`.
+
+To set the current active project you can run `odo set project <name>`:
+```shell
+odo set project myproject
+```
+
+Example:
+```shell
+odo set project myproject    
+  ✓  Current active project set to "myproject"
+```
+
+:::note
+This command updates your current `kubeconfig` configuration, using either of the aliases.
+So running either `odo set project` or `odo set namespace` performs the exact same operation in your configuration.
+:::

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -24,6 +24,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cli/preference"
 	"github.com/redhat-developer/odo/pkg/odo/cli/project"
 	"github.com/redhat-developer/odo/pkg/odo/cli/registry"
+	"github.com/redhat-developer/odo/pkg/odo/cli/set"
 	"github.com/redhat-developer/odo/pkg/odo/cli/telemetry"
 	"github.com/redhat-developer/odo/pkg/odo/cli/utils"
 	"github.com/redhat-developer/odo/pkg/odo/cli/version"
@@ -181,6 +182,7 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 		describe.NewCmdDescribe(describe.RecommendedCommandName, util.GetFullName(fullName, describe.RecommendedCommandName)),
 		registry.NewCmdRegistry(registry.RecommendedCommandName, util.GetFullName(fullName, registry.RecommendedCommandName)),
 		create.NewCmdCreate(create.RecommendedCommandName, util.GetFullName(fullName, create.RecommendedCommandName)),
+		set.NewCmdSet(set.RecommendedCommandName, util.GetFullName(fullName, set.RecommendedCommandName)),
 	)
 
 	// Add all subcommands to base commands

--- a/pkg/odo/cli/set/namespace/namespace.go
+++ b/pkg/odo/cli/set/namespace/namespace.go
@@ -1,0 +1,135 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	dfutil "github.com/devfile/library/pkg/util"
+
+	"github.com/redhat-developer/odo/pkg/devfile/location"
+	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/odo/cmdline"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	scontext "github.com/redhat-developer/odo/pkg/segment/context"
+
+	"k8s.io/klog"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/spf13/cobra"
+)
+
+const RecommendedCommandName = "namespace"
+
+var (
+	setExample = ktemplates.Examples(`
+	# Set the specified namespace as the current active namespace in the config
+	%[1]s my-namespace
+	`)
+
+	setLongDesc = ktemplates.LongDesc(`Set the current active namespace.
+	
+	If executed inside a component directory, this command will not update the namespace of the existing component.
+	`)
+
+	setShortDesc = `Set the current active namespace`
+)
+
+// SetOptions encapsulates the options for the odo namespace create command
+type SetOptions struct {
+	// Context
+	*genericclioptions.Context
+
+	// Clients
+	clientset *clientset.Clientset
+
+	// Destination directory
+	contextDir string
+
+	// Parameters
+	namespaceName string
+
+	// value can be either 'project' or 'namespace', depending on what command is called
+	commandName string
+}
+
+// NewSetOptions creates a SetOptions instance
+func NewSetOptions() *SetOptions {
+	return &SetOptions{}
+}
+
+func (so *SetOptions) SetClientset(clientset *clientset.Clientset) {
+	so.clientset = clientset
+}
+
+// Complete completes SetOptions after they've been created
+func (so *SetOptions) Complete(cmdline cmdline.Cmdline, args []string) (err error) {
+	so.namespaceName = args[0]
+	so.Context, err = genericclioptions.New(genericclioptions.NewCreateParameters(cmdline))
+	if err != nil {
+		return err
+	}
+	so.contextDir, err = so.clientset.FS.Getwd()
+	if err != nil {
+		return err
+	}
+	if scontext.GetTelemetryStatus(cmdline.Context()) {
+		scontext.SetClusterType(cmdline.Context(), so.KClient)
+	}
+	return nil
+}
+
+// Validate validates the parameters of the SetOptions
+func (so *SetOptions) Validate() error {
+	return dfutil.ValidateK8sResourceName("namespace name", so.namespaceName)
+}
+
+// Run runs the 'set namespace' command
+func (so *SetOptions) Run(ctx context.Context) error {
+	devfilePresent, err := location.DirectoryContainsDevfile(so.clientset.FS, so.contextDir)
+	if err != nil {
+		// Purposely ignoring the error, as it is not mandatory for this command
+		klog.V(2).Infof("Unexpected error while checking if running inside a component directory: %v", err)
+	}
+	if devfilePresent {
+		log.Warningf("This is being executed inside a component directory. This will not update the %s of the existing component",
+			so.commandName)
+	}
+
+	err = so.clientset.ProjectClient.SetCurrent(so.namespaceName)
+	if err != nil {
+		return err
+	}
+
+	log.Successf("Current active %[1]s set to %q", so.commandName, so.namespaceName)
+
+	return nil
+}
+
+// NewCmdNamespaceSet creates the 'set namespace' command
+func NewCmdNamespaceSet(name, fullName string) *cobra.Command {
+	o := NewSetOptions()
+	// To help the UI messages deal better with namespace vs project
+	o.commandName = name
+	if len(os.Args) > 2 {
+		o.commandName = os.Args[2]
+	}
+
+	namespaceSetCmd := &cobra.Command{
+		Use:     name,
+		Short:   setShortDesc,
+		Long:    setLongDesc,
+		Example: fmt.Sprintf(setExample, fullName),
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(o, cmd, args)
+		},
+		Annotations: map[string]string{"command": "main"},
+		Aliases:     []string{"project"},
+	}
+
+	clientset.Add(namespaceSetCmd, clientset.FILESYSTEM, clientset.PROJECT)
+
+	return namespaceSetCmd
+}

--- a/pkg/odo/cli/set/set.go
+++ b/pkg/odo/cli/set/set.go
@@ -1,0 +1,36 @@
+package set
+
+import (
+	"fmt"
+
+	"github.com/redhat-developer/odo/pkg/odo/cli/set/namespace"
+	"github.com/redhat-developer/odo/pkg/odo/util"
+
+	"github.com/spf13/cobra"
+)
+
+// RecommendedCommandName is the recommended namespace command name
+const RecommendedCommandName = "set"
+
+// NewCmdSet implements the namespace odo command
+func NewCmdSet(name, fullName string) *cobra.Command {
+
+	namespaceSetCmd := namespace.NewCmdNamespaceSet(namespace.RecommendedCommandName,
+		util.GetFullName(fullName, namespace.RecommendedCommandName))
+	setCmd := &cobra.Command{
+		Use:   name + " [options]",
+		Short: "Perform set operation",
+		Long:  "Perform set operation",
+		Example: fmt.Sprintf("%s\n",
+			namespaceSetCmd.Example,
+		),
+		Annotations: map[string]string{"command": "main"},
+	}
+
+	setCmd.AddCommand(namespaceSetCmd)
+
+	// Add a defined annotation in order to appear in the help menu
+	setCmd.SetUsageTemplate(util.CmdUsageTemplate)
+
+	return setCmd
+}

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -20,7 +20,10 @@ type CliRunner interface {
 	DeletePod(podName string, projectName string)
 	GetAllNamespaceProjects() []string
 	GetNamespaceProject() string
-	CheckNamespaceProjectExists(name string) bool
+
+	// HasNamespaceProject returns whether the specified namespace or project exists in the cluster
+	HasNamespaceProject(name string) bool
+
 	GetActiveNamespace() string
 	GetEnvsDevFileDeployment(componentName, appName, projectName string) map[string]string
 	GetEnvRefNames(componentName, appName, projectName string) []string

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -383,8 +383,10 @@ func (kubectl KubectlRunner) GetNamespaceProject() string {
 	return Cmd(kubectl.path, "get", "namespace").ShouldPass().Out()
 }
 
-func (kubectl KubectlRunner) CheckNamespaceProjectExists(name string) bool {
-	return Cmd(kubectl.path, "get", "namespace", name).ShouldPass().pass
+func (kubectl KubectlRunner) HasNamespaceProject(name string) bool {
+	out := Cmd(kubectl.path, "get", "namespace", name, "-o", "jsonpath={.metadata.name}").
+		ShouldRun().Out()
+	return strings.Contains(out, name)
 }
 
 func (kubectl KubectlRunner) GetActiveNamespace() string {

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -575,8 +575,10 @@ func (oc OcRunner) GetNamespaceProject() string {
 	return Cmd(oc.path, "get", "project").ShouldPass().Out()
 }
 
-func (oc OcRunner) CheckNamespaceProjectExists(name string) bool {
-	return Cmd(oc.path, "get", "project", name).ShouldPass().pass
+func (oc OcRunner) HasNamespaceProject(name string) bool {
+	out := Cmd(oc.path, "get", "project", name, "-o", "jsonpath={.metadata.name}").
+		ShouldRun().Out()
+	return strings.Contains(out, name)
 }
 
 func (oc OcRunner) GetActiveNamespace() string {

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -111,16 +111,19 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 				}
 			})
 
-			It("should set again the " + commandName, func() {
-				helper.Cmd("odo", "set", commandName, commonVar.Project).ShouldPass()
-				Expect(commonVar.CliRunner.GetActiveNamespace()).Should(Equal(commonVar.Project))
-			})
+			It("should successfully set the "+commandName, func() {
+				anotherNs := "my-fake-ns-" + helper.RandString(3)
 
-			It(fmt.Sprintf("should set the %s even if it does not exist in the cluster", commandName), func() {
-				fakeNamespace := "my-fake-ns-" + helper.RandString(3)
-				Expect(commonVar.CliRunner.GetAllNamespaceProjects()).ShouldNot(ContainElement(fakeNamespace))
-				helper.Cmd("odo", "set", commandName, fakeNamespace).ShouldPass()
-				Expect(commonVar.CliRunner.GetActiveNamespace()).To(Equal(fakeNamespace))
+				By(fmt.Sprintf("setting it to a valid %s", commandName), func() {
+					Expect(commonVar.CliRunner.GetActiveNamespace()).ShouldNot(Equal(anotherNs))
+					helper.Cmd("odo", "set", commandName, anotherNs).ShouldPass()
+					Expect(commonVar.CliRunner.GetActiveNamespace()).To(Equal(anotherNs))
+				})
+
+				By("setting it again to its previous value", func() {
+					helper.Cmd("odo", "set", commandName, anotherNs).ShouldPass()
+					Expect(commonVar.CliRunner.GetActiveNamespace()).To(Equal(anotherNs))
+				})
 			})
 
 			It(fmt.Sprintf("should not succeed to set the %s", commandName), func() {

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -33,7 +33,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 				defer func(ns string) {
 					commonVar.CliRunner.DeleteNamespaceProject(ns)
 				}(namespace)
-				Expect(commonVar.CliRunner.CheckNamespaceProjectExists(namespace)).To(BeTrue())
+				Expect(commonVar.CliRunner.HasNamespaceProject(namespace)).To(BeTrue())
 				Expect(commonVar.CliRunner.GetActiveNamespace()).To(Equal(namespace))
 			})
 
@@ -55,7 +55,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 
 				BeforeEach(func() {
 					namespace = helper.CreateRandProject()
-					Expect(commonVar.CliRunner.CheckNamespaceProjectExists(namespace)).To(BeTrue())
+					Expect(commonVar.CliRunner.HasNamespaceProject(namespace)).To(BeTrue())
 				})
 
 				checkNsDeletionFunc := func(additionalArgs []string, nsCheckerFunc func()) {
@@ -73,15 +73,15 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 
 				It(fmt.Sprintf("should successfully delete the %s asynchronously", commandName), func() {
 					checkNsDeletionFunc(nil, func() {
-						Eventually(func() []string {
-							return commonVar.CliRunner.GetAllNamespaceProjects()
-						}, 60*time.Second).ShouldNot(ContainElement(namespace))
+						Eventually(func() bool {
+							return commonVar.CliRunner.HasNamespaceProject(namespace)
+						}, 60*time.Second).Should(BeFalse())
 					})
 				})
 
 				It(fmt.Sprintf("should successfully delete the %s synchronously with --wait", commandName), func() {
 					checkNsDeletionFunc([]string{"--wait"}, func() {
-						Expect(commonVar.CliRunner.GetAllNamespaceProjects()).ShouldNot(ContainElement(namespace))
+						Expect(commonVar.CliRunner.HasNamespaceProject(namespace)).To(BeFalse())
 					})
 				})
 			})


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This PR continues the work started by @valaparthvi by implementing the missing `odo set namespace/project` command.

**Which issue(s) this PR fixes:**
Relates to #5525

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 


**How to test changes / Special notes to the reviewer:**
Note: as depicted in the acceptance criteria, if `odo set namespace` is executed inside a component directory, it should show a warning, that this won't update the namespace of the existing component.

```
❯ odo help set namespace
Set the current active namespace.

 If executed inside a component directory, this command will not update the namespace of the existing component.

Usage:
  odo set namespace [flags]

Aliases:
  namespace, project

Examples:
  # Set the specified namespace as the current active namespace in the config
  odo set namespace my-namespace

Flags:
  -h, --help   Help for namespace

Additional Flags:
      --kubeconfig string    Paths to a kubeconfig. Only required if out-of-cluster.
  -v, --v Level              Number for the log level verbosity. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec   Comma-separated list of pattern=N settings for file-filtered logging
```
