### PR TITLE
Add `build-command` flag to `odo dev` to run non-default Build command

### DIFF
--- a/docs/website/docs/command-reference/dev.md
+++ b/docs/website/docs/command-reference/dev.md
@@ -47,7 +47,7 @@ will first delete all resources deployed into the cluster for this session befor
 
 #### Running an alternative build command
 By default, `odo dev` builds the application using the default Build command defined in the Devfile,
-i.e, the command with a group `kind` set to `build` and with `isDefault` set to `true`., if any.
+i.e, the command with a group `kind` set to `build` and with `isDefault` set to `true`, if any.
 
 Passing the `build-command` flag allows to override this behavior by running any other command, provided it is in the `build` group in the Devfile.
 

--- a/docs/website/docs/command-reference/dev.md
+++ b/docs/website/docs/command-reference/dev.md
@@ -45,6 +45,59 @@ will first delete all resources deployed into the cluster for this session befor
 
 ### Running an alternative command
 
+#### Running an alternative build command
+By default, `odo dev` builds the application using the default Build command defined in the Devfile,
+i.e, the command with a group `kind` set to `build` and with `isDefault` set to `true`., if any.
+
+Passing the `build-command` flag allows to override this behavior by running any other command, provided it is in the `build` group in the Devfile.
+
+For example, given the following excerpt from a Devfile:
+```yaml
+- id: my-build
+  exec:
+    commandLine: go build main.go
+    component: tools
+    workingDir: ${PROJECT_SOURCE}
+    group:
+      isDefault: true
+      kind: build
+
+- id: my-build-with-version
+  exec:
+    commandLine: go build -ldflags="-X main.version=v1.0.0" main.go
+    component: tools
+    workingDir: ${PROJECT_SOURCE}
+    group:
+      kind: build
+```
+
+- running `odo dev` will build the application using the default `my-build` command.
+- running `odo dev --build-command my-build-with-version` will build the application using the `my-build-with-version` command:
+```shell
+$ odo dev --build-command my-build-with-version
+
+  __
+ /  \__     Developing using the my-sample-go Devfile
+ \__/  \    Namespace: default
+ /  \__/    odo version: v3.0.0-alpha3
+ \__/
+
+↪ Deploying to the cluster in developer mode
+ ✓  Waiting for Kubernetes resources [39s]
+ ✓  Syncing files into the container [84ms]
+ ✓  Building your application in container on cluster (command: my-build-with-version) [456ms]
+ •  Executing the application (command: run)  ...
+
+Your application is now running on the cluster
+ - Forwarding from 127.0.0.1:40001 -> 8080
+
+Watching for changes in the current directory /path/to/my/sources/go-app
+Press Ctrl+c to exit `odo dev` and delete resources from the cluster
+
+```
+
+#### Running an alternative run command
+
 By default, `odo dev` executes the default Run command defined in the Devfile, 
 i.e, the command with a group `kind` set to `run` and its `isDefault` field set to `true`.
 

--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -34,6 +34,7 @@ func (o *DevClient) Start(
 	ignorePaths []string,
 	path string,
 	debug bool,
+	buildCommand string,
 	runCommand string,
 ) error {
 	klog.V(4).Infoln("Creating new adapter")
@@ -53,6 +54,7 @@ func (o *DevClient) Start(
 		Path:            path,
 		IgnoredFiles:    ignorePaths,
 		Debug:           debug,
+		DevfileBuildCmd: buildCommand,
 		DevfileRunCmd:   runCommand,
 	}
 
@@ -73,6 +75,7 @@ func (o *DevClient) Watch(
 	h Handler,
 	ctx context.Context,
 	debug bool,
+	buildCommand string,
 	runCommand string,
 	variables map[string]string,
 ) error {
@@ -90,6 +93,7 @@ func (o *DevClient) Watch(
 		FileIgnores:         ignorePaths,
 		InitialDevfileObj:   devfileObj,
 		Debug:               debug,
+		DevfileBuildCmd:     buildCommand,
 		DevfileRunCmd:       runCommand,
 		DebugPort:           envSpecificInfo.GetDebugPort(),
 		Variables:           variables,

--- a/pkg/dev/interface.go
+++ b/pkg/dev/interface.go
@@ -15,6 +15,7 @@ import (
 type Client interface {
 	// Start the resources in devfileObj on the platformContext. It then pushes the files in path to the container.
 	// If debug is true, executes the debug command, or the run command by default.
+	// If buildCommand is set, this will look up the specified build command in the Devfile. Otherwise, it uses the default one.
 	// If runCommand is set, this will look up the specified run command in the Devfile and execute it. Otherwise, it uses the default one.
 	Start(
 		devfileObj parser.DevfileObj,
@@ -22,6 +23,7 @@ type Client interface {
 		ignorePaths []string,
 		path string,
 		debug bool,
+		buildCommand string,
 		runCommand string,
 	) error
 
@@ -29,6 +31,7 @@ type Client interface {
 	// It logs messages to out and uses the Handler h to perform push operation when anything changes in path.
 	// It uses devfileObj to notify user to restart odo dev if they change endpoint information in the devfile.
 	// If debug is true, the debug command will be started after a sync, or the run command by default.
+	// If buildCommand is set, this will look up the specified build command in the Devfile. Otherwise, it uses the default one.
 	// If runCommand is set, this will look up the specified run command in the Devfile and execute it. Otherwise, it uses the default one.
 	Watch(
 		devfileObj parser.DevfileObj,
@@ -38,6 +41,7 @@ type Client interface {
 		h Handler,
 		ctx context.Context,
 		debug bool,
+		buildCommand string,
 		runCommand string,
 		variables map[string]string,
 	) error

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -352,7 +352,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		doExecuteBuildCommand := func() error {
 			execHandler := component.NewExecHandler(a.kubeClient, a.AppName, a.ComponentName, a.pod.Name,
 				"Building your application in container on cluster", parameters.Show)
-			return libdevfile.Build(a.Devfile, execHandler)
+			return libdevfile.Build(a.Devfile, a.devfileBuildCmd, execHandler)
 		}
 		if componentExists {
 			if parameters.RunModeChanged || cmd.Exec == nil || !util.SafeGetBool(cmd.Exec.HotReloadCapable) {

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -63,12 +63,13 @@ type DevOptions struct {
 	contextDir string
 
 	// Flags
-	noWatchFlag     bool
-	randomPortsFlag bool
-	debugFlag       bool
-	varFileFlag     string
-	varsFlag        []string
-	runCommandFlag  string
+	noWatchFlag      bool
+	randomPortsFlag  bool
+	debugFlag        bool
+	varFileFlag      string
+	varsFlag         []string
+	buildCommandFlag string
+	runCommandFlag   string
 
 	// Variables to override Devfile variables
 	variables map[string]string
@@ -216,7 +217,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 		"odo version: "+version.VERSION)
 
 	log.Section("Deploying to the cluster in developer mode")
-	err = o.clientset.DevClient.Start(devFileObj, platformContext, o.ignorePaths, path, o.debugFlag, o.runCommandFlag)
+	err = o.clientset.DevClient.Start(devFileObj, platformContext, o.ignorePaths, path, o.debugFlag, o.buildCommandFlag, o.runCommandFlag)
 	if err != nil {
 		return err
 	}
@@ -272,7 +273,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 		err = o.clientset.WatchClient.CleanupDevResources(devFileObj, log.GetStdout())
 	} else {
 		d := Handler{}
-		err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx, o.debugFlag, o.runCommandFlag, o.variables)
+		err = o.clientset.DevClient.Watch(devFileObj, path, o.ignorePaths, o.out, &d, o.ctx, o.debugFlag, o.buildCommandFlag, o.runCommandFlag, o.variables)
 	}
 	return err
 }
@@ -338,6 +339,8 @@ It forwards endpoints with exposure values 'public' or 'internal' to a port on l
 	devCmd.Flags().BoolVar(&o.debugFlag, "debug", false, "Execute the debug command within the component")
 	devCmd.Flags().StringArrayVar(&o.varsFlag, "var", []string{}, "Variable to override Devfile variable and variables in var-file")
 	devCmd.Flags().StringVar(&o.varFileFlag, "var-file", "", "File containing variables to override Devfile variables")
+	devCmd.Flags().StringVar(&o.buildCommandFlag, "build-command", "",
+		"Alternative build command. The default one will be used if this flag is not set.")
 	devCmd.Flags().StringVar(&o.runCommandFlag, "run-command", "",
 		"Alternative run command to execute. The default one will be used if this flag is not set.")
 	clientset.Add(devCmd, clientset.DEV, clientset.INIT, clientset.KUBERNETES, clientset.STATE, clientset.FILESYSTEM)

--- a/tests/examples/source/devfiles/nodejs/devfile-with-alternative-commands.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-alternative-commands.yaml
@@ -24,6 +24,13 @@ commands:
       group:
         kind: build
         isDefault: true
+  - id: my-custom-build
+    exec:
+      component: runtime
+      commandLine: 'echo waiting for one second before starting & sleep 1; mkdir /projects/file-from-my-custom-build && npm install'
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
   - id: devrun
     exec:
       component: runtime


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area dev

**What does this PR do / why we need it:**
This adds a `build-command` flag to `odo dev`. See #5776 for more context.

**Which issue(s) this PR fixes:**
Fixes #5776

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-5891--odo-docusaurus-preview.netlify.app/docs/command-reference/dev#running-an-alternative-build-command)

**How to test changes / Special notes to the reviewer:**
`odo dev --build-command <command>` should allow to build the application using the specified `<command>`, provided it is in the `build` group.