### PR TITLE
When typing odo foobar --help should error out with invalid command

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -159,9 +159,22 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 	verbosity := pflag.Lookup("v")
 	verbosity.Usage += ". Level varies from 0 to 9 (default 0)."
 
-	rootCmd.SetUsageTemplate(rootUsageTemplate)
 	cobra.AddTemplateFunc("CapitalizeFlagDescriptions", capitalizeFlagDescriptions)
 	cobra.AddTemplateFunc("ModifyAdditionalFlags", modifyAdditionalFlags)
+	rootCmd.SetUsageTemplate(rootUsageTemplate)
+
+	// Create a custom help function that will exit when we enter an invalid command, for example:
+	// odo foobar --help
+	// which will exit with an error message: "unknown command 'foobar', type --help for a list of all commands"
+	helpCmd := rootCmd.HelpFunc()
+	rootCmd.SetHelpFunc(func(command *cobra.Command, args []string) {
+		// Simple way of checking to see if the command has a parent (if it doesn't, it does not exist)
+		if !command.HasParent() && len(args) > 0 {
+			fmt.Printf("unknown command '%s', type --help for a list of all commands\n", args[0])
+			os.Exit(1)
+		}
+		helpCmd(command, args)
+	})
 
 	rootCmdList := append([]*cobra.Command{},
 		login.NewCmdLogin(login.RecommendedCommandName, util.GetFullName(fullName, login.RecommendedCommandName)),

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/odo/cli/logs"
 
+	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cli/add"
 	"github.com/redhat-developer/odo/pkg/odo/cli/alizer"
 	"github.com/redhat-developer/odo/pkg/odo/cli/build_images"
@@ -170,7 +171,7 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 	rootCmd.SetHelpFunc(func(command *cobra.Command, args []string) {
 		// Simple way of checking to see if the command has a parent (if it doesn't, it does not exist)
 		if !command.HasParent() && len(args) > 0 {
-			fmt.Printf("unknown command '%s', type --help for a list of all commands\n", args[0])
+			fmt.Fprintf(log.GetStderr(), "unknown command '%s', type --help for a list of all commands\n", args[0])
 			os.Exit(1)
 		}
 		helpCmd(command, args)

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -52,6 +52,11 @@ var _ = Describe("odo generic", func() {
 		Expect(output).To(ContainSubstring("Invalid command - see available commands/subcommands above"))
 	})
 
+	It("returns error when using an invalid command with --help", func() {
+		output := helper.Cmd("odo", "hello", "--help").ShouldFail().Err()
+		Expect(output).To(ContainSubstring("unknown command 'hello', type --help for a list of all commands"))
+	})
+
 	Context("When deleting two project one after the other", func() {
 		It("should be able to delete sequentially", func() {
 			project1 := helper.CreateRandProject()


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

/kind bug

**What does this PR do / why we need it:**

When we type:
```sh
odo foobar --help
```

We should error out that it's an invalid command.

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5439

**PR acceptance criteria:**

- [X] Integration test

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>