### PR TITLE
Speed up tests on K8s by not blocking until test namespace is gone

### DIFF
--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -16,7 +16,10 @@ type CliRunner interface {
 	CreateAndSetRandNamespaceProject() string
 	CreateAndSetRandNamespaceProjectOfLength(i int) string
 	SetProject(namespace string) string
-	DeleteNamespaceProject(projectName string)
+
+	// DeleteNamespaceProject deletes the specified namespace or project, optionally waiting until it is gone
+	DeleteNamespaceProject(projectName string, wait bool)
+
 	DeletePod(podName string, projectName string)
 	GetAllNamespaceProjects() []string
 	GetNamespaceProject() string

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -246,7 +246,7 @@ func CommonAfterEach(commonVar CommonVar) {
 	}
 
 	// delete the random project/namespace created in CommonBeforeEach
-	commonVar.CliRunner.DeleteNamespaceProject(commonVar.Project)
+	commonVar.CliRunner.DeleteNamespaceProject(commonVar.Project, false)
 
 	// restores the original kubeconfig and working directory
 	Chdir(commonVar.OriginalWorkingDirectory)

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -180,9 +181,9 @@ func (kubectl KubectlRunner) CreateAndSetRandNamespaceProjectOfLength(i int) str
 }
 
 // DeleteNamespaceProject deletes a specified project in kubernetes cluster
-func (kubectl KubectlRunner) DeleteNamespaceProject(projectName string) {
+func (kubectl KubectlRunner) DeleteNamespaceProject(projectName string, wait bool) {
 	fmt.Fprintf(GinkgoWriter, "Deleting project: %s\n", projectName)
-	Cmd("kubectl", "delete", "namespaces", projectName, "--wait=false").ShouldPass()
+	Cmd("kubectl", "delete", "namespaces", projectName, "--wait="+strconv.FormatBool(wait)).ShouldPass()
 }
 
 func (kubectl KubectlRunner) GetEnvsDevFileDeployment(componentName, appName, projectName string) map[string]string {

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -182,7 +182,7 @@ func (kubectl KubectlRunner) CreateAndSetRandNamespaceProjectOfLength(i int) str
 // DeleteNamespaceProject deletes a specified project in kubernetes cluster
 func (kubectl KubectlRunner) DeleteNamespaceProject(projectName string) {
 	fmt.Fprintf(GinkgoWriter, "Deleting project: %s\n", projectName)
-	Cmd("kubectl", "delete", "namespaces", projectName).ShouldPass()
+	Cmd("kubectl", "delete", "namespaces", projectName, "--wait=false").ShouldPass()
 }
 
 func (kubectl KubectlRunner) GetEnvsDevFileDeployment(componentName, appName, projectName string) map[string]string {

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -338,9 +339,9 @@ func (oc OcRunner) SetProject(namespace string) string {
 }
 
 // DeleteNamespaceProject deletes a specified project in oc cluster
-func (oc OcRunner) DeleteNamespaceProject(projectName string) {
+func (oc OcRunner) DeleteNamespaceProject(projectName string, wait bool) {
 	fmt.Fprintf(GinkgoWriter, "Deleting project: %s\n", projectName)
-	session := Cmd("odo", "project", "delete", projectName, "-f").ShouldPass().Out()
+	session := Cmd("odo", "project", "delete", projectName, "-f", "--wait="+strconv.FormatBool(wait)).ShouldPass().Out()
 	Expect(session).To(ContainSubstring("Deleted project : " + projectName))
 }
 

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -31,7 +31,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 			It(fmt.Sprintf("should successfully create the %s", commandName), func() {
 				helper.Cmd("odo", "create", commandName, namespace, "--wait").ShouldPass()
 				defer func(ns string) {
-					commonVar.CliRunner.DeleteNamespaceProject(ns)
+					commonVar.CliRunner.DeleteNamespaceProject(ns, false)
 				}(namespace)
 				Expect(commonVar.CliRunner.HasNamespaceProject(namespace)).To(BeTrue())
 				Expect(commonVar.CliRunner.GetActiveNamespace()).To(Equal(namespace))

--- a/tests/integration/devfile/cmd_delete_test.go
+++ b/tests/integration/devfile/cmd_delete_test.go
@@ -255,7 +255,7 @@ ComponentSettings:
 					projectName = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 				})
 				AfterEach(func() {
-					commonVar.CliRunner.DeleteNamespaceProject(projectName)
+					commonVar.CliRunner.DeleteNamespaceProject(projectName, false)
 				})
 				When("the component is deleted", func() {
 					BeforeEach(func() {

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -13,11 +13,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 	segment "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/util"
 
 	"github.com/onsi/gomega/gexec"
+
 	"github.com/redhat-developer/odo/tests/helper"
 	"github.com/redhat-developer/odo/tests/integration/devfile/utils"
 )
@@ -212,7 +214,7 @@ var _ = Describe("odo dev command tests", func() {
 				})
 
 				AfterEach(func() {
-					commonVar.CliRunner.DeleteNamespaceProject(otherNS)
+					commonVar.CliRunner.DeleteNamespaceProject(otherNS, false)
 				})
 
 				It("should run odo dev on initial namespace", func() {

--- a/tests/integration/devfile/cmd_devfile_deploy_test.go
+++ b/tests/integration/devfile/cmd_devfile_deploy_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
@@ -114,7 +115,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 					})
 
 					AfterEach(func() {
-						commonVar.CliRunner.DeleteNamespaceProject(otherNS)
+						commonVar.CliRunner.DeleteNamespaceProject(otherNS, false)
 					})
 
 					It("should run odo deploy on initial namespace", func() {


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**
When running against my local K8s cluster, I noticed that we were spending several seconds just waiting for the test namespace to be gone, as part of the tear-down logic.
However, when running against an OpenShift cluster, project/namespace deletion appears not to be blocking.
I might be missing something, but I was wondering if it wouldn't make sense to have the same behavior in `helper_kubectl.go`.

This might not have any notable impact in CI, but I noticed substantial gains when iterating locally.

Example with a simple test suite (execution time went from ~116 seconds to ~25 seconds with the test namespace deleted asynchronously):

**Before these changes**
```
❯ time ginkgo -focus 'odo devfile init command tests' tests/integration/devfile                                                                                                                                                                                                  
Running Suite: Devfile Suite                                                                                                                                                                                                                                                     
============================                                                                                                                                                                                                                                                     
Random Seed: 1653660542                                                                                                                                                                                                                                                          
Will run 18 of 147 specs   

•••••••••••••••••                                                   

Ran 18 of 147 Specs in 116.800 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 129 Skipped
PASS

Ginkgo ran 1 suite in 1m58.857849553s
Test Suite Passed
ginkgo -focus 'odo devfile init command tests' tests/integration/devfile  11.99s user 3.18s system 12% cpu 1:58.86 total
```

**With these changes**
```
❯ time ginkgo -focus 'odo devfile init command tests' tests/integration/devfile 
Running Suite: Devfile Suite
============================
Random Seed: 1653660125
Will run 18 of 147 specs

•••••••••••••••••

Ran 18 of 147 Specs in 24.615 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 129 Skipped
PASS

Ginkgo ran 1 suite in 26.710032151s
Test Suite Passed
ginkgo -focus 'odo devfile init command tests' tests/integration/devfile  11.21s user 2.76s system 52% cpu 26.713 total
```


**Which issue(s) this PR fixes:**
No related issue

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

