### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
+# This is a configuration file for Dependabot, a GitHub tool that tries to keep dependencies updated on a regular basis
+# by raising pull requests to update those dependencies.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -35,3 +35,7 @@ updates:
   labels:
     - "area/dependency"
     - "kind/task"
+
+## Feel free to add other package managers here if needed.
+## See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+## for the full list of supported ecosystems.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
   labels:
   - "area/dependency"
   - "kind/task"
+  - "ok-to-test"
 
 # Maintain dependencies for Website builds
 - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,18 @@ updates:
   labels:
   - "area/dependency"
   - "kind/task"
+
+# Maintain dependencies for Website builds
+- package-ecosystem: "npm"
+  directory: "/docs/website"
+  # Set this to 0 to disable version updates
+  open-pull-requests-limit: 3
+  commit-message:
+    prefix: "Website"
+  schedule:
+    interval: "weekly"
+  reviewers:
+    - "odo-mantainers"
+  labels:
+    - "area/dependency"
+    - "kind/task"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+# Maintain dependencies for Go
+- package-ecosystem: "gomod"
+  directory: "/"
+  # Set this to 0 to disable version updates
+  open-pull-requests-limit: 5
+  commit-message:
+    prefix: "Go"
+  schedule:
+    interval: "weekly"
+  reviewers:
+  - "odo-mantainers"
+  labels:
+  - "area/dependency"
+  - "kind/task"


### PR DESCRIPTION
**What type of PR is this:**
/area dependency

**What does this PR do / why we need it:**
As quickly discussed during the last Cabal meeting, this PR configures [Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) in our repo. Dependabot will automatically create PRs with dependency updates for the package managers we configured. As such, I added a minimal configuration file that maintains both our Go and NPM dependencies.

The goal is to see if Dependabot could be relevant in helping us keep our dependencies up-to-date.

Once this is merged, we will see what kind of PRs Dependabot raises. We can revert this later or disable Dependabot if the PRs it creates do not make sense.

I think GitHub Dependabot is free for public repos.

**Which issue(s) this PR fixes:**
&#45;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Didn't try it, but it might be possible to test Dependabot locally, per [this blog post](https://mikebifulco.com/posts/run-dependabot-locally). But the goal here is to have this merged and take a look at Dependabot PRs.