### PR TITLE
Add `run-command` flag to `odo dev` to run non-default Run command

### DIFF
--- a/docs/website/docs/command-reference/dev.md
+++ b/docs/website/docs/command-reference/dev.md
@@ -43,7 +43,62 @@ In the above example, three things have happened:
 You can press Ctrl-c at any time to terminate the development session. The command can take a few moment to terminate, as it
 will first delete all resources deployed into the cluster for this session before terminating.
 
-### Sustituting variables
+### Running an alternative command
+
+By default, `odo dev` executes the default Run command defined in the Devfile, 
+i.e, the command with a group `kind` set to `run` and its `isDefault` field set to `true`.
+
+Passing the `run-command` flag allows to override this behavior by running any other non-default command, provided it is in the `run` group in the Devfile.
+
+For example, given the following excerpt from a Devfile:
+```yaml
+- id: my-run
+  exec:
+    commandLine: mvn spring-boot:run
+    component: tools
+    workingDir: ${PROJECT_SOURCE}
+    group:
+      isDefault: true
+      kind: run
+
+- id: my-run-with-postgres
+  exec:
+    commandLine: mvn spring-boot:run -Dspring-boot.run.profiles=postgres
+    component: tools
+    workingDir: ${PROJECT_SOURCE}
+    group:
+      isDefault: false
+      kind: run
+```
+
+- running `odo dev` will run the default `my-run` command
+- running `odo dev --run-command my-run-with-postgres` will run the `my-run-with-postgres` command:
+```shell
+$ odo dev --run-command my-run-with-postgres
+
+  __
+ /  \__     Developing using the my-java-springboot-app Devfile
+ \__/  \    Namespace: default
+ /  \__/    odo version: v3.0.0-alpha3
+ \__/
+
+↪ Deploying to the cluster in developer mode
+ ✓  Added storage m2 to my-java-springboot-app
+ ✓  Creating kind ServiceBinding [8ms]
+ ✓  Waiting for Kubernetes resources [39s]
+ ✓  Syncing files into the container [84ms]
+ ✓  Building your application in container on cluster (command: build) [51s]
+ •  Executing the application (command: my-run-with-postgres)  ...
+
+Your application is now running on the cluster
+ - Forwarding from 127.0.0.1:40002 -> 8080
+
+Watching for changes in the current directory /path/to/my/sources/java-springboot-app
+Press Ctrl+c to exit `odo dev` and delete resources from the cluster
+
+```
+
+### Substituting variables
 
 The Devfile can define variables to make the Devfile parameterizable. The Devfile can define values for these variables, and you 
 can override the values for variables from the command line when running `odo dev`, using the `--var` and `--var-file` options.

--- a/pkg/dev/interface.go
+++ b/pkg/dev/interface.go
@@ -7,20 +7,40 @@ import (
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/common"
 
 	"github.com/devfile/library/pkg/devfile/parser"
+
 	"github.com/redhat-developer/odo/pkg/devfile/adapters/kubernetes"
 	"github.com/redhat-developer/odo/pkg/watch"
 )
 
 type Client interface {
 	// Start the resources in devfileObj on the platformContext. It then pushes the files in path to the container.
-	// If debug is true, executes the debug command, or the run command by default
-	Start(devfileObj parser.DevfileObj, platformContext kubernetes.KubernetesContext, ignorePaths []string, path string, debug bool) error
+	// If debug is true, executes the debug command, or the run command by default.
+	// If runCommand is set, this will look up the specified run command in the Devfile and execute it. Otherwise, it uses the default one.
+	Start(
+		devfileObj parser.DevfileObj,
+		platformContext kubernetes.KubernetesContext,
+		ignorePaths []string,
+		path string,
+		debug bool,
+		runCommand string,
+	) error
 
 	// Watch watches for any changes to the files under path while ignoring the files/directories in ignorePaths.
 	// It logs messages to out and uses the Handler h to perform push operation when anything changes in path.
 	// It uses devfileObj to notify user to restart odo dev if they change endpoint information in the devfile.
-	// If debug is true, the debug command will be started after a sync, or the run command by default
-	Watch(devfileObj parser.DevfileObj, path string, ignorePaths []string, out io.Writer, h Handler, ctx context.Context, debug bool, variables map[string]string) error
+	// If debug is true, the debug command will be started after a sync, or the run command by default.
+	// If runCommand is set, this will look up the specified run command in the Devfile and execute it. Otherwise, it uses the default one.
+	Watch(
+		devfileObj parser.DevfileObj,
+		path string,
+		ignorePaths []string,
+		out io.Writer,
+		h Handler,
+		ctx context.Context,
+		debug bool,
+		runCommand string,
+		variables map[string]string,
+	) error
 }
 
 type Handler interface {

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -142,7 +142,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		return err
 	}
 
-	pushDevfileCommands, err := libdevfile.ValidateAndGetPushCommands(a.Devfile.Data, a.devfileBuildCmd, a.devfileRunCmd)
+	pushDevfileCommands, err := libdevfile.ValidateAndGetPushCommands(a.Devfile, a.devfileBuildCmd, a.devfileRunCmd)
 	if err != nil {
 		return fmt.Errorf("failed to validate devfile build and run commands: %w", err)
 	}
@@ -158,9 +158,9 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	currentMode := envinfo.Run
 
 	if parameters.Debug {
-		pushDevfileDebugCommands, e := libdevfile.ValidateAndGetDebugCommands(a.Devfile.Data, a.devfileDebugCmd)
+		pushDevfileDebugCommands, e := libdevfile.ValidateAndGetCommand(a.Devfile, a.devfileDebugCmd, devfilev1.DebugCommandGroupKind)
 		if e != nil {
-			return fmt.Errorf("debug command is not valid: %w", err)
+			return fmt.Errorf("debug command is not valid: %w", e)
 		}
 		pushDevfileCommands[devfilev1.DebugCommandGroupKind] = pushDevfileDebugCommands
 		currentMode = envinfo.Debug
@@ -350,7 +350,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		doExecuteBuildCommand := func() error {
 			execHandler := component.NewExecHandler(a.kubeClient, a.AppName, a.ComponentName, a.pod.Name,
 				"Building your application in container on cluster", parameters.Show)
-			return libdevfile.Build(a.Devfile, execHandler, true)
+			return libdevfile.Build(a.Devfile, execHandler)
 		}
 		if componentExists {
 			if parameters.RunModeChanged || cmd.Exec == nil || !util.SafeGetBool(cmd.Exec.HotReloadCapable) {

--- a/pkg/libdevfile/errors.go
+++ b/pkg/libdevfile/errors.go
@@ -9,15 +9,20 @@ import (
 // NoCommandFoundError is returned when no command of the specified kind is found in devfile
 type NoCommandFoundError struct {
 	kind v1alpha2.CommandGroupKind
+	name string
 }
 
-func NewNoCommandFoundError(kind v1alpha2.CommandGroupKind) NoCommandFoundError {
+func NewNoCommandFoundError(kind v1alpha2.CommandGroupKind, name string) NoCommandFoundError {
 	return NoCommandFoundError{
 		kind: kind,
+		name: name,
 	}
 }
 func (e NoCommandFoundError) Error() string {
-	return fmt.Sprintf("no %s command found in devfile", e.kind)
+	if e.name == "" {
+		return fmt.Sprintf("no %s command found in devfile", e.kind)
+	}
+	return fmt.Sprintf("no %s command with name %q found in Devfile", e.kind, e.name)
 }
 
 // NoDefaultCommandFoundError is returned when several commands of the specified kind exist

--- a/pkg/libdevfile/libdevfile_test.go
+++ b/pkg/libdevfile/libdevfile_test.go
@@ -13,7 +13,6 @@ import (
 	devfileFileSystem "github.com/devfile/library/pkg/testingutil/filesystem"
 	dfutil "github.com/devfile/library/pkg/util"
 	"github.com/golang/mock/gomock"
-	"github.com/kylelemons/godebug/pretty"
 	"k8s.io/utils/pointer"
 
 	"github.com/redhat-developer/odo/pkg/libdevfile/generator"
@@ -23,161 +22,240 @@ import (
 
 var buildGroup = v1alpha2.BuildCommandGroupKind
 var runGroup = v1alpha2.RunCommandGroupKind
-var debugGroup = v1alpha2.DebugCommandGroupKind
 
-func TestGetDefaultCommand(t *testing.T) {
+func TestGetCommand(t *testing.T) {
 
-	runDefault1 := generator.GetExecCommand(generator.ExecCommandParams{
-		Kind:      v1alpha2.RunCommandGroupKind,
-		Id:        "run-default-1",
-		IsDefault: pointer.BoolPtr(true),
-	})
-	deployDefault1 := generator.GetCompositeCommand(generator.CompositeCommandParams{
-		Kind:      v1alpha2.DeployCommandGroupKind,
-		Id:        "deploy-default-1",
-		IsDefault: pointer.BoolPtr(true),
-	})
-	deployDefault2 := generator.GetExecCommand(generator.ExecCommandParams{
-		Kind:      v1alpha2.DeployCommandGroupKind,
-		Id:        "deploy-default-2",
-		IsDefault: pointer.BoolPtr(true),
-	})
-	deployNoDefault1 := generator.GetApplyCommand(generator.ApplyCommandParams{
-		Kind:      v1alpha2.DeployCommandGroupKind,
-		Id:        "deploy-no-default-1",
-		IsDefault: pointer.BoolPtr(false),
-	})
-	deployUnspecDefault1 := generator.GetCompositeCommand(generator.CompositeCommandParams{
-		Kind:      v1alpha2.DeployCommandGroupKind,
-		Id:        "deploy-unspec-default-1",
-		IsDefault: nil,
-	})
+	commands := [...]string{"ls -la", "pwd"}
+	components := [...]string{"alias1", "alias2"}
 
-	type args struct {
-		devfileObj func() parser.DevfileObj
-		kind       v1alpha2.CommandGroupKind
-	}
 	tests := []struct {
-		name    string
-		args    args
-		want    v1alpha2.Command
-		wantErr error
+		name           string
+		requestedType  []v1alpha2.CommandGroupKind
+		execCommands   []v1alpha2.Command
+		compCommands   []v1alpha2.Command
+		reqCommandName string
+		retCommandName string
+		wantErr        bool
+		wantPresent    bool
 	}{
 		{
-			name: "a single deploy command, default",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1, deployDefault1})
-					return parser.DevfileObj{
-						Data: data,
-					}
-				},
-				kind: v1alpha2.DeployCommandGroupKind,
+			name: "Case 1: Valid devfile",
+			execCommands: []v1alpha2.Command{
+				getExecCommand("build", buildGroup),
+				getExecCommand("run", runGroup),
 			},
-			wantErr: nil,
-			want:    deployDefault1,
+			requestedType: []v1alpha2.CommandGroupKind{buildGroup, runGroup},
+			wantErr:       false,
 		},
 		{
-			name: "a single deploy command, not default",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1, deployNoDefault1})
-					return parser.DevfileObj{
-						Data: data,
-					}
-				},
-				kind: v1alpha2.DeployCommandGroupKind,
+			name: "Case 2: Valid devfile with devrun and devbuild",
+			execCommands: []v1alpha2.Command{
+				getExecCommand("build", buildGroup),
+				getExecCommand("run", runGroup),
 			},
-			wantErr: nil,
-			want:    deployNoDefault1,
+			requestedType: []v1alpha2.CommandGroupKind{buildGroup, runGroup},
+			wantErr:       false,
 		},
 		{
-			name: "a single deploy command, unspecified default",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1, deployUnspecDefault1})
-					return parser.DevfileObj{
-						Data: data,
-					}
+			name: "Case 3: Valid devfile with empty workdir",
+			execCommands: []v1alpha2.Command{
+				{
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: runGroup},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
 				},
-				kind: v1alpha2.DeployCommandGroupKind,
 			},
-			wantErr: nil,
-			want:    deployUnspecDefault1,
+			requestedType: []v1alpha2.CommandGroupKind{runGroup},
+			wantErr:       false,
 		},
 		{
-			name: "several deploy commands, only one is default",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1, deployDefault1, deployNoDefault1, deployUnspecDefault1})
-					return parser.DevfileObj{
-						Data: data,
-					}
+			name: "Case 4.1: Mismatched command type",
+			execCommands: []v1alpha2.Command{
+				{
+					Id: "build command",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: runGroup},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
 				},
-				kind: v1alpha2.DeployCommandGroupKind,
 			},
-			wantErr: nil,
-			want:    deployDefault1,
+			reqCommandName: "build command",
+			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
+			wantErr:        true,
 		},
 		{
-			name: "no deploy command",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1})
-					return parser.DevfileObj{
-						Data: data,
-					}
+			name: "Case 4.2: Matching command by name and type",
+			execCommands: []v1alpha2.Command{
+				{
+					Id: "build command",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
 				},
-				kind: v1alpha2.DeployCommandGroupKind,
 			},
-			wantErr: NewNoCommandFoundError(v1alpha2.DeployCommandGroupKind),
+			reqCommandName: "build command",
+			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
+			wantErr:        false,
+			wantPresent:    true,
 		},
 		{
-			name: "two deploy default commands",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1, deployDefault1, deployDefault2})
-					return parser.DevfileObj{
-						Data: data,
-					}
+			name: "Case 5: Default command is returned",
+			execCommands: []v1alpha2.Command{
+				{
+					Id: "defaultRunCommand",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: util.GetBoolPtr(true)},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
 				},
-				kind: v1alpha2.DeployCommandGroupKind,
+				{
+					Id: "runCommand",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: runGroup},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
+				},
 			},
-			wantErr: NewMoreThanOneDefaultCommandFoundError(v1alpha2.DeployCommandGroupKind),
+			retCommandName: "defaultRunCommand",
+			requestedType:  []v1alpha2.CommandGroupKind{runGroup},
+			wantErr:        false,
+			wantPresent:    true,
 		},
 		{
-			name: "two deploy commands, no one is default",
-			args: args{
-				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{runDefault1, deployNoDefault1, deployUnspecDefault1})
-					return parser.DevfileObj{
-						Data: data,
-					}
+			name: "Case 6: Composite command is returned",
+			execCommands: []v1alpha2.Command{
+				{
+					Id: "build",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(false)},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
 				},
-				kind: v1alpha2.DeployCommandGroupKind,
+				{
+					Id: "run",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: runGroup},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
+				},
 			},
-			wantErr: NewNoDefaultCommandFoundError(v1alpha2.DeployCommandGroupKind),
+			compCommands: []v1alpha2.Command{
+				{
+					Id: "myComposite",
+					CommandUnion: v1alpha2.CommandUnion{
+						Composite: &v1alpha2.CompositeCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
+								},
+							},
+							Commands: []string{"build", "run"},
+						},
+					},
+				},
+			},
+			retCommandName: "myComposite",
+			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
+			wantErr:        false,
+			wantPresent:    true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetDefaultCommand(tt.args.devfileObj(), tt.args.kind)
-			if err != tt.wantErr {
-				t.Errorf("GetDefaultCommand() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			components := []v1alpha2.Component{testingutil.GetFakeContainerComponent(tt.execCommands[0].Exec.Component)}
+			devObj := parser.DevfileObj{
+				Data: func() data.DevfileData {
+					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
+					if err != nil {
+						t.Error(err)
+					}
+					err = devfileData.AddCommands(tt.execCommands)
+					if err != nil {
+						t.Error(err)
+					}
+					err = devfileData.AddCommands(tt.compCommands)
+					if err != nil {
+						t.Error(err)
+					}
+					err = devfileData.AddComponents(components)
+					if err != nil {
+						t.Error(err)
+					}
+					return devfileData
+				}(),
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetDefaultCommand() = %v, want %v", got, tt.want)
+
+			for _, gtype := range tt.requestedType {
+				cmd, ok, err := GetCommand(devObj, tt.reqCommandName, gtype)
+				if tt.wantErr != (err != nil) {
+					t.Errorf("TestGetCommand unexpected error for command: %v wantErr: %v err: %v", gtype, tt.wantErr, err)
+					return
+				} else if tt.wantErr {
+					return
+				}
+				if tt.wantPresent != ok {
+					t.Errorf("TestGetCommand unexpected presence for command: %v wantPresent: %v ok: %v", gtype, tt.wantPresent, ok)
+					return
+				}
+
+				if len(tt.retCommandName) > 0 && cmd.Id != tt.retCommandName {
+					t.Errorf("TestGetCommand error: command names do not match expected: %v actual: %v", tt.retCommandName, cmd.Id)
+				}
 			}
 		})
 	}
+
 }
 
 func TestDeploy(t *testing.T) {
@@ -234,11 +312,11 @@ func TestDeploy(t *testing.T) {
 			name: "deploy an image and two kubernetes components",
 			args: args{
 				devfileObj: func() parser.DevfileObj {
-					data, _ := data.NewDevfileData(string(data.APISchemaVersion200))
-					_ = data.AddCommands([]v1alpha2.Command{deployDefault1, applyImageCommand, applyDeploymentCommand, applyServiceCommand})
-					_ = data.AddComponents([]v1alpha2.Component{imageComponent, deploymentComponent, serviceComponent})
+					dData, _ := data.NewDevfileData(string(data.APISchemaVersion200))
+					_ = dData.AddCommands([]v1alpha2.Command{deployDefault1, applyImageCommand, applyDeploymentCommand, applyServiceCommand})
+					_ = dData.AddComponents([]v1alpha2.Component{imageComponent, deploymentComponent, serviceComponent})
 					return parser.DevfileObj{
-						Data: data,
+						Data: dData,
 					}
 				},
 				handler: func(ctrl *gomock.Controller) Handler {
@@ -250,6 +328,23 @@ func TestDeploy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "deploy with no deploy command",
+			args: args{
+				devfileObj: func() parser.DevfileObj {
+					dData, _ := data.NewDevfileData(string(data.APISchemaVersion200))
+					_ = dData.AddCommands([]v1alpha2.Command{applyServiceCommand})
+					_ = dData.AddComponents([]v1alpha2.Component{deploymentComponent, serviceComponent})
+					return parser.DevfileObj{
+						Data: dData,
+					}
+				},
+				handler: func(ctrl *gomock.Controller) Handler {
+					return NewMockHandler(ctrl)
+				},
+			},
+			wantErr: true,
+		},
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
@@ -257,6 +352,96 @@ func TestDeploy(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			if err := Deploy(tt.args.devfileObj(), tt.args.handler(ctrl)); (err != nil) != tt.wantErr {
 				t.Errorf("Deploy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	containerComp := v1alpha2.Component{
+		Name: "my-container",
+		ComponentUnion: v1alpha2.ComponentUnion{
+			Container: &v1alpha2.ContainerComponent{
+				Container: v1alpha2.Container{
+					Image: "my-image",
+				},
+			},
+		},
+	}
+	defaultBuildCommand := generator.GetExecCommand(generator.ExecCommandParams{
+		Kind:        v1alpha2.BuildCommandGroupKind,
+		Id:          "my-default-build-command",
+		IsDefault:   pointer.BoolPtr(true),
+		CommandLine: "build my-app",
+		Component:   containerComp.Name,
+	})
+	nonDefaultBuildCommandExplicit := generator.GetExecCommand(generator.ExecCommandParams{
+		Kind:        v1alpha2.BuildCommandGroupKind,
+		Id:          "my-explicit-non-default-build-command",
+		IsDefault:   pointer.BoolPtr(false),
+		CommandLine: "build my-app",
+		Component:   containerComp.Name,
+	})
+	nonDefaultBuildCommandImplicit := generator.GetExecCommand(generator.ExecCommandParams{
+		Kind:        v1alpha2.BuildCommandGroupKind,
+		Id:          "my-implicit-non-default-build-command",
+		CommandLine: "build my-app",
+		Component:   containerComp.Name,
+	})
+	type args struct {
+		devfileObj func() parser.DevfileObj
+		handler    func(ctrl *gomock.Controller) Handler
+	}
+	for _, tt := range []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "missing default command",
+			args: args{
+				devfileObj: func() parser.DevfileObj {
+					dData, _ := data.NewDevfileData(string(data.APISchemaVersion200))
+					_ = dData.AddCommands([]v1alpha2.Command{nonDefaultBuildCommandExplicit, nonDefaultBuildCommandImplicit})
+					_ = dData.AddComponents([]v1alpha2.Component{containerComp})
+					return parser.DevfileObj{
+						Data: dData,
+					}
+				},
+				handler: func(ctrl *gomock.Controller) Handler {
+					h := NewMockHandler(ctrl)
+					h.EXPECT().Execute(gomock.Eq(defaultBuildCommand)).Times(0)
+					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
+					return h
+				},
+			},
+		},
+		{
+			name: "with default command",
+			args: args{
+				devfileObj: func() parser.DevfileObj {
+					dData, _ := data.NewDevfileData(string(data.APISchemaVersion200))
+					_ = dData.AddCommands([]v1alpha2.Command{defaultBuildCommand, nonDefaultBuildCommandExplicit, nonDefaultBuildCommandImplicit})
+					_ = dData.AddComponents([]v1alpha2.Component{containerComp})
+					return parser.DevfileObj{
+						Data: dData,
+					}
+				},
+				handler: func(ctrl *gomock.Controller) Handler {
+					h := NewMockHandler(ctrl)
+					h.EXPECT().Execute(gomock.Eq(defaultBuildCommand)).Times(1)
+					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
+					return h
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Build(tt.args.devfileObj(), tt.args.handler(gomock.NewController(t)))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -782,7 +967,7 @@ func TestGetK8sManifestWithVariablesSubstituted(t *testing.T) {
 	}
 }
 
-func TestGetCommand(t *testing.T) {
+func TestValidateAndGetCommand(t *testing.T) {
 
 	commands := [...]string{"ls -la", "pwd"}
 	components := [...]string{"alias1", "alias2"}
@@ -797,25 +982,25 @@ func TestGetCommand(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name: "Case 1: Valid devfile",
+			name: "Case 1: Valid devfile, but error returned because no default command",
 			execCommands: []v1alpha2.Command{
 				getExecCommand("build", buildGroup),
 				getExecCommand("run", runGroup),
 			},
 			requestedType: []v1alpha2.CommandGroupKind{buildGroup, runGroup},
-			wantErr:       false,
+			wantErr:       true,
 		},
 		{
-			name: "Case 2: Valid devfile with devrun and devbuild",
+			name: "Case 2: Valid devfile with devrun and devbuild, but error returned because no default command",
 			execCommands: []v1alpha2.Command{
 				getExecCommand("build", buildGroup),
 				getExecCommand("run", runGroup),
 			},
 			requestedType: []v1alpha2.CommandGroupKind{buildGroup, runGroup},
-			wantErr:       false,
+			wantErr:       true,
 		},
 		{
-			name: "Case 3: Valid devfile with empty workdir",
+			name: "Case 3: Valid devfile with empty workdir, but error returned because no default command",
 			execCommands: []v1alpha2.Command{
 				{
 					CommandUnion: v1alpha2.CommandUnion{
@@ -832,10 +1017,10 @@ func TestGetCommand(t *testing.T) {
 				},
 			},
 			requestedType: []v1alpha2.CommandGroupKind{runGroup},
-			wantErr:       false,
+			wantErr:       true,
 		},
 		{
-			name: "Case 4: Mismatched command type",
+			name: "Case 4.1: Mismatched command type",
 			execCommands: []v1alpha2.Command{
 				{
 					Id: "build command",
@@ -855,6 +1040,28 @@ func TestGetCommand(t *testing.T) {
 			reqCommandName: "build command",
 			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
 			wantErr:        true,
+		},
+		{
+			name: "Case 4.2: Matching command by name and type",
+			execCommands: []v1alpha2.Command{
+				{
+					Id: "build command",
+					CommandUnion: v1alpha2.CommandUnion{
+						Exec: &v1alpha2.ExecCommand{
+							LabeledCommand: v1alpha2.LabeledCommand{
+								BaseCommand: v1alpha2.BaseCommand{
+									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
+								},
+							},
+							CommandLine: commands[0],
+							Component:   components[0],
+						},
+					},
+				},
+			},
+			reqCommandName: "build command",
+			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
+			wantErr:        false,
 		},
 		{
 			name: "Case 5: Default command is returned",
@@ -970,8 +1177,8 @@ func TestGetCommand(t *testing.T) {
 			}
 
 			for _, gtype := range tt.requestedType {
-				cmd, err := getCommand(devObj.Data, tt.reqCommandName, gtype)
-				if !tt.wantErr == (err != nil) {
+				cmd, err := ValidateAndGetCommand(devObj, tt.reqCommandName, gtype)
+				if tt.wantErr != (err != nil) {
 					t.Errorf("TestGetCommand unexpected error for command: %v wantErr: %v err: %v", gtype, tt.wantErr, err)
 					return
 				} else if tt.wantErr {
@@ -985,1231 +1192,6 @@ func TestGetCommand(t *testing.T) {
 		})
 	}
 
-}
-
-func Test_getCommandAssociatedToGroup(t *testing.T) {
-
-	commands := [...]string{"ls -la", "pwd"}
-	components := [...]string{"alias1", "alias2"}
-
-	tests := []struct {
-		name           string
-		requestedType  []v1alpha2.CommandGroupKind
-		execCommands   []v1alpha2.Command
-		compCommands   []v1alpha2.Command
-		retCommandName string
-		wantErr        bool
-	}{
-		{
-			name: "Case 1: Valid devfile",
-			execCommands: []v1alpha2.Command{
-				getExecCommand("", buildGroup),
-				getExecCommand("", runGroup),
-			},
-			requestedType: []v1alpha2.CommandGroupKind{buildGroup, runGroup},
-			wantErr:       false,
-		},
-		{
-			name: "Case 2: Valid devfile with devrun and devbuild",
-			execCommands: []v1alpha2.Command{
-				getExecCommand("", buildGroup),
-				getExecCommand("", runGroup),
-			},
-			requestedType: []v1alpha2.CommandGroupKind{buildGroup, runGroup},
-			wantErr:       false,
-		},
-		{
-			name: "Case 3: Valid devfile with empty workdir",
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			requestedType: []v1alpha2.CommandGroupKind{runGroup},
-			wantErr:       false,
-		},
-		{
-			name: "Case 4: Default command is returned",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "defaultruncommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "runcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			retCommandName: "defaultruncommand",
-			requestedType:  []v1alpha2.CommandGroupKind{runGroup},
-			wantErr:        false,
-		},
-		{
-			name: "Case 5: Valid devfile, has composite command",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build1",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "build2",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "run",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			compCommands: []v1alpha2.Command{
-				{
-					Id: "mycomp",
-					CommandUnion: v1alpha2.CommandUnion{
-						Composite: &v1alpha2.CompositeCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							Commands: []string{"build1", "run"},
-						},
-					},
-				},
-			},
-			retCommandName: "mycomp",
-			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
-			wantErr:        false,
-		},
-		{
-			name: "Case 6: Default composite command",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(false)},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "run",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			compCommands: []v1alpha2.Command{
-				{
-					Id: "mycomp",
-					CommandUnion: v1alpha2.CommandUnion{
-						Composite: &v1alpha2.CompositeCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							Commands: []string{"build", "run"},
-						},
-					},
-				},
-				{
-					Id: "mycomp2",
-					CommandUnion: v1alpha2.CommandUnion{
-						Composite: &v1alpha2.CompositeCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(false)},
-								},
-							},
-							Commands: []string{"build", "run"},
-						},
-					},
-				},
-			},
-			retCommandName: "mycomp",
-			requestedType:  []v1alpha2.CommandGroupKind{buildGroup},
-			wantErr:        false,
-		},
-		{
-			name: "Case 7: no build and debug commands",
-			execCommands: []v1alpha2.Command{
-				getExecCommand("", runGroup),
-			},
-			requestedType: []v1alpha2.CommandGroupKind{buildGroup, debugGroup},
-			wantErr:       false,
-		},
-		{
-			name: "Case 8: no default build and debug commands",
-			execCommands: []v1alpha2.Command{
-				getExecCommand("build-0", buildGroup),
-				getExecCommand("build-1", buildGroup),
-				getExecCommand("debug-0", debugGroup),
-				getExecCommand("debug-1", debugGroup),
-				getExecCommand("", runGroup),
-			},
-			requestedType: []v1alpha2.CommandGroupKind{buildGroup, debugGroup},
-			wantErr:       false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			components := []v1alpha2.Component{testingutil.GetFakeContainerComponent(tt.execCommands[0].Exec.Component)}
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.compCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents(components)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			for _, gtype := range tt.requestedType {
-				cmd, err := getCommandAssociatedToGroup(devObj.Data, gtype)
-				if !tt.wantErr == (err != nil) {
-					t.Errorf("TestGetCommandFromDevfile unexpected error for command: %v wantErr: %v err: %v", gtype, tt.wantErr, err)
-					return
-				} else if tt.wantErr {
-					return
-				}
-
-				if len(tt.retCommandName) > 0 && cmd.Id != tt.retCommandName {
-					t.Errorf("TestGetCommandFromDevfile error: command names do not match expected: %v actual: %v", tt.retCommandName, cmd.Id)
-				}
-			}
-		})
-	}
-
-}
-
-func Test_getCommandByName(t *testing.T) {
-
-	commands := [...]string{"ls -la", "pwd"}
-	components := [...]string{"alias1", "alias2"}
-	invalidComponent := "garbagealias"
-
-	tests := []struct {
-		name           string
-		requestedType  v1alpha2.CommandGroupKind
-		execCommands   []v1alpha2.Command
-		compCommands   []v1alpha2.Command
-		reqCommandName string
-		retCommandName string
-		wantErr        bool
-	}{
-		{
-			name: "Case 1: Valid devfile",
-			execCommands: []v1alpha2.Command{
-				getExecCommand("a", buildGroup),
-				getExecCommand("b", runGroup),
-			},
-			reqCommandName: "b",
-			retCommandName: "b",
-			requestedType:  runGroup,
-			wantErr:        false,
-		},
-		{
-			name: "Case 2: Valid devfile with empty workdir",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build command",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			reqCommandName: "build command",
-			retCommandName: "build command",
-			requestedType:  runGroup,
-			wantErr:        false,
-		},
-		{
-			name: "Case 3: Invalid command",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build command",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   invalidComponent,
-						},
-					},
-				},
-			},
-			reqCommandName: "build command wrong",
-			requestedType:  runGroup,
-			wantErr:        true,
-		},
-		{
-			name: "Case 4: Mismatched command type",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build command",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			reqCommandName: "build command",
-			requestedType:  buildGroup,
-			wantErr:        true,
-		},
-		{
-			name: "Case 5: Multiple default commands but should be with the flag",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "defaultruncommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "runcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			reqCommandName: "defaultruncommand",
-			retCommandName: "defaultruncommand",
-			requestedType:  runGroup,
-			wantErr:        false,
-		},
-		{
-			name: "Case 6: No default command but should be with the flag",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "defaultruncommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "runcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			reqCommandName: "defaultruncommand",
-			retCommandName: "defaultruncommand",
-			requestedType:  runGroup,
-			wantErr:        false,
-		},
-		{
-			name: "Case 7: No Command Group",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "defaultruncommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			reqCommandName: "defaultruncommand",
-			retCommandName: "defaultruncommand",
-			requestedType:  runGroup,
-			wantErr:        false,
-		},
-		{
-			name: "Case 8: Valid devfile with composite commands",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(false)},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-				{
-					Id: "run",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: commands[0],
-							Component:   components[0],
-						},
-					},
-				},
-			},
-			compCommands: []v1alpha2.Command{
-				{
-					Id: "mycomp",
-					CommandUnion: v1alpha2.CommandUnion{
-						Composite: &v1alpha2.CompositeCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							Commands: []string{"build", "run"},
-						},
-					},
-				},
-				{
-					Id: "mycomp2",
-					CommandUnion: v1alpha2.CommandUnion{
-						Composite: &v1alpha2.CompositeCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(false)},
-								},
-							},
-							Commands: []string{"build", "run"},
-						},
-					},
-				},
-			},
-			reqCommandName: "mycomp",
-			retCommandName: "mycomp",
-			requestedType:  buildGroup,
-			wantErr:        false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			components := []v1alpha2.Component{testingutil.GetFakeContainerComponent(tt.execCommands[0].Exec.Component)}
-			if tt.execCommands[0].Exec.Component == invalidComponent {
-				components = []v1alpha2.Component{testingutil.GetFakeContainerComponent("randomComponent")}
-			}
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.compCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents(components)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			cmd, err := getCommandByName(devObj.Data, tt.requestedType, tt.reqCommandName)
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestGetCommand unexpected error for command: %v wantErr: %v err: %v", tt.requestedType, tt.wantErr, err)
-				return
-			} else if tt.wantErr {
-				return
-			}
-
-			if cmd.Exec != nil {
-				if cmd.Id != tt.retCommandName {
-					t.Errorf("TestGetCommand error: command names do not match expected: %v actual: %v", tt.retCommandName, cmd.Id)
-				}
-			}
-		})
-	}
-
-}
-
-func TestGetBuildCommand(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-	emptyString := ""
-
-	tests := []struct {
-		name         string
-		commandName  string
-		execCommands []v1alpha2.Command
-		wantCommand  v1alpha2.Command
-		wantErr      bool
-	}{
-		{
-			name:        "Case 1: Default Build Command",
-			commandName: emptyString,
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantCommand: v1alpha2.Command{
-				CommandUnion: v1alpha2.CommandUnion{
-					Exec: &v1alpha2.ExecCommand{
-						LabeledCommand: v1alpha2.LabeledCommand{
-							BaseCommand: v1alpha2.BaseCommand{
-								Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
-							},
-						},
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case 2: Build Command passed through the odo flag",
-			commandName: "flagcommand",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "flagcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-				{
-					Id: "build command",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantCommand: v1alpha2.Command{
-				Id: "flagcommand",
-				CommandUnion: v1alpha2.CommandUnion{
-					Exec: &v1alpha2.ExecCommand{
-						LabeledCommand: v1alpha2.LabeledCommand{
-							BaseCommand: v1alpha2.BaseCommand{
-								Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-							},
-						},
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case 3: Build Command not found",
-			commandName: "customcommand123",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "build command",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents([]v1alpha2.Component{testingutil.GetFakeContainerComponent(component)})
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			command, err := GetBuildCommand(devObj.Data, tt.commandName)
-
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestGetBuildCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
-			} else if !tt.wantErr && !reflect.DeepEqual(tt.wantCommand, command) {
-				t.Errorf("TestGetBuildCommand: unexpected command returned: %v", pretty.Compare(tt.wantCommand, command))
-			}
-
-		})
-	}
-
-}
-
-func TestGetDebugCommand(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-	emptyString := ""
-
-	var emptyCommand v1alpha2.Command
-
-	tests := []struct {
-		name         string
-		commandName  string
-		execCommands []v1alpha2.Command
-		wantErr      bool
-	}{
-		{
-			name:        "Case: Default Debug Command",
-			commandName: emptyString,
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{
-										IsDefault: util.GetBoolPtr(true),
-										Kind:      v1alpha2.DebugCommandGroupKind,
-									},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case: Custom Debug Command",
-			commandName: "customdebugcommand",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "customdebugcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{
-										IsDefault: util.GetBoolPtr(false),
-										Kind:      v1alpha2.DebugCommandGroupKind,
-									},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case: Missing Debug Command",
-			commandName: "customcommand123",
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{
-										IsDefault: util.GetBoolPtr(true),
-										Kind:      v1alpha2.BuildCommandGroupKind,
-									},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents([]v1alpha2.Component{testingutil.GetFakeContainerComponent(component)})
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			command, err := GetDebugCommand(devObj.Data, tt.commandName)
-
-			if tt.wantErr && err == nil {
-				t.Errorf("Error was expected but got no error")
-			} else if !tt.wantErr {
-				if err != nil {
-					t.Errorf("TestGetDebugCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
-				} else if reflect.DeepEqual(emptyCommand, command) {
-					t.Errorf("TestGetDebugCommand: unexpected empty command returned for command: %v", tt.commandName)
-				}
-			}
-		})
-	}
-}
-
-func TestGetTestCommand(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-	emptyString := ""
-
-	var emptyCommand v1alpha2.Command
-
-	tests := []struct {
-		name         string
-		commandName  string
-		execCommands []v1alpha2.Command
-		wantErr      bool
-	}{
-		{
-			name:        "Case: Default Test Command",
-			commandName: emptyString,
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{
-										IsDefault: util.GetBoolPtr(true),
-										Kind:      v1alpha2.TestCommandGroupKind,
-									},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case: Custom Test Command",
-			commandName: "customtestcommand",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "customtestcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{
-										IsDefault: util.GetBoolPtr(false),
-										Kind:      v1alpha2.TestCommandGroupKind,
-									},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case: Missing Test Command",
-			commandName: "customcommand123",
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{
-										IsDefault: util.GetBoolPtr(true),
-										Kind:      v1alpha2.BuildCommandGroupKind,
-									},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents([]v1alpha2.Component{testingutil.GetFakeContainerComponent(component)})
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			command, err := GetTestCommand(devObj.Data, tt.commandName)
-
-			if tt.wantErr && err == nil {
-				t.Errorf("Error was expected but got no error")
-			} else if !tt.wantErr {
-				if err != nil {
-					t.Errorf("TestGetTestCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
-				} else if reflect.DeepEqual(emptyCommand, command) {
-					t.Errorf("TestGetTestCommand: unexpected empty command returned for command: %v", tt.commandName)
-				}
-			}
-		})
-	}
-}
-
-func TestGetRunCommand(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-	emptyString := ""
-
-	var emptyCommand v1alpha2.Command
-
-	tests := []struct {
-		name         string
-		commandName  string
-		execCommands []v1alpha2.Command
-		wantErr      bool
-	}{
-		{
-			name:        "Case 1: Default Run Command",
-			commandName: emptyString,
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: util.GetBoolPtr(true)},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case 2: Run Command passed through odo flag",
-			commandName: "flagcommand",
-			execCommands: []v1alpha2.Command{
-				{
-					Id: "flagcommand",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-				{
-					Id: "run command",
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:        "Case 3: Missing Run Command",
-			commandName: "",
-			execCommands: []v1alpha2.Command{
-				{
-					CommandUnion: v1alpha2.CommandUnion{
-						Exec: &v1alpha2.ExecCommand{
-							LabeledCommand: v1alpha2.LabeledCommand{
-								BaseCommand: v1alpha2.BaseCommand{
-									Group: &v1alpha2.CommandGroup{Kind: buildGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents([]v1alpha2.Component{testingutil.GetFakeContainerComponent(component)})
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(tt.execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			command, err := GetRunCommand(devObj.Data, tt.commandName)
-
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestGetRunCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
-			} else if !tt.wantErr && reflect.DeepEqual(emptyCommand, command) {
-				t.Errorf("TestGetRunCommand: unexpected empty command returned for command: %v", tt.commandName)
-			}
-		})
-	}
-
-}
-
-func TestValidateAndGetDebugCommands(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-	emptyString := ""
-
-	execCommands := []v1alpha2.Command{
-		{
-			CommandUnion: v1alpha2.CommandUnion{
-				Exec: &v1alpha2.ExecCommand{
-					LabeledCommand: v1alpha2.LabeledCommand{
-						BaseCommand: v1alpha2.BaseCommand{
-							Group: &v1alpha2.CommandGroup{
-								IsDefault: util.GetBoolPtr(true),
-								Kind:      v1alpha2.DebugCommandGroupKind,
-							},
-						},
-					},
-					CommandLine: command,
-					Component:   component,
-					WorkingDir:  workDir,
-				},
-			},
-		},
-		{
-			Id: "customdebugcommand",
-			CommandUnion: v1alpha2.CommandUnion{
-				Exec: &v1alpha2.ExecCommand{
-					LabeledCommand: v1alpha2.LabeledCommand{
-						BaseCommand: v1alpha2.BaseCommand{
-							Group: &v1alpha2.CommandGroup{
-								IsDefault: util.GetBoolPtr(false),
-								Kind:      v1alpha2.DebugCommandGroupKind,
-							},
-						},
-					},
-					CommandLine: command,
-					Component:   component,
-					WorkingDir:  workDir,
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name          string
-		debugCommand  string
-		componentType v1alpha2.ComponentType
-		wantErr       bool
-	}{
-		{
-			name:          "Case: Default Devfile Commands",
-			debugCommand:  emptyString,
-			componentType: v1alpha2.ContainerComponentType,
-			wantErr:       false,
-		},
-		{
-			name:          "Case: provided debug Command",
-			debugCommand:  "customdebugcommand",
-			componentType: v1alpha2.ContainerComponentType,
-			wantErr:       false,
-		},
-		{
-			name:          "Case: invalid debug Command",
-			debugCommand:  "invaliddebugcommand",
-			componentType: v1alpha2.ContainerComponentType,
-			wantErr:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents([]v1alpha2.Component{testingutil.GetFakeContainerComponent(component)})
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			debugCommand, err := ValidateAndGetDebugCommands(devObj.Data, tt.debugCommand)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Error was expected but got no error")
-				} else {
-					return
-				}
-			} else {
-				if err != nil {
-					t.Errorf("TestValidateAndGetDebugDevfileCommands: unexpected error %v", err)
-				}
-			}
-
-			if !reflect.DeepEqual(nil, debugCommand) && debugCommand.Id != tt.debugCommand {
-				t.Errorf("TestValidateAndGetDebugDevfileCommands name of debug command is wrong want: %v got: %v", tt.debugCommand, debugCommand.Id)
-			}
-		})
-	}
 }
 
 func TestValidateAndGetPushCommands(t *testing.T) {
@@ -2272,6 +1254,22 @@ func TestValidateAndGetPushCommands(t *testing.T) {
 		},
 	}
 
+	defaultBuildCommand := v1alpha2.Command{
+		Id: "default build command",
+		CommandUnion: v1alpha2.CommandUnion{
+			Exec: &v1alpha2.ExecCommand{
+				LabeledCommand: v1alpha2.LabeledCommand{
+					BaseCommand: v1alpha2.BaseCommand{
+						Group: &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: util.GetBoolPtr(true)},
+					},
+				},
+				CommandLine: command,
+				Component:   component,
+				WorkingDir:  workDir,
+			},
+		},
+	}
+
 	wrongCompTypeCmd := v1alpha2.Command{
 
 		Id: "wrong",
@@ -2299,18 +1297,28 @@ func TestValidateAndGetPushCommands(t *testing.T) {
 		wantErr             bool
 	}{
 		{
-			name:             "Case 1: Default Devfile Commands",
-			buildCommand:     emptyString,
-			runCommand:       emptyString,
-			execCommands:     execCommands,
-			numberOfCommands: 2,
+			name:         "Case 1: Default Devfile Commands",
+			buildCommand: emptyString,
+			runCommand:   emptyString,
+			execCommands: execCommands,
+			//only the default run command is returned, because the build command is not marked as default
+			numberOfCommands: 1,
 			wantErr:          false,
 		},
 		{
-			name:             "Case 2: Default Build Command, and Provided Run Command",
+			name:         "Case 2: Default Build Command, and Provided Run Command",
+			buildCommand: emptyString,
+			runCommand:   "customcommand",
+			execCommands: execCommands,
+			//only the specified run command is returned, because the build command is not marked as default
+			numberOfCommands: 1,
+			wantErr:          false,
+		},
+		{
+			name:             "Case 2.2: Default Build Command, and Default Run Command",
 			buildCommand:     emptyString,
-			runCommand:       "customcommand",
-			execCommands:     execCommands,
+			runCommand:       emptyString,
+			execCommands:     append(execCommands, defaultBuildCommand),
 			numberOfCommands: 2,
 			wantErr:          false,
 		},
@@ -2375,7 +1383,7 @@ func TestValidateAndGetPushCommands(t *testing.T) {
 				}(),
 			}
 
-			pushCommands, err := ValidateAndGetPushCommands(devObj.Data, tt.buildCommand, tt.runCommand)
+			pushCommands, err := ValidateAndGetPushCommands(devObj, tt.buildCommand, tt.runCommand)
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("TestValidateAndGetPushDevfileCommands unexpected error when validating commands wantErr: %v err: %v", tt.wantErr, err)
 			} else if tt.wantErr && err != nil {
@@ -2388,118 +1396,6 @@ func TestValidateAndGetPushCommands(t *testing.T) {
 		})
 	}
 
-}
-
-func TestValidateAndGetTestCommands(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-	emptyString := ""
-
-	execCommands := []v1alpha2.Command{
-		{
-			CommandUnion: v1alpha2.CommandUnion{
-				Exec: &v1alpha2.ExecCommand{
-					LabeledCommand: v1alpha2.LabeledCommand{
-						BaseCommand: v1alpha2.BaseCommand{
-							Group: &v1alpha2.CommandGroup{
-								IsDefault: util.GetBoolPtr(true),
-								Kind:      v1alpha2.TestCommandGroupKind,
-							},
-						},
-					},
-					CommandLine: command,
-					Component:   component,
-					WorkingDir:  workDir,
-				},
-			},
-		},
-		{
-			Id: "customtestcommand",
-			CommandUnion: v1alpha2.CommandUnion{
-				Exec: &v1alpha2.ExecCommand{
-					LabeledCommand: v1alpha2.LabeledCommand{
-						BaseCommand: v1alpha2.BaseCommand{
-							Group: &v1alpha2.CommandGroup{
-								IsDefault: util.GetBoolPtr(false),
-								Kind:      v1alpha2.TestCommandGroupKind,
-							},
-						},
-					},
-					CommandLine: command,
-					Component:   component,
-					WorkingDir:  workDir,
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name          string
-		testCommand   string
-		componentType v1alpha2.ComponentType
-		wantErr       bool
-	}{
-		{
-			name:          "Case: Default Devfile Commands",
-			testCommand:   emptyString,
-			componentType: v1alpha2.ContainerComponentType,
-			wantErr:       false,
-		},
-		{
-			name:          "Case: provided test Command",
-			testCommand:   "customtestcommand",
-			componentType: v1alpha2.ContainerComponentType,
-			wantErr:       false,
-		},
-		{
-			name:          "Case: invalid test Command",
-			testCommand:   "invalidtestcommand",
-			componentType: v1alpha2.ContainerComponentType,
-			wantErr:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devObj := parser.DevfileObj{
-				Data: func() data.DevfileData {
-					devfileData, err := data.NewDevfileData(string(data.APISchemaVersion200))
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddComponents([]v1alpha2.Component{testingutil.GetFakeContainerComponent(component)})
-					if err != nil {
-						t.Error(err)
-					}
-					err = devfileData.AddCommands(execCommands)
-					if err != nil {
-						t.Error(err)
-					}
-					return devfileData
-				}(),
-			}
-
-			testCommand, err := ValidateAndGetTestCommands(devObj.Data, tt.testCommand)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Error was expected but got no error")
-				} else {
-					return
-				}
-			} else {
-				if err != nil {
-					t.Errorf("TestValidateAndGetTestDevfileCommands: unexpected error %v", err)
-				}
-			}
-
-			if !reflect.DeepEqual(nil, testCommand) && testCommand.Id != tt.testCommand {
-				t.Errorf("TestValidateAndGetTestDevfileCommands name of test command is wrong want: %v got: %v", tt.testCommand, testCommand.Id)
-			}
-		})
-	}
 }
 
 func TestGetContainerComponentsForCommand(t *testing.T) {

--- a/tests/examples/source/devfiles/nodejs/devfile-with-two-run-commands.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-two-run-commands.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000-tcp"
+          targetPort: 3000
+      mountSources: true
+commands:
+  - id: devbuild
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: true
+  - id: devrun
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+        isDefault: true
+  - id: my-custom-run
+    exec:
+      component: runtime
+      commandLine: 'echo waiting for one second before starting & sleep 1; mkdir /projects/file-from-my-custom-run && npm start'
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -184,8 +184,8 @@ func (o DevSession) CheckNotSynced(timeout time.Duration) {
 // RunDevMode runs a dev session and executes the `inside` code when the dev mode is completely started
 // The inside handler is passed the internal session pointer, the contents of the standard and error outputs,
 // and a slice of strings - ports - giving the redirections in the form localhost:<port_number> to access ports opened by component
-func RunDevMode(inside func(session *gexec.Session, outContents []byte, errContents []byte, ports map[string]string)) error {
-	session, outContents, errContents, urls, err := StartDevMode()
+func RunDevMode(additionalOpts []string, inside func(session *gexec.Session, outContents []byte, errContents []byte, ports map[string]string)) error {
+	session, outContents, errContents, urls, err := StartDevMode(additionalOpts...)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/devfile/cmd_dev_test.go
+++ b/tests/integration/devfile/cmd_dev_test.go
@@ -62,7 +62,7 @@ var _ = Describe("odo dev command tests", func() {
 			Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
 		})
 		It("should show validation errors if the devfile is incorrect", func() {
-			err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "kind: run", "kind: build")
 				helper.WaitForOutputToContain("Error occurred on Push", 180, 10, session)
 			})
@@ -72,7 +72,7 @@ var _ = Describe("odo dev command tests", func() {
 			// Create a new file A
 			fileAPath, fileAText := helper.CreateSimpleFile(commonVar.Context, "my-file-", ".txt")
 			// watch that project
-			err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 				// Change some other file B
 				helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "App started", "App is super started")
 
@@ -84,7 +84,7 @@ var _ = Describe("odo dev command tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("ensure that index information is updated", func() {
-			err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 				indexAfterPush, err := util.ReadFileIndex(filepath.Join(commonVar.Context, ".odo", "odo-file-index.json"))
 				Expect(err).ToNot(HaveOccurred())
 
@@ -219,7 +219,7 @@ var _ = Describe("odo dev command tests", func() {
 				})
 
 				It("should run odo dev on initial namespace", func() {
-					err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+					err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 						output := commonVar.CliRunner.Run("get", "deployment").Err.Contents()
 						Expect(string(output)).To(ContainSubstring("No resources found in " + otherNS + " namespace."))
 
@@ -252,7 +252,7 @@ var _ = Describe("odo dev command tests", func() {
 			When("odo dev is stopped", func() {
 				It("should delete component from the cluster", func() {
 					deploymentName := fmt.Sprintf("%s-%s", cmpName, "app")
-					err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+					err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 						out := commonVar.CliRunner.Run("get", "deployment", "-n", commonVar.Project).Out.Contents()
 						Expect(string(out)).To(ContainSubstring(deploymentName))
 					})
@@ -387,7 +387,7 @@ var _ = Describe("odo dev command tests", func() {
 			})
 
 			It("should expose the endpoint on localhost", func() {
-				err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+				err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 					url := fmt.Sprintf("http://%s", ports["3000"])
 					resp, err := http.Get(url)
 					Expect(err).ToNot(HaveOccurred())
@@ -407,7 +407,7 @@ var _ = Describe("odo dev command tests", func() {
 			})
 
 			It("should expose two endpoints on localhost", func() {
-				err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+				err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 					url1 := fmt.Sprintf("http://%s", ports["3000"])
 					url2 := fmt.Sprintf("http://%s", ports["4567"])
 
@@ -455,7 +455,7 @@ var _ = Describe("odo dev command tests", func() {
 
 			When("an endpoint is added after first run of odo dev", func() {
 				It("should print the message to run odo dev again", func() {
-					err := helper.RunDevMode(func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
+					err := helper.RunDevMode(nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
 						helper.ReplaceString("devfile.yaml", "exposure: none", "exposure: public")
 						helper.WaitForErroutToContain("devfile.yaml has been changed; please restart the `odo dev` command", 180, 10, session)
 					})
@@ -567,7 +567,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should be able to exec command", func() {
-			err := helper.RunDevMode(func(session *gexec.Session, out, err []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 				podName := commonVar.CliRunner.GetRunningPodNameByComponent(devfileCmpName, commonVar.Project)
 				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
 				helper.MatchAllInOutput(output, []string{"test_env_variable", "test_build_env_variable"})
@@ -584,7 +584,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should be able to exec command", func() {
-			err := helper.RunDevMode(func(session *gexec.Session, out, err []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 				podName := commonVar.CliRunner.GetRunningPodNameByComponent(devfileCmpName, commonVar.Project)
 				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
 				helper.MatchAllInOutput(output, []string{"test_build_env_variable1", "test_build_env_variable2", "test_env_variable1", "test_env_variable2"})
@@ -601,7 +601,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should be able to exec command", func() {
-			err := helper.RunDevMode(func(session *gexec.Session, out, err []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 				podName := commonVar.CliRunner.GetRunningPodNameByComponent(devfileCmpName, commonVar.Project)
 				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
 				helper.MatchAllInOutput(output, []string{"build env variable with space", "env with space"})
@@ -1378,7 +1378,7 @@ var _ = Describe("odo dev command tests", func() {
 		})
 
 		It("should create vcs-uri annotation for the deployment when running odo dev", func() {
-			err := helper.RunDevMode(func(session *gexec.Session, outContents []byte, errContents []byte, ports map[string]string) {
+			err := helper.RunDevMode(nil, func(session *gexec.Session, outContents []byte, errContents []byte, ports map[string]string) {
 				annotations := commonVar.CliRunner.GetAnnotationsDeployment(devfileCmpName, "app", commonVar.Project)
 				var valueFound bool
 				for key, value := range annotations {
@@ -1390,6 +1390,93 @@ var _ = Describe("odo dev command tests", func() {
 				Expect(valueFound).To(BeTrue())
 			})
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("running an alternative non-default run command", func() {
+		BeforeEach(func() {
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-with-two-run-commands.yaml"),
+				filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+		})
+
+		It("should error out if called with an invalid command", func() {
+			output := helper.Cmd("odo", "dev", "--random-ports", "--run-command", "run-command-does-not-exist").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("no run command with name \"run-command-does-not-exist\" found in Devfile"))
+		})
+
+		It("should error out if called with a command of another kind", func() {
+			//devbuild is a valid build command, not a run command
+			output := helper.Cmd("odo", "dev", "--random-ports", "--run-command", "devbuild").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("no run command with name \"devbuild\" found in Devfile"))
+		})
+
+		testForCmd := func(devfileCmd string, checkFunc func(stdout, stderr string)) {
+			err := helper.RunDevMode(
+				[]string{"--run-command", devfileCmd},
+				func(session *gexec.Session, outContents []byte, errContents []byte, ports map[string]string) {
+					stdout := string(outContents)
+					stderr := string(errContents)
+
+					By("checking the output of the command", func() {
+						helper.MatchAllInOutput(stdout, []string{
+							"Building your application in container on cluster (command: devbuild)",
+							fmt.Sprintf("Executing the application (command: %s)", devfileCmd),
+						})
+					})
+
+					if checkFunc != nil {
+						checkFunc(stdout, stderr)
+					}
+
+					By("verifying the exposed application endpoint", func() {
+						url := fmt.Sprintf("http://%s", ports["3000"])
+						resp, err := http.Get(url)
+						Expect(err).ToNot(HaveOccurred())
+						defer resp.Body.Close()
+
+						body, _ := io.ReadAll(resp.Body)
+						helper.MatchAllInOutput(string(body), []string{"Hello from Node.js Starter Application!"})
+					})
+
+				})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		It("should execute the custom non-default run command successfully", func() {
+			testForCmd("my-custom-run", func(stdout, stderr string) {
+				By("checking that it did not execute the default run command", func() {
+					helper.DontMatchAllInOutput(stdout, []string{
+						"Executing the application (command: devrun)",
+					})
+				})
+
+				By("verifying that the custom command ran successfully", func() {
+					podName := commonVar.CliRunner.GetRunningPodNameByComponent("nodejs", commonVar.Project)
+					res := commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+						podName,
+						"runtime",
+						commonVar.Project,
+						[]string{"stat", "/projects/file-from-my-custom-run"},
+						func(cmdOp string, err error) bool {
+							return err == nil
+						},
+					)
+					Expect(res).To(BeTrue())
+				})
+			})
+		})
+
+		It("should execute the default run command successfully if specified explicitly", func() {
+			//devrun is the default run command
+			testForCmd("devrun", func(stdout, stderr string) {
+				By("checking that it did not execute the custom run command", func() {
+					helper.DontMatchAllInOutput(stdout, []string{
+						"Executing the application (command: my-custom-run)",
+					})
+				})
+			})
 		})
 	})
 

--- a/tests/interactive/cmd_deploy_test.go
+++ b/tests/interactive/cmd_deploy_test.go
@@ -62,11 +62,11 @@ var _ = Describe("odo deploy interactive command tests", func() {
 					helper.ExpectString(ctx, "Enter component name")
 					helper.SendLine(ctx, "my-app")
 
-					helper.ExpectString(ctx, "no deploy command found in devfile")
+					helper.ExpectString(ctx, "no default deploy command found in devfile")
 				})
 
 			Expect(err).To(Not(BeNil()))
-			Expect(output).To(ContainSubstring("no deploy command found in devfile"))
+			Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
 			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 		})
 
@@ -94,11 +94,11 @@ var _ = Describe("odo deploy interactive command tests", func() {
 					helper.ExpectString(ctx, "Enter component name")
 					helper.SendLine(ctx, "my-app")
 
-					helper.ExpectString(ctx, "no deploy command found in devfile")
+					helper.ExpectString(ctx, "no default deploy command found in devfile")
 				})
 
 			Expect(err).To(Not(BeNil()))
-			Expect(output).To(ContainSubstring("no deploy command found in devfile"))
+			Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
 			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 		})
 
@@ -129,7 +129,7 @@ var _ = Describe("odo deploy interactive command tests", func() {
 					helper.ExpectString(ctx, "Enter component name")
 					helper.SendLine(ctx, "my-app")
 
-					helper.ExpectString(ctx, "no deploy command found in devfile")
+					helper.ExpectString(ctx, "no default deploy command found in devfile")
 				})
 
 			Expect(err).To(Not(BeNil()))


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area dev

**What does this PR do / why we need it:**
See #5775 for the use case.

**Which issue(s) this PR fixes:**
Fixes #5775 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-5878--odo-docusaurus-preview.netlify.app/docs/3.0.0/command-reference/dev#running-an-alternative-command)

**How to test changes / Special notes to the reviewer:**
`odo dev --run-command <command>` should allow to run the specified `<command>`, provided it is in the `run` group.