### PR TITLE
update documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Documentation.md
+++ b/.github/ISSUE_TEMPLATE/Documentation.md
@@ -3,7 +3,8 @@ name: Documentation
 about: Report mistakes or request for documentation
 ---
 
-/kind documentation
+/area documentation
+/kind bug
 
 <!--
 


### PR DESCRIPTION
/area documentation


documentation should be in /area documentation

`kind` is meant to be more like kind of an issue (bug, epic, user-story, feature request etc...) 
`area` is to what area the issue/pr is related to 
each issue or PR can have only one kind, but multiple areas 