### PR TITLE
Fix ordering of command reference docs

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/add-binding.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/add-binding.md
@@ -1,6 +1,5 @@
 ---
 title: odo add binding
-sidebar_position: 4
 ---
 
 The `odo add binding` command can add a link between an operator-backed service and a component. odo uses the Service Binding Operator to create this link. Running this command will make the necessary changes to the Devfile, and once pushed to the cluster, it creates an instance of the `ServiceBinding` resource.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/build-images.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/build-images.md
@@ -1,6 +1,5 @@
 ---
 title: odo build-images
-sidebar_position: 4
 ---
 
 odo can build container images based on Dockerfiles, and push these images to their registries.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/create-namespace.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/create-namespace.md
@@ -1,6 +1,5 @@
 ---
 title: odo create namespace
-sidebar_position: 3
 ---
 
 `odo create namespace` lets you create a namespace/project on your cluster. If you are on a Kubernetes cluster, running the command will create a Namespace resource for you, and for an OpenShift cluster, it will create a Project resource.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/delete-component.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/delete-component.md
@@ -1,6 +1,5 @@
 ---
 title: odo delete component
-sidebar_position: 3
 ---
 
 `odo delete component` command is useful for deleting resources that are managed by `odo`. It deletes the component and its related innerloop, and outerloop resources from the cluster.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/delete-namespace.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/delete-namespace.md
@@ -1,6 +1,5 @@
 ---
 title: odo delete namespace
-sidebar_position: 3
 ---
 
 `odo delete namespace` lets you delete a namespace/project on your cluster. If you are on a Kubernetes cluster, running the command will delete a Namespace resource for you, and for an OpenShift cluster, it will delete a Project resource.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/deploy.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/deploy.md
@@ -1,6 +1,5 @@
 ---
 title: odo deploy
-sidebar_position: 2
 ---
 
 odo can be used to deploy components in a similar manner they would be deployed by a CI/CD system, 

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/describe.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/describe.md
@@ -1,6 +1,5 @@
 ---
 title: odo describe
-sidebar_position: 3
 ---
 
 `odo describe component` command is useful for getting information about a component managed by `odo`. 

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/dev.md
@@ -1,6 +1,5 @@
 ---
 title: odo dev
-sidebar_position: 2
 ---
 
 ## Description

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/init.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/init.md
@@ -1,6 +1,5 @@
 ---
 title: odo init
-sidebar_position: 1
 ---
 
 The `odo init` command is the first command to be executed when you want to bootstrap a new component, using `odo`. If sources already exist,

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/json-output.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/json-output.md
@@ -1,6 +1,7 @@
 ---
 title: JSON Output
-sidebar_position: 20
+# Put JSON output to the top
+sidebar_position: 1
 ---
 
 For `odo` to be used as a backend by graphical user interfaces (GUIs),

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/list-namespace.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/list-namespace.md
@@ -1,6 +1,5 @@
 ---
 title: odo list namespace
-sidebar_position: 2
 ---
 
 ## Description

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/list.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/list.md
@@ -1,6 +1,5 @@
 ---
 title: odo list
-sidebar_position: 3
 ---
 
 `odo list` command is useful for getting information about components running on a specific namespace.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/preference.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/preference.md
@@ -1,6 +1,5 @@
 ---
 title: odo preference
-sidebar_position: 8
 ---
 
 

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/registry.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/registry.md
@@ -1,6 +1,5 @@
 ---
 title: odo registry
-sidebar_position: 1
 ---
 
 The `odo registry` command lists all the Devfile stacks from Devfile registries.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/set-namespace.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/set-namespace.md
@@ -1,6 +1,5 @@
 ---
 title: odo set namespace
-sidebar_position: 3
 ---
 
 `odo set namespace` lets you set a namespace/project as the current active one in your local `kubeconfig` configuration.


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind documentation

**What does this PR do / why we need it:**

Fixes the ordering of the command reference so it is alphabetical (with
JSON output being the top doc)

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5766

**PR acceptance criteria:**

- [X] Documentation

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>