### PR TITLE
download golangci-lint binary with test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,6 @@ GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1
 GINKGO_FLAGS=$(GINKGO_FLAGS_ALL) -nodes=$(TEST_EXEC_NODES)
 # GolangCi version for unit-validate test
 GOLANGCI_LINT_VERSION=1.37.0
- 
-ARCH=$(shell uname -m)
 
 RUN_GINKGO = go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo
 
@@ -114,14 +112,7 @@ clean:
 
 .PHONY: goget-tools
 goget-tools:
-ifeq '$(ARCH)' 'x86_64'
-	wget https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz
-else
-	wget https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-$(ARCH).tar.gz
-endif
-	mkdir -p $(shell go env GOPATH)/bin
-	tar --no-same-owner -xzf golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz
-	mv golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64/golangci-lint $(shell go env GOPATH)/bin/golangci-lint
+	(curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v$(GOLANGCI_LINT_VERSION)) || go install -mod=readonly github.com/golangci/golangci-lint/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
 
 .PHONY: goget-ginkgo
 goget-ginkgo:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,10 @@ GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --slow-spec-threshold=$(S
 GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1
 # Flags for tests that may be run in parallel
 GINKGO_FLAGS=$(GINKGO_FLAGS_ALL) -nodes=$(TEST_EXEC_NODES)
-
+# GolangCi version for unit-validate test
+GOLANGCI_LINT_VERSION=1.37.0
+ 
+ARCH=$(shell uname -m)
 
 RUN_GINKGO = go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo
 
@@ -111,8 +114,14 @@ clean:
 
 .PHONY: goget-tools
 goget-tools:
+ifeq '$(ARCH)' 'x86_64'
+	wget https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz
+else
+	wget https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-$(ARCH).tar.gz
+endif
 	mkdir -p $(shell go env GOPATH)/bin
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.37.0
+	tar --no-same-owner -xzf golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz
+	mv golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64/golangci-lint $(shell go env GOPATH)/bin/golangci-lint
 
 .PHONY: goget-ginkgo
 goget-ginkgo:

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -11,6 +11,18 @@ export PATH=$PATH:$GOPATH/bin
 # otherwise /.cache is used, and it fails on permission denied
 export GOLANGCI_LINT_CACHE="/tmp/.cache"
 
+ARCH=`uname -i`
+if [ "$ARCH" = "x86_64" ]; then
+  export GOARCH=amd64
+else
+  export GOARCH=$ARCH
+fi
+
+wget https://github.com/golangci/golangci-lint/releases/download/v1.37.0/golangci-lint-1.37.0-linux-$GOARCH.tar.gz
+tar --no-same-owner -xzf golangci-lint-1.37.0-linux-amd64.tar.gz
+mv golangci-lint-1.37.0-linux-amd64/golangci-lint $(go env GOPATH)/bin/golangci-lint
+chmod +x $(go env GOPATH)/bin/golangci-lint
+
 make validate
 make test
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -11,7 +11,7 @@ export PATH=$PATH:$GOPATH/bin
 # otherwise /.cache is used, and it fails on permission denied
 export GOLANGCI_LINT_CACHE="/tmp/.cache"
 
-make goget-tools 
+make goget-tools
 make validate
 make test
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -11,18 +11,7 @@ export PATH=$PATH:$GOPATH/bin
 # otherwise /.cache is used, and it fails on permission denied
 export GOLANGCI_LINT_CACHE="/tmp/.cache"
 
-ARCH=`uname -i`
-if [ "$ARCH" = "x86_64" ]; then
-  export GOARCH=amd64
-else
-  export GOARCH=$ARCH
-fi
-
-wget https://github.com/golangci/golangci-lint/releases/download/v1.37.0/golangci-lint-1.37.0-linux-$GOARCH.tar.gz
-tar --no-same-owner -xzf golangci-lint-1.37.0-linux-amd64.tar.gz
-mv golangci-lint-1.37.0-linux-amd64/golangci-lint $(go env GOPATH)/bin/golangci-lint
-chmod +x $(go env GOPATH)/bin/golangci-lint
-
+make goget-tools 
 make validate
 make test
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -11,7 +11,6 @@ export PATH=$PATH:$GOPATH/bin
 # otherwise /.cache is used, and it fails on permission denied
 export GOLANGCI_LINT_CACHE="/tmp/.cache"
 
-make goget-tools
 make validate
 make test
 


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**

/area testing

**What does this PR do / why we need it:**

Removing golangci-lint from the script, as the installation is added as [pre step](https://github.com/anandrkskd/release/blob/0692f2611817db9766dd338317b5627e4c4b52cf/ci-operator/config/redhat-developer/odo/redhat-developer-odo-main.yaml#L14) in unit test set on prow, it downloads the binary directly for the test.

**Which issue(s) this PR fixes:**

Fixes [#5879](https://github.com/redhat-developer/odo/issues/5879)

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
