### PR TITLE
Fix: configuration shows volumes as containers

### DIFF
--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -107,7 +107,6 @@ func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags ma
 }
 
 func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileObj) (parser.DevfileObj, error) {
-	// TODO: Add tests
 	config, err := getPortsAndEnvVar(devfileobj)
 	var zeroDevfile parser.DevfileObj
 	if err != nil {
@@ -235,21 +234,19 @@ func PrintConfiguration(config asker.DevfileConfiguration) {
 
 func getPortsAndEnvVar(obj parser.DevfileObj) (asker.DevfileConfiguration, error) {
 	var config = asker.DevfileConfiguration{}
-	components, err := obj.Data.GetComponents(parsercommon.DevfileOptions{})
+	components, err := obj.Data.GetComponents(parsercommon.DevfileOptions{ComponentOptions: parsercommon.ComponentOptions{ComponentType: v1alpha2.ContainerComponentType}})
 	if err != nil {
 		return config, err
 	}
 	for _, component := range components {
 		var ports = []string{}
 		var envMap = map[string]string{}
-		if component.Container != nil {
-			// TODO: Fix this for component that are not a container
-			for _, ep := range component.Container.Endpoints {
-				ports = append(ports, strconv.Itoa(ep.TargetPort))
-			}
-			for _, env := range component.Container.Env {
-				envMap[env.Name] = env.Value
-			}
+
+		for _, ep := range component.Container.Endpoints {
+			ports = append(ports, strconv.Itoa(ep.TargetPort))
+		}
+		for _, env := range component.Container.Env {
+			envMap[env.Name] = env.Value
 		}
 		config[component.Name] = asker.ContainerConfiguration{
 			Ports: ports,


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR fixes the Devfile Volume component shown when personalizing devfile configuration.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5779 

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `touch pom.xml a.java`
2. `odo init`
3. Select java-springboot project type.
4. Make sure `m2` Volume component does not appear on the list.
```sh
➜  odo init
  __
 /  \__     Initializing new component
 \__/  \    Files: Source code detected, a Devfile will be determined based upon source code autodetection
 /  \__/    odo version: v3.0.0-alpha3
 \__/

Interactive mode enabled, please answer the following questions:
Based on the files in the current directory odo detected
Language: java
Project type: spring
The devfile "java-springboot" from the registry "MyRegistry" will be downloaded.
? Is this correct? Yes
 ✓  Downloading devfile "java-springboot" from registry "MyRegistry" [4s]
Current component configuration:
Container "tools":
  Opened ports:
   - 8080
  Environment variables:
   - DEBUG_PORT = 5858
? Select container for which you want to change configuration? NONE - configuration is correct
? Enter component name: my-java-springboot-app

Your new component 'my-java-springboot-app' is ready in the current directory.
To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.
```