### PR TITLE
Use cached discovery client

### DIFF
--- a/docs/website/docs/command-reference/list.md
+++ b/docs/website/docs/command-reference/list.md
@@ -18,3 +18,18 @@ defined in the local Devfile,
 
 * `--namespace` - Namespace to list the components from (optional). By default, the current namespace defined in kubeconfig is used
 * `-o json` - Outputs the list in JSON format. See [JSON output](json-output.md) for more information
+
+:::tip use of cache
+
+`odo list` makes use of cache for performance reasons. This is the same cache that is referred by `kubectl` command 
+when you do `kubectl api-resources --cached=true`. As a result, if you were to install an Operator/CRD on the 
+Kubernetes cluster, and create a resource from it using odo, you might not see it in the `odo list` output. This 
+would be the case for 10 minutes timeframe for which the cache is considered valid. Beyond this 10 minutes, the 
+cache is updated anyway.
+
+If you would like to invalidate the cache before the 10 minutes timeframe, you could manually delete it by doing:
+```shell
+rm -rf ~/.kube/cache/discovery/api.crc.testing_6443/
+```
+Above example shows how to invalidate the cache for a CRC cluster. Note that you will have to modify the `api.crc.
+testing_6443` part based on the cluster you are working against.

--- a/pkg/kclient/all.go
+++ b/pkg/kclient/all.go
@@ -18,7 +18,7 @@ import (
 // Code into this file is heavily inspired from https://github.com/ahmetb/kubectl-tree
 
 func (c *Client) GetAllResourcesFromSelector(selector string, ns string) ([]unstructured.Unstructured, error) {
-	apis, err := findAPIs(c.discoveryClient)
+	apis, err := findAPIs(c.cachedDiscoveryClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -53,9 +53,10 @@ type Client struct {
 	// DynamicClient interacts with client-go's `dynamic` package. It is used
 	// to dynamically create service from an operator. It can take an arbitrary
 	// yaml and create k8s/OpenShift resource from it.
-	DynamicClient   dynamic.Interface
-	discoveryClient discovery.DiscoveryInterface
-	restmapper      *restmapper.DeferredDiscoveryRESTMapper
+	DynamicClient         dynamic.Interface
+	discoveryClient       discovery.DiscoveryInterface
+	cachedDiscoveryClient discovery.CachedDiscoveryInterface
+	restmapper            *restmapper.DeferredDiscoveryRESTMapper
 
 	supportedResources map[string]bool
 	// Is server side apply supported by cluster
@@ -155,8 +156,13 @@ func NewForConfig(config clientcmd.ClientConfig) (client *Client, err error) {
 		return nil, err
 	}
 
+	client.discoveryClient, err = discovery.NewDiscoveryClientForConfig(client.KubeClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	config_flags := genericclioptions.NewConfigFlags(true)
-	client.discoveryClient, err = config_flags.ToDiscoveryClient()
+	client.cachedDiscoveryClient, err = config_flags.ToDiscoveryClient()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
 	"github.com/blang/semver"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -153,7 +155,8 @@ func NewForConfig(config clientcmd.ClientConfig) (client *Client, err error) {
 		return nil, err
 	}
 
-	client.discoveryClient, err = discovery.NewDiscoveryClientForConfig(client.KubeClientConfig)
+	config_flags := genericclioptions.NewConfigFlags(true)
+	client.discoveryClient, err = config_flags.ToDiscoveryClient()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <shahdharmit@gmail.com>


**What does this PR do / why we need it:**
~This PR changes odo to use a cached discovery client.~
This PR adds a cached discovery client along with the existing discovery 
client. Functions can use the client appropriate for their use.

A cached discovery client refers its cache under `~/.kube/cache` instead
of checking with the cluster every time.

**Which issue(s) this PR fixes:**

Fixes part of #5872

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes:**
* Spin up a k8s/ocp cluster other than one on the local box. For example, use ClusterBot.
* Execute `odo list -v2` and look for the line that reads: `all.go:119] queried api discovery in`. Also, worth noting is the line that reads: `all.go:61] all goroutines have returned in`.
* Note the time it takes and compare the same with odo built from current `main` branch.

Here are two comparative runs that I did. `odo` is the binary built using code in this PR, while `odo-main` is the binary built using `main` branch.

```sh
$ for i in `seq 1 10`; do time odo list 1>/dev/null; done     
odo list > /dev/null  0.60s user 0.15s system 14% cpu 5.357 total
odo list > /dev/null  0.46s user 0.07s system 13% cpu 4.009 total
odo list > /dev/null  0.48s user 0.08s system 13% cpu 4.190 total
odo list > /dev/null  0.46s user 0.07s system 13% cpu 3.815 total
odo list > /dev/null  0.51s user 0.08s system 12% cpu 4.686 total
odo list > /dev/null  0.47s user 0.07s system 15% cpu 3.646 total
odo list > /dev/null  0.46s user 0.08s system 13% cpu 4.120 total
odo list > /dev/null  0.55s user 0.11s system 9% cpu 6.706 total
odo list > /dev/null  0.49s user 0.09s system 14% cpu 3.853 total
odo list > /dev/null  0.49s user 0.07s system 15% cpu 3.558 total


$ for i in `seq 1 10`; do time odo-main list 1>/dev/null; done
odo-main list > /dev/null  0.65s user 0.13s system 13% cpu 5.633 total
odo-main list > /dev/null  0.55s user 0.09s system 5% cpu 11.381 total
odo-main list > /dev/null  0.48s user 0.09s system 11% cpu 4.915 total
odo-main list > /dev/null  0.58s user 0.09s system 10% cpu 6.531 total
odo-main list > /dev/null  0.61s user 0.12s system 10% cpu 6.999 total
odo-main list > /dev/null  0.50s user 0.08s system 11% cpu 4.917 total
odo-main list > /dev/null  0.58s user 0.12s system 13% cpu 5.420 total
odo-main list > /dev/null  0.51s user 0.08s system 12% cpu 4.603 total
odo-main list > /dev/null  0.58s user 0.08s system 16% cpu 3.965 total
odo-main list > /dev/null  0.59s user 0.11s system 8% cpu 8.230 total
```