### PR TITLE
odo add binding without devfile.yaml

### DIFF
--- a/docs/website/versioned_docs/version-3.0.0/command-reference/add-binding.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/add-binding.md
@@ -3,7 +3,17 @@ title: odo add binding
 ---
 
 ## Description
-The `odo add binding` command adds a link between an Operator-backed service and a component. odo uses the [Service Binding Operator](https://github.com/redhat-developer/service-binding-operator/) to create this link. Running this command will modify the Devfile, and once pushed (using `odo dev`) to the cluster, it creates an instance of the `ServiceBinding` resource.
+The `odo add binding` command adds a link between an Operator-backed service and a component. odo uses the [Service Binding Operator](https://github.com/redhat-developer/service-binding-operator/) to create this link. 
+
+Running this command from a directory containing a Devfile will modify the Devfile, and once pushed (using `odo dev`) to the cluster, it creates an instance of the `ServiceBinding` resource.
+
+Running this command from a directory without a Devfile in the interactive mode will perform one or several operations,
+depending on your choice:
+- display the YAML definition of the Service binding in the output,
+- save the YAML definition of the ServiceBinding on a file,
+- create an instance of the ServiceBinding resource on the cluster.
+
+In non-interactive mode from a directory without a Devfile, the only possible operation is to display the YAML definition of the Service binding in the output.
 
 Currently, it only allows connecting to the Operator-backed services which support binding via the Service Binding Operator.
 To know about the Operators supported by the Service Binding Operator, read its [README](https://github.com/redhat-developer/service-binding-operator#known-bindable-operators).
@@ -11,13 +21,14 @@ To know about the Operators supported by the Service Binding Operator, read its 
 ## Running the Command
 
 ### Pre-requisites
-* A directory containing a Devfile; if you don't have one, see [odo init](init.md) on obtaining a devfile.
 * A cluster with the Service Binding Operator installed (see installation instructions for [Kubernetes](../overview/cluster-setup/kubernetes.md#installing-the-service-binding-operator) and [OpenShift](../overview/cluster-setup/openshift.md#installing-the-service-binding-operator) cluster)
 * Operator-backed services or resources you want to bind your application to
+* Optional, a directory containing a Devfile; if you don't have one, see [odo init](init.md) on obtaining a devfile.
 
 ### Interactive Mode
 In the interactive mode, you will be guided to choose:
 * a service from the list of bindable service instances as supported by the Service Binding Operator,
+* if a Devfile is not present in the directory, a workload resource,
 * option to bind the service as a file (see [Understanding Bind as Files](#understanding-bind-as-files) for more information on this),
 * a name for the binding.
 
@@ -29,6 +40,7 @@ odo add binding
 ### Non-interactive mode
 In the non-interactive mode, you will have to specify the following required information through the command-line:
 * `--service` flag to specify the service you want to bind to,
+* `--workload` flag to specify the workload resource, if a Devfile is not present in the directory,
 * `--name` flag to specify a name for the binding (see [Understanding Bind as Files](#understanding-bind-as-files) for more information on this)
 * `--bind-as-files` flag to specify if the service should be bound as a file; this flag is set to true by default.
 
@@ -46,8 +58,8 @@ If the service is bound as files, this data will be written to a file and stored
 Note that every piece of data is stored in its own individual file or environment variable.
 For example, if your data includes a username and password, then 2 separate files, or 2 environment variables will be created to store them both.
 
-#### Formats supported by the `--service` flag
-The `--service` flag supports the following formats to specify the service name:
+#### Formats supported by the `--service` and `--workload` flags
+The `--service` and `--workload` flags support the following formats to specify the service or workload name:
 * `<name>`
 * `<name>.<kind>`
 * `<name>.<kind>.<apigroup>`

--- a/docs/website/versioned_docs/version-3.0.0/command-reference/add-binding.md
+++ b/docs/website/versioned_docs/version-3.0.0/command-reference/add-binding.md
@@ -58,12 +58,17 @@ If the service is bound as files, this data will be written to a file and stored
 Note that every piece of data is stored in its own individual file or environment variable.
 For example, if your data includes a username and password, then 2 separate files, or 2 environment variables will be created to store them both.
 
-#### Formats supported by the `--service` and `--workload` flags
-The `--service` and `--workload` flags support the following formats to specify the service or workload name:
+#### Formats supported by the `--service` flag
+The `--service` flag supports the following formats to specify the service name:
 * `<name>`
 * `<name>.<kind>`
 * `<name>.<kind>.<apigroup>`
 * `<name>/<kind>`
+* `<name>/<kind>.<apigroup>`
+
+#### Formats supported by the `--workload` flag
+The `--workload` flag supports the following formats to specify the workload name:
+* `<name>.<kind>.<apigroup>`
 * `<name>/<kind>.<apigroup>`
 
 The above formats are helpful when multiple services with the same name exist on the cluster.

--- a/pkg/binding/add.go
+++ b/pkg/binding/add.go
@@ -128,9 +128,12 @@ func (o *BindingClient) AddBinding(
 		backend = o.flagsBackend
 	}
 
-	options, err := backend.SelectCreationOptions(flags)
-	if err != nil {
-		return err
+	var options []asker.CreationOption
+	for len(options) == 0 {
+		options, err = backend.SelectCreationOptions(flags)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Note: we cannot directly marshal the serviceBinding object to yaml because it doesn't do that in the correct k8s manifest format

--- a/pkg/binding/add.go
+++ b/pkg/binding/add.go
@@ -2,15 +2,20 @@ package binding
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/devfile/library/pkg/devfile/parser"
 	sboApi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/redhat-developer/odo/pkg/binding/asker"
 	backendpkg "github.com/redhat-developer/odo/pkg/binding/backend"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/libdevfile"
+	"github.com/redhat-developer/odo/pkg/log"
 )
 
 // ValidateAddBinding calls Validate method of the adequate backend
@@ -34,6 +39,20 @@ func (o *BindingClient) SelectServiceInstance(flags map[string]string, serviceMa
 	return backend.SelectServiceInstance(flags[backendpkg.FLAG_SERVICE], serviceMap)
 }
 
+func (o *BindingClient) SelectWorkloadInstance(flags map[string]string) (string, schema.GroupVersionKind, error) {
+	var backend backendpkg.AddBindingBackend
+	if len(flags) == 0 {
+		backend = o.interactiveBackend
+	} else {
+		backend = o.flagsBackend
+	}
+	resource, gvk, err := backend.SelectWorkloadInstance(flags[backendpkg.FLAG_WORKLOAD])
+	if err != nil {
+		return "", schema.GroupVersionKind{}, err
+	}
+	return resource, gvk, nil
+}
+
 func (o *BindingClient) AskBindingName(serviceName, componentName string, flags map[string]string) (string, error) {
 	var backend backendpkg.AddBindingBackend
 	if len(flags) == 0 {
@@ -55,19 +74,24 @@ func (o *BindingClient) AskBindAsFiles(flags map[string]string) (bool, error) {
 	return backend.AskBindAsFiles(flags)
 }
 
-func (o *BindingClient) AddBinding(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
+func (o *BindingClient) AddBindingToDevfile(
+	bindingName string,
+	bindAsFiles bool,
+	unstructuredService unstructured.Unstructured,
+	obj parser.DevfileObj,
+) (parser.DevfileObj, error) {
 	service, err := o.kubernetesClient.NewServiceBindingServiceObject(unstructuredService, bindingName)
 	if err != nil {
 		return obj, err
 	}
 
 	deploymentName := fmt.Sprintf("%s-app", obj.GetMetadataName())
-	deploymentGVR, err := o.kubernetesClient.GetDeploymentAPIVersion()
+	deploymentGVK, err := o.kubernetesClient.GetDeploymentAPIVersion()
 	if err != nil {
 		return obj, err
 	}
 
-	serviceBinding := kclient.NewServiceBindingObject(bindingName, bindAsFiles, deploymentName, deploymentGVR, []sboApi.Mapping{}, []sboApi.Service{service}, sboApi.ServiceBindingStatus{})
+	serviceBinding := kclient.NewServiceBindingObject(bindingName, bindAsFiles, deploymentName, deploymentGVK, []sboApi.Mapping{}, []sboApi.Service{service}, sboApi.ServiceBindingStatus{})
 
 	// Note: we cannot directly marshal the serviceBinding object to yaml because it doesn't do that in the correct k8s manifest format
 	serviceBindingUnstructured, err := kclient.ConvertK8sResourceToUnstructured(serviceBinding)
@@ -80,4 +104,88 @@ func (o *BindingClient) AddBinding(bindingName string, bindAsFiles bool, unstruc
 	}
 
 	return libdevfile.AddKubernetesComponentToDevfile(string(yamlDesc), serviceBinding.Name, obj)
+}
+
+func (o *BindingClient) AddBinding(
+	flags map[string]string,
+	bindingName string,
+	bindAsFiles bool,
+	unstructuredService unstructured.Unstructured,
+	workloadName string,
+	workloadGVK schema.GroupVersionKind,
+) error {
+	service, err := o.kubernetesClient.NewServiceBindingServiceObject(unstructuredService, bindingName)
+	if err != nil {
+		return err
+	}
+
+	serviceBinding := kclient.NewServiceBindingObject(bindingName, bindAsFiles, workloadName, workloadGVK, []sboApi.Mapping{}, []sboApi.Service{service}, sboApi.ServiceBindingStatus{})
+
+	var backend backendpkg.AddBindingBackend
+	if len(flags) == 0 {
+		backend = o.interactiveBackend
+	} else {
+		backend = o.flagsBackend
+	}
+
+	options, err := backend.SelectCreationOptions(flags)
+	if err != nil {
+		return err
+	}
+
+	// Note: we cannot directly marshal the serviceBinding object to yaml because it doesn't do that in the correct k8s manifest format
+	serviceBindingUnstructured, err := kclient.ConvertK8sResourceToUnstructured(serviceBinding)
+	if err != nil {
+		return err
+	}
+	yamlDesc, err := yaml.Marshal(serviceBindingUnstructured.UnstructuredContent())
+	if err != nil {
+		return err
+	}
+
+	var filename string
+	for _, option := range options {
+		if option == asker.OutputToFile {
+			filename, err = backend.AskOutputFilePath(flags, filepath.Join("kubernetes", serviceBinding.GetName()+".yaml"))
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	for _, option := range options {
+		switch option {
+		case asker.OutputToFile:
+			err = os.MkdirAll(filepath.Dir(filename), 0750)
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(filename, yamlDesc, 0600)
+			if err != nil {
+				return err
+			}
+
+		case asker.OutputToStdout:
+			fmt.Println(string(yamlDesc))
+
+		case asker.CreateOnCluster:
+			_, err = o.kubernetesClient.PatchDynamicResource(serviceBindingUnstructured)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Display the info after outputting to stdout
+	for _, option := range options {
+		switch option {
+		case asker.OutputToFile:
+			log.Infof("The ServiceBinding has been written to the file %q", filename)
+
+		case asker.CreateOnCluster:
+			log.Infof("The ServiceBinding has been created in the cluster")
+		}
+	}
+	return nil
 }

--- a/pkg/binding/add.go
+++ b/pkg/binding/add.go
@@ -19,14 +19,14 @@ import (
 )
 
 // ValidateAddBinding calls Validate method of the adequate backend
-func (o *BindingClient) ValidateAddBinding(flags map[string]string) error {
+func (o *BindingClient) ValidateAddBinding(flags map[string]string, withDevfile bool) error {
 	var backend backendpkg.AddBindingBackend
 	if len(flags) == 0 {
 		backend = o.interactiveBackend
 	} else {
 		backend = o.flagsBackend
 	}
-	return backend.Validate(flags)
+	return backend.Validate(flags, withDevfile)
 }
 
 func (o *BindingClient) SelectServiceInstance(flags map[string]string, serviceMap map[string]unstructured.Unstructured) (string, error) {

--- a/pkg/binding/asker/interface.go
+++ b/pkg/binding/asker/interface.go
@@ -22,8 +22,8 @@ type Asker interface {
 	AskServiceBindingName(defaultName string) (string, error)
 	// AskBindAsFiles asks if service should be binded as files
 	AskBindAsFiles() (bool, error)
-	// SelectCreationOption asks to select a creation option for the servicebinding
-	SelectCreationOption() ([]CreationOption, error)
+	// SelectCreationOptions asks to select creation options for the servicebinding
+	SelectCreationOptions() ([]CreationOption, error)
 	// AskOutputFilePath asks for the path of the file to output service binding
 	AskOutputFilePath(defaultValue string) (string, error)
 }

--- a/pkg/binding/asker/interface.go
+++ b/pkg/binding/asker/interface.go
@@ -1,10 +1,28 @@
 package asker
 
+type CreationOption int
+
+const (
+	CreateOnCluster CreationOption = iota
+	OutputToStdout
+	OutputToFile
+)
+
 type Asker interface {
+	// SelectWorkloadResource takes a list of workloads resources and asks user to select one
+	SelectWorkloadResource(options []string) (int, error)
+	// SelectWorkloadResourceName takes a list of workloads resources names and asks user to select one
+	SelectWorkloadResourceName(names []string) (string, error)
+	// AskWorkloadResourceName asks user to type resource name
+	AskWorkloadResourceName() (string, error)
 	// AskServiceInstance takes a list of services and asks user to select one
 	AskServiceInstance(serviceInstanceOptions []string) (string, error)
 	// AskServiceBindingName asks for service binding name to be set
 	AskServiceBindingName(defaultName string) (string, error)
 	// AskBindAsFiles asks if service should be binded as files
 	AskBindAsFiles() (bool, error)
+	// SelectCreationOption asks to select a creation option for the servicebinding
+	SelectCreationOption() ([]CreationOption, error)
+	// AskOutputFilePath asks for the path of the file to output service binding
+	AskOutputFilePath(defaultValue string) (string, error)
 }

--- a/pkg/binding/asker/interface.go
+++ b/pkg/binding/asker/interface.go
@@ -12,7 +12,8 @@ type Asker interface {
 	// SelectWorkloadResource takes a list of workloads resources and asks user to select one
 	SelectWorkloadResource(options []string) (int, error)
 	// SelectWorkloadResourceName takes a list of workloads resources names and asks user to select one
-	SelectWorkloadResourceName(names []string) (string, error)
+	// returns back true if the user selected to go back
+	SelectWorkloadResourceName(names []string) (back bool, selected string, err error)
 	// AskWorkloadResourceName asks user to type resource name
 	AskWorkloadResourceName() (string, error)
 	// AskServiceInstance takes a list of services and asks user to select one

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -30,10 +30,11 @@ func (s *Survey) SelectWorkloadResource(options []string) (int, error) {
 	return answer, nil
 }
 
-func (s *Survey) SelectWorkloadResourceName(names []string) (string, error) {
+func (s *Survey) SelectWorkloadResourceName(names []string) (bool, string, error) {
 	sort.Strings(names)
 	notFoundOption := "DOES NOT EXIST YET"
-	names = append(names, notFoundOption)
+	goBackOption := "** GO BACK **"
+	names = append(names, notFoundOption, goBackOption)
 	question := &survey.Select{
 		Message: "Select workload resource name you want to bind:",
 		Options: names,
@@ -41,12 +42,15 @@ func (s *Survey) SelectWorkloadResourceName(names []string) (string, error) {
 	var answer string
 	err := survey.AskOne(question, &answer)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 	if answer == notFoundOption {
-		return "", nil
+		return false, "", nil
 	}
-	return answer, nil
+	if answer == goBackOption {
+		return true, "", nil
+	}
+	return false, answer, nil
 }
 
 func (s *Survey) AskWorkloadResourceName() (string, error) {

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -17,6 +17,51 @@ func NewSurveyAsker() *Survey {
 	return &Survey{}
 }
 
+func (s *Survey) SelectWorkloadResource(options []string) (int, error) {
+	question := &survey.Select{
+		Message: "Select workload resource you want to bind:",
+		Options: options,
+	}
+	var answer int
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return 0, err
+	}
+	return answer, nil
+}
+
+func (s *Survey) SelectWorkloadResourceName(names []string) (string, error) {
+	sort.Strings(names)
+	notFoundOption := "DOES NOT EXIST YET"
+	names = append(names, notFoundOption)
+	question := &survey.Select{
+		Message: "Select workload resource name you want to bind:",
+		Options: names,
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	if answer == notFoundOption {
+		return "", nil
+	}
+	return answer, nil
+}
+
+func (s *Survey) AskWorkloadResourceName() (string, error) {
+	question := &survey.Input{
+		Message: "Enter the Workload's name:",
+		Default: "",
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
 func (s *Survey) AskServiceInstance(serviceInstances []string) (string, error) {
 	sort.Strings(serviceInstances)
 	question := &survey.Select{
@@ -60,4 +105,34 @@ func (o *Survey) AskBindAsFiles() (bool, error) {
 		bindAsFile = true
 	}
 	return bindAsFile, nil
+}
+
+func (o *Survey) SelectCreationOption() ([]CreationOption, error) {
+	options := []int{}
+	prompt := &survey.MultiSelect{
+		Message: "What do you want to do with the ServiceBinding:",
+		Options: []string{"create it on cluster", "display it", "save to file"}, // respect order of CreateOption constants
+	}
+	err := survey.AskOne(prompt, &options)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]CreationOption, 0, len(options))
+	for _, option := range options {
+		result = append(result, CreationOption(option))
+	}
+	return result, nil
+}
+
+func (o *Survey) AskOutputFilePath(defaultValue string) (string, error) {
+	question := &survey.Input{
+		Message: "Save the ServiceBinding to file:",
+		Default: defaultValue,
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	return answer, nil
 }

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -114,8 +114,9 @@ func (o *Survey) AskBindAsFiles() (bool, error) {
 func (o *Survey) SelectCreationOption() ([]CreationOption, error) {
 	options := []int{}
 	prompt := &survey.MultiSelect{
-		Message: "Check with spacebar the operations to perform with the ServiceBinding:",
+		Message: "Check(with Space Bar) one or more operations to perform with the ServiceBinding:",
 		Options: []string{"create it on cluster", "display it", "save it to file"}, // respect order of CreateOption constants
+		Help:    "Use the Space Bar to select one or more operations to perform with the ServiceBinding",
 	}
 	err := survey.AskOne(prompt, &options)
 	if err != nil {

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -111,11 +111,11 @@ func (o *Survey) AskBindAsFiles() (bool, error) {
 	return bindAsFile, nil
 }
 
-func (o *Survey) SelectCreationOption() ([]CreationOption, error) {
+func (o *Survey) SelectCreationOptions() ([]CreationOption, error) {
 	options := []int{}
 	prompt := &survey.MultiSelect{
 		Message: "Check(with Space Bar) one or more operations to perform with the ServiceBinding:",
-		Options: []string{"create it on cluster", "display it", "save it to file"}, // respect order of CreateOption constants
+		Options: []string{"create it on cluster", "display it", "save it to file"}, // respect order of CreationOption constants
 		Help:    "Use the Space Bar to select one or more operations to perform with the ServiceBinding",
 	}
 	err := survey.AskOne(prompt, &options)

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -110,8 +110,8 @@ func (o *Survey) AskBindAsFiles() (bool, error) {
 func (o *Survey) SelectCreationOption() ([]CreationOption, error) {
 	options := []int{}
 	prompt := &survey.MultiSelect{
-		Message: "What do you want to do with the ServiceBinding:",
-		Options: []string{"create it on cluster", "display it", "save to file"}, // respect order of CreateOption constants
+		Message: "Check with spacebar the operations to perform with the ServiceBinding:",
+		Options: []string{"create it on cluster", "display it", "save it to file"}, // respect order of CreateOption constants
 	}
 	err := survey.AskOne(prompt, &options)
 	if err != nil {

--- a/pkg/binding/backend/flags.go
+++ b/pkg/binding/backend/flags.go
@@ -27,7 +27,7 @@ func NewFlagsBackend() *FlagsBackend {
 	return &FlagsBackend{}
 }
 
-func (o *FlagsBackend) Validate(flags map[string]string) error {
+func (o *FlagsBackend) Validate(flags map[string]string, withDevfile bool) error {
 	if flags[FLAG_SERVICE] == "" {
 		return errors.New("missing --service parameter: please add --service <name>[/<kind>.<apigroup>] to specify the service instance for binding")
 	}
@@ -35,6 +35,13 @@ func (o *FlagsBackend) Validate(flags map[string]string) error {
 		return errors.New("missing --name parameter: please add --name <name> to specify a name for the service binding instance")
 	}
 
+	if withDevfile && flags[FLAG_WORKLOAD] != "" {
+		return errors.New("--workload cannot be used from a directory containing a Devfile")
+	}
+
+	if !withDevfile && flags[FLAG_WORKLOAD] == "" {
+		return errors.New("missing --workload parameter: please add --workload <workload> so specify a workload to bind information to")
+	}
 	return dfutil.ValidateK8sResourceName(FLAG_NAME, flags[FLAG_NAME])
 }
 

--- a/pkg/binding/backend/flags.go
+++ b/pkg/binding/backend/flags.go
@@ -52,7 +52,7 @@ func (o *FlagsBackend) SelectWorkloadInstance(workloadName string) (string, sche
 			return selectedName, gvk, nil
 		}
 	}
-	return "", schema.GroupVersionKind{}, fmt.Errorf("group/kind %q not found on the cluster", selectedKind+"/"+selectedGroup)
+	return "", schema.GroupVersionKind{}, fmt.Errorf("group/kind %q not found on the cluster", selectedGroup+"/"+selectedKind)
 }
 
 // SelectServiceInstance parses the service's name, kind, and group from arg:serviceName,

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -2,23 +2,70 @@ package backend
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/redhat-developer/odo/pkg/binding/asker"
+	"github.com/redhat-developer/odo/pkg/kclient"
 )
 
 // InteractiveBackend is a backend that will ask information interactively using the `asker` package
 type InteractiveBackend struct {
-	askerClient asker.Asker
+	askerClient      asker.Asker
+	kubernetesClient kclient.ClientInterface
 }
 
-func NewInteractiveBackend(askerClient asker.Asker) *InteractiveBackend {
+func NewInteractiveBackend(askerClient asker.Asker, kubernetesClient kclient.ClientInterface) *InteractiveBackend {
 	return &InteractiveBackend{
-		askerClient: askerClient,
+		askerClient:      askerClient,
+		kubernetesClient: kubernetesClient,
 	}
 }
 
 func (o *InteractiveBackend) Validate(_ map[string]string) error {
 	return nil
+}
+
+func (o *InteractiveBackend) SelectWorkloadInstance(workloadName string) (string, schema.GroupVersionKind, error) {
+
+	// Ask to select the kind
+	options, allWorkloadsKinds, err := o.kubernetesClient.GetWorkloadKinds()
+	if err != nil {
+		return "", schema.GroupVersionKind{}, err
+	}
+	i, err := o.askerClient.SelectWorkloadResource(options)
+	if err != nil {
+		return "", schema.GroupVersionKind{}, err
+	}
+	selectedGVK := allWorkloadsKinds[i]
+
+	// Get the resources of this kind
+	gvr, err := o.kubernetesClient.GetGVRFromGVK(selectedGVK)
+	if err != nil {
+		return "", schema.GroupVersionKind{}, err
+	}
+	resourceList, err := o.kubernetesClient.ListDynamicResources(gvr)
+	if err != nil {
+		return "", schema.GroupVersionKind{}, err
+	}
+
+	// Ask to select the name of the resource
+	names := make([]string, 0, len(resourceList.Items))
+	for _, resource := range resourceList.Items {
+		names = append(names, resource.GetName())
+	}
+	name, err := o.askerClient.SelectWorkloadResourceName(names)
+	if err != nil {
+		return "", schema.GroupVersionKind{}, err
+	}
+
+	// Ask the name if DOES NOT EXIST is selected
+	if name == "" {
+		name, err = o.askerClient.AskWorkloadResourceName()
+		if err != nil {
+			return "", schema.GroupVersionKind{}, err
+		}
+	}
+	return name, selectedGVK, nil
 }
 
 func (o *InteractiveBackend) SelectServiceInstance(_ string, serviceMap map[string]unstructured.Unstructured) (string, error) {
@@ -35,4 +82,12 @@ func (o *InteractiveBackend) AskBindingName(defaultName string, _ map[string]str
 
 func (o *InteractiveBackend) AskBindAsFiles(_ map[string]string) (bool, error) {
 	return o.askerClient.AskBindAsFiles()
+}
+
+func (o *InteractiveBackend) SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error) {
+	return o.askerClient.SelectCreationOption()
+}
+
+func (o *InteractiveBackend) AskOutputFilePath(flags map[string]string, defaultValue string) (string, error) {
+	return o.askerClient.AskOutputFilePath(defaultValue)
 }

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -113,7 +113,7 @@ func (o *InteractiveBackend) AskBindAsFiles(_ map[string]string) (bool, error) {
 }
 
 func (o *InteractiveBackend) SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error) {
-	return o.askerClient.SelectCreationOption()
+	return o.askerClient.SelectCreationOptions()
 }
 
 func (o *InteractiveBackend) AskOutputFilePath(flags map[string]string, defaultValue string) (string, error) {

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -29,7 +29,7 @@ func NewInteractiveBackend(askerClient asker.Asker, kubernetesClient kclient.Cli
 	}
 }
 
-func (o *InteractiveBackend) Validate(_ map[string]string) error {
+func (o *InteractiveBackend) Validate(_ map[string]string, _ bool) error {
 	return nil
 }
 

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -33,7 +33,7 @@ func (o *InteractiveBackend) Validate(_ map[string]string, _ bool) error {
 	return nil
 }
 
-func (o *InteractiveBackend) SelectWorkloadInstance(workloadName string) (string, schema.GroupVersionKind, error) {
+func (o *InteractiveBackend) SelectWorkloadInstance(_ string) (string, schema.GroupVersionKind, error) {
 
 	step := step_select_kind
 	var selectedGVK schema.GroupVersionKind

--- a/pkg/binding/backend/interface.go
+++ b/pkg/binding/backend/interface.go
@@ -1,12 +1,17 @@
 package backend
 
 import (
+	"github.com/redhat-developer/odo/pkg/binding/asker"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type AddBindingBackend interface {
 	// Validate returns error if the backend failed to validate; mainly useful for flags backend
 	Validate(flags map[string]string) error
+	// SelectWorkloadInstance asks user to select the workload to be bind;
+	// it returns the workload name in the form of '<name> (<kind>.<apigroup>)'
+	SelectWorkloadInstance(workloadName string) (string, schema.GroupVersionKind, error)
 	// SelectServiceInstance asks user to select the service to be bound to the component;
 	// it returns the service name in the form of '<name> (<kind>.<apigroup>)'
 	SelectServiceInstance(serviceName string, serviceMap map[string]unstructured.Unstructured) (string, error)
@@ -14,4 +19,8 @@ type AddBindingBackend interface {
 	AskBindingName(defaultName string, flags map[string]string) (string, error)
 	// AskBindAsFiles asks if service should be binded as files
 	AskBindAsFiles(flags map[string]string) (bool, error)
+	// SelectCreationOption asks to select how to output the created servicebinding
+	SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error)
+	// AskOutputFilePath asks for the path of the file to output service binding
+	AskOutputFilePath(flags map[string]string, defaultValue string) (string, error)
 }

--- a/pkg/binding/backend/interface.go
+++ b/pkg/binding/backend/interface.go
@@ -8,7 +8,7 @@ import (
 
 type AddBindingBackend interface {
 	// Validate returns error if the backend failed to validate; mainly useful for flags backend
-	Validate(flags map[string]string) error
+	Validate(flags map[string]string, withDevfile bool) error
 	// SelectWorkloadInstance asks user to select the workload to be bind;
 	// it returns the workload name in the form of '<name> (<kind>.<apigroup>)'
 	SelectWorkloadInstance(workloadName string) (string, schema.GroupVersionKind, error)

--- a/pkg/binding/backend/mock.go
+++ b/pkg/binding/backend/mock.go
@@ -8,7 +8,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	asker "github.com/redhat-developer/odo/pkg/binding/asker"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // MockAddBindingBackend is a mock of AddBindingBackend interface.
@@ -64,6 +66,21 @@ func (mr *MockAddBindingBackendMockRecorder) AskBindingName(defaultName, flags i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskBindingName", reflect.TypeOf((*MockAddBindingBackend)(nil).AskBindingName), defaultName, flags)
 }
 
+// SelectCreationOption mocks base method.
+func (m *MockAddBindingBackend) SelectCreationOption(flags map[string]string) (asker.CreationOption, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectCreationOption", flags)
+	ret0, _ := ret[0].(asker.CreationOption)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectCreationOption indicates an expected call of SelectCreationOption.
+func (mr *MockAddBindingBackendMockRecorder) SelectCreationOption(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectCreationOption", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectCreationOption), flags)
+}
+
 // SelectServiceInstance mocks base method.
 func (m *MockAddBindingBackend) SelectServiceInstance(serviceName string, serviceMap map[string]unstructured.Unstructured) (string, error) {
 	m.ctrl.T.Helper()
@@ -77,6 +94,22 @@ func (m *MockAddBindingBackend) SelectServiceInstance(serviceName string, servic
 func (mr *MockAddBindingBackendMockRecorder) SelectServiceInstance(serviceName, serviceMap interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectServiceInstance", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectServiceInstance), serviceName, serviceMap)
+}
+
+// SelectWorkloadInstance mocks base method.
+func (m *MockAddBindingBackend) SelectWorkloadInstance(workloadName string) (string, schema.GroupVersionKind, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectWorkloadInstance", workloadName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(schema.GroupVersionKind)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SelectWorkloadInstance indicates an expected call of SelectWorkloadInstance.
+func (mr *MockAddBindingBackendMockRecorder) SelectWorkloadInstance(workloadName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectWorkloadInstance", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectWorkloadInstance), workloadName)
 }
 
 // Validate mocks base method.

--- a/pkg/binding/backend/mock.go
+++ b/pkg/binding/backend/mock.go
@@ -66,19 +66,34 @@ func (mr *MockAddBindingBackendMockRecorder) AskBindingName(defaultName, flags i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskBindingName", reflect.TypeOf((*MockAddBindingBackend)(nil).AskBindingName), defaultName, flags)
 }
 
-// SelectCreationOption mocks base method.
-func (m *MockAddBindingBackend) SelectCreationOption(flags map[string]string) (asker.CreationOption, error) {
+// AskOutputFilePath mocks base method.
+func (m *MockAddBindingBackend) AskOutputFilePath(flags map[string]string, defaultValue string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectCreationOption", flags)
-	ret0, _ := ret[0].(asker.CreationOption)
+	ret := m.ctrl.Call(m, "AskOutputFilePath", flags, defaultValue)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SelectCreationOption indicates an expected call of SelectCreationOption.
-func (mr *MockAddBindingBackendMockRecorder) SelectCreationOption(flags interface{}) *gomock.Call {
+// AskOutputFilePath indicates an expected call of AskOutputFilePath.
+func (mr *MockAddBindingBackendMockRecorder) AskOutputFilePath(flags, defaultValue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectCreationOption", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectCreationOption), flags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskOutputFilePath", reflect.TypeOf((*MockAddBindingBackend)(nil).AskOutputFilePath), flags, defaultValue)
+}
+
+// SelectCreationOptions mocks base method.
+func (m *MockAddBindingBackend) SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectCreationOptions", flags)
+	ret0, _ := ret[0].([]asker.CreationOption)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectCreationOptions indicates an expected call of SelectCreationOptions.
+func (mr *MockAddBindingBackendMockRecorder) SelectCreationOptions(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectCreationOptions", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectCreationOptions), flags)
 }
 
 // SelectServiceInstance mocks base method.
@@ -113,15 +128,15 @@ func (mr *MockAddBindingBackendMockRecorder) SelectWorkloadInstance(workloadName
 }
 
 // Validate mocks base method.
-func (m *MockAddBindingBackend) Validate(flags map[string]string) error {
+func (m *MockAddBindingBackend) Validate(flags map[string]string, withDevfile bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", flags)
+	ret := m.ctrl.Call(m, "Validate", flags, withDevfile)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockAddBindingBackendMockRecorder) Validate(flags interface{}) *gomock.Call {
+func (mr *MockAddBindingBackendMockRecorder) Validate(flags, withDevfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockAddBindingBackend)(nil).Validate), flags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockAddBindingBackend)(nil).Validate), flags, withDevfile)
 }

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -39,7 +39,7 @@ func NewBindingClient(kubernetesClient kclient.ClientInterface) *BindingClient {
 	askerClient := asker.NewSurveyAsker()
 	return &BindingClient{
 		flagsBackend:       backendpkg.NewFlagsBackend(),
-		interactiveBackend: backendpkg.NewInteractiveBackend(askerClient),
+		interactiveBackend: backendpkg.NewInteractiveBackend(askerClient, kubernetesClient),
 		kubernetesClient:   kubernetesClient,
 	}
 }
@@ -49,7 +49,10 @@ func NewBindingClient(kubernetesClient kclient.ClientInterface) *BindingClient {
 func (o *BindingClient) GetFlags(flags map[string]string) map[string]string {
 	bindingFlags := map[string]string{}
 	for flag, value := range flags {
-		if flag == backendpkg.FLAG_NAME || flag == backendpkg.FLAG_SERVICE || flag == backendpkg.FLAG_BIND_AS_FILES {
+		if flag == backendpkg.FLAG_NAME ||
+			flag == backendpkg.FLAG_WORKLOAD ||
+			flag == backendpkg.FLAG_SERVICE ||
+			flag == backendpkg.FLAG_BIND_AS_FILES {
 			bindingFlags[flag] = value
 		}
 	}

--- a/pkg/binding/interface.go
+++ b/pkg/binding/interface.go
@@ -3,6 +3,7 @@ package binding
 import (
 	"github.com/devfile/library/pkg/devfile/parser"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/redhat-developer/odo/pkg/api"
 )
@@ -23,12 +24,16 @@ type Client interface {
 	ValidateAddBinding(flags map[string]string) error
 	// SelectServiceInstance returns the service to bind to the component
 	SelectServiceInstance(flags map[string]string, serviceMap map[string]unstructured.Unstructured) (string, error)
+	// SelectWorkloadInstance returns the workload to bind, when a devfile is not in use
+	SelectWorkloadInstance(flags map[string]string) (string, schema.GroupVersionKind, error)
 	// AskBindingName returns the name to be set for the binding
 	AskBindingName(serviceName, componentName string, flags map[string]string) (string, error)
 	// AskBindAsFiles asks if the service should be bound as files
 	AskBindAsFiles(flags map[string]string) (bool, error)
-	// AddBinding adds the ServiceBinding manifest to the devfile
-	AddBinding(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error)
+	// AddBindingToDevfile adds the ServiceBinding manifest to the devfile
+	AddBindingToDevfile(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error)
+	// AddBinding creates a binding in stdout, file, cluster
+	AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) error
 
 	// list.go
 

--- a/pkg/binding/interface.go
+++ b/pkg/binding/interface.go
@@ -21,7 +21,7 @@ type Client interface {
 	// add.go
 
 	// ValidateAddBinding returns error if the backend failed to validate; mainly useful for flags backend
-	ValidateAddBinding(flags map[string]string) error
+	ValidateAddBinding(flags map[string]string, withDevfile bool) error
 	// SelectServiceInstance returns the service to bind to the component
 	SelectServiceInstance(flags map[string]string, serviceMap map[string]unstructured.Unstructured) (string, error)
 	// SelectWorkloadInstance returns the workload to bind, when a devfile is not in use

--- a/pkg/binding/interface.go
+++ b/pkg/binding/interface.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/redhat-developer/odo/pkg/api"
+	"github.com/redhat-developer/odo/pkg/binding/asker"
 )
 
 type Client interface {
@@ -21,6 +22,7 @@ type Client interface {
 	// add.go
 
 	// ValidateAddBinding returns error if the backend failed to validate; mainly useful for flags backend
+	// withDevfile indicates if a Devfile is present in the current directory
 	ValidateAddBinding(flags map[string]string, withDevfile bool) error
 	// SelectServiceInstance returns the service to bind to the component
 	SelectServiceInstance(flags map[string]string, serviceMap map[string]unstructured.Unstructured) (string, error)
@@ -32,8 +34,17 @@ type Client interface {
 	AskBindAsFiles(flags map[string]string) (bool, error)
 	// AddBindingToDevfile adds the ServiceBinding manifest to the devfile
 	AddBindingToDevfile(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error)
-	// AddBinding creates a binding in stdout, file, cluster
-	AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) error
+	// AddBinding creates a binding in file and cluster (if options selected)
+	// and returns the selected options, the binding definition as string (if option selected)
+	// and the filename where definition is written (if options selected)
+	AddBinding(
+		flags map[string]string,
+		bindingName string,
+		bindAsFiles bool,
+		unstructuredService unstructured.Unstructured,
+		workloadName string,
+		workloadGVK schema.GroupVersionKind,
+	) (selectedOptions []asker.CreationOption, bindingDef string, filename string, err error)
 
 	// list.go
 

--- a/pkg/binding/list_test.go
+++ b/pkg/binding/list_test.go
@@ -42,7 +42,7 @@ var bindingServiceBinding = kclient.NewServiceBindingObject(
 	"my-nodejs-app-cluster-sample",
 	true,
 	"my-nodejs-app-app",
-	deploymentGVR,
+	deploymentGVK,
 	nil,
 	[]v1alpha1.Service{
 		{

--- a/pkg/binding/mock.go
+++ b/pkg/binding/mock.go
@@ -218,17 +218,17 @@ func (mr *MockClientMockRecorder) SelectWorkloadInstance(flags interface{}) *gom
 }
 
 // ValidateAddBinding mocks base method.
-func (m *MockClient) ValidateAddBinding(flags map[string]string) error {
+func (m *MockClient) ValidateAddBinding(flags map[string]string, withDevfile bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAddBinding", flags)
+	ret := m.ctrl.Call(m, "ValidateAddBinding", flags, withDevfile)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateAddBinding indicates an expected call of ValidateAddBinding.
-func (mr *MockClientMockRecorder) ValidateAddBinding(flags interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ValidateAddBinding(flags, withDevfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAddBinding", reflect.TypeOf((*MockClient)(nil).ValidateAddBinding), flags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAddBinding", reflect.TypeOf((*MockClient)(nil).ValidateAddBinding), flags, withDevfile)
 }
 
 // ValidateRemoveBinding mocks base method.

--- a/pkg/binding/mock.go
+++ b/pkg/binding/mock.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	api "github.com/redhat-developer/odo/pkg/api"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,18 +38,32 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddBinding mocks base method.
-func (m *MockClient) AddBinding(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
+func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBinding", bindingName, bindAsFiles, unstructuredService, obj)
+	ret := m.ctrl.Call(m, "AddBinding", flags, bindingName, bindAsFiles, unstructuredService, workloadName, workloadGVK)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddBinding indicates an expected call of AddBinding.
+func (mr *MockClientMockRecorder) AddBinding(flags, bindingName, bindAsFiles, unstructuredService, workloadName, workloadGVK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinding", reflect.TypeOf((*MockClient)(nil).AddBinding), flags, bindingName, bindAsFiles, unstructuredService, workloadName, workloadGVK)
+}
+
+// AddBindingToDevfile mocks base method.
+func (m *MockClient) AddBindingToDevfile(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddBindingToDevfile", bindingName, bindAsFiles, unstructuredService, obj)
 	ret0, _ := ret[0].(parser.DevfileObj)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AddBinding indicates an expected call of AddBinding.
-func (mr *MockClientMockRecorder) AddBinding(bindingName, bindAsFiles, unstructuredService, obj interface{}) *gomock.Call {
+// AddBindingToDevfile indicates an expected call of AddBindingToDevfile.
+func (mr *MockClientMockRecorder) AddBindingToDevfile(bindingName, bindAsFiles, unstructuredService, obj interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinding", reflect.TypeOf((*MockClient)(nil).AddBinding), bindingName, bindAsFiles, unstructuredService, obj)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindingToDevfile", reflect.TypeOf((*MockClient)(nil).AddBindingToDevfile), bindingName, bindAsFiles, unstructuredService, obj)
 }
 
 // AskBindAsFiles mocks base method.
@@ -184,6 +199,22 @@ func (m *MockClient) SelectServiceInstance(flags map[string]string, serviceMap m
 func (mr *MockClientMockRecorder) SelectServiceInstance(flags, serviceMap interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectServiceInstance", reflect.TypeOf((*MockClient)(nil).SelectServiceInstance), flags, serviceMap)
+}
+
+// SelectWorkloadInstance mocks base method.
+func (m *MockClient) SelectWorkloadInstance(flags map[string]string) (string, schema.GroupVersionKind, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectWorkloadInstance", flags)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(schema.GroupVersionKind)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SelectWorkloadInstance indicates an expected call of SelectWorkloadInstance.
+func (mr *MockClientMockRecorder) SelectWorkloadInstance(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectWorkloadInstance", reflect.TypeOf((*MockClient)(nil).SelectWorkloadInstance), flags)
 }
 
 // ValidateAddBinding mocks base method.

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -7,6 +7,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/api"
 	bindingApi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 	specApi "github.com/redhat-developer/service-binding-operator/apis/spec/v1alpha3"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -19,6 +20,11 @@ const (
 	ServiceBindingKind    = "ServiceBinding"
 	BindableKindsResource = "bindablekinds"
 )
+
+var WorkloadKinds = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind("Deployment"),
+	appsv1.SchemeGroupVersion.WithKind("StatefulSet"),
+}
 
 // IsServiceBindingSupported checks if resource of type service binding request present on the cluster
 func (c *Client) IsServiceBindingSupported() (bool, error) {
@@ -102,7 +108,7 @@ func NewServiceBindingObject(
 	bindingName string,
 	bindAsFiles bool,
 	deploymentName string,
-	deploymentGVR schema.GroupVersionResource,
+	deploymentGVK schema.GroupVersionKind,
 	mappings []bindingApi.Mapping,
 	services []bindingApi.Service,
 	status bindingApi.ServiceBindingStatus,
@@ -120,10 +126,10 @@ func NewServiceBindingObject(
 			BindAsFiles:            bindAsFiles,
 			Application: bindingApi.Application{
 				Ref: bindingApi.Ref{
-					Name:     deploymentName,
-					Group:    deploymentGVR.Group,
-					Version:  deploymentGVR.Version,
-					Resource: deploymentGVR.Resource,
+					Name:    deploymentName,
+					Group:   deploymentGVK.Group,
+					Version: deploymentGVK.Version,
+					Kind:    deploymentGVK.Kind,
 				},
 			},
 			Mappings: mappings,

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -301,6 +301,7 @@ func (c Client) APIServiceBindingFromSpec(spec specApi.ServiceBinding) api.Servi
 
 // GetWorkloadKinds returns all the workload kinds present in the cluster
 // It considers that all native resources are present and tests only for custom resources
+// Returns an array of Kinds and an array of GVKs
 func (c Client) GetWorkloadKinds() ([]string, []schema.GroupVersionKind, error) {
 	var allWorkloadsKinds = []schema.GroupVersionKind{}
 	var options []string

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -292,25 +292,25 @@ func (c *Client) removeDuplicateEnv(deploymentName string) error {
 
 // GetDeploymentAPIVersion returns a map with Group, Version, Resource information of Deployment objects
 // depending on the GVR supported by the cluster
-func (c *Client) GetDeploymentAPIVersion() (schema.GroupVersionResource, error) {
+func (c *Client) GetDeploymentAPIVersion() (schema.GroupVersionKind, error) {
 	extV1Beta1, err := c.IsDeploymentExtensionsV1Beta1()
 	if err != nil {
-		return schema.GroupVersionResource{}, err
+		return schema.GroupVersionKind{}, err
 	}
 
 	if extV1Beta1 {
 		// this indicates we're running on OCP 3.11 cluster
-		return schema.GroupVersionResource{
-			Group:    "extensions",
-			Version:  "v1beta1",
-			Resource: "deployments",
+		return schema.GroupVersionKind{
+			Group:   "extensions",
+			Version: "v1beta1",
+			Kind:    "Deployment",
 		}, nil
 	}
 
-	return schema.GroupVersionResource{
-		Group:    "apps",
-		Version:  "v1",
-		Resource: "deployments",
+	return schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
 	}, nil
 }
 

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -40,6 +40,7 @@ type ClientInterface interface {
 	NewServiceBindingServiceObject(unstructuredService unstructured.Unstructured, bindingName string) (bindingApi.Service, error)
 	APIServiceBindingFromBinding(binding bindingApi.ServiceBinding) (api.ServiceBinding, error)
 	APIServiceBindingFromSpec(spec specApi.ServiceBinding) api.ServiceBinding
+	GetWorkloadKinds() ([]string, []schema.GroupVersionKind, error)
 
 	// deployment.go
 	GetDeploymentByName(name string) (*appsv1.Deployment, error)
@@ -98,6 +99,7 @@ type ClientInterface interface {
 	GetRestMappingFromGVK(gvk schema.GroupVersionKind) (*meta.RESTMapping, error)
 	GetOperatorGVRList() ([]meta.RESTMapping, error)
 	GetGVKFromGVR(gvr schema.GroupVersionResource) (schema.GroupVersionKind, error)
+	GetGVRFromGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error)
 
 	// owner_reference.go
 	TryWithBlockOwnerDeletion(ownerReference metav1.OwnerReference, exec func(ownerReference metav1.OwnerReference) error) error

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -51,7 +51,7 @@ type ClientInterface interface {
 	CreateDeployment(deploy appsv1.Deployment) (*appsv1.Deployment, error)
 	UpdateDeployment(deploy appsv1.Deployment) (*appsv1.Deployment, error)
 	ApplyDeployment(deploy appsv1.Deployment) (*appsv1.Deployment, error)
-	GetDeploymentAPIVersion() (schema.GroupVersionResource, error)
+	GetDeploymentAPIVersion() (schema.GroupVersionKind, error)
 	IsDeploymentExtensionsV1Beta1() (bool, error)
 
 	// dynamic.go

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -633,6 +633,21 @@ func (mr *MockClientInterfaceMockRecorder) GetGVKFromGVR(gvr interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGVKFromGVR", reflect.TypeOf((*MockClientInterface)(nil).GetGVKFromGVR), gvr)
 }
 
+// GetGVRFromGVK mocks base method.
+func (m *MockClientInterface) GetGVRFromGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGVRFromGVK", gvk)
+	ret0, _ := ret[0].(schema.GroupVersionResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGVRFromGVK indicates an expected call of GetGVRFromGVK.
+func (mr *MockClientInterfaceMockRecorder) GetGVRFromGVK(gvk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGVRFromGVK", reflect.TypeOf((*MockClientInterface)(nil).GetGVRFromGVK), gvk)
+}
+
 // GetNamespace mocks base method.
 func (m *MockClientInterface) GetNamespace(name string) (*v11.Namespace, error) {
 	m.ctrl.T.Helper()
@@ -916,6 +931,22 @@ func (m *MockClientInterface) GetSpecServiceBinding(name string) (v1alpha3.Servi
 func (mr *MockClientInterfaceMockRecorder) GetSpecServiceBinding(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpecServiceBinding", reflect.TypeOf((*MockClientInterface)(nil).GetSpecServiceBinding), name)
+}
+
+// GetWorkloadKinds mocks base method.
+func (m *MockClientInterface) GetWorkloadKinds() ([]string, []schema.GroupVersionKind, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkloadKinds")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].([]schema.GroupVersionKind)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetWorkloadKinds indicates an expected call of GetWorkloadKinds.
+func (mr *MockClientInterfaceMockRecorder) GetWorkloadKinds() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadKinds", reflect.TypeOf((*MockClientInterface)(nil).GetWorkloadKinds))
 }
 
 // IsCSVSupported mocks base method.

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -545,10 +545,10 @@ func (mr *MockClientInterfaceMockRecorder) GetCustomResourcesFromCSV(csv interfa
 }
 
 // GetDeploymentAPIVersion mocks base method.
-func (m *MockClientInterface) GetDeploymentAPIVersion() (schema.GroupVersionResource, error) {
+func (m *MockClientInterface) GetDeploymentAPIVersion() (schema.GroupVersionKind, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeploymentAPIVersion")
-	ret0, _ := ret[0].(schema.GroupVersionResource)
+	ret0, _ := ret[0].(schema.GroupVersionKind)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -211,6 +211,21 @@ func (c *Client) GetGVKFromGVR(gvr schema.GroupVersionResource) (schema.GroupVer
 	return mapper.KindFor(gvr)
 }
 
+func (c *Client) GetGVRFromGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	cfg := c.GetClientConfig()
+
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
+}
+
 // GetOperatorGVRList creates a slice of rest mappings that are provided by Operators (CSV)
 func (c *Client) GetOperatorGVRList() ([]meta.RESTMapping, error) {
 	var operatorGVRList []meta.RESTMapping

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -11,9 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/restmapper"
 
 	"github.com/go-openapi/spec"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -175,51 +172,19 @@ func addParam(schema *spec.Schema, param olm.SpecDescriptor) {
 // GetRestMappingFromUnstructured returns rest mappings from unstructured data
 func (c *Client) GetRestMappingFromUnstructured(u unstructured.Unstructured) (*meta.RESTMapping, error) {
 	gvk := u.GroupVersionKind()
-
-	cfg := c.GetClientConfig()
-
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return &meta.RESTMapping{}, err
-	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-
-	return mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	return c.restmapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }
 
 func (c *Client) GetRestMappingFromGVK(gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
-	// TODO: Remove GetRestMappingFromUnstructured, use GetRestMappingFromGVK instead
-	cfg := c.GetClientConfig()
-
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return &meta.RESTMapping{}, err
-	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-
-	return mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	return c.restmapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }
 
 func (c *Client) GetGVKFromGVR(gvr schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	cfg := c.GetClientConfig()
-
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return schema.GroupVersionKind{}, err
-	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-	return mapper.KindFor(gvr)
+	return c.restmapper.KindFor(gvr)
 }
 
 func (c *Client) GetGVRFromGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
-	cfg := c.GetClientConfig()
-
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return schema.GroupVersionResource{}, err
-	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	mapping, err := c.restmapper.RESTMapping(gvk.GroupKind())
 	if err != nil {
 		return schema.GroupVersionResource{}, err
 	}

--- a/pkg/odo/cli/add/binding/binding.go
+++ b/pkg/odo/cli/add/binding/binding.go
@@ -37,6 +37,7 @@ var addBindingExample = ktemplates.Examples(`
 
 # Add binding between service named 'myservice' of kind 'Redis' and the deployment app (without Devfile)
 %[1]s --service myservice/Redis --name myRedisService --workload app/Deployment.apps
+%[1]s --service myservice/Redis --name myRedisService --workload app.Deployment.apps
 `)
 
 type AddBindingOptions struct {

--- a/pkg/odo/cli/add/binding/binding.go
+++ b/pkg/odo/cli/add/binding/binding.go
@@ -35,6 +35,8 @@ var addBindingExample = ktemplates.Examples(`
 
 %[1]s --service myservice.Redis --name myRedisService
 
+# Add binding between service named 'myservice' of kind 'Redis' and the deployment app (without Devfile)
+%[1]s --service myservice/Redis --name myRedisService --workload app/Deployment.apps
 `)
 
 type AddBindingOptions struct {
@@ -73,7 +75,8 @@ func (o *AddBindingOptions) Complete(cmdline cmdline.Cmdline, args []string) (er
 }
 
 func (o *AddBindingOptions) Validate() (err error) {
-	return o.clientset.BindingClient.ValidateAddBinding(o.flags)
+	withDevfile := o.EnvSpecificInfo.GetDevfileObj().Data != nil
+	return o.clientset.BindingClient.ValidateAddBinding(o.flags, withDevfile)
 }
 
 func (o *AddBindingOptions) Run(_ context.Context) error {

--- a/pkg/preference/mock.go
+++ b/pkg/preference/mock.go
@@ -5,245 +5,36 @@
 package preference
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// IsSet mocks base method
-func (m *MockClient) IsSet(parameter string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsSet", parameter)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsSet indicates an expected call of IsSet
-func (mr *MockClientMockRecorder) IsSet(parameter interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSet", reflect.TypeOf((*MockClient)(nil).IsSet), parameter)
-}
-
-// SetConfiguration mocks base method
-func (m *MockClient) SetConfiguration(parameter, value string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfiguration", parameter, value)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetConfiguration indicates an expected call of SetConfiguration
-func (mr *MockClientMockRecorder) SetConfiguration(parameter, value interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfiguration", reflect.TypeOf((*MockClient)(nil).SetConfiguration), parameter, value)
-}
-
-// DeleteConfiguration mocks base method
-func (m *MockClient) DeleteConfiguration(parameter string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteConfiguration", parameter)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteConfiguration indicates an expected call of DeleteConfiguration
-func (mr *MockClientMockRecorder) DeleteConfiguration(parameter interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteConfiguration", reflect.TypeOf((*MockClient)(nil).DeleteConfiguration), parameter)
-}
-
-// GetUpdateNotification mocks base method
-func (m *MockClient) GetUpdateNotification() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUpdateNotification")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// GetUpdateNotification indicates an expected call of GetUpdateNotification
-func (mr *MockClientMockRecorder) GetUpdateNotification() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateNotification", reflect.TypeOf((*MockClient)(nil).GetUpdateNotification))
-}
-
-// GetTimeout mocks base method
-func (m *MockClient) GetTimeout() time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTimeout")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// GetTimeout indicates an expected call of GetTimeout
-func (mr *MockClientMockRecorder) GetTimeout() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeout", reflect.TypeOf((*MockClient)(nil).GetTimeout))
-}
-
-// GetPushTimeout mocks base method
-func (m *MockClient) GetPushTimeout() time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPushTimeout")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// GetPushTimeout indicates an expected call of GetPushTimeout
-func (mr *MockClientMockRecorder) GetPushTimeout() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPushTimeout", reflect.TypeOf((*MockClient)(nil).GetPushTimeout))
-}
-
-// GetEphemeralSourceVolume mocks base method
-func (m *MockClient) GetEphemeralSourceVolume() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEphemeralSourceVolume")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// GetEphemeralSourceVolume indicates an expected call of GetEphemeralSourceVolume
-func (mr *MockClientMockRecorder) GetEphemeralSourceVolume() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEphemeralSourceVolume", reflect.TypeOf((*MockClient)(nil).GetEphemeralSourceVolume))
-}
-
-// GetConsentTelemetry mocks base method
-func (m *MockClient) GetConsentTelemetry() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConsentTelemetry")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// GetConsentTelemetry indicates an expected call of GetConsentTelemetry
-func (mr *MockClientMockRecorder) GetConsentTelemetry() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsentTelemetry", reflect.TypeOf((*MockClient)(nil).GetConsentTelemetry))
-}
-
-// GetRegistryCacheTime mocks base method
-func (m *MockClient) GetRegistryCacheTime() time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegistryCacheTime")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// GetRegistryCacheTime indicates an expected call of GetRegistryCacheTime
-func (mr *MockClientMockRecorder) GetRegistryCacheTime() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistryCacheTime", reflect.TypeOf((*MockClient)(nil).GetRegistryCacheTime))
-}
-
-// RegistryHandler mocks base method
-func (m *MockClient) RegistryHandler(operation, registryName, registryURL string, forceFlag, isSecure bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegistryHandler", operation, registryName, registryURL, forceFlag, isSecure)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegistryHandler indicates an expected call of RegistryHandler
-func (mr *MockClientMockRecorder) RegistryHandler(operation, registryName, registryURL, forceFlag, isSecure interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryHandler", reflect.TypeOf((*MockClient)(nil).RegistryHandler), operation, registryName, registryURL, forceFlag, isSecure)
-}
-
-// UpdateNotification mocks base method
-func (m *MockClient) UpdateNotification() *bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNotification")
-	ret0, _ := ret[0].(*bool)
-	return ret0
-}
-
-// UpdateNotification indicates an expected call of UpdateNotification
-func (mr *MockClientMockRecorder) UpdateNotification() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNotification", reflect.TypeOf((*MockClient)(nil).UpdateNotification))
-}
-
-// Timeout mocks base method
-func (m *MockClient) Timeout() *time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Timeout")
-	ret0, _ := ret[0].(*time.Duration)
-	return ret0
-}
-
-// Timeout indicates an expected call of Timeout
-func (mr *MockClientMockRecorder) Timeout() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timeout", reflect.TypeOf((*MockClient)(nil).Timeout))
-}
-
-// PushTimeout mocks base method
-func (m *MockClient) PushTimeout() *time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PushTimeout")
-	ret0, _ := ret[0].(*time.Duration)
-	return ret0
-}
-
-// PushTimeout indicates an expected call of PushTimeout
-func (mr *MockClientMockRecorder) PushTimeout() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushTimeout", reflect.TypeOf((*MockClient)(nil).PushTimeout))
-}
-
-// RegistryCacheTime mocks base method
-func (m *MockClient) RegistryCacheTime() *time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegistryCacheTime")
-	ret0, _ := ret[0].(*time.Duration)
-	return ret0
-}
-
-// RegistryCacheTime indicates an expected call of RegistryCacheTime
-func (mr *MockClientMockRecorder) RegistryCacheTime() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryCacheTime", reflect.TypeOf((*MockClient)(nil).RegistryCacheTime))
-}
-
-// EphemeralSourceVolume mocks base method
-func (m *MockClient) EphemeralSourceVolume() *bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EphemeralSourceVolume")
-	ret0, _ := ret[0].(*bool)
-	return ret0
-}
-
-// EphemeralSourceVolume indicates an expected call of EphemeralSourceVolume
-func (mr *MockClientMockRecorder) EphemeralSourceVolume() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EphemeralSourceVolume", reflect.TypeOf((*MockClient)(nil).EphemeralSourceVolume))
-}
-
-// ConsentTelemetry mocks base method
+// ConsentTelemetry mocks base method.
 func (m *MockClient) ConsentTelemetry() *bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsentTelemetry")
@@ -251,41 +42,139 @@ func (m *MockClient) ConsentTelemetry() *bool {
 	return ret0
 }
 
-// ConsentTelemetry indicates an expected call of ConsentTelemetry
+// ConsentTelemetry indicates an expected call of ConsentTelemetry.
 func (mr *MockClientMockRecorder) ConsentTelemetry() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsentTelemetry", reflect.TypeOf((*MockClient)(nil).ConsentTelemetry))
 }
 
-// RegistryList mocks base method
-func (m *MockClient) RegistryList() *[]Registry {
+// DeleteConfiguration mocks base method.
+func (m *MockClient) DeleteConfiguration(parameter string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegistryList")
-	ret0, _ := ret[0].(*[]Registry)
+	ret := m.ctrl.Call(m, "DeleteConfiguration", parameter)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RegistryList indicates an expected call of RegistryList
-func (mr *MockClientMockRecorder) RegistryList() *gomock.Call {
+// DeleteConfiguration indicates an expected call of DeleteConfiguration.
+func (mr *MockClientMockRecorder) DeleteConfiguration(parameter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryList", reflect.TypeOf((*MockClient)(nil).RegistryList))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteConfiguration", reflect.TypeOf((*MockClient)(nil).DeleteConfiguration), parameter)
 }
 
-// RegistryNameExists mocks base method
-func (m *MockClient) RegistryNameExists(name string) bool {
+// EphemeralSourceVolume mocks base method.
+func (m *MockClient) EphemeralSourceVolume() *bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegistryNameExists", name)
+	ret := m.ctrl.Call(m, "EphemeralSourceVolume")
+	ret0, _ := ret[0].(*bool)
+	return ret0
+}
+
+// EphemeralSourceVolume indicates an expected call of EphemeralSourceVolume.
+func (mr *MockClientMockRecorder) EphemeralSourceVolume() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EphemeralSourceVolume", reflect.TypeOf((*MockClient)(nil).EphemeralSourceVolume))
+}
+
+// GetConsentTelemetry mocks base method.
+func (m *MockClient) GetConsentTelemetry() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConsentTelemetry")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// RegistryNameExists indicates an expected call of RegistryNameExists
-func (mr *MockClientMockRecorder) RegistryNameExists(name interface{}) *gomock.Call {
+// GetConsentTelemetry indicates an expected call of GetConsentTelemetry.
+func (mr *MockClientMockRecorder) GetConsentTelemetry() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryNameExists", reflect.TypeOf((*MockClient)(nil).RegistryNameExists), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsentTelemetry", reflect.TypeOf((*MockClient)(nil).GetConsentTelemetry))
 }
 
-// NewPreferenceList mocks base method
+// GetEphemeralSourceVolume mocks base method.
+func (m *MockClient) GetEphemeralSourceVolume() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEphemeralSourceVolume")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetEphemeralSourceVolume indicates an expected call of GetEphemeralSourceVolume.
+func (mr *MockClientMockRecorder) GetEphemeralSourceVolume() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEphemeralSourceVolume", reflect.TypeOf((*MockClient)(nil).GetEphemeralSourceVolume))
+}
+
+// GetPushTimeout mocks base method.
+func (m *MockClient) GetPushTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPushTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetPushTimeout indicates an expected call of GetPushTimeout.
+func (mr *MockClientMockRecorder) GetPushTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPushTimeout", reflect.TypeOf((*MockClient)(nil).GetPushTimeout))
+}
+
+// GetRegistryCacheTime mocks base method.
+func (m *MockClient) GetRegistryCacheTime() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegistryCacheTime")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetRegistryCacheTime indicates an expected call of GetRegistryCacheTime.
+func (mr *MockClientMockRecorder) GetRegistryCacheTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistryCacheTime", reflect.TypeOf((*MockClient)(nil).GetRegistryCacheTime))
+}
+
+// GetTimeout mocks base method.
+func (m *MockClient) GetTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetTimeout indicates an expected call of GetTimeout.
+func (mr *MockClientMockRecorder) GetTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeout", reflect.TypeOf((*MockClient)(nil).GetTimeout))
+}
+
+// GetUpdateNotification mocks base method.
+func (m *MockClient) GetUpdateNotification() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpdateNotification")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetUpdateNotification indicates an expected call of GetUpdateNotification.
+func (mr *MockClientMockRecorder) GetUpdateNotification() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateNotification", reflect.TypeOf((*MockClient)(nil).GetUpdateNotification))
+}
+
+// IsSet mocks base method.
+func (m *MockClient) IsSet(parameter string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSet", parameter)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSet indicates an expected call of IsSet.
+func (mr *MockClientMockRecorder) IsSet(parameter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSet", reflect.TypeOf((*MockClient)(nil).IsSet), parameter)
+}
+
+// NewPreferenceList mocks base method.
 func (m *MockClient) NewPreferenceList() PreferenceList {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewPreferenceList")
@@ -293,8 +182,120 @@ func (m *MockClient) NewPreferenceList() PreferenceList {
 	return ret0
 }
 
-// NewPreferenceList indicates an expected call of NewPreferenceList
+// NewPreferenceList indicates an expected call of NewPreferenceList.
 func (mr *MockClientMockRecorder) NewPreferenceList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewPreferenceList", reflect.TypeOf((*MockClient)(nil).NewPreferenceList))
+}
+
+// PushTimeout mocks base method.
+func (m *MockClient) PushTimeout() *time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PushTimeout")
+	ret0, _ := ret[0].(*time.Duration)
+	return ret0
+}
+
+// PushTimeout indicates an expected call of PushTimeout.
+func (mr *MockClientMockRecorder) PushTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushTimeout", reflect.TypeOf((*MockClient)(nil).PushTimeout))
+}
+
+// RegistryCacheTime mocks base method.
+func (m *MockClient) RegistryCacheTime() *time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryCacheTime")
+	ret0, _ := ret[0].(*time.Duration)
+	return ret0
+}
+
+// RegistryCacheTime indicates an expected call of RegistryCacheTime.
+func (mr *MockClientMockRecorder) RegistryCacheTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryCacheTime", reflect.TypeOf((*MockClient)(nil).RegistryCacheTime))
+}
+
+// RegistryHandler mocks base method.
+func (m *MockClient) RegistryHandler(operation, registryName, registryURL string, forceFlag, isSecure bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryHandler", operation, registryName, registryURL, forceFlag, isSecure)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegistryHandler indicates an expected call of RegistryHandler.
+func (mr *MockClientMockRecorder) RegistryHandler(operation, registryName, registryURL, forceFlag, isSecure interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryHandler", reflect.TypeOf((*MockClient)(nil).RegistryHandler), operation, registryName, registryURL, forceFlag, isSecure)
+}
+
+// RegistryList mocks base method.
+func (m *MockClient) RegistryList() *[]Registry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryList")
+	ret0, _ := ret[0].(*[]Registry)
+	return ret0
+}
+
+// RegistryList indicates an expected call of RegistryList.
+func (mr *MockClientMockRecorder) RegistryList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryList", reflect.TypeOf((*MockClient)(nil).RegistryList))
+}
+
+// RegistryNameExists mocks base method.
+func (m *MockClient) RegistryNameExists(name string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryNameExists", name)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RegistryNameExists indicates an expected call of RegistryNameExists.
+func (mr *MockClientMockRecorder) RegistryNameExists(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryNameExists", reflect.TypeOf((*MockClient)(nil).RegistryNameExists), name)
+}
+
+// SetConfiguration mocks base method.
+func (m *MockClient) SetConfiguration(parameter, value string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConfiguration", parameter, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetConfiguration indicates an expected call of SetConfiguration.
+func (mr *MockClientMockRecorder) SetConfiguration(parameter, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfiguration", reflect.TypeOf((*MockClient)(nil).SetConfiguration), parameter, value)
+}
+
+// Timeout mocks base method.
+func (m *MockClient) Timeout() *time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Timeout")
+	ret0, _ := ret[0].(*time.Duration)
+	return ret0
+}
+
+// Timeout indicates an expected call of Timeout.
+func (mr *MockClientMockRecorder) Timeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timeout", reflect.TypeOf((*MockClient)(nil).Timeout))
+}
+
+// UpdateNotification mocks base method.
+func (m *MockClient) UpdateNotification() *bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNotification")
+	ret0, _ := ret[0].(*bool)
+	return ret0
+}
+
+// UpdateNotification indicates an expected call of UpdateNotification.
+func (mr *MockClientMockRecorder) UpdateNotification() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNotification", reflect.TypeOf((*MockClient)(nil).UpdateNotification))
 }

--- a/pkg/service/link.go
+++ b/pkg/service/link.go
@@ -174,7 +174,7 @@ func pushLinksWithoutOperator(client kclient.ClientInterface, devfileObj parser.
 
 	var processingPipeline sboPipeline.Pipeline
 
-	deploymentGVR, err := client.GetDeploymentAPIVersion()
+	deploymentGVK, err := client.GetDeploymentAPIVersion()
 	if err != nil {
 		return false, err
 	}
@@ -191,10 +191,10 @@ func pushLinksWithoutOperator(client kclient.ClientInterface, devfileObj parser.
 			newServiceBinding.Namespace = client.GetCurrentNamespace()
 			newServiceBinding.Spec.Application = sboApi.Application{
 				Ref: sboApi.Ref{
-					Name:     deployment.Name,
-					Group:    deploymentGVR.Group,
-					Version:  deploymentGVR.Version,
-					Resource: deploymentGVR.Resource,
+					Name:    deployment.Name,
+					Group:   deploymentGVK.Group,
+					Version: deploymentGVK.Version,
+					Kind:    deploymentGVK.Kind,
 				},
 			}
 			newServiceBinding.Status.Secret = secretName

--- a/tests/integration/devfile/cmd_add_binding_test.go
+++ b/tests/integration/devfile/cmd_add_binding_test.go
@@ -33,9 +33,24 @@ var _ = Describe("odo add binding command tests", func() {
 	var _ = AfterEach(func() {
 		helper.CommonAfterEach(commonVar)
 	})
+
+	It("should fail creating a binding without workload parameter", func() {
+		stderr := helper.Cmd("odo", "add", "binding", "--name", "aname", "--service", "cluster-sample").ShouldFail().Err()
+		Expect(stderr).To(ContainSubstring("missing --workload parameter"))
+	})
+
+	It("should create a binding using the workload parameter", func() {
+		helper.Cmd("odo", "add", "binding", "--name", "aname", "--service", "cluster-sample", "--workload", "app/Deployment.apps").ShouldPass()
+	})
+
 	When("the component is bootstrapped", func() {
 		BeforeEach(func() {
 			helper.Cmd("odo", "init", "--name", "mynode", "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml"), "--starter", "nodejs-starter").ShouldPass()
+		})
+
+		It("should fail using the --workload parameter", func() {
+			stderr := helper.Cmd("odo", "add", "binding", "--name", "aname", "--service", "cluster-sample", "--workload", "app/Deployment.apps").ShouldFail().Err()
+			Expect(stderr).To(ContainSubstring("--workload cannot be used from a directory containing a Devfile"))
 		})
 
 		When("adding a binding", func() {

--- a/tests/interactive/cmd_add_binding_test.go
+++ b/tests/interactive/cmd_add_binding_test.go
@@ -144,7 +144,7 @@ var _ = Describe("odo init interactive command tests", func() {
 				helper.ExpectString(ctx, "How do you want to bind the service?")
 				helper.SendLine(ctx, "Bind as Files")
 
-				helper.ExpectString(ctx, "Check with spacebar the operations to perform with the ServiceBinding")
+				helper.ExpectString(ctx, "Check(with Space Bar) one or more operations to perform with the ServiceBinding")
 				helper.SendLine(ctx, " \x1B[B \x1B[B ")
 
 				helper.ExpectString(ctx, "Save the ServiceBinding to file:")

--- a/tests/interactive/cmd_add_binding_test.go
+++ b/tests/interactive/cmd_add_binding_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/redhat-developer/odo/tests/helper"
 
@@ -96,6 +97,74 @@ var _ = Describe("odo init interactive command tests", func() {
 			Expect(err).To(BeNil())
 			components := helper.GetDevfileComponents(filepath.Join(commonVar.Context, "devfile.yaml"), bindingName)
 			Expect(components).ToNot(BeNil())
+		})
+	})
+
+	When("running a deployment", func() {
+		BeforeEach(func() {
+			commonVar.CliRunner.Run("create", "deployment", "nginx", "--image=nginx")
+		})
+
+		AfterEach(func() {
+			commonVar.CliRunner.Run("delete", "deployment", "nginx")
+		})
+
+		It("should successsfully add binding without devfile", func() {
+			command := []string{"odo", "add", "binding"}
+
+			_, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
+				outputFile := "binding.yaml"
+				expected := `spec:
+  application:
+    group: apps
+    kind: Deployment
+    name: nginx
+    version: v1
+  bindAsFiles: true
+  detectBindingResources: true
+  services:
+  - group: postgresql.k8s.enterprisedb.io
+    id: nginx-cluster-sample
+    kind: Cluster
+    name: cluster-sample
+    resource: clusters
+    version: v1`
+				helper.ExpectString(ctx, "Select service instance you want to bind to:")
+				helper.SendLine(ctx, "cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)")
+
+				helper.ExpectString(ctx, "Select workload resource you want to bind:")
+				helper.SendLine(ctx, "Deployment")
+
+				helper.ExpectString(ctx, "Select workload resource name you want to bind:")
+				helper.SendLine(ctx, "nginx")
+
+				helper.ExpectString(ctx, "Enter the Binding's name")
+				helper.SendLine(ctx, "\n")
+
+				helper.ExpectString(ctx, "How do you want to bind the service?")
+				helper.SendLine(ctx, "Bind as Files")
+
+				helper.ExpectString(ctx, "Check with spacebar the operations to perform with the ServiceBinding")
+				helper.SendLine(ctx, " \x1B[B \x1B[B ")
+
+				helper.ExpectString(ctx, "Save the ServiceBinding to file:")
+				helper.SendLine(ctx, outputFile)
+
+				for _, line := range strings.Split(expected, "\n") {
+					helper.ExpectString(ctx, line)
+				}
+				helper.ExpectString(ctx, "The ServiceBinding has been created in the cluster")
+				inCluster := commonVar.CliRunner.Run("get", "servicebinding", "nginx-cluster-sample", "-o", "yaml").Out.Contents()
+				Expect(string(inCluster)).To(ContainSubstring(expected))
+
+				helper.ExpectString(ctx, fmt.Sprintf("The ServiceBinding has been written to the file %q", outputFile))
+				helper.VerifyFileExists("binding.yaml")
+				fileContent, err := os.ReadFile(filepath.Join(commonVar.Context, outputFile))
+				Expect(err).Should(Succeed())
+				Expect(string(fileContent)).To(ContainSubstring(expected))
+			})
+
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/tests/interactive/cmd_add_binding_test.go
+++ b/tests/interactive/cmd_add_binding_test.go
@@ -21,9 +21,6 @@ var _ = Describe("odo init interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		if helper.IsKubernetesCluster() {
-			Skip("Operators have not been setup on Kubernetes cluster yet. Remove this once the issue has been fixed.")
-		}
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

- ServiceBinding service is now referenced by its Kind, not its Resource, to be consistent with the value added as flag (with Kind)
- Ability to run `odo add binding` withtout devfile.yaml
  - in interactive mode, output as:
    - file
    - stdout
    - creat on cluster
  - in non-interactive mode, with `--workload` flag, output as:
    - stdout


**Which issue(s) this PR fixes:**

Fixes #5772 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
