### PR TITLE
Return odo analyze result as an array

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/json-output.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/json-output.md
@@ -19,17 +19,19 @@ The structures used to return information using JSON output are defined in [the 
 
 ## odo analyze -o json
 
-The `analyze` command analyzes the files in the current directory to select the best devfile to use,
+The `analyze` command analyzes the files in the current directory to select the best devfiles to use,
 from the devfiles in the registries defined in the list of preferred registries with the command `odo preference registry`.
 
-The output of this command contains a devfile name and a registry name:
+The output of this command contains a list of devfile name and registry name:
 
 ```bash
 $ odo analyze -o json
-{
-    "devfile": "nodejs",
-    "devfileRegistry": "DefaultDevfileRegistry"
-}
+[
+	{
+	    "devfile": "nodejs",
+	    "devfileRegistry": "DefaultDevfileRegistry"
+	}
+]
 $ echo $?
 0
 ```

--- a/pkg/odo/cli/alizer/alizer.go
+++ b/pkg/odo/cli/alizer/alizer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/redhat-developer/odo/pkg/alizer"
+	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
@@ -53,7 +54,7 @@ func (o *AlizerOptions) RunForJsonOutput(ctx context.Context) (out interface{}, 
 		return nil, err
 	}
 	result := alizer.GetDevfileLocationFromDetection(df, reg)
-	return result, nil
+	return []api.DevfileLocation{*result}, nil
 }
 
 func NewCmdAlizer(name, fullName string) *cobra.Command {

--- a/tests/integration/devfile/cmd_analyze_test.go
+++ b/tests/integration/devfile/cmd_analyze_test.go
@@ -33,8 +33,8 @@ var _ = Describe("odo analyze command tests", func() {
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stderr).To(BeEmpty())
 			Expect(helper.IsJSON(stdout)).To(BeTrue())
-			helper.JsonPathContentIs(stdout, "devfile", "nodejs")
-			helper.JsonPathContentIs(stdout, "devfileRegistry", "DefaultDevfileRegistry")
+			helper.JsonPathContentIs(stdout, "0.devfile", "nodejs")
+			helper.JsonPathContentIs(stdout, "0.devfileRegistry", "DefaultDevfileRegistry")
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

The `odo analyze` command returns the result as an array.

For the mement, the result always contains a single Devfile  location.

**Which issue(s) this PR fixes:**

Related to  #5642 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
