### PR TITLE
Allow to set `namingStrategy` when using `odo add binding`

### DIFF
--- a/docs/website/docs/command-reference/add-binding.md
+++ b/docs/website/docs/command-reference/add-binding.md
@@ -43,12 +43,15 @@ In the non-interactive mode, you will have to specify the following required inf
 * `--workload` flag to specify the workload resource, if a Devfile is not present in the directory,
 * `--name` flag to specify a name for the binding (see [Understanding Bind as Files](#understanding-bind-as-files) for more information on this)
 * `--bind-as-files` flag to specify if the service should be bound as a file; this flag is set to true by default.
-
+* `--naming-strategy` flag to specify the naming strategy to use for binding names. This flag is empty by default, 
+  but it can be set to pre-defined strategies: `none`, `lowercase`, or `uppercase`.
+  Otherwise, it is treated as a custom Go template, and it is handled accordingly.
+  Refer to [this page](https://docs.openshift.com/container-platform/4.10/applications/connecting_applications_to_services/binding-workloads-using-sbo.html#sbo-naming-strategies_binding-workloads-using-sbo) for more details on naming strategies.
 
 ```shell
 # Add binding between a service named 'cluster-sample',
 # and the component present in the working directory in the non-interactive mode
-odo add binding --name mybinding --service myRedisService.Redis
+odo add binding --name mybinding --service cluster-sample
 ```
 
 #### Understanding Bind as Files

--- a/docs/website/docs/command-reference/describe-binding.md
+++ b/docs/website/docs/command-reference/describe-binding.md
@@ -29,6 +29,7 @@ For each of these resources, the following information is displayed:
 - the resource name,
 - the list of the services to which the component is bound using this service binding,
 - if the variables are bound as files or as environment variables,
+- the naming strategy used for binding names, if any,
 - if the binding information is auto-detected.
 
 When the service binding are not deployed yet to the cluster:
@@ -42,6 +43,7 @@ Services:
  •  cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)
 Bind as files: false
 Detect binding resources: true
+Naming strategy: uppercase
 Available binding information: unknown
 
 Service Binding Name: my-nodejs-app-redis-standalone
@@ -66,6 +68,7 @@ Services:
  •  cluster-sample-2 (Cluster.postgresql.k8s.enterprisedb.io)
 Bind as files: false
 Detect binding resources: true
+Naming strategy: uppercase
 Available binding information:
  •  CLUSTER_PASSWORD
  •  CLUSTER_PROVIDER

--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -437,7 +437,8 @@ $ odo describe binding -o json
 				}
 			],
 			"detectBindingResources": false,
-			"bindAsFiles": true
+			"bindAsFiles": true,
+			"namingStrategy": "lowercase"
 		},
 		"status": {
 			"bindingFiles": [

--- a/pkg/api/binding.go
+++ b/pkg/api/binding.go
@@ -16,6 +16,7 @@ type ServiceBindingSpec struct {
 	Services               []corev1.ObjectReference `json:"services"`
 	DetectBindingResources bool                     `json:"detectBindingResources"`
 	BindAsFiles            bool                     `json:"bindAsFiles"`
+	NamingStrategy         string                   `json:"namingStrategy,omitempty"`
 }
 
 type ServiceBindingStatus struct {

--- a/pkg/binding/asker/interface.go
+++ b/pkg/binding/asker/interface.go
@@ -14,6 +14,9 @@ type Asker interface {
 	// SelectWorkloadResourceName takes a list of workloads resources names and asks user to select one
 	// returns back true if the user selected to go back
 	SelectWorkloadResourceName(names []string) (back bool, selected string, err error)
+	// SelectNamingStrategy asks for the naming strategy to be used from a list of options.
+	// If NamingStrategyCustom is returned, it means the user needs to be prompted for a value. See AskNamingStrategy.
+	SelectNamingStrategy() (string, error)
 	// AskWorkloadResourceName asks user to type resource name
 	AskWorkloadResourceName() (string, error)
 	// AskServiceInstance takes a list of services and asks user to select one
@@ -22,6 +25,8 @@ type Asker interface {
 	AskServiceBindingName(defaultName string) (string, error)
 	// AskBindAsFiles asks if service should be binded as files
 	AskBindAsFiles() (bool, error)
+	// AskNamingStrategy prompts for the naming strategy to be used
+	AskNamingStrategy() (string, error)
 	// SelectCreationOptions asks to select creation options for the servicebinding
 	SelectCreationOptions() ([]CreationOption, error)
 	// AskOutputFilePath asks for the path of the file to output service binding

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -11,6 +11,14 @@ const (
 	bindAsEnvVar = "Bind As Environment Variables"
 )
 
+const (
+	namingStrategyDefault   = "DEFAULT"
+	namingStrategyNone      = "none"
+	namingStrategylowercase = "lowercase"
+	namingStrategyUpperCase = "uppercase"
+	NamingStrategyCustom    = "CUSTOM"
+)
+
 type Survey struct{}
 
 var _ Asker = (*Survey)(nil)
@@ -53,6 +61,22 @@ func (s *Survey) SelectWorkloadResourceName(names []string) (bool, string, error
 		return true, "", nil
 	}
 	return false, answer, nil
+}
+
+func (s *Survey) SelectNamingStrategy() (string, error) {
+	question := &survey.Select{
+		Message: "Select naming strategy for binding names:",
+		Options: []string{namingStrategyDefault, namingStrategyNone, namingStrategylowercase, namingStrategyUpperCase, NamingStrategyCustom},
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	if answer == namingStrategyDefault {
+		return "", nil
+	}
+	return answer, nil
 }
 
 func (s *Survey) AskWorkloadResourceName() (string, error) {
@@ -111,6 +135,19 @@ func (o *Survey) AskBindAsFiles() (bool, error) {
 		bindAsFile = true
 	}
 	return bindAsFile, nil
+}
+
+func (o *Survey) AskNamingStrategy() (string, error) {
+	question := &survey.Input{
+		Message: "Enter the naming strategy:",
+		Default: "",
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	return answer, nil
 }
 
 func (o *Survey) SelectCreationOptions() ([]CreationOption, error) {

--- a/pkg/binding/backend/flags.go
+++ b/pkg/binding/backend/flags.go
@@ -7,17 +7,19 @@ import (
 	"strings"
 
 	dfutil "github.com/devfile/library/pkg/util"
-	"github.com/redhat-developer/odo/pkg/binding/asker"
-	"github.com/redhat-developer/odo/pkg/kclient"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/redhat-developer/odo/pkg/binding/asker"
+	"github.com/redhat-developer/odo/pkg/kclient"
 )
 
 const (
-	FLAG_WORKLOAD      = "workload"
-	FLAG_SERVICE       = "service"
-	FLAG_NAME          = "name"
-	FLAG_BIND_AS_FILES = "bind-as-files"
+	FLAG_WORKLOAD        = "workload"
+	FLAG_SERVICE         = "service"
+	FLAG_NAME            = "name"
+	FLAG_BIND_AS_FILES   = "bind-as-files"
+	FLAG_NAMING_STRATEGY = "naming-strategy"
 )
 
 // FlagsBackend is a backend that will extract all needed information from flags passed to the command
@@ -105,6 +107,10 @@ func (o *FlagsBackend) AskBindAsFiles(flags map[string]string) (bool, error) {
 		return false, fmt.Errorf("unable to set %q to --%v, value must be a boolean", flags[FLAG_BIND_AS_FILES], FLAG_BIND_AS_FILES)
 	}
 	return bindAsFiles, nil
+}
+
+func (o *FlagsBackend) AskNamingStrategy(flags map[string]string) (string, error) {
+	return flags[FLAG_NAMING_STRATEGY], nil
 }
 
 func (o *FlagsBackend) SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error) {

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -114,6 +114,17 @@ func (o *InteractiveBackend) AskBindAsFiles(_ map[string]string) (bool, error) {
 	return o.askerClient.AskBindAsFiles()
 }
 
+func (o *InteractiveBackend) AskNamingStrategy(_ map[string]string) (string, error) {
+	namingStrategy, err := o.askerClient.SelectNamingStrategy()
+	if err != nil {
+		return "", err
+	}
+	if namingStrategy == asker.NamingStrategyCustom {
+		return o.askerClient.AskNamingStrategy()
+	}
+	return namingStrategy, nil
+}
+
 func (o *InteractiveBackend) SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error) {
 	return o.askerClient.SelectCreationOptions()
 }

--- a/pkg/binding/backend/interface.go
+++ b/pkg/binding/backend/interface.go
@@ -1,9 +1,10 @@
 package backend
 
 import (
-	"github.com/redhat-developer/odo/pkg/binding/asker"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/redhat-developer/odo/pkg/binding/asker"
 )
 
 type AddBindingBackend interface {
@@ -19,6 +20,8 @@ type AddBindingBackend interface {
 	AskBindingName(defaultName string, flags map[string]string) (string, error)
 	// AskBindAsFiles asks if service should be binded as files
 	AskBindAsFiles(flags map[string]string) (bool, error)
+	// AskNamingStrategy asks for the naming strategy to be used
+	AskNamingStrategy(flags map[string]string) (string, error)
 	// SelectCreationOption asks to select how to output the created servicebinding
 	SelectCreationOptions(flags map[string]string) ([]asker.CreationOption, error)
 	// AskOutputFilePath asks for the path of the file to output service binding

--- a/pkg/binding/backend/mock.go
+++ b/pkg/binding/backend/mock.go
@@ -66,6 +66,21 @@ func (mr *MockAddBindingBackendMockRecorder) AskBindingName(defaultName, flags i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskBindingName", reflect.TypeOf((*MockAddBindingBackend)(nil).AskBindingName), defaultName, flags)
 }
 
+// AskNamingStrategy mocks base method.
+func (m *MockAddBindingBackend) AskNamingStrategy(flags map[string]string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AskNamingStrategy", flags)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AskNamingStrategy indicates an expected call of AskNamingStrategy.
+func (mr *MockAddBindingBackendMockRecorder) AskNamingStrategy(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskNamingStrategy", reflect.TypeOf((*MockAddBindingBackend)(nil).AskNamingStrategy), flags)
+}
+
 // AskOutputFilePath mocks base method.
 func (m *MockAddBindingBackend) AskOutputFilePath(flags map[string]string, defaultValue string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -54,7 +54,8 @@ func (o *BindingClient) GetFlags(flags map[string]string) map[string]string {
 		if flag == backendpkg.FLAG_NAME ||
 			flag == backendpkg.FLAG_WORKLOAD ||
 			flag == backendpkg.FLAG_SERVICE ||
-			flag == backendpkg.FLAG_BIND_AS_FILES {
+			flag == backendpkg.FLAG_BIND_AS_FILES ||
+			flag == backendpkg.FLAG_NAMING_STRATEGY {
 			bindingFlags[flag] = value
 		}
 	}

--- a/pkg/binding/interface.go
+++ b/pkg/binding/interface.go
@@ -32,8 +32,16 @@ type Client interface {
 	AskBindingName(serviceName, componentName string, flags map[string]string) (string, error)
 	// AskBindAsFiles asks if the service should be bound as files
 	AskBindAsFiles(flags map[string]string) (bool, error)
+	// AskNamingStrategy asks the naming strategy to be used for the binding
+	AskNamingStrategy(flags map[string]string) (string, error)
 	// AddBindingToDevfile adds the ServiceBinding manifest to the devfile
-	AddBindingToDevfile(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error)
+	AddBindingToDevfile(
+		bindingName string,
+		bindAsFiles bool,
+		namingStrategy string,
+		unstructuredService unstructured.Unstructured,
+		obj parser.DevfileObj,
+	) (parser.DevfileObj, error)
 	// AddBinding creates a binding in file and cluster (if options selected)
 	// and returns the selected options, the binding definition as string (if option selected)
 	// and the filename where definition is written (if options selected)
@@ -41,6 +49,7 @@ type Client interface {
 		flags map[string]string,
 		bindingName string,
 		bindAsFiles bool,
+		namingStrategy string,
 		unstructuredService unstructured.Unstructured,
 		workloadName string,
 		workloadGVK schema.GroupVersionKind,

--- a/pkg/binding/list_test.go
+++ b/pkg/binding/list_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/golang/mock/gomock"
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	bindingApis "github.com/redhat-developer/service-binding-operator/apis"
@@ -42,6 +43,7 @@ var bindingServiceBinding = kclient.NewServiceBindingObject(
 	"my-nodejs-app-cluster-sample",
 	true,
 	"my-nodejs-app-app",
+	"",
 	deploymentGVK,
 	nil,
 	[]v1alpha1.Service{
@@ -112,7 +114,7 @@ func TestBindingClient_ListAllBindings(t *testing.T) {
 					return client
 				},
 			}, args: args{
-				devfileObj: getDevfileObjWithServiceBinding("aname", true),
+				devfileObj: getDevfileObjWithServiceBinding("aname", true, ""),
 				context:    "/apath",
 			},
 			want:          []api.ServiceBinding{apiServiceBinding},
@@ -136,7 +138,7 @@ func TestBindingClient_ListAllBindings(t *testing.T) {
 					return client
 				},
 			}, args: args{
-				devfileObj: getDevfileObjWithServiceBinding("aname", true),
+				devfileObj: getDevfileObjWithServiceBinding("aname", true, ""),
 				context:    "/apath",
 			},
 			want: []api.ServiceBinding{

--- a/pkg/binding/mock.go
+++ b/pkg/binding/mock.go
@@ -39,9 +39,9 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddBinding mocks base method.
-func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) ([]asker.CreationOption, string, string, error) {
+func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, namingStrategy string, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) ([]asker.CreationOption, string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBinding", flags, bindingName, bindAsFiles, unstructuredService, workloadName, workloadGVK)
+	ret := m.ctrl.Call(m, "AddBinding", flags, bindingName, bindAsFiles, namingStrategy, unstructuredService, workloadName, workloadGVK)
 	ret0, _ := ret[0].([]asker.CreationOption)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -50,24 +50,24 @@ func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bin
 }
 
 // AddBinding indicates an expected call of AddBinding.
-func (mr *MockClientMockRecorder) AddBinding(flags, bindingName, bindAsFiles, unstructuredService, workloadName, workloadGVK interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) AddBinding(flags, bindingName, bindAsFiles, namingStrategy, unstructuredService, workloadName, workloadGVK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinding", reflect.TypeOf((*MockClient)(nil).AddBinding), flags, bindingName, bindAsFiles, unstructuredService, workloadName, workloadGVK)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinding", reflect.TypeOf((*MockClient)(nil).AddBinding), flags, bindingName, bindAsFiles, namingStrategy, unstructuredService, workloadName, workloadGVK)
 }
 
 // AddBindingToDevfile mocks base method.
-func (m *MockClient) AddBindingToDevfile(bindingName string, bindAsFiles bool, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
+func (m *MockClient) AddBindingToDevfile(bindingName string, bindAsFiles bool, namingStrategy string, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBindingToDevfile", bindingName, bindAsFiles, unstructuredService, obj)
+	ret := m.ctrl.Call(m, "AddBindingToDevfile", bindingName, bindAsFiles, namingStrategy, unstructuredService, obj)
 	ret0, _ := ret[0].(parser.DevfileObj)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddBindingToDevfile indicates an expected call of AddBindingToDevfile.
-func (mr *MockClientMockRecorder) AddBindingToDevfile(bindingName, bindAsFiles, unstructuredService, obj interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) AddBindingToDevfile(bindingName, bindAsFiles, namingStrategy, unstructuredService, obj interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindingToDevfile", reflect.TypeOf((*MockClient)(nil).AddBindingToDevfile), bindingName, bindAsFiles, unstructuredService, obj)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindingToDevfile", reflect.TypeOf((*MockClient)(nil).AddBindingToDevfile), bindingName, bindAsFiles, namingStrategy, unstructuredService, obj)
 }
 
 // AskBindAsFiles mocks base method.
@@ -98,6 +98,21 @@ func (m *MockClient) AskBindingName(serviceName, componentName string, flags map
 func (mr *MockClientMockRecorder) AskBindingName(serviceName, componentName, flags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskBindingName", reflect.TypeOf((*MockClient)(nil).AskBindingName), serviceName, componentName, flags)
+}
+
+// AskNamingStrategy mocks base method.
+func (m *MockClient) AskNamingStrategy(flags map[string]string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AskNamingStrategy", flags)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AskNamingStrategy indicates an expected call of AskNamingStrategy.
+func (mr *MockClientMockRecorder) AskNamingStrategy(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskNamingStrategy", reflect.TypeOf((*MockClient)(nil).AskNamingStrategy), flags)
 }
 
 // GetBindingFromCluster mocks base method.

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -121,6 +121,7 @@ func NewServiceBindingObject(
 	bindingName string,
 	bindAsFiles bool,
 	workloadName string,
+	namingStrategy string,
 	workloadGVK schema.GroupVersionKind,
 	mappings []bindingApi.Mapping,
 	services []bindingApi.Service,
@@ -137,6 +138,7 @@ func NewServiceBindingObject(
 		Spec: bindingApi.ServiceBindingSpec{
 			DetectBindingResources: true,
 			BindAsFiles:            bindAsFiles,
+			NamingStrategy:         namingStrategy,
 			Application: bindingApi.Application{
 				Ref: bindingApi.Ref{
 					Name:    workloadName,
@@ -266,6 +268,7 @@ func (c Client) APIServiceBindingFromBinding(binding bindingApi.ServiceBinding) 
 			Services:               dstSvcs,
 			DetectBindingResources: binding.Spec.DetectBindingResources,
 			BindAsFiles:            binding.Spec.BindAsFiles,
+			NamingStrategy:         binding.Spec.NamingStrategy,
 		},
 	}, nil
 }

--- a/pkg/odo/cli/describe/binding.go
+++ b/pkg/odo/cli/describe/binding.go
@@ -143,6 +143,10 @@ func printSingleBindingHumanReadableOutput(binding api.ServiceBinding) bool {
 	log.Describef("Bind as files: ", strconv.FormatBool(binding.Spec.BindAsFiles))
 	log.Describef("Detect binding resources: ", strconv.FormatBool(binding.Spec.DetectBindingResources))
 
+	if binding.Spec.NamingStrategy != "" {
+		log.Describef("Naming strategy: ", binding.Spec.NamingStrategy)
+	}
+
 	if binding.Status == nil {
 		log.Describef("Available binding information: ", "unknown")
 		return true

--- a/tests/examples/source/devfiles/nodejs/devfile-with-service-binding-files.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-service-binding-files.yaml
@@ -58,6 +58,7 @@ components:
           name: my-nodejs-app-app
           kind: Deployment
           version: v1
+        namingStrategy: lowercase
         bindAsFiles: true
         detectBindingResources: true
         services:

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -275,6 +275,13 @@ func JsonPathContentContain(json string, path string, value string) {
 	Expect(result.String()).To(ContainSubstring(value), fmt.Sprintf("content of path %q should contain %q but is %q", path, value, result.String()))
 }
 
+// JsonPathDoesNotExist expects that the content of the path does not exist in the JSON string
+func JsonPathDoesNotExist(json string, path string) {
+	result := gjson.Get(json, path)
+	Expect(result.Exists()).To(BeFalse(),
+		fmt.Sprintf("content should not contain %q but is %q", path, result.String()))
+}
+
 func JsonPathContentIsValidUserPort(json string, path string) {
 	result := gjson.Get(json, path)
 	intVal, err := strconv.Atoi(result.String())

--- a/tests/integration/devfile/cmd_add_binding_test.go
+++ b/tests/integration/devfile/cmd_add_binding_test.go
@@ -40,7 +40,69 @@ var _ = Describe("odo add binding command tests", func() {
 	})
 
 	It("should create a binding using the workload parameter", func() {
-		helper.Cmd("odo", "add", "binding", "--name", "aname", "--service", "cluster-sample", "--workload", "app/Deployment.apps").ShouldPass()
+		stdout := helper.Cmd("odo", "add", "binding",
+			"--name", "aname",
+			"--service", "cluster-sample",
+			"--workload", "app/Deployment.apps",
+		).ShouldPass().Out()
+		Expect(stdout).To(BeEquivalentTo(`apiVersion: binding.operators.coreos.com/v1alpha1
+kind: ServiceBinding
+metadata:
+  creationTimestamp: null
+  name: aname
+spec:
+  application:
+    group: apps
+    kind: Deployment
+    name: app
+    version: v1
+  bindAsFiles: true
+  detectBindingResources: true
+  services:
+  - group: postgresql.k8s.enterprisedb.io
+    id: aname
+    kind: Cluster
+    name: cluster-sample
+    resource: clusters
+    version: v1
+status:
+  secret: ""
+
+`))
+	})
+
+	It("should create a binding using the workload parameter and naming strategy", func() {
+		stdout := helper.Cmd("odo", "add", "binding",
+			"--name", "aname",
+			"--service", "cluster-sample",
+			"--workload", "app/Deployment.apps",
+			"--naming-strategy", "lowercase",
+		).ShouldPass().Out()
+		Expect(stdout).To(BeEquivalentTo(`apiVersion: binding.operators.coreos.com/v1alpha1
+kind: ServiceBinding
+metadata:
+  creationTimestamp: null
+  name: aname
+spec:
+  application:
+    group: apps
+    kind: Deployment
+    name: app
+    version: v1
+  bindAsFiles: true
+  detectBindingResources: true
+  namingStrategy: lowercase
+  services:
+  - group: postgresql.k8s.enterprisedb.io
+    id: aname
+    kind: Cluster
+    name: cluster-sample
+    resource: clusters
+    version: v1
+status:
+  secret: ""
+
+`))
 	})
 
 	When("the component is bootstrapped", func() {

--- a/tests/integration/devfile/cmd_describe_list_binding_test.go
+++ b/tests/integration/devfile/cmd_describe_list_binding_test.go
@@ -46,6 +46,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, "0.spec.services.0.name", "cluster-sample")
 				helper.JsonPathContentIs(stdout, "0.spec.detectBindingResources", "true")
 				helper.JsonPathContentIs(stdout, "0.spec.bindAsFiles", "true")
+				helper.JsonPathContentIs(stdout, "0.spec.namingStrategy", "lowercase")
 				helper.JsonPathContentIs(stdout, "0.status", "")
 			})
 			By("human readable output", func() {
@@ -56,6 +57,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
 				Expect(stdout).To(ContainSubstring("Bind as files: true"))
 				Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
+				Expect(stdout).To(ContainSubstring("Naming strategy: lowercase"))
 				Expect(stdout).To(ContainSubstring("Available binding information: unknown"))
 				Expect(stdout).To(ContainSubstring("Binding information for one or more ServiceBinding is not available"))
 			})
@@ -121,6 +123,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
 				helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "true")
 				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
+				helper.JsonPathContentIs(stdout, prefix+"spec.namingStrategy", "lowercase")
 				helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
 				helper.JsonPathContentIs(stdout, prefix+"status.bindingEnvVars", "")
 			},
@@ -132,6 +135,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
 				Expect(stdout).To(ContainSubstring("Bind as files: true"))
 				Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
+				Expect(stdout).To(ContainSubstring("Naming strategy: lowercase"))
 				Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
 			},
 			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
@@ -190,6 +194,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "false")
 				helper.JsonPathContentIs(stdout, prefix+"status.bindingFiles", "")
 				helper.JsonPathContentContain(stdout, prefix+"status.bindingEnvVars", "PASSWORD")
+				helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
 			},
 			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
 				if list {
@@ -200,6 +205,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				Expect(stdout).To(ContainSubstring("Bind as files: false"))
 				Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
 				Expect(stdout).To(ContainSubstring("PASSWORD"))
+				Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
 			},
 			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
 				Expect(stderr).To(BeEmpty())
@@ -257,6 +263,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
 				helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
 				helper.JsonPathContentIs(stdout, prefix+"status.bindingEnvVars", "")
+				helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
 			},
 			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
 				if list {
@@ -267,6 +274,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				Expect(stdout).To(ContainSubstring("Bind as files: true"))
 				Expect(stdout).To(ContainSubstring("Detect binding resources: false"))
 				Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
+				Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
 			},
 			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
 				Expect(stderr).To(BeEmpty())
@@ -324,6 +332,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
 				helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
 				helper.JsonPathContentContain(stdout, prefix+"status.bindingEnvVars", "PASSWD")
+				helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
 			},
 			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
 				if list {
@@ -335,6 +344,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				Expect(stdout).To(ContainSubstring("Detect binding resources: false"))
 				Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
 				Expect(stdout).To(ContainSubstring("PASSWD"))
+				Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
 			},
 			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
 				Expect(stderr).To(BeEmpty())

--- a/tests/integration/devfile/cmd_describe_list_binding_test.go
+++ b/tests/integration/devfile/cmd_describe_list_binding_test.go
@@ -78,6 +78,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
 				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
 				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
+				helper.JsonPathContentIs(stdout, "bindings.0.spec.namingStrategy", "lowercase")
 				helper.JsonPathContentIs(stdout, "bindings.0.status", "")
 				helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
 				helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
@@ -150,6 +151,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
 				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
 				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
+				helper.JsonPathContentIs(stdout, "bindings.0.spec.namingStrategy", "lowercase")
 				helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
 				helper.JsonPathContentIs(stdout, "bindings.0.status.bindingEnvVars", "")
 				if devfile {
@@ -227,6 +229,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				} else {
 					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
 				}
+				helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
 			},
 			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
 				lines := strings.Split(stdout, "\n")
@@ -296,6 +299,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				} else {
 					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
 				}
+				helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
 			},
 			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
 				lines := strings.Split(stdout, "\n")
@@ -366,6 +370,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 				} else {
 					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
 				}
+				helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
 			},
 			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
 				lines := strings.Split(stdout, "\n")


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This PR makes it possible to set the `namingStrategy` field when using `odo add binding`.
For consistency, this supports both interactive and non-interactive modes.

**Which issue(s) this PR fixes:**
Fixes #5816

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-5912--odo-docusaurus-preview.netlify.app/)

**How to test changes / Special notes to the reviewer:**

- Interactive mode: new questions added when running `odo add binding`
- Non-Interactive mode: new `--naming-strategy` flag added to `odo add binding`
