### PR TITLE
Removed setup operator code block for s390x

### DIFF
--- a/scripts/configure-cluster/common/setup-operators.sh
+++ b/scripts/configure-cluster/common/setup-operators.sh
@@ -37,15 +37,6 @@ if [ "$KUBERNETES" == "true" ]; then
 
   # install "service-binding-operator" using "kubectl" in "operators" namespace; use "operatorhubio-catalog" catalog source from "olm" namespace
   install_service_binding_operator kubectl operators service-binding-operator operatorhubio-catalog olm
-elif [ $(uname -m) == "s390x" ]; then
-  # create "operator-ibm-catalog" CatalogSource for s390x
-  oc apply -f https://raw.githubusercontent.com/redhat-developer/odo/main/docs/website/manifests/catalog-source-$(uname -m).yaml
-
-  # install "cloud-native-postgresql" using "oc" in "openshift-operators" namespace; use "operator-ibm-catalog" catalog source from "openshift-marketplace" namespace
-  install_postgres_operator oc openshift-operators operator-ibm-catalog openshift-marketplace
-
-  # install "service-binding-operator" using "oc" in "openshift-operators" namespace; use "operator-ibm-catalog" catalog source from "openshift-marketplace" namespace
-  install_service_binding_operator oc openshift-operators service-binding-operator operator-ibm-catalog openshift-marketplace
 else
   # install "cloud-native-postgresql" using "oc" in "openshift-operators" namespace; use "certified-operators" catalog source from "openshift-marketplace" namespace
   install_postgres_operator oc openshift-operators certified-operators openshift-marketplace


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR removes the specific setup operator code block for s390x and will be using the default code to get the postgresql/service binding operator installed on s390x platform.

**Which issue(s) this PR fixes:**

CI failures on s390x due to new operator setup.
Ref: https://github.com/redhat-developer/odo/pull/5641/files#diff-510a35137f161ddca098f30a15bcaac95c9f4f33b75a0bd861a7d8e77a56b1f1

**PR acceptance criteria:**

- [x] Unit test 
