### PR TITLE
Wait for deployment rollout only when binding created / modified

### DIFF
--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -51,7 +51,7 @@ type ClientInterface interface {
 	IsDeploymentExtensionsV1Beta1() (bool, error)
 
 	// dynamic.go
-	CreateDynamicResource(exampleCustomResource unstructured.Unstructured) error
+	PatchDynamicResource(exampleCustomResource unstructured.Unstructured) (bool, error)
 	ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
 	GetDynamicResource(gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error)
 	UpdateDynamicResource(gvr schema.GroupVersionResource, name string, u *unstructured.Unstructured) error

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -107,20 +107,6 @@ func (mr *MockClientInterfaceMockRecorder) CreateDeployment(deploy interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeployment", reflect.TypeOf((*MockClientInterface)(nil).CreateDeployment), deploy)
 }
 
-// CreateDynamicResource mocks base method.
-func (m *MockClientInterface) CreateDynamicResource(exampleCustomResource unstructured.Unstructured) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDynamicResource", exampleCustomResource)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateDynamicResource indicates an expected call of CreateDynamicResource.
-func (mr *MockClientInterfaceMockRecorder) CreateDynamicResource(exampleCustomResource interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).CreateDynamicResource), exampleCustomResource)
-}
-
 // CreateNamespace mocks base method.
 func (m *MockClientInterface) CreateNamespace(name string) (*v11.Namespace, error) {
 	m.ctrl.T.Helper()
@@ -811,21 +797,6 @@ func (mr *MockClientInterfaceMockRecorder) GetProject(projectName interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockClientInterface)(nil).GetProject), projectName)
 }
 
-// GetReplicaSetByName mocks base method.
-func (m *MockClientInterface) GetReplicaSetByName(name string) (*v10.ReplicaSet, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReplicaSetByName", name)
-	ret0, _ := ret[0].(*v10.ReplicaSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReplicaSetByName indicates an expected call of GetReplicaSetByName.
-func (mr *MockClientInterfaceMockRecorder) GetReplicaSetByName(name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicaSetByName", reflect.TypeOf((*MockClientInterface)(nil).GetReplicaSetByName), name)
-}
-
 // GetResourceSpecDefinition mocks base method.
 func (m *MockClientInterface) GetResourceSpecDefinition(group, version, kind string) (*spec.Schema, error) {
 	m.ctrl.T.Helper()
@@ -1123,6 +1094,21 @@ func (m *MockClientInterface) NewServiceBindingServiceObject(unstructuredService
 func (mr *MockClientInterfaceMockRecorder) NewServiceBindingServiceObject(unstructuredService, bindingName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewServiceBindingServiceObject", reflect.TypeOf((*MockClientInterface)(nil).NewServiceBindingServiceObject), unstructuredService, bindingName)
+}
+
+// PatchDynamicResource mocks base method.
+func (m *MockClientInterface) PatchDynamicResource(exampleCustomResource unstructured.Unstructured) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchDynamicResource", exampleCustomResource)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchDynamicResource indicates an expected call of PatchDynamicResource.
+func (mr *MockClientInterfaceMockRecorder) PatchDynamicResource(exampleCustomResource interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDynamicResource", reflect.TypeOf((*MockClientInterface)(nil).PatchDynamicResource), exampleCustomResource)
 }
 
 // RunLogout mocks base method.

--- a/pkg/service/link.go
+++ b/pkg/service/link.go
@@ -90,7 +90,8 @@ func pushLinksWithOperator(client kclient.ClientInterface, devfileObj parser.Dev
 		u.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
 		u.SetLabels(labels)
 
-		err = createOperatorService(client, u)
+		var updated bool
+		updated, err = updateOperatorService(client, u)
 		delete(deployed, u.GetKind()+"/"+crdName)
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
@@ -104,7 +105,7 @@ func pushLinksWithOperator(client kclient.ClientInterface, devfileObj parser.Dev
 		// uncomment/modify when service linking is enabled in v3
 		// name := u.GetName()
 		// log.Successf("Created link %q using Service Binding Operator on the cluster; component will be restarted", name)
-		restartNeeded = true
+		restartNeeded = restartNeeded || updated
 	}
 
 	for key, val := range deployed {


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR tests during the patch of the service binding if this one has been created/updated or not, during `odo dev`.

If the binding has not been created or updated, odo dev does not wait for the pod to restart

**Which issue(s) this PR fixes:**

Fixes #5781 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
