### PR TITLE
ignore dynamic resource when not found

### DIFF
--- a/pkg/kclient/dynamic.go
+++ b/pkg/kclient/dynamic.go
@@ -40,7 +40,7 @@ func (c *Client) CreateDynamicResource(resource unstructured.Unstructured) error
 }
 
 // ListDynamicResource returns an unstructured list of instances of a Custom
-// Resource currently deployed in the active namespace of the cluster
+// Resource currently deployed in the active namespace of the cluster.
 func (c *Client) ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 
 	if c.DynamicClient == nil {
@@ -49,6 +49,10 @@ func (c *Client) ListDynamicResources(gvr schema.GroupVersionResource) (*unstruc
 
 	list, err := c.DynamicClient.Resource(gvr).Namespace(c.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// Assume this is a cluster scoped resource (not namespace scoped) and skip it
+			return &unstructured.UnstructuredList{}, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

If there are cluster scoped resources that are reported in the
`BindableKinds`, they will be included when trying to retrieve Service
Instances. When this happens and we try to search for those resources
in a namespace, Kubernetes will return the error that they are not found.

We can not assume all developers would have access to these
cluster scoped resources, so we can not safely run additional checks to
verify they are cluster scoped resources. However, if nothing is found,
it is safe to assume they can not be bound to as the developer does not
have access to them.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

N/A

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

- Add service binding annotations to a cluster scoped CRD
- Run `odo add binding`
- Ensure you can see the Service Bindings you would expect
