### PR TITLE
Fix misleading add binding  error message

### DIFF
--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -60,6 +60,15 @@ func (o *BindingClient) GetFlags(flags map[string]string) map[string]string {
 }
 
 func (o *BindingClient) GetServiceInstances() (map[string]unstructured.Unstructured, error) {
+	isServiceBindingInstalled, err := o.kubernetesClient.IsServiceBindingSupported()
+	if err != nil {
+		return nil, err
+	}
+	if !isServiceBindingInstalled {
+		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
+		return nil, fmt.Errorf("Service Binding Operator is not installed on the cluster, please ensure it is installed before proceeding. See installation instructions: https://odo.dev/docs/overview/cluster-setup/")
+		//revive:enable:error-strings
+	}
 	// Get the BindableKinds/bindable-kinds object
 	bindableKind, err := o.kubernetesClient.GetBindableKinds()
 	if err != nil {

--- a/pkg/binding/binding_test.go
+++ b/pkg/binding/binding_test.go
@@ -112,6 +112,7 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 			fields: fields{
 				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
 					client := kclient.NewMockClientInterface(ctrl)
+					client.EXPECT().IsServiceBindingSupported().Return(true, nil)
 					client.EXPECT().GetBindableKinds().Return(serviceBindingInstance, nil)
 					client.EXPECT().GetBindableKindStatusRestMapping(serviceBindingInstance.Status).Return([]*meta.RESTMapping{
 						{Resource: clusterGVR, GroupVersionKind: clusterGVK},
@@ -131,6 +132,7 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 			fields: fields{
 				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
 					client := kclient.NewMockClientInterface(ctrl)
+					client.EXPECT().IsServiceBindingSupported().Return(true, nil)
 					client.EXPECT().GetBindableKinds().Return(serviceBindingInstance, nil)
 					client.EXPECT().GetBindableKindStatusRestMapping(serviceBindingInstance.Status).Return(nil, nil)
 					return client
@@ -143,6 +145,7 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 			name: "do not fail if no instances of the bindable kind services was found",
 			fields: fields{kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
 				client := kclient.NewMockClientInterface(ctrl)
+				client.EXPECT().IsServiceBindingSupported().Return(true, nil)
 				client.EXPECT().GetBindableKinds().Return(serviceBindingInstance, nil)
 				client.EXPECT().GetBindableKindStatusRestMapping(serviceBindingInstance.Status).Return([]*meta.RESTMapping{
 					{Resource: clusterGVR, GroupVersionKind: clusterGVK},
@@ -153,6 +156,16 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 			}},
 			want:    map[string]unstructured.Unstructured{},
 			wantErr: false,
+		},
+		{
+			name: "error out if the servicebinding CRD is not found",
+			fields: fields{kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
+				client := kclient.NewMockClientInterface(ctrl)
+				client.EXPECT().IsServiceBindingSupported().Return(false, nil)
+				return client
+			}},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -62,7 +62,7 @@ func (c *Client) GetBindableKinds() (bindingApi.BindableKinds, error) {
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			//revive:disable:error-strings This is a top-level error message displayed as is to the end user
-			return bindableKind, errors.New("Service Binding Operator is not installed or it is not completely installed. Please ensure that it is installed successfully before proceeding.")
+			return bindableKind, errors.New("No bindable operators found on the cluster. Please ensure that at least one bindable operator is installed successfully before proceeding. Known Bindable operators: https://github.com/redhat-developer/service-binding-operator#known-bindable-operators")
 			//revive:enable:error-strings
 		}
 		return bindableKind, err


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR fixes the misleading error message when running `odo add binding`.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5882

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test (WIP)

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Run `odo add binding` when -
1. Service Binding Operator is not installed.
```sh
$ odo add binding
 ✗  Service Binding Operator is not installed on the cluster, please ensure it is installed before proceeding.
```
2. No Bindable operator is installed
```sh
$ odo add binding
✗  No bindable operators found on the cluster. Please ensure that at least one bindable operator is installed successfully before proceeding. Kno
wn Bindable operators: https://github.com/redhat-developer/service-binding-operator#known-bindable-operators
```
3. No service instance is present on the cluster
```sh
$ odo add binding                                                               
✗  No bindable service instances found
```
