### PR TITLE
Adds support to follow/tail/stream odo logs

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/logs.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/logs.md
@@ -23,6 +23,7 @@ container name to help differentiate between the containers. In the output, you 
 
 It also supports `--follow` flag which allows you to follow/tail/stream the logs of the containers. It works by using 
 the same commands as above albeit, with a `--follow` flag:
-* Use `odo logs --dev` to follow the logs for the containers created by `odo dev` command.
-* Use `odo logs --deploy` to follow the logs for the containers created by `odo deploy` command.
-* Use `odo logs` (without any flag) to follow the logs of all the containers created by both `odo dev` and `odo deploy`.
+* Use `odo logs --dev --follow` to follow the logs for the containers created by `odo dev` command.
+* Use `odo logs --deploy --follow` to follow the logs for the containers created by `odo deploy` command.
+* Use `odo logs --follow` (without `--dev` or `--deploy`) to follow the logs of all the containers created by both `odo 
+  dev` and `odo deploy`.

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/logs.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/logs.md
@@ -20,3 +20,9 @@ init` command.
 Note that if multiple containers are named the same (for example, `main`), the `odo logs` output appends a number to 
 container name to help differentiate between the containers. In the output, you will see containers named as `main`, 
 `main[1]`, `main[2]`, so on and so forth.
+
+It also supports `--follow` flag which allows you to follow/tail/stream the logs of the containers. It works by using 
+the same commands as above albeit, with a `--follow` flag:
+* Use `odo logs --dev` to follow the logs for the containers created by `odo dev` command.
+* Use `odo logs --deploy` to follow the logs for the containers created by `odo deploy` command.
+* Use `odo logs` (without any flag) to follow the logs of all the containers created by both `odo dev` and `odo deploy`.

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -222,11 +222,9 @@ func (c *Client) GetPodLogs(podName, containerName string, followLog bool) (io.R
 
 	// If the log is being followed, set it to follow / don't wait
 	if followLog {
-		tailLines := int64(1)
 		podLogOptions = corev1.PodLogOptions{
 			Follow:    true,
 			Previous:  false,
-			TailLines: &tailLines,
 			Container: containerName,
 		}
 	}

--- a/pkg/logs/interface.go
+++ b/pkg/logs/interface.go
@@ -5,8 +5,9 @@ import "io"
 type Client interface {
 	// GetLogsForMode gets logs of the containers for the specified mode (Dev, Deploy or both) of the provided
 	// component name and namespace. It returns a slice of maps where container name is the key and its logs are
-	// the value. Each map is a key-value pair of container name and its logs for a specific pod
+	// the value. Each map is a key-value pair of container name and its logs for a specific pod. Setting follow boolean
+	// to true helps follow/tail the logs of the pods.
 	// The accepted values for mode are ComponentDevMode, ComponentDeployMode and ComponentAnyMode
-	// found in the pkg/labels package
-	GetLogsForMode(mode string, componentName string, namespace string) ([]map[string]io.ReadCloser, error)
+	// found in the pkg/labels package.
+	GetLogsForMode(mode string, componentName string, namespace string, follow bool) ([]map[string]io.ReadCloser, error)
 }

--- a/pkg/odo/cli/logs/logs.go
+++ b/pkg/odo/cli/logs/logs.go
@@ -207,13 +207,14 @@ func printLogs(containerName string, rd io.ReadCloser, out io.Writer, colour col
 	for scanner.Scan() {
 		line := scanner.Text()
 		mu.Lock()
+		defer mu.Unlock()
 		color.Set(colour)
+		defer color.Unset()
+
 		_, err := fmt.Fprintln(out, containerName+": "+line)
 		if err != nil {
 			return err
 		}
-		color.Unset()
-		mu.Unlock()
 	}
 
 	return nil

--- a/pkg/odo/cli/logs/logs.go
+++ b/pkg/odo/cli/logs/logs.go
@@ -206,12 +206,15 @@ func printLogs(containerName string, rd io.ReadCloser, out io.Writer, colour col
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		mu.Lock()
-		defer mu.Unlock()
-		color.Set(colour)
-		defer color.Unset()
+		err := func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			color.Set(colour)
+			defer color.Unset()
 
-		_, err := fmt.Fprintln(out, containerName+": "+line)
+			_, err := fmt.Fprintln(out, containerName+": "+line)
+			return err
+		}()
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/logs/logs.go
+++ b/pkg/odo/cli/logs/logs.go
@@ -130,7 +130,7 @@ func (o *LogsOptions) Run(ctx context.Context) error {
 		// 1. user specifies --dev flag, but the component's running in Deploy mode
 		// 2. user specified --deploy flag, but the component's running in Dev mode
 		// 3. user passes no flag, but component is running in neither Dev nor Deploy mode
-		fmt.Fprintf(o.out, "no containers running in the specified mode for the component %q", o.componentName)
+		fmt.Fprintf(o.out, "no containers running in the specified mode for the component %q\n", o.componentName)
 		return nil
 	}
 

--- a/pkg/odo/cli/logs/logs.go
+++ b/pkg/odo/cli/logs/logs.go
@@ -149,7 +149,7 @@ func (o *LogsOptions) Run(ctx context.Context) error {
 				colour := log.ColorPicker()
 				if !follow {
 					// ensure that only one go routine does printLogs at a time; this is helpful when logs are longer
-					// than just a few lines in that logs for each container are printed before starting printing those
+					// than just a few lines in that logs for each container are printed before starting to print those
 					// of the next container
 					mu.Lock()
 				}
@@ -167,7 +167,10 @@ func (o *LogsOptions) Run(ctx context.Context) error {
 	case err := <-errChan:
 		return err
 	default:
-		// do nothing
+		// do nothing; this makes sure that we are not blocking on errChan channel
+		// without this default block, odo logs (without follow) will be stuck/blocked on getting something from
+		// errChan channel and the command won't exit.
+
 	}
 	wg.Wait()
 	return nil

--- a/tests/examples/source/devfiles/nodejs/devfile-deploy-functional-pods.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-deploy-functional-pods.yaml
@@ -9,7 +9,6 @@ metadata:
   projectType: nodejs
 variables:
   CONTAINER_IMAGE: quay.io/tkral/devfile-nodejs-deploy:latest
-  LOGS_IMAGE: docker.io/dharmit/infiniteloop
 commands:
   - id: install
     exec:
@@ -114,7 +113,9 @@ components:
         spec:
           containers:
           - name: main
-            image: "{{LOGS_IMAGE}}"
+            image: alpine
+            command: ["/bin/sh"]
+            args: [ "-c", "while true; do echo \"`date` - this is infinite while loop\"; sleep 5; done" ]
   - name: outerloop-pod
     kubernetes:
       inlined: |
@@ -125,4 +126,6 @@ components:
         spec:
           containers:
           - name: main
-            image: "{{LOGS_IMAGE}}"
+            image: alpine
+            command: ["/bin/sh"]
+            args: [ "-c", "while true; do echo \"`date` - this is infinite while loop\"; sleep 5; done" ]

--- a/tests/examples/source/devfiles/nodejs/devfile-deploy-functional-pods.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-deploy-functional-pods.yaml
@@ -9,6 +9,7 @@ metadata:
   projectType: nodejs
 variables:
   CONTAINER_IMAGE: quay.io/tkral/devfile-nodejs-deploy:latest
+  LOGS_IMAGE: docker.io/dharmit/infiniteloop
 commands:
   - id: install
     exec:
@@ -113,7 +114,7 @@ components:
         spec:
           containers:
           - name: main
-            image: "{{CONTAINER_IMAGE}}"
+            image: "{{LOGS_IMAGE}}"
   - name: outerloop-pod
     kubernetes:
       inlined: |
@@ -124,4 +125,4 @@ components:
         spec:
           containers:
           - name: main
-            image: "{{CONTAINER_IMAGE}}"
+            image: "{{LOGS_IMAGE}}"

--- a/tests/helper/helper_logs.go
+++ b/tests/helper/helper_logs.go
@@ -1,0 +1,41 @@
+package helper
+
+import (
+	"github.com/onsi/gomega/gexec"
+)
+
+type LogsSession struct {
+	session *gexec.Session
+}
+
+// StartLogsFollow starts a session with `odo logs --follow`
+// It returns a session structure, the contents of the standard and error outputs
+func StartLogsFollow(opts ...string) (LogsSession, []byte, []byte, error) {
+	args := []string{"logs", "--follow"}
+	args = append(args, opts...)
+	session := CmdRunner("odo", args...)
+	result := LogsSession{
+		session: session,
+	}
+	outContents := session.Out.Contents()
+	errContents := session.Err.Contents()
+	err := session.Out.Clear()
+	if err != nil {
+		return LogsSession{}, nil, nil, err
+	}
+	err = session.Err.Clear()
+	if err != nil {
+		return LogsSession{}, nil, nil, err
+	}
+	return result, outContents, errContents, nil
+}
+
+// OutContents returns the contents of the session's stdout
+func (o *LogsSession) OutContents() []byte {
+	return o.session.Out.Contents()
+}
+
+// Kill the `odo logs --follow` session
+func (o *LogsSession) Kill() {
+	o.session.Kill()
+}

--- a/tests/integration/devfile/cmd_logs_test.go
+++ b/tests/integration/devfile/cmd_logs_test.go
@@ -3,6 +3,7 @@ package devfile
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -80,6 +81,29 @@ var _ = Describe("odo logs command tests", func() {
 				out = helper.Cmd("odo", "logs", "--deploy").ShouldPass().Out()
 				Expect(out).To(ContainSubstring("no containers running in the specified mode for the component"))
 			})
+			When("--follow flag is specified", func() {
+				var logsSession helper.LogsSession
+				var err error
+
+				BeforeEach(func() {
+					logsSession, _, _, err = helper.StartLogsFollow("--dev")
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					logsSession.Kill()
+				})
+				It("should successfully follow logs of running component", func() {
+					var linesOfLogs int
+					Consistently(func() bool {
+						logs := logsSession.OutContents()
+						if len(string(logs)) < linesOfLogs {
+							return false
+						}
+						linesOfLogs = len(logs)
+						return true
+					}, 20*time.Second, 5).Should(BeTrue())
+				})
+			})
 		})
 
 		When("running in Deploy mode", func() {
@@ -101,6 +125,29 @@ var _ = Describe("odo logs command tests", func() {
 				// `odo logs --deploy`
 				out = helper.Cmd("odo", "logs", "--deploy").ShouldPass().Out()
 				helper.MatchAllInOutput(out, []string{"main:", "main[1]:", "main[2]:"})
+			})
+			When("--follow flag is specified", func() {
+				var logsSession helper.LogsSession
+				var err error
+
+				BeforeEach(func() {
+					logsSession, _, _, err = helper.StartLogsFollow("--deploy")
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					logsSession.Kill()
+				})
+				It("should successfully follow logs of running component", func() {
+					var linesOfLogs int
+					Consistently(func() bool {
+						logs := logsSession.OutContents()
+						if len(string(logs)) < linesOfLogs {
+							return false
+						}
+						linesOfLogs = len(logs)
+						return true
+					}, 20*time.Second, 5).Should(BeTrue())
+				})
 			})
 		})
 
@@ -135,6 +182,29 @@ var _ = Describe("odo logs command tests", func() {
 				// `odo logs --dev --deploy`
 				out = helper.Cmd("odo", "logs", "--deploy", "--dev").ShouldFail().Err()
 				Expect(out).To(ContainSubstring("pass only one of --dev or --deploy flags; pass no flag to see logs for both modes"))
+			})
+			When("--follow flag is specified", func() {
+				var logsSession helper.LogsSession
+				var err error
+
+				BeforeEach(func() {
+					logsSession, _, _, err = helper.StartLogsFollow()
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					logsSession.Kill()
+				})
+				It("should successfully follow logs of running component", func() {
+					var linesOfLogs int
+					Consistently(func() bool {
+						logs := logsSession.OutContents()
+						if len(string(logs)) < linesOfLogs {
+							return false
+						}
+						linesOfLogs = len(logs)
+						return true
+					}, 20*time.Second, 5).Should(BeTrue())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**
It allows the users to follow/stream the logs for the components.

**Which issue(s) this PR fixes:**

Fixes #5715

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
Use the devfile modified in this PR and run following set of commands:
1. `odo logs` / `odo logs --follow`
2. `odo logs --dev` / `odo logs --dev --follow`
3. `odo logs --deploy` / `odo logs --deploy --follow`
4. `odo logs --dev --deploy` / `odo logs --dev --deploy --follow` (this one should fail.)