### PR TITLE
Fix flaky `kubeexec` unit test case with env vars

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/commandhandler.go
+++ b/pkg/devfile/adapters/kubernetes/component/commandhandler.go
@@ -138,9 +138,9 @@ func devfileCommandToRemoteCmdDefinition(devfileCmd devfilev1.Command) (remotecm
 		return remotecmd.CommandDefinition{}, errors.New(" only Exec commands are supported")
 	}
 
-	envVars := make(map[string]string, len(devfileCmd.Exec.Env))
+	envVars := make([]remotecmd.CommandEnvVar, 0, len(devfileCmd.Exec.Env))
 	for _, e := range devfileCmd.Exec.Env {
-		envVars[e.Name] = e.Value
+		envVars = append(envVars, remotecmd.CommandEnvVar{Key: e.Name, Value: e.Value})
 	}
 
 	return remotecmd.CommandDefinition{

--- a/pkg/remotecmd/kubeexec.go
+++ b/pkg/remotecmd/kubeexec.go
@@ -62,8 +62,8 @@ func (k *kubeExecProcessHandler) StartProcessForCommand(
 	// deal with environment variables
 	cmdLine := def.CmdLine
 	envCommands := make([]string, 0, len(def.EnvVars))
-	for key, val := range def.EnvVars {
-		envCommands = append(envCommands, fmt.Sprintf("%s='%s'", key, val))
+	for _, envVar := range def.EnvVars {
+		envCommands = append(envCommands, fmt.Sprintf("%s='%s'", envVar.Key, envVar.Value))
 	}
 	var setEnvCmd string
 	if len(envCommands) != 0 {

--- a/pkg/remotecmd/kubexec_test.go
+++ b/pkg/remotecmd/kubexec_test.go
@@ -148,9 +148,15 @@ func TestKubeExecProcessHandler_StartProcessForCommand(t *testing.T) {
 		Id:         "my-exec-cmd",
 		CmdLine:    "tail -f /path/to/a/file",
 		WorkingDir: "/path/to/working/dir",
-		EnvVars: map[string]string{
-			"ENV_VAR1": "value1",
-			"ENV_VAR2": "value2",
+		EnvVars: []CommandEnvVar{
+			{
+				Key:   "ENV_VAR1",
+				Value: "value1",
+			},
+			{
+				Key:   "ENV_VAR2",
+				Value: "value2",
+			},
 		},
 	}
 	for _, tt := range []struct {

--- a/pkg/remotecmd/types.go
+++ b/pkg/remotecmd/types.go
@@ -40,14 +40,20 @@ type CommandDefinition struct {
 	WorkingDir string
 
 	// EnvVars are environment variables to set.
-	EnvVars map[string]string
+	EnvVars []CommandEnvVar
 
 	// CmdLine is the command-line that will get executed.
 	CmdLine string
+}
 
-	//// RedirectOutputToMain indicates whether to redirect this command output streams to the main (PID 1) one.
-	//// This can be useful to have the output of this command show up in `odo logs` or `kubectl logs`.
-	//RedirectOutputToMain bool
+// CommandEnvVar represents an environment variable used as part of running any CommandDefinition.
+type CommandEnvVar struct {
+
+	// Key of the environment variable.
+	Key string
+
+	// Value of the environment variable.
+	Value string
 }
 
 // CommandOutputHandler is a function that is expected to handle the output and error returned by a command executed.


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**
Unit tests in `pkg/remotecmd/kubeexec_test.go` expect an exact command-line string to be passed when running commands in containers. The problem is that the environment variables are stored in a map, the iteration order of which is not guaranteed.

Initially reported in https://github.com/redhat-developer/odo/pull/5823#issuecomment-1160383237

**Which issue(s) this PR fixes:**

```
==================
--- FAIL: TestKubeExecProcessHandler_StartProcessForCommand (10.00s)
    --- FAIL: TestKubeExecProcessHandler_StartProcessForCommand/command_with_all_fields_returned_no_error (10.00s)
        remotecmd.go:36: Unexpected call to *kclient.MockClientInterface.ExecCMDInContainer([my-container my-pod [/bin/sh -c echo $$ > /opt/odo/.odo_devfile_cmd_my-exec-cmd.pid && cd /path/to/working/dir && export ENV_VAR2='value2' ENV_VAR1='value1' && (tail -f /path/to/a/file) 1>>/proc/1/fd/1 2>>/proc/1/fd/2] 0xc00047a030 0xc00047a040 <nil> false]) at /workspace/dcb6538f-a4d0-4109-85f2-86d8f7960de8/pkg/remotecmd/remotecmd.go:36 because: 
            expected call at /workspace/dcb6538f-a4d0-4109-85f2-86d8f7960de8/pkg/remotecmd/kubexec_test.go:185 doesn't match the argument at index 2.
            Got: [/bin/sh -c echo $$ > /opt/odo/.odo_devfile_cmd_my-exec-cmd.pid && cd /path/to/working/dir && export ENV_VAR2='value2' ENV_VAR1='value1' && (tail -f /path/to/a/file) 1>>/proc/1/fd/1 2>>/proc/1/fd/2]
            Want: is equal to [/bin/sh -c echo $$ > /opt/odo/.odo_devfile_cmd_my-exec-cmd.pid && cd /path/to/working/dir && export ENV_VAR1='value1' ENV_VAR2='value2' && (tail -f /path/to/a/file) 1>>/proc/1/fd/1 2>>/proc/1/fd/2]
        kubexec_test.go:219: timeout waiting for output handler to get called
        controller.go:137: missing call(s) to *kclient.MockClientInterface.ExecCMDInContainer(is equal to my-container, is equal to my-pod, is equal to [/bin/sh -c echo $$ > /opt/odo/.odo_devfile_cmd_my-exec-cmd.pid && cd /path/to/working/dir && export ENV_VAR1='value1' ENV_VAR2='value2' && (tail -f /path/to/a/file) 1>>/proc/1/fd/1 2>>/proc/1/fd/2], is anything, is anything, is anything, is anything) /workspace/dcb6538f-a4d0-4109-85f2-86d8f7960de8/pkg/remotecmd/kubexec_test.go:185
        controller.go:137: aborting test due to missing call(s)
        testing.go:1092: race detected during execution of test
    testing.go:1092: race detected during execution of test
FAIL
FAIL	[github.com/redhat-developer/odo/pkg/remotecmd](http://github.com/redhat-developer/odo/pkg/remotecmd)	16.453s
```

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
All tests in `kubeexec_test.go` should pass.

cc @feloy 