### PR TITLE
Allow binding to services from other namespaces

### DIFF
--- a/docs/website/docs/command-reference/add-binding.md
+++ b/docs/website/docs/command-reference/add-binding.md
@@ -27,7 +27,10 @@ To know about the Operators supported by the Service Binding Operator, read its 
 
 ### Interactive Mode
 In the interactive mode, you will be guided to choose:
-* a service from the list of bindable service instances as supported by the Service Binding Operator,
+* the namespace containing the service instance you want to bind to,
+* a service from the list of bindable service instances as supported by the Service Binding Operator;
+  if a namespace is selected, the list of services will show the services in that namespace;
+  otherwise, the list of services will show the services in the current namespace,
 * if a Devfile is not present in the directory, a workload resource,
 * option to bind the service as a file (see [Understanding Bind as Files](#understanding-bind-as-files) for more information on this),
 * a name for the binding.
@@ -40,6 +43,7 @@ odo add binding
 ### Non-interactive mode
 In the non-interactive mode, you will have to specify the following required information through the command-line:
 * `--service` flag to specify the service you want to bind to,
+* `--service-namespace` flag to specify the namespace containing the service you want to bind to; the current namespace is used if this flag is not specified.
 * `--workload` flag to specify the workload resource, if a Devfile is not present in the directory,
 * `--name` flag to specify a name for the binding (see [Understanding Bind as Files](#understanding-bind-as-files) for more information on this)
 * `--bind-as-files` flag to specify if the service should be bound as a file; this flag is set to true by default.

--- a/docs/website/docs/command-reference/describe-binding.md
+++ b/docs/website/docs/command-reference/describe-binding.md
@@ -28,6 +28,7 @@ with the kind `ServiceBinding` and one of these apiVersion:
 For each of these resources, the following information is displayed:
 - the resource name,
 - the list of the services to which the component is bound using this service binding,
+- for each service listed, the namespace containing the service, if any; otherwise, it means that the current namespace was used,
 - if the variables are bound as files or as environment variables,
 - the naming strategy used for binding names, if any,
 - if the binding information is auto-detected.
@@ -40,7 +41,7 @@ ServiceBinding used by the current component:
 
 Service Binding Name: my-nodejs-app-cluster-sample
 Services:
- •  cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)
+ •  cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: shared-ns-1)
 Bind as files: false
 Detect binding resources: true
 Naming strategy: uppercase
@@ -65,7 +66,7 @@ ServiceBinding used by the current component:
 
 Service Binding Name: my-nodejs-app-cluster-sample-2
 Services:
- •  cluster-sample-2 (Cluster.postgresql.k8s.enterprisedb.io)
+ •  cluster-sample-2 (Cluster.postgresql.k8s.enterprisedb.io) (namespace: shared-ns-1)
 Bind as files: false
 Detect binding resources: true
 Naming strategy: uppercase

--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -433,7 +433,8 @@ $ odo describe binding -o json
 				{
 					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
 					"kind": "Cluster",
-					"name": "cluster-sample"
+					"name": "cluster-sample",
+					"namespace": "shared-services-ns"
 				}
 			],
 			"detectBindingResources": false,
@@ -509,7 +510,8 @@ $ odo describe binding --name my-first-binding -o json
 			{
 				"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
 				"kind": "Cluster",
-				"name": "cluster-sample"
+				"name": "cluster-sample",
+                "namespace": "shared-services-ns"
 			}
 		],
 		"detectBindingResources": false,

--- a/docs/website/docs/command-reference/list-binding.md
+++ b/docs/website/docs/command-reference/list-binding.md
@@ -27,8 +27,8 @@ Example:
 
 ```sh
 $ odo list binding
- NAME                              APPLICATION                     SERVICES                                                   RUNNING IN 
- binding-to-redis                  my-nodejs-app-app (Deployment)  redis (Service)                                            Dev
- * my-nodejs-app-cluster-sample    my-nodejs-app-app (Deployment)  cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)    Dev       
- * my-nodejs-app-cluster-sample-2  my-nodejs-app-app (Deployment)  cluster-sample-2 (Cluster.postgresql.k8s.enterprisedb.io)  Dev       
+ NAME                              APPLICATION                     SERVICES                                                                            RUNNING IN 
+ binding-to-redis                  my-nodejs-app-app (Deployment)  redis (Service)                                                                     Dev
+ * my-nodejs-app-cluster-sample    my-nodejs-app-app (Deployment)  cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: shared-ns-1)    Dev       
+ * my-nodejs-app-cluster-sample-2  my-nodejs-app-app (Deployment)  cluster-sample-2 (Cluster.postgresql.k8s.enterprisedb.io)                           Dev       
 ```

--- a/pkg/binding/add.go
+++ b/pkg/binding/add.go
@@ -28,7 +28,7 @@ func (o *BindingClient) SelectNamespace(flags map[string]string) (string, error)
 	return backend.SelectNamespace(flags)
 }
 
-// ValidateAddBinding calls Validate method of the adequate backend
+// ValidateAddBinding calls Validate method of the adequate backend and then checks if the ServiceBinding Operator is installed in the cluster.
 func (o *BindingClient) ValidateAddBinding(flags map[string]string, withDevfile bool) error {
 	var backend backendpkg.AddBindingBackend
 	if len(flags) == 0 {
@@ -36,7 +36,12 @@ func (o *BindingClient) ValidateAddBinding(flags map[string]string, withDevfile 
 	} else {
 		backend = o.flagsBackend
 	}
-	return backend.Validate(flags, withDevfile)
+	err := backend.Validate(flags, withDevfile)
+	if err != nil {
+		return err
+	}
+
+	return o.checkServiceBindingOperatorInstalled()
 }
 
 func (o *BindingClient) SelectServiceInstance(flags map[string]string, serviceMap map[string]unstructured.Unstructured) (string, error) {

--- a/pkg/binding/add.go
+++ b/pkg/binding/add.go
@@ -18,6 +18,16 @@ import (
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 )
 
+func (o *BindingClient) SelectNamespace(flags map[string]string) (string, error) {
+	var backend backendpkg.AddBindingBackend
+	if len(flags) == 0 {
+		backend = o.interactiveBackend
+	} else {
+		backend = o.flagsBackend
+	}
+	return backend.SelectNamespace(flags)
+}
+
 // ValidateAddBinding calls Validate method of the adequate backend
 func (o *BindingClient) ValidateAddBinding(flags map[string]string, withDevfile bool) error {
 	var backend backendpkg.AddBindingBackend

--- a/pkg/binding/add.go
+++ b/pkg/binding/add.go
@@ -97,11 +97,12 @@ func (o *BindingClient) AskNamingStrategy(flags map[string]string) (string, erro
 func (o *BindingClient) AddBindingToDevfile(
 	bindingName string,
 	bindAsFiles bool,
+	serviceNs string,
 	namingStrategy string,
 	unstructuredService unstructured.Unstructured,
 	obj parser.DevfileObj,
 ) (parser.DevfileObj, error) {
-	service, err := o.kubernetesClient.NewServiceBindingServiceObject(unstructuredService, bindingName)
+	service, err := o.kubernetesClient.NewServiceBindingServiceObject(serviceNs, unstructuredService, bindingName)
 	if err != nil {
 		return obj, err
 	}
@@ -132,12 +133,13 @@ func (o *BindingClient) AddBinding(
 	flags map[string]string,
 	bindingName string,
 	bindAsFiles bool,
+	serviceNs string,
 	namingStrategy string,
 	unstructuredService unstructured.Unstructured,
 	workloadName string,
 	workloadGVK schema.GroupVersionKind,
 ) ([]asker.CreationOption, string, string, error) {
-	service, err := o.kubernetesClient.NewServiceBindingServiceObject(unstructuredService, bindingName)
+	service, err := o.kubernetesClient.NewServiceBindingServiceObject(serviceNs, unstructuredService, bindingName)
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/pkg/binding/asker/interface.go
+++ b/pkg/binding/asker/interface.go
@@ -8,7 +8,24 @@ const (
 	OutputToFile
 )
 
+type ServiceInstancesNamespaceListOption int
+
+const (
+	CurrentNamespace ServiceInstancesNamespaceListOption = iota + 1
+	AllAccessibleNamespaces
+)
+
 type Asker interface {
+	// SelectNamespaceListOption asks the user to select how service instances should be listed,
+	// i.e. from the current namespace or from all accessible namespaces.
+	// If user selects to list from all accessible namespaces, callers should fetch the list of namespaces
+	// and prompt users to either pick or enter one.
+	// See SelectNamespace and AskNamespace methods.
+	SelectNamespaceListOption() (ServiceInstancesNamespaceListOption, error)
+	// AskNamespace asks the user to enter a namespace
+	AskNamespace() (string, error)
+	// SelectNamespace takes a list of namespaces and asks the user to pick one of them
+	SelectNamespace(options []string) (string, error)
 	// SelectWorkloadResource takes a list of workloads resources and asks user to select one
 	SelectWorkloadResource(options []string) (int, error)
 	// SelectWorkloadResourceName takes a list of workloads resources names and asks user to select one

--- a/pkg/binding/asker/survey_asker.go
+++ b/pkg/binding/asker/survey_asker.go
@@ -1,6 +1,7 @@
 package asker
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -25,6 +26,57 @@ var _ Asker = (*Survey)(nil)
 
 func NewSurveyAsker() *Survey {
 	return &Survey{}
+}
+
+func (s *Survey) SelectNamespaceListOption() (ServiceInstancesNamespaceListOption, error) {
+	const (
+		currentNsOption       = "current namespace"
+		allAccessibleNsOption = "all accessible namespaces"
+	)
+	question := &survey.Select{
+		Message: "Do you want to list services from:",
+		Options: []string{currentNsOption, allAccessibleNsOption},
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return 0, err
+	}
+
+	switch answer {
+	case currentNsOption:
+		return CurrentNamespace, nil
+	case allAccessibleNsOption:
+		return AllAccessibleNamespaces, nil
+	default:
+		return 0, fmt.Errorf("unknown namespace list option: %s", answer)
+	}
+}
+
+func (s *Survey) AskNamespace() (string, error) {
+	question := &survey.Input{
+		Message: "Enter the namespace containing the service instances or press Enter to use the current namespace:",
+		Default: "",
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
+func (s *Survey) SelectNamespace(options []string) (string, error) {
+	question := &survey.Select{
+		Message: "Select the namespace containing the service instances:",
+		Options: options,
+	}
+	var answer string
+	err := survey.AskOne(question, &answer)
+	if err != nil {
+		return "", err
+	}
+	return answer, nil
 }
 
 func (s *Survey) SelectWorkloadResource(options []string) (int, error) {

--- a/pkg/binding/backend/flags.go
+++ b/pkg/binding/backend/flags.go
@@ -15,11 +15,12 @@ import (
 )
 
 const (
-	FLAG_WORKLOAD        = "workload"
-	FLAG_SERVICE         = "service"
-	FLAG_NAME            = "name"
-	FLAG_BIND_AS_FILES   = "bind-as-files"
-	FLAG_NAMING_STRATEGY = "naming-strategy"
+	FLAG_WORKLOAD          = "workload"
+	FLAG_SERVICE           = "service"
+	FLAG_SERVICE_NAMESPACE = "service-namespace"
+	FLAG_NAME              = "name"
+	FLAG_BIND_AS_FILES     = "bind-as-files"
+	FLAG_NAMING_STRATEGY   = "naming-strategy"
 )
 
 // FlagsBackend is a backend that will extract all needed information from flags passed to the command
@@ -57,6 +58,10 @@ func (o *FlagsBackend) SelectWorkloadInstance(workloadName string) (string, sche
 		}
 	}
 	return "", schema.GroupVersionKind{}, fmt.Errorf("group/kind %q not found on the cluster", selectedGroup+"/"+selectedKind)
+}
+
+func (o *FlagsBackend) SelectNamespace(flags map[string]string) (string, error) {
+	return flags[FLAG_SERVICE_NAMESPACE], nil
 }
 
 // SelectServiceInstance parses the service's name, kind, and group from arg:serviceName,

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -1,11 +1,18 @@
 package backend
 
 import (
+	"fmt"
+	"sort"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog"
 
 	"github.com/redhat-developer/odo/pkg/binding/asker"
 	"github.com/redhat-developer/odo/pkg/kclient"
+	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/project"
 )
 
 type selectWorkloadStep int
@@ -19,14 +26,16 @@ const (
 // InteractiveBackend is a backend that will ask information interactively using the `asker` package
 type InteractiveBackend struct {
 	askerClient      asker.Asker
+	projectClient    project.Client
 	kubernetesClient kclient.ClientInterface
 }
 
 var _ AddBindingBackend = (*InteractiveBackend)(nil)
 
-func NewInteractiveBackend(askerClient asker.Asker, kubernetesClient kclient.ClientInterface) *InteractiveBackend {
+func NewInteractiveBackend(askerClient asker.Asker, projectClient project.Client, kubernetesClient kclient.ClientInterface) *InteractiveBackend {
 	return &InteractiveBackend{
 		askerClient:      askerClient,
+		projectClient:    projectClient,
 		kubernetesClient: kubernetesClient,
 	}
 }
@@ -98,6 +107,39 @@ loop:
 	return selectedName, selectedGVK, nil
 }
 
+// SelectNamespace prompts users to select the namespace which services instances should be listed from.
+// If they choose all the namespaces they have access to, it attempts to get the list of accessible namespaces in the cluster,
+// from which the user can select one.
+// If the list is empty (e.g. because of permission-related issues), the user is prompted to manually provide a namespace.
+func (o *InteractiveBackend) SelectNamespace(_ map[string]string) (string, error) {
+	option, err := o.askerClient.SelectNamespaceListOption()
+	if err != nil {
+		return "", err
+	}
+
+	switch option {
+	case asker.CurrentNamespace:
+		return "", nil
+	case asker.AllAccessibleNamespaces:
+		klog.V(2).Infof("Listing all projects/namespaces...")
+		var nsList []string
+		nsList, err = o.getAllNamespaces()
+		if err != nil {
+			return "", err
+		}
+		sort.Strings(nsList)
+		klog.V(4).Infof("all accessible namespaces: %v", nsList)
+		if len(nsList) == 0 {
+			//User needs to provide a namespace
+			return o.askerClient.AskNamespace()
+		}
+		//Let users select a namespace from the list
+		return o.askerClient.SelectNamespace(nsList)
+	default:
+		return "", fmt.Errorf("unknown namespace list option: %d", option)
+	}
+}
+
 func (o *InteractiveBackend) SelectServiceInstance(_ string, serviceMap map[string]unstructured.Unstructured) (string, error) {
 	var options []string
 	for name := range serviceMap {
@@ -131,4 +173,23 @@ func (o *InteractiveBackend) SelectCreationOptions(flags map[string]string) ([]a
 
 func (o *InteractiveBackend) AskOutputFilePath(flags map[string]string, defaultValue string) (string, error) {
 	return o.askerClient.AskOutputFilePath(defaultValue)
+}
+
+func (o *InteractiveBackend) getAllNamespaces() ([]string, error) {
+	accessibleNsList, err := o.projectClient.List()
+	if err != nil {
+		klog.V(2).Infof("Failed to list namespaces/projects: %v", err)
+		if kerrors.IsForbidden(err) {
+			// If status is forbidden, this might be an RBAC error due to user not having permission to list namespaces.
+			// In this case, user will need to manually specify the namespace.
+			log.Warningf("Failed to list namespaces/projects: %v", err)
+			return nil, nil
+		}
+		return nil, err
+	}
+	nsList := make([]string, 0, len(accessibleNsList.Items))
+	for _, ns := range accessibleNsList.Items {
+		nsList = append(nsList, ns.Name)
+	}
+	return nsList, nil
 }

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -61,7 +61,7 @@ loop:
 			if err != nil {
 				return "", schema.GroupVersionKind{}, err
 			}
-			resourceList, err := o.kubernetesClient.ListDynamicResources(gvr)
+			resourceList, err := o.kubernetesClient.ListDynamicResources("", gvr)
 			if err != nil {
 				return "", schema.GroupVersionKind{}, err
 			}

--- a/pkg/binding/backend/interface.go
+++ b/pkg/binding/backend/interface.go
@@ -8,6 +8,9 @@ import (
 )
 
 type AddBindingBackend interface {
+	// SelectNamespace returns the namespace which services instances should be listed from.
+	// An empty return value means that service instances will be listed from the current namespace.
+	SelectNamespace(flags map[string]string) (string, error)
 	// Validate returns error if the backend failed to validate; mainly useful for flags backend
 	Validate(flags map[string]string, withDevfile bool) error
 	// SelectWorkloadInstance asks user to select the workload to be bind;

--- a/pkg/binding/backend/mock.go
+++ b/pkg/binding/backend/mock.go
@@ -111,6 +111,21 @@ func (mr *MockAddBindingBackendMockRecorder) SelectCreationOptions(flags interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectCreationOptions", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectCreationOptions), flags)
 }
 
+// SelectNamespace mocks base method.
+func (m *MockAddBindingBackend) SelectNamespace(flags map[string]string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectNamespace", flags)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectNamespace indicates an expected call of SelectNamespace.
+func (mr *MockAddBindingBackendMockRecorder) SelectNamespace(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectNamespace", reflect.TypeOf((*MockAddBindingBackend)(nil).SelectNamespace), flags)
+}
+
 // SelectServiceInstance mocks base method.
 func (m *MockAddBindingBackend) SelectServiceInstance(serviceName string, serviceMap map[string]unstructured.Unstructured) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -65,15 +65,11 @@ func (o *BindingClient) GetFlags(flags map[string]string) map[string]string {
 }
 
 func (o *BindingClient) GetServiceInstances(namespace string) (map[string]unstructured.Unstructured, error) {
-	isServiceBindingInstalled, err := o.kubernetesClient.IsServiceBindingSupported()
+	err := o.checkServiceBindingOperatorInstalled()
 	if err != nil {
 		return nil, err
 	}
-	if !isServiceBindingInstalled {
-		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
-		return nil, fmt.Errorf("Service Binding Operator is not installed on the cluster, please ensure it is installed before proceeding. See installation instructions: https://odo.dev/docs/overview/cluster-setup/")
-		//revive:enable:error-strings
-	}
+
 	// Get the BindableKinds/bindable-kinds object
 	bindableKind, err := o.kubernetesClient.GetBindableKinds()
 	if err != nil {
@@ -285,4 +281,18 @@ func (o *BindingClient) getStatusFromSpec(name string) (*api.ServiceBindingStatu
 		BindingFiles:   bindingFiles,
 		BindingEnvVars: bindingEnvVars,
 	}, nil
+}
+
+func (o *BindingClient) checkServiceBindingOperatorInstalled() error {
+	isServiceBindingInstalled, err := o.kubernetesClient.IsServiceBindingSupported()
+	if err != nil {
+		return err
+	}
+	if !isServiceBindingInstalled {
+		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
+		return fmt.Errorf("Service Binding Operator is not installed on the cluster, please ensure it is installed before proceeding. " +
+			"See installation instructions: https://odo.dev/docs/overview/cluster-setup/")
+		//revive:enable:error-strings
+	}
+	return nil
 }

--- a/pkg/binding/binding_test.go
+++ b/pkg/binding/binding_test.go
@@ -119,7 +119,7 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 						{Resource: clusterGVR, GroupVersionKind: clusterGVK},
 					}, nil)
 
-					client.EXPECT().ListDynamicResources(clusterGVR).Return(&unstructured.UnstructuredList{Items: []unstructured.Unstructured{clusterUnstructured}}, nil)
+					client.EXPECT().ListDynamicResources("", clusterGVR).Return(&unstructured.UnstructuredList{Items: []unstructured.Unstructured{clusterUnstructured}}, nil)
 					return client
 				},
 			},
@@ -152,7 +152,7 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 					{Resource: clusterGVR, GroupVersionKind: clusterGVK},
 				}, nil)
 
-				client.EXPECT().ListDynamicResources(clusterGVR).Return(&unstructured.UnstructuredList{Items: nil}, nil)
+				client.EXPECT().ListDynamicResources("", clusterGVR).Return(&unstructured.UnstructuredList{Items: nil}, nil)
 				return client
 			}},
 			want:    map[string]unstructured.Unstructured{},

--- a/pkg/binding/binding_test.go
+++ b/pkg/binding/binding_test.go
@@ -218,6 +218,7 @@ func TestBindingClient_GetServiceInstances(t *testing.T) {
 
 func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 	bindingName := "my-nodejs-app-cluster-sample"
+	ns := "my-ns"
 
 	var clusterUnstructured unstructured.Unstructured
 	clusterUnstructured.SetGroupVersionKind(clusterGVK)
@@ -236,6 +237,20 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 		},
 	}
 
+	serviceBindingRefWithNs := servicebinding.Service{
+		Id: &bindingName,
+		NamespacedRef: servicebinding.NamespacedRef{
+			Ref: servicebinding.Ref{
+				Group:    clusterGVK.Group,
+				Version:  clusterGVK.Version,
+				Kind:     clusterGVK.Kind,
+				Name:     clusterUnstructured.GetName(),
+				Resource: "clusters",
+			},
+			Namespace: &ns,
+		},
+	}
+
 	type fields struct {
 		kubernetesClient func(ctrl *gomock.Controller) kclient.ClientInterface
 	}
@@ -243,6 +258,7 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 		bindingName         string
 		bindAsFiles         bool
 		namingStrategy      string
+		namespace           string
 		unstructuredService unstructured.Unstructured
 		obj                 parser.DevfileObj
 	}
@@ -258,7 +274,7 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 			fields: fields{
 				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
 					client := kclient.NewMockClientInterface(ctrl)
-					client.EXPECT().NewServiceBindingServiceObject(clusterUnstructured, bindingName).Return(serviceBindingRef, nil)
+					client.EXPECT().NewServiceBindingServiceObject("", clusterUnstructured, bindingName).Return(serviceBindingRef, nil)
 					client.EXPECT().GetDeploymentAPIVersion().Return(deploymentGVK, nil)
 					return client
 				},
@@ -269,7 +285,27 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 				unstructuredService: clusterUnstructured,
 				obj:                 odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs()),
 			},
-			want:    getDevfileObjWithServiceBinding(bindingName, false, ""),
+			want:    getDevfileObjWithServiceBinding(bindingName, "", false, ""),
+			wantErr: false,
+		},
+		{
+			name: "successfully add binding with namespace",
+			fields: fields{
+				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
+					client := kclient.NewMockClientInterface(ctrl)
+					client.EXPECT().NewServiceBindingServiceObject(ns, clusterUnstructured, bindingName).Return(serviceBindingRefWithNs, nil)
+					client.EXPECT().GetDeploymentAPIVersion().Return(deploymentGVK, nil)
+					return client
+				},
+			},
+			args: args{
+				bindingName:         bindingName,
+				bindAsFiles:         false,
+				namespace:           ns,
+				unstructuredService: clusterUnstructured,
+				obj:                 odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs()),
+			},
+			want:    getDevfileObjWithServiceBinding(bindingName, ns, false, ""),
 			wantErr: false,
 		},
 		{
@@ -277,7 +313,7 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 			fields: fields{
 				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
 					client := kclient.NewMockClientInterface(ctrl)
-					client.EXPECT().NewServiceBindingServiceObject(clusterUnstructured, bindingName).Return(serviceBindingRef, nil)
+					client.EXPECT().NewServiceBindingServiceObject("", clusterUnstructured, bindingName).Return(serviceBindingRef, nil)
 					client.EXPECT().GetDeploymentAPIVersion().Return(deploymentGVK, nil)
 					return client
 				},
@@ -288,7 +324,27 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 				unstructuredService: clusterUnstructured,
 				obj:                 odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs()),
 			},
-			want:    getDevfileObjWithServiceBinding(bindingName, true, ""),
+			want:    getDevfileObjWithServiceBinding(bindingName, "", true, ""),
+			wantErr: false,
+		},
+		{
+			name: "successfully added binding for a Service Binding bound as files and namespace",
+			fields: fields{
+				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
+					client := kclient.NewMockClientInterface(ctrl)
+					client.EXPECT().NewServiceBindingServiceObject(ns, clusterUnstructured, bindingName).Return(serviceBindingRefWithNs, nil)
+					client.EXPECT().GetDeploymentAPIVersion().Return(deploymentGVK, nil)
+					return client
+				},
+			},
+			args: args{
+				bindingName:         bindingName,
+				bindAsFiles:         true,
+				namespace:           ns,
+				unstructuredService: clusterUnstructured,
+				obj:                 odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs()),
+			},
+			want:    getDevfileObjWithServiceBinding(bindingName, ns, true, ""),
 			wantErr: false,
 		},
 		{
@@ -296,7 +352,7 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 			fields: fields{
 				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
 					client := kclient.NewMockClientInterface(ctrl)
-					client.EXPECT().NewServiceBindingServiceObject(clusterUnstructured, bindingName).Return(serviceBindingRef, nil)
+					client.EXPECT().NewServiceBindingServiceObject("", clusterUnstructured, bindingName).Return(serviceBindingRef, nil)
 					client.EXPECT().GetDeploymentAPIVersion().Return(deploymentGVK, nil)
 					return client
 				},
@@ -308,7 +364,28 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 				unstructuredService: clusterUnstructured,
 				obj:                 odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs()),
 			},
-			want:    getDevfileObjWithServiceBinding(bindingName, true, "uppercase"),
+			want:    getDevfileObjWithServiceBinding(bindingName, "", true, "uppercase"),
+			wantErr: false,
+		},
+		{
+			name: "successfully added binding for a Service Binding with naming strategy and namespace",
+			fields: fields{
+				kubernetesClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
+					client := kclient.NewMockClientInterface(ctrl)
+					client.EXPECT().NewServiceBindingServiceObject(ns, clusterUnstructured, bindingName).Return(serviceBindingRefWithNs, nil)
+					client.EXPECT().GetDeploymentAPIVersion().Return(deploymentGVK, nil)
+					return client
+				},
+			},
+			args: args{
+				bindingName:         bindingName,
+				bindAsFiles:         true,
+				namespace:           ns,
+				namingStrategy:      "uppercase",
+				unstructuredService: clusterUnstructured,
+				obj:                 odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs()),
+			},
+			want:    getDevfileObjWithServiceBinding(bindingName, ns, true, "uppercase"),
 			wantErr: false,
 		},
 	}
@@ -318,7 +395,7 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 			o := &BindingClient{
 				kubernetesClient: tt.fields.kubernetesClient(ctrl),
 			}
-			got, err := o.AddBindingToDevfile(tt.args.bindingName, tt.args.bindAsFiles, tt.args.namingStrategy, tt.args.unstructuredService, tt.args.obj)
+			got, err := o.AddBindingToDevfile(tt.args.bindingName, tt.args.bindAsFiles, tt.args.namespace, tt.args.namingStrategy, tt.args.unstructuredService, tt.args.obj)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AddBindingToDevfile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -330,7 +407,7 @@ func TestBindingClient_AddBindingToDevfile(t *testing.T) {
 	}
 }
 
-func getDevfileObjWithServiceBinding(bindingName string, bindAsFiles bool, namingStrategy string) parser.DevfileObj {
+func getDevfileObjWithServiceBinding(bindingName string, ns string, bindAsFiles bool, namingStrategy string) parser.DevfileObj {
 	obj := odoTestingUtil.GetTestDevfileObj(filesystem.NewFakeFs())
 	_ = obj.Data.AddComponents([]v1alpha2.Component{{
 		Name: bindingName,
@@ -339,7 +416,7 @@ func getDevfileObjWithServiceBinding(bindingName string, bindAsFiles bool, namin
 				K8sLikeComponent: v1alpha2.K8sLikeComponent{
 					BaseComponent: v1alpha2.BaseComponent{},
 					K8sLikeComponentLocation: v1alpha2.K8sLikeComponentLocation{
-						Inlined: getServiceBindingInlinedContent(bindAsFiles, namingStrategy),
+						Inlined: getServiceBindingInlinedContent(ns, bindAsFiles, namingStrategy),
 					},
 				},
 			},
@@ -348,7 +425,7 @@ func getDevfileObjWithServiceBinding(bindingName string, bindAsFiles bool, namin
 	return obj
 }
 
-func getServiceBindingInlinedContent(bindAsFiles bool, namingStrategy string) string {
+func getServiceBindingInlinedContent(ns string, bindAsFiles bool, namingStrategy string) string {
 	h := fmt.Sprintf(`apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
@@ -362,7 +439,8 @@ spec:
     version: v1
   bindAsFiles: %v
   detectBindingResources: true`, bindAsFiles)
-	f := `
+
+	fNoNamespace := `
   services:
   - group: postgresql.k8s.enterprisedb.io
     id: my-nodejs-app-cluster-sample
@@ -373,9 +451,32 @@ spec:
 status:
   secret: ""
 `
+
+	fNamespace := fmt.Sprintf(`
+  services:
+  - group: postgresql.k8s.enterprisedb.io
+    id: my-nodejs-app-cluster-sample
+    kind: Cluster
+    name: cluster-sample
+    namespace: %s
+    resource: clusters
+    version: v1
+status:
+  secret: ""
+`, ns)
+
 	if namingStrategy != "" {
+		if ns != "" {
+			return fmt.Sprintf(`%s
+  namingStrategy: %s%s`, h, namingStrategy, fNamespace)
+		}
 		return fmt.Sprintf(`%s
-  namingStrategy: %s%s`, h, namingStrategy, f)
+  namingStrategy: %s%s`, h, namingStrategy, fNoNamespace)
 	}
-	return h + f
+
+	if ns != "" {
+		return h + fNamespace
+	}
+
+	return h + fNoNamespace
 }

--- a/pkg/binding/interface.go
+++ b/pkg/binding/interface.go
@@ -41,6 +41,7 @@ type Client interface {
 	AddBindingToDevfile(
 		bindingName string,
 		bindAsFiles bool,
+		serviceNs string,
 		namingStrategy string,
 		unstructuredService unstructured.Unstructured,
 		obj parser.DevfileObj,
@@ -52,6 +53,7 @@ type Client interface {
 		flags map[string]string,
 		bindingName string,
 		bindAsFiles bool,
+		serviceNs string,
 		namingStrategy string,
 		unstructuredService unstructured.Unstructured,
 		workloadName string,

--- a/pkg/binding/interface.go
+++ b/pkg/binding/interface.go
@@ -12,8 +12,8 @@ import (
 type Client interface {
 	// GetFlags gets the necessary flags for binding
 	GetFlags(flags map[string]string) map[string]string
-	// GetServiceInstances returns a map of bindable instance name with its unstructured.Unstructured object, and an error
-	GetServiceInstances() (map[string]unstructured.Unstructured, error)
+	// GetServiceInstances returns a map of bindable instance name with its unstructured.Unstructured object from the specified namespace, and an error
+	GetServiceInstances(namespace string) (map[string]unstructured.Unstructured, error)
 	// GetBindingsFromDevfile returns the bindings defined in the devfile with the status extracted from cluster
 	GetBindingsFromDevfile(devfileObj parser.DevfileObj, context string) ([]api.ServiceBinding, error)
 	// GetBindingFromCluster returns information about a binding in the cluster (either from group binding.operators.coreos.com or servicebinding.io)
@@ -21,6 +21,9 @@ type Client interface {
 
 	// add.go
 
+	// SelectNamespace returns the namespace which services instances should be listed from.
+	// An empty return value means that service instances will be listed from the current namespace.
+	SelectNamespace(flags map[string]string) (string, error)
 	// ValidateAddBinding returns error if the backend failed to validate; mainly useful for flags backend
 	// withDevfile indicates if a Devfile is present in the current directory
 	ValidateAddBinding(flags map[string]string, withDevfile bool) error

--- a/pkg/binding/list_test.go
+++ b/pkg/binding/list_test.go
@@ -114,7 +114,7 @@ func TestBindingClient_ListAllBindings(t *testing.T) {
 					return client
 				},
 			}, args: args{
-				devfileObj: getDevfileObjWithServiceBinding("aname", true, ""),
+				devfileObj: getDevfileObjWithServiceBinding("aname", "", true, ""),
 				context:    "/apath",
 			},
 			want:          []api.ServiceBinding{apiServiceBinding},
@@ -138,7 +138,7 @@ func TestBindingClient_ListAllBindings(t *testing.T) {
 					return client
 				},
 			}, args: args{
-				devfileObj: getDevfileObjWithServiceBinding("aname", true, ""),
+				devfileObj: getDevfileObjWithServiceBinding("aname", "", true, ""),
 				context:    "/apath",
 			},
 			want: []api.ServiceBinding{

--- a/pkg/binding/mock.go
+++ b/pkg/binding/mock.go
@@ -39,9 +39,9 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddBinding mocks base method.
-func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, namingStrategy string, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) ([]asker.CreationOption, string, string, error) {
+func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bindAsFiles bool, serviceNs, namingStrategy string, unstructuredService unstructured.Unstructured, workloadName string, workloadGVK schema.GroupVersionKind) ([]asker.CreationOption, string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBinding", flags, bindingName, bindAsFiles, namingStrategy, unstructuredService, workloadName, workloadGVK)
+	ret := m.ctrl.Call(m, "AddBinding", flags, bindingName, bindAsFiles, serviceNs, namingStrategy, unstructuredService, workloadName, workloadGVK)
 	ret0, _ := ret[0].([]asker.CreationOption)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -50,24 +50,24 @@ func (m *MockClient) AddBinding(flags map[string]string, bindingName string, bin
 }
 
 // AddBinding indicates an expected call of AddBinding.
-func (mr *MockClientMockRecorder) AddBinding(flags, bindingName, bindAsFiles, namingStrategy, unstructuredService, workloadName, workloadGVK interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) AddBinding(flags, bindingName, bindAsFiles, serviceNs, namingStrategy, unstructuredService, workloadName, workloadGVK interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinding", reflect.TypeOf((*MockClient)(nil).AddBinding), flags, bindingName, bindAsFiles, namingStrategy, unstructuredService, workloadName, workloadGVK)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinding", reflect.TypeOf((*MockClient)(nil).AddBinding), flags, bindingName, bindAsFiles, serviceNs, namingStrategy, unstructuredService, workloadName, workloadGVK)
 }
 
 // AddBindingToDevfile mocks base method.
-func (m *MockClient) AddBindingToDevfile(bindingName string, bindAsFiles bool, namingStrategy string, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
+func (m *MockClient) AddBindingToDevfile(bindingName string, bindAsFiles bool, serviceNs, namingStrategy string, unstructuredService unstructured.Unstructured, obj parser.DevfileObj) (parser.DevfileObj, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBindingToDevfile", bindingName, bindAsFiles, namingStrategy, unstructuredService, obj)
+	ret := m.ctrl.Call(m, "AddBindingToDevfile", bindingName, bindAsFiles, serviceNs, namingStrategy, unstructuredService, obj)
 	ret0, _ := ret[0].(parser.DevfileObj)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddBindingToDevfile indicates an expected call of AddBindingToDevfile.
-func (mr *MockClientMockRecorder) AddBindingToDevfile(bindingName, bindAsFiles, namingStrategy, unstructuredService, obj interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) AddBindingToDevfile(bindingName, bindAsFiles, serviceNs, namingStrategy, unstructuredService, obj interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindingToDevfile", reflect.TypeOf((*MockClient)(nil).AddBindingToDevfile), bindingName, bindAsFiles, namingStrategy, unstructuredService, obj)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindingToDevfile", reflect.TypeOf((*MockClient)(nil).AddBindingToDevfile), bindingName, bindAsFiles, serviceNs, namingStrategy, unstructuredService, obj)
 }
 
 // AskBindAsFiles mocks base method.

--- a/pkg/binding/mock.go
+++ b/pkg/binding/mock.go
@@ -160,18 +160,18 @@ func (mr *MockClientMockRecorder) GetFlags(flags interface{}) *gomock.Call {
 }
 
 // GetServiceInstances mocks base method.
-func (m *MockClient) GetServiceInstances() (map[string]unstructured.Unstructured, error) {
+func (m *MockClient) GetServiceInstances(namespace string) (map[string]unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceInstances")
+	ret := m.ctrl.Call(m, "GetServiceInstances", namespace)
 	ret0, _ := ret[0].(map[string]unstructured.Unstructured)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetServiceInstances indicates an expected call of GetServiceInstances.
-func (mr *MockClientMockRecorder) GetServiceInstances() *gomock.Call {
+func (mr *MockClientMockRecorder) GetServiceInstances(namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceInstances", reflect.TypeOf((*MockClient)(nil).GetServiceInstances))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceInstances", reflect.TypeOf((*MockClient)(nil).GetServiceInstances), namespace)
 }
 
 // ListAllBindings mocks base method.
@@ -203,6 +203,21 @@ func (m *MockClient) RemoveBinding(bindingName string, obj parser.DevfileObj) (p
 func (mr *MockClientMockRecorder) RemoveBinding(bindingName, obj interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveBinding", reflect.TypeOf((*MockClient)(nil).RemoveBinding), bindingName, obj)
+}
+
+// SelectNamespace mocks base method.
+func (m *MockClient) SelectNamespace(flags map[string]string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectNamespace", flags)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectNamespace indicates an expected call of SelectNamespace.
+func (mr *MockClientMockRecorder) SelectNamespace(flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectNamespace", reflect.TypeOf((*MockClient)(nil).SelectNamespace), flags)
 }
 
 // SelectServiceInstance mocks base method.

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -96,10 +96,15 @@ func (c Client) GetBindableKindStatusRestMapping(bindableKindStatuses []bindingA
 }
 
 // NewServiceBindingServiceObject returns the bindingApi.Service object based on the RESTMapping
-func (c *Client) NewServiceBindingServiceObject(unstructuredService unstructured.Unstructured, bindingName string) (bindingApi.Service, error) {
+func (c *Client) NewServiceBindingServiceObject(serviceNs string, unstructuredService unstructured.Unstructured, bindingName string) (bindingApi.Service, error) {
 	serviceRESTMapping, err := c.GetRestMappingFromUnstructured(unstructuredService)
 	if err != nil {
 		return bindingApi.Service{}, err
+	}
+
+	var ns *string
+	if serviceNs != "" {
+		ns = &serviceNs
 	}
 
 	return bindingApi.Service{
@@ -112,6 +117,7 @@ func (c *Client) NewServiceBindingServiceObject(unstructuredService unstructured
 				Name:     unstructuredService.GetName(),
 				Resource: serviceRESTMapping.Resource.Resource,
 			},
+			Namespace: ns,
 		},
 	}, nil
 }

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -243,6 +243,9 @@ func (c Client) APIServiceBindingFromBinding(binding bindingApi.ServiceBinding) 
 			Group:   srcSvc.Group,
 			Version: srcSvc.Version,
 		}.WithKind(srcSvc.Kind).ToAPIVersionAndKind()
+		if srcSvc.Namespace != nil {
+			dstSvc.Namespace = *srcSvc.Namespace
+		}
 		dstSvcs = append(dstSvcs, dstSvc)
 	}
 

--- a/pkg/kclient/binding.go
+++ b/pkg/kclient/binding.go
@@ -201,7 +201,7 @@ func (c Client) ListServiceBindingsFromAllGroups() ([]specApi.ServiceBinding, []
 		return nil, nil, nil
 	}
 
-	specsU, err := c.ListDynamicResources(specApi.GroupVersionResource)
+	specsU, err := c.ListDynamicResources("", specApi.GroupVersionResource)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -211,7 +211,7 @@ func (c Client) ListServiceBindingsFromAllGroups() ([]specApi.ServiceBinding, []
 		return nil, nil, err
 	}
 
-	bindingsU, err := c.ListDynamicResources(bindingApi.GroupVersionResource)
+	bindingsU, err := c.ListDynamicResources("", bindingApi.GroupVersionResource)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kclient/dynamic.go
+++ b/pkg/kclient/dynamic.go
@@ -52,15 +52,20 @@ func (c *Client) PatchDynamicResource(resource unstructured.Unstructured) (bool,
 	return newGeneration > previousGeneration, nil
 }
 
-// ListDynamicResource returns an unstructured list of instances of a Custom
-// Resource currently deployed in the active namespace of the cluster.
-func (c *Client) ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
+// ListDynamicResources returns an unstructured list of instances of a Custom
+// Resource currently deployed in the specified namespace of the cluster. The current namespace is used if the namespace is not specified.
+func (c *Client) ListDynamicResources(namespace string, gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 
 	if c.DynamicClient == nil {
 		return nil, nil
 	}
 
-	list, err := c.DynamicClient.Resource(gvr).Namespace(c.Namespace).List(context.TODO(), metav1.ListOptions{})
+	ns := namespace
+	if ns == "" {
+		ns = c.Namespace
+	}
+
+	list, err := c.DynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			// Assume this is a cluster scoped resource (not namespace scoped) and skip it

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -38,7 +38,7 @@ type ClientInterface interface {
 	GetBindingServiceBinding(name string) (bindingApi.ServiceBinding, error)
 	GetSpecServiceBinding(name string) (specApi.ServiceBinding, error)
 	ListServiceBindingsFromAllGroups() ([]specApi.ServiceBinding, []bindingApi.ServiceBinding, error)
-	NewServiceBindingServiceObject(unstructuredService unstructured.Unstructured, bindingName string) (bindingApi.Service, error)
+	NewServiceBindingServiceObject(serviceNs string, unstructuredService unstructured.Unstructured, bindingName string) (bindingApi.Service, error)
 	APIServiceBindingFromBinding(binding bindingApi.ServiceBinding) (api.ServiceBinding, error)
 	APIServiceBindingFromSpec(spec specApi.ServiceBinding) api.ServiceBinding
 	GetWorkloadKinds() ([]string, []schema.GroupVersionKind, error)

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -7,9 +7,6 @@ import (
 	"github.com/go-openapi/spec"
 	projectv1 "github.com/openshift/api/project/v1"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/redhat-developer/odo/pkg/api"
-	bindingApi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
-	specApi "github.com/redhat-developer/service-binding-operator/apis/spec/v1alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -21,6 +18,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/redhat-developer/odo/pkg/api"
+	bindingApi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
+	specApi "github.com/redhat-developer/service-binding-operator/apis/spec/v1alpha3"
 )
 
 type ClientInterface interface {
@@ -57,7 +58,7 @@ type ClientInterface interface {
 
 	// dynamic.go
 	PatchDynamicResource(exampleCustomResource unstructured.Unstructured) (bool, error)
-	ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
+	ListDynamicResources(namespace string, gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error)
 	GetDynamicResource(gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error)
 	UpdateDynamicResource(gvr schema.GroupVersionResource, name string, u *unstructured.Unstructured) error
 	DeleteDynamicResource(name string, gvr schema.GroupVersionResource, wait bool) error

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -1160,18 +1160,18 @@ func (mr *MockClientInterfaceMockRecorder) ListServices(selector interface{}) *g
 }
 
 // NewServiceBindingServiceObject mocks base method.
-func (m *MockClientInterface) NewServiceBindingServiceObject(unstructuredService unstructured.Unstructured, bindingName string) (v1alpha10.Service, error) {
+func (m *MockClientInterface) NewServiceBindingServiceObject(serviceNs string, unstructuredService unstructured.Unstructured, bindingName string) (v1alpha10.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewServiceBindingServiceObject", unstructuredService, bindingName)
+	ret := m.ctrl.Call(m, "NewServiceBindingServiceObject", serviceNs, unstructuredService, bindingName)
 	ret0, _ := ret[0].(v1alpha10.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewServiceBindingServiceObject indicates an expected call of NewServiceBindingServiceObject.
-func (mr *MockClientInterfaceMockRecorder) NewServiceBindingServiceObject(unstructuredService, bindingName interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) NewServiceBindingServiceObject(serviceNs, unstructuredService, bindingName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewServiceBindingServiceObject", reflect.TypeOf((*MockClientInterface)(nil).NewServiceBindingServiceObject), unstructuredService, bindingName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewServiceBindingServiceObject", reflect.TypeOf((*MockClientInterface)(nil).NewServiceBindingServiceObject), serviceNs, unstructuredService, bindingName)
 }
 
 // PatchDynamicResource mocks base method.

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -1054,18 +1054,18 @@ func (mr *MockClientInterfaceMockRecorder) ListClusterServiceVersions() *gomock.
 }
 
 // ListDynamicResources mocks base method.
-func (m *MockClientInterface) ListDynamicResources(gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
+func (m *MockClientInterface) ListDynamicResources(namespace string, gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDynamicResources", gvr)
+	ret := m.ctrl.Call(m, "ListDynamicResources", namespace, gvr)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDynamicResources indicates an expected call of ListDynamicResources.
-func (mr *MockClientInterfaceMockRecorder) ListDynamicResources(gvr interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) ListDynamicResources(namespace, gvr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDynamicResources", reflect.TypeOf((*MockClientInterface)(nil).ListDynamicResources), gvr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDynamicResources", reflect.TypeOf((*MockClientInterface)(nil).ListDynamicResources), namespace, gvr)
 }
 
 // ListPVCNames mocks base method.

--- a/pkg/odo/cli/add/binding/binding.go
+++ b/pkg/odo/cli/add/binding/binding.go
@@ -87,7 +87,12 @@ func (o *AddBindingOptions) Validate() (err error) {
 func (o *AddBindingOptions) Run(_ context.Context) error {
 	withDevfile := o.EnvSpecificInfo.GetDevfileObj().Data != nil
 
-	serviceMap, err := o.clientset.BindingClient.GetServiceInstances()
+	ns, err := o.clientset.BindingClient.SelectNamespace(o.flags)
+	if err != nil {
+		return err
+	}
+
+	serviceMap, err := o.clientset.BindingClient.GetServiceInstances(ns)
 	if err != nil {
 		return err
 	}
@@ -149,6 +154,9 @@ func (o *AddBindingOptions) Run(_ context.Context) error {
 		if len(o.flags) == 0 {
 			kindGroup := strings.ReplaceAll(strings.ReplaceAll(splitService[1], "(", ""), ")", "")
 			exitMessage += fmt.Sprintf("\nYou can automate this command by executing:\n  odo add binding --service %s.%s --name %s", serviceName, kindGroup, bindingName)
+			if ns != "" {
+				exitMessage += fmt.Sprintf(" --service-namespace %s", ns)
+			}
 			if !bindAsFiles {
 				exitMessage += " --bind-as-files=false"
 			}
@@ -201,6 +209,7 @@ func NewCmdBinding(name, fullName string) *cobra.Command {
 	bindingCmd.Flags().String(backend.FLAG_NAME, "", "Name of the Binding to create")
 	bindingCmd.Flags().String(backend.FLAG_WORKLOAD, "", "Name of the workload to bind, only when no devfile is present in current directory")
 	bindingCmd.Flags().String(backend.FLAG_SERVICE, "", "Name of the service to bind")
+	bindingCmd.Flags().String(backend.FLAG_SERVICE_NAMESPACE, "", "Namespace of the service to bind to. Default is the component namespace.")
 	bindingCmd.Flags().Bool(backend.FLAG_BIND_AS_FILES, true, "Bind the service as a file")
 	bindingCmd.Flags().String(backend.FLAG_NAMING_STRATEGY, "",
 		"Naming strategy to use for binding names. "+

--- a/pkg/odo/cli/add/binding/binding.go
+++ b/pkg/odo/cli/add/binding/binding.go
@@ -98,7 +98,11 @@ func (o *AddBindingOptions) Run(_ context.Context) error {
 	}
 
 	if len(serviceMap) == 0 {
-		return fmt.Errorf("No bindable service instances found")
+		msg := "current namespace"
+		if ns != "" {
+			msg = fmt.Sprintf("namespace %q", ns)
+		}
+		return fmt.Errorf("No bindable service instances found in %s", msg)
 	}
 
 	service, err := o.clientset.BindingClient.SelectServiceInstance(o.flags, serviceMap)

--- a/pkg/odo/cli/add/binding/binding.go
+++ b/pkg/odo/cli/add/binding/binding.go
@@ -144,7 +144,7 @@ func (o *AddBindingOptions) Run(_ context.Context) error {
 	if withDevfile {
 		var devfileobj parser.DevfileObj
 		devfileobj, err = o.clientset.BindingClient.AddBindingToDevfile(
-			bindingName, bindAsFiles, namingStrategy, serviceMap[service], o.EnvSpecificInfo.GetDevfileObj())
+			bindingName, bindAsFiles, ns, namingStrategy, serviceMap[service], o.EnvSpecificInfo.GetDevfileObj())
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ func (o *AddBindingOptions) Run(_ context.Context) error {
 	}
 
 	options, output, filename, err := o.clientset.BindingClient.AddBinding(
-		o.flags, bindingName, bindAsFiles, namingStrategy, serviceMap[service], workloadName, workloadGVK)
+		o.flags, bindingName, bindAsFiles, ns, namingStrategy, serviceMap[service], workloadName, workloadGVK)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/describe/binding.go
+++ b/pkg/odo/cli/describe/binding.go
@@ -138,7 +138,11 @@ func printSingleBindingHumanReadableOutput(binding api.ServiceBinding) bool {
 	log.Info("Services:")
 	for _, service := range binding.Spec.Services {
 		gvk := schema.FromAPIVersionAndKind(service.APIVersion, service.Kind)
-		log.Printf("%s (%s.%s)", service.Name, gvk.Kind, gvk.Group)
+		if service.Namespace != "" {
+			log.Printf("%s (%s.%s) (namespace: %s)", service.Name, gvk.Kind, gvk.Group, service.Namespace)
+		} else {
+			log.Printf("%s (%s.%s)", service.Name, gvk.Kind, gvk.Group)
+		}
 	}
 	log.Describef("Bind as files: ", strconv.FormatBool(binding.Spec.BindAsFiles))
 	log.Describef("Detect binding resources: ", strconv.FormatBool(binding.Spec.DetectBindingResources))

--- a/pkg/odo/cli/list/binding/binding.go
+++ b/pkg/odo/cli/list/binding/binding.go
@@ -171,11 +171,15 @@ func HumanReadableOutput(namespace string, list api.ResourcesList) {
 			if group != "" {
 				group = "." + group
 			}
-			services += fmt.Sprintf("%s (%s%s)",
+			svcDesc := fmt.Sprintf("%s (%s%s)",
 				serviceSpec.Name,
 				serviceSpec.Kind,
 				group,
 			)
+			if serviceSpec.Namespace != "" {
+				svcDesc += fmt.Sprintf(" (namespace: %s)", serviceSpec.Namespace)
+			}
+			services += svcDesc
 		}
 
 		runningIn := "None"

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -12,9 +12,10 @@
 package clientset
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/odo/pkg/logs"
 	"github.com/redhat-developer/odo/pkg/portForward"
-	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/odo/pkg/alizer"
 	"github.com/redhat-developer/odo/pkg/dev"
@@ -82,7 +83,7 @@ var subdeps map[string][]string = map[string][]string{
 	REGISTRY:         {FILESYSTEM, PREFERENCE},
 	STATE:            {FILESYSTEM},
 	WATCH:            {DELETE_COMPONENT, STATE},
-	BINDING:          {KUBERNETES},
+	BINDING:          {PROJECT, KUBERNETES},
 	/* Add sub-dependencies here, if any */
 }
 
@@ -174,7 +175,7 @@ func Fetch(command *cobra.Command) (*Clientset, error) {
 		dep.WatchClient = watch.NewWatchClient(dep.DeleteClient, dep.StateClient)
 	}
 	if isDefined(command, BINDING) {
-		dep.BindingClient = binding.NewBindingClient(dep.KubernetesClient)
+		dep.BindingClient = binding.NewBindingClient(dep.ProjectClient, dep.KubernetesClient)
 	}
 	if isDefined(command, PORT_FORWARD) {
 		dep.PortForwardClient = portForward.NewPFClient(dep.KubernetesClient, dep.StateClient)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog"
 
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
 	servicebinding "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 )
 
@@ -120,7 +121,7 @@ func ListOperatorServices(client kclient.ClientInterface) ([]unstructured.Unstru
 func GetCRInstances(client kclient.ClientInterface, customResource *olm.CRDDescription) (*unstructured.UnstructuredList, error) {
 	klog.V(4).Infof("Getting instances of: %s\n", customResource.Name)
 
-	instances, err := client.ListDynamicResources(kclient.GetGVRFromCR(customResource))
+	instances, err := client.ListDynamicResources("", kclient.GetGVRFromCR(customResource))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/cmd_add_binding_test.go
+++ b/tests/integration/cmd_add_binding_test.go
@@ -105,6 +105,51 @@ status:
 `))
 	})
 
+	When("binding to a service in a different namespace", func() {
+		var otherNS string
+		var nsWithNoService string
+
+		BeforeEach(func() {
+			otherNS = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+			addBindableKindInOtherNs := commonVar.CliRunner.Run("-n", otherNS, "apply", "-f",
+				helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
+			Expect(addBindableKindInOtherNs.ExitCode()).To(BeEquivalentTo(0))
+
+			nsWithNoService = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+
+			commonVar.CliRunner.SetProject(commonVar.Project)
+		})
+
+		AfterEach(func() {
+			commonVar.CliRunner.DeleteNamespaceProject(nsWithNoService, false)
+			commonVar.CliRunner.DeleteNamespaceProject(otherNS, false)
+		})
+
+		It("should error out if service is not found in the namespace selected", func() {
+			stderr := helper.Cmd("odo", "add", "binding",
+				"--name", "aname",
+				"--service-namespace", nsWithNoService, "--service", "cluster-sample",
+				"--workload", "app/Deployment.apps").ShouldFail().Err()
+			Expect(stderr).To(ContainSubstring(fmt.Sprintf("No bindable service instances found in namespace %q", nsWithNoService)))
+		})
+
+		It("should error out if service is not found in list of services of namespace selected", func() {
+			unknownService := "cluster-sample-not-found"
+			stderr := helper.Cmd("odo", "add", "binding",
+				"--name", "aname",
+				"--service-namespace", otherNS, "--service", unknownService,
+				"--workload", "app/Deployment.apps").ShouldFail().Err()
+			Expect(stderr).To(ContainSubstring(fmt.Sprintf("%q service not found", unknownService)))
+		})
+
+		It("should create a binding using the workload parameter", func() {
+			helper.Cmd("odo", "add", "binding",
+				"--name", "aname",
+				"--service-namespace", otherNS, "--service", "cluster-sample",
+				"--workload", "app/Deployment.apps").ShouldPass()
+		})
+	})
+
 	When("the component is bootstrapped", func() {
 		BeforeEach(func() {
 			helper.Cmd("odo", "init", "--name", "mynode", "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml"), "--starter", "nodejs-starter").ShouldPass()
@@ -115,42 +160,89 @@ status:
 			Expect(stderr).To(ContainSubstring("--workload cannot be used from a directory containing a Devfile"))
 		})
 
-		When("adding a binding", func() {
-			var bindingName string
-			BeforeEach(func() {
-				bindingName = fmt.Sprintf("binding-%s", helper.RandString(4))
-				helper.Cmd("odo", "add", "binding", "--name", bindingName, "--service", "cluster-sample").ShouldPass()
-			})
-			It("should successfully add binding between component and service in the devfile", func() {
-				components := helper.GetDevfileComponents(filepath.Join(commonVar.Context, "devfile.yaml"), bindingName)
-				Expect(components).ToNot(BeNil())
-			})
-			When("odo dev is run", func() {
+		for _, ctx := range []struct {
+			name           string
+			beforeEachFunc func(bindingName string) string
+			afterEachFunc  func(ns string)
+		}{
+			{
+				name: "current namespace",
+				beforeEachFunc: func(bindingName string) string {
+					helper.Cmd("odo", "add", "binding", "--name", bindingName, "--service", "cluster-sample").ShouldPass()
+					return commonVar.Project
+				},
+			},
+			{
+				name: "other namespace",
+				beforeEachFunc: func(bindingName string) string {
+					otherNS := commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+					addBindableKindInOtherNs := commonVar.CliRunner.Run("-n", otherNS, "apply", "-f",
+						helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
+					Expect(addBindableKindInOtherNs.ExitCode()).To(BeEquivalentTo(0))
+
+					commonVar.CliRunner.SetProject(commonVar.Project)
+
+					helper.Cmd("odo", "add", "binding", "--name", bindingName,
+						"--service", "cluster-sample", "--service-namespace", otherNS).ShouldPass()
+
+					return otherNS
+				},
+				afterEachFunc: func(ns string) {
+					commonVar.CliRunner.DeleteNamespaceProject(ns, false)
+				},
+			},
+		} {
+			ctx := ctx
+
+			When("adding a binding ("+ctx.name+")", func() {
+				var bindingName string
+				var ns string
+
 				BeforeEach(func() {
-					devSession, _, _, _, err = helper.StartDevMode()
-					Expect(err).ToNot(HaveOccurred())
+					bindingName = fmt.Sprintf("binding-%s", helper.RandString(4))
+					ns = ctx.beforeEachFunc(bindingName)
 				})
+
 				AfterEach(func() {
-					devSession.Stop()
-					devSession.WaitEnd()
+					if ctx.afterEachFunc != nil {
+						ctx.afterEachFunc(ns)
+					}
 				})
-				It("should successfully bind component and service", func() {
-					stdout := commonVar.CliRunner.Run("get", "servicebinding", bindingName).Out.Contents()
-					Expect(stdout).To(ContainSubstring("ApplicationsBound"))
+
+				It("should successfully add binding between component and service in the devfile", func() {
+					components := helper.GetDevfileComponents(filepath.Join(commonVar.Context, "devfile.yaml"), bindingName)
+					Expect(components).ToNot(BeNil())
 				})
-				When("odo dev command is stopped", func() {
+
+				When("odo dev is run", func() {
 					BeforeEach(func() {
+						devSession, _, _, _, err = helper.StartDevMode()
+						Expect(err).ToNot(HaveOccurred())
+					})
+					AfterEach(func() {
 						devSession.Stop()
 						devSession.WaitEnd()
 					})
 
-					It("should have successfully delete the binding", func() {
-						_, errOut := commonVar.CliRunner.GetServiceBinding(bindingName, commonVar.Project)
-						Expect(errOut).To(ContainSubstring("not found"))
+					It("should successfully bind component and service", func() {
+						stdout := commonVar.CliRunner.Run("get", "servicebinding", bindingName).Out.Contents()
+						Expect(stdout).To(ContainSubstring("ApplicationsBound"))
+					})
+
+					When("odo dev command is stopped", func() {
+						BeforeEach(func() {
+							devSession.Stop()
+							devSession.WaitEnd()
+						})
+
+						It("should have successfully delete the binding", func() {
+							_, errOut := commonVar.CliRunner.GetServiceBinding(bindingName, commonVar.Project)
+							Expect(errOut).To(ContainSubstring("not found"))
+						})
 					})
 				})
 			})
-		})
+		}
 
 		When("no bindable instance is present on the cluster", func() {
 			BeforeEach(func() {

--- a/tests/integration/cmd_describe_list_binding_test.go
+++ b/tests/integration/cmd_describe_list_binding_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,468 +26,579 @@ var _ = Describe("odo describe/list binding command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("creating a component with a binding", func() {
-		cmpName := "my-nodejs-app"
-		BeforeEach(func() {
-			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-files.yaml")).ShouldPass()
-		})
+	for _, ns := range []string{"", fmt.Sprintf("binding-%s", helper.RandString(3))} {
+		ns := ns
 
-		It("should describe the binding without running odo dev", func() {
-			By("JSON output", func() {
-				res := helper.Cmd("odo", "describe", "binding", "-o", "json").ShouldPass()
-				stdout, stderr := res.Out(), res.Err()
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, "0.name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, "0.spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, "0.spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, "0.spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, "0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, "0.spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, "0.spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, "0.spec.detectBindingResources", "true")
-				helper.JsonPathContentIs(stdout, "0.spec.bindAsFiles", "true")
-				helper.JsonPathContentIs(stdout, "0.spec.namingStrategy", "lowercase")
-				helper.JsonPathContentIs(stdout, "0.status", "")
-			})
-			By("human readable output", func() {
-				res := helper.Cmd("odo", "describe", "binding").ShouldPass()
-				stdout, _ := res.Out(), res.Err()
-				Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
-				Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
-				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(stdout).To(ContainSubstring("Bind as files: true"))
-				Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
-				Expect(stdout).To(ContainSubstring("Naming strategy: lowercase"))
-				Expect(stdout).To(ContainSubstring("Available binding information: unknown"))
-				Expect(stdout).To(ContainSubstring("Binding information for one or more ServiceBinding is not available"))
-			})
-		})
-
-		It("should list the binding without running odo dev", func() {
-			By("JSON output", func() {
-				res := helper.Cmd("odo", "list", "binding", "-o", "json").ShouldPass()
-				stdout, stderr := res.Out(), res.Err()
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.namingStrategy", "lowercase")
-				helper.JsonPathContentIs(stdout, "bindings.0.status", "")
-				helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
-				helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
-			})
-			By("human readable output", func() {
-				res := helper.Cmd("odo", "list", "binding").ShouldPass()
-				stdout, _ := res.Out(), res.Err()
-				lines := strings.Split(stdout, "\n")
-				Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
-				Expect(lines[3]).To(ContainSubstring("* "))
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
-				Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(lines[3]).To(ContainSubstring("None"))
-			})
-		})
-	})
-
-	for _, ctx := range []struct {
-		title                             string
-		devfile                           string
-		assertDescribeJsonOutput          func(list bool, stdout, stderr string)
-		assertDescribeHumanReadableOutput func(list bool, stdout, stderr string)
-		assertListJsonOutput              func(devfile bool, stdout, stderr string)
-		assertListHumanReadableOutput     func(devfile bool, stdout, stderr string)
-	}{
-		{
-			title:   "creating a component with a binding as files",
-			devfile: helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-files.yaml"),
-			assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
-				prefix := ""
-				if list {
-					prefix = "0."
-				}
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "true")
-				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
-				helper.JsonPathContentIs(stdout, prefix+"spec.namingStrategy", "lowercase")
-				helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
-				helper.JsonPathContentIs(stdout, prefix+"status.bindingEnvVars", "")
-			},
-			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
-				if list {
-					Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
-				}
-				Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
-				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(stdout).To(ContainSubstring("Bind as files: true"))
-				Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
-				Expect(stdout).To(ContainSubstring("Naming strategy: lowercase"))
-				Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
-			},
-			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.namingStrategy", "lowercase")
-				helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
-				helper.JsonPathContentIs(stdout, "bindings.0.status.bindingEnvVars", "")
-				if devfile {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
-				} else {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
-				}
-			},
-			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
-				lines := strings.Split(stdout, "\n")
-				Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
-				if devfile {
-					Expect(lines[3]).To(ContainSubstring("* "))
-				} else {
-					Expect(lines[3]).ToNot(ContainSubstring("* "))
-				}
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
-				Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(lines[3]).To(ContainSubstring("Dev"))
-			},
-		},
-		{
-			title:   "creating a component with a binding as environment variables",
-			devfile: helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-envvars.yaml"),
-			assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
-				prefix := ""
-				if list {
-					prefix = "0."
-				}
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "true")
-				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "false")
-				helper.JsonPathContentIs(stdout, prefix+"status.bindingFiles", "")
-				helper.JsonPathContentContain(stdout, prefix+"status.bindingEnvVars", "PASSWORD")
-				helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
-			},
-			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
-				if list {
-					Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
-				}
-				Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
-				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(stdout).To(ContainSubstring("Bind as files: false"))
-				Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
-				Expect(stdout).To(ContainSubstring("PASSWORD"))
-				Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
-			},
-			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "false")
-				helper.JsonPathContentIs(stdout, "bindings.0.status.bindingFiles", "")
-				helper.JsonPathContentContain(stdout, "bindings.0.status.bindingEnvVars", "PASSWORD")
-				if devfile {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
-				} else {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
-				}
-				helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
-			},
-			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
-				lines := strings.Split(stdout, "\n")
-				Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
-				if devfile {
-					Expect(lines[3]).To(ContainSubstring("* "))
-				} else {
-					Expect(lines[3]).ToNot(ContainSubstring("* "))
-				}
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
-				Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(lines[3]).To(ContainSubstring("Dev"))
-			},
-		},
-		{
-			title:   "creating a component with a spec binding",
-			devfile: helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-spec-service-binding.yaml"),
-			assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
-				prefix := ""
-				if list {
-					prefix = "0."
-				}
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "false")
-				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
-				helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
-				helper.JsonPathContentIs(stdout, prefix+"status.bindingEnvVars", "")
-				helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
-			},
-			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
-				if list {
-					Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
-				}
-				Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
-				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(stdout).To(ContainSubstring("Bind as files: true"))
-				Expect(stdout).To(ContainSubstring("Detect binding resources: false"))
-				Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
-				Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
-			},
-			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "false")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
-				helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
-				helper.JsonPathContentIs(stdout, "bindings.0.status.bindingEnvVars", "")
-				if devfile {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
-				} else {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
-				}
-				helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
-			},
-			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
-				lines := strings.Split(stdout, "\n")
-				Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
-				if devfile {
-					Expect(lines[3]).To(ContainSubstring("* "))
-				} else {
-					Expect(lines[3]).ToNot(ContainSubstring("* "))
-				}
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
-				Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(lines[3]).To(ContainSubstring("Dev"))
-			},
-		},
-		{
-			title:   "creating a component with a spec binding and envvars",
-			devfile: helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-spec-service-binding-envvars.yaml"),
-			assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
-				prefix := ""
-				if list {
-					prefix = "0."
-				}
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "false")
-				helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
-				helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
-				helper.JsonPathContentContain(stdout, prefix+"status.bindingEnvVars", "PASSWD")
-				helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
-			},
-			assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
-				if list {
-					Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
-				}
-				Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
-				Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(stdout).To(ContainSubstring("Bind as files: true"))
-				Expect(stdout).To(ContainSubstring("Detect binding resources: false"))
-				Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
-				Expect(stdout).To(ContainSubstring("PASSWD"))
-				Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
-			},
-			assertListJsonOutput: func(devfile bool, stdout, stderr string) {
-				Expect(stderr).To(BeEmpty())
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "false")
-				helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
-				helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
-				helper.JsonPathContentContain(stdout, "bindings.0.status.bindingEnvVars", "PASSWD")
-				if devfile {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
-				} else {
-					helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
-				}
-				helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
-			},
-			assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
-				lines := strings.Split(stdout, "\n")
-				Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
-				if devfile {
-					Expect(lines[3]).To(ContainSubstring("* "))
-				} else {
-					Expect(lines[3]).ToNot(ContainSubstring("* "))
-				}
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
-				Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
-				Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
-				Expect(lines[3]).To(ContainSubstring("Dev"))
-			},
-		},
-	} {
-		// this is a workaround to ensure that for loop works well with `It` blocks
-		ctx := ctx
-		When(ctx.title, func() {
+		When(fmt.Sprintf("creating a component with a binding (service in namespace %q)", ns), func() {
 			cmpName := "my-nodejs-app"
 			BeforeEach(func() {
-				helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", ctx.devfile).ShouldPass()
+				helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-files.yaml")).ShouldPass()
+				if ns != "" {
+					helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"),
+						"name: cluster-sample",
+						fmt.Sprintf(`name: cluster-sample
+          namespace: %s`, ns))
+				}
 			})
 
-			When("Starting a Pg service", func() {
-				BeforeEach(func() {
-					// Ensure that the operators are installed
-					commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")
-					commonVar.CliRunner.EnsureOperatorIsInstalled("cloud-native-postgresql")
-					Eventually(func() string {
-						out, _ := commonVar.CliRunner.GetBindableKinds()
-						return out
-					}, 120, 3).Should(ContainSubstring("Cluster"))
-					addBindableKind := commonVar.CliRunner.Run("apply", "-f", helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
-					Expect(addBindableKind.ExitCode()).To(BeEquivalentTo(0))
+			It("should describe the binding without running odo dev", func() {
+				By("JSON output", func() {
+					res := helper.Cmd("odo", "describe", "binding", "-o", "json").ShouldPass()
+					stdout, stderr := res.Out(), res.Err()
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, "0.name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, "0.spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, "0.spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, "0.spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, "0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, "0.spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, "0.spec.services.0.name", "cluster-sample")
+					if ns != "" {
+						helper.JsonPathContentIs(stdout, "0.spec.services.0.namespace", ns)
+					} else {
+						helper.JsonPathDoesNotExist(stdout, "0.spec.services.0.namespace")
+					}
+					helper.JsonPathContentIs(stdout, "0.spec.detectBindingResources", "true")
+					helper.JsonPathContentIs(stdout, "0.spec.bindAsFiles", "true")
+					helper.JsonPathContentIs(stdout, "0.spec.namingStrategy", "lowercase")
+					helper.JsonPathContentIs(stdout, "0.status", "")
 				})
+				By("human readable output", func() {
+					res := helper.Cmd("odo", "describe", "binding").ShouldPass()
+					stdout, _ := res.Out(), res.Err()
+					Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
+					Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
+					if ns != "" {
+						Expect(stdout).To(ContainSubstring(fmt.Sprintf("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: %s)", ns)))
+					} else {
+						Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+						Expect(stdout).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					}
+					Expect(stdout).To(ContainSubstring("Bind as files: true"))
+					Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
+					Expect(stdout).To(ContainSubstring("Naming strategy: lowercase"))
+					Expect(stdout).To(ContainSubstring("Available binding information: unknown"))
+					Expect(stdout).To(ContainSubstring("Binding information for one or more ServiceBinding is not available"))
+				})
+			})
 
-				When("running dev session", func() {
-					var session helper.DevSession
-					BeforeEach(func() {
-						var err error
-						session, _, _, _, err = helper.StartDevMode()
-						Expect(err).ToNot(HaveOccurred())
-					})
-
-					AfterEach(func() {
-						session.Kill()
-						session.WaitEnd()
-					})
-
-					It("should describe the binding", func() {
-						By("JSON output", func() {
-							res := helper.Cmd("odo", "describe", "binding", "-o", "json").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							ctx.assertDescribeJsonOutput(true, stdout, stderr)
-						})
-						By("human readable output", func() {
-							res := helper.Cmd("odo", "describe", "binding").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							ctx.assertDescribeHumanReadableOutput(true, stdout, stderr)
-						})
-
-						By("JSON output from another directory with name flag", func() {
-							err := os.Chdir("/")
-							Expect(err).ToNot(HaveOccurred())
-							res := helper.Cmd("odo", "describe", "binding", "--name", "my-nodejs-app-cluster-sample", "-o", "json").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							ctx.assertDescribeJsonOutput(false, stdout, stderr)
-						})
-						By("human readable output from another directory with name flag", func() {
-							err := os.Chdir("/")
-							Expect(err).ToNot(HaveOccurred())
-							res := helper.Cmd("odo", "describe", "binding", "--name", "my-nodejs-app-cluster-sample").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							ctx.assertDescribeHumanReadableOutput(false, stdout, stderr)
-						})
-
-					})
-
-					It("should list the binding", func() {
-						By("JSON output", func() {
-							res := helper.Cmd("odo", "list", "binding", "-o", "json").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							if ctx.assertListJsonOutput != nil {
-								ctx.assertListJsonOutput(true, stdout, stderr)
-							}
-						})
-						By("human readable output", func() {
-							res := helper.Cmd("odo", "list", "binding").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							if ctx.assertListHumanReadableOutput != nil {
-								ctx.assertListHumanReadableOutput(true, stdout, stderr)
-							}
-						})
-
-						By("JSON output from another directory", func() {
-							err := os.Chdir("/")
-							Expect(err).ToNot(HaveOccurred())
-							res := helper.Cmd("odo", "list", "binding", "-o", "json").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							if ctx.assertListJsonOutput != nil {
-								ctx.assertListJsonOutput(false, stdout, stderr)
-							}
-						})
-						By("human readable output from another directory with name flag", func() {
-							err := os.Chdir("/")
-							Expect(err).ToNot(HaveOccurred())
-							res := helper.Cmd("odo", "list", "binding").ShouldPass()
-							stdout, stderr := res.Out(), res.Err()
-							if ctx.assertListHumanReadableOutput != nil {
-								ctx.assertListHumanReadableOutput(false, stdout, stderr)
-							}
-						})
-					})
+			It("should list the binding without running odo dev", func() {
+				By("JSON output", func() {
+					res := helper.Cmd("odo", "list", "binding", "-o", "json").ShouldPass()
+					stdout, stderr := res.Out(), res.Err()
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
+					if ns != "" {
+						helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.namespace", ns)
+					} else {
+						helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.services.0.namespace")
+					}
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.namingStrategy", "lowercase")
+					helper.JsonPathContentIs(stdout, "bindings.0.status", "")
+					helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
+					helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
+				})
+				By("human readable output", func() {
+					res := helper.Cmd("odo", "list", "binding").ShouldPass()
+					stdout, _ := res.Out(), res.Err()
+					lines := strings.Split(stdout, "\n")
+					Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
+					Expect(lines[3]).To(ContainSubstring("* "))
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
+					if ns != "" {
+						Expect(lines[3]).To(ContainSubstring(fmt.Sprintf("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: %s)", ns)))
+					} else {
+						Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+						Expect(lines[3]).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					}
+					Expect(lines[3]).To(ContainSubstring("None"))
 				})
 			})
 		})
+
+		for _, ctx := range []struct {
+			title                             string
+			devfile                           string
+			isServiceNsSupported              bool
+			assertDescribeJsonOutput          func(list bool, stdout, stderr string)
+			assertDescribeHumanReadableOutput func(list bool, stdout, stderr string)
+			assertListJsonOutput              func(devfile bool, stdout, stderr string)
+			assertListHumanReadableOutput     func(devfile bool, stdout, stderr string)
+		}{
+			{
+				title:                "creating a component with a binding as files",
+				devfile:              helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-files.yaml"),
+				isServiceNsSupported: true,
+				assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
+					prefix := ""
+					if list {
+						prefix = "0."
+					}
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
+					if ns != "" {
+						helper.JsonPathContentIs(stdout, prefix+"spec.services.0.namespace", ns)
+					} else {
+						helper.JsonPathDoesNotExist(stdout, prefix+"spec.services.0.namespace")
+					}
+					helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "true")
+					helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
+					helper.JsonPathContentIs(stdout, prefix+"spec.namingStrategy", "lowercase")
+					helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
+					helper.JsonPathContentIs(stdout, prefix+"status.bindingEnvVars", "")
+				},
+				assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
+					if list {
+						Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
+					}
+					Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
+					if ns != "" {
+						Expect(stdout).To(ContainSubstring(fmt.Sprintf("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: %s)", ns)))
+					} else {
+						Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+						Expect(stdout).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					}
+					Expect(stdout).To(ContainSubstring("Bind as files: true"))
+					Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
+					Expect(stdout).To(ContainSubstring("Naming strategy: lowercase"))
+					Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
+				},
+				assertListJsonOutput: func(devfile bool, stdout, stderr string) {
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
+					if ns != "" {
+						helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.namespace", ns)
+					} else {
+						helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.services.0.namespace")
+					}
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.namingStrategy", "lowercase")
+					helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
+					helper.JsonPathContentIs(stdout, "bindings.0.status.bindingEnvVars", "")
+					if devfile {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
+					} else {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
+					}
+				},
+				assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
+					lines := strings.Split(stdout, "\n")
+					Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
+					if devfile {
+						Expect(lines[3]).To(ContainSubstring("* "))
+					} else {
+						Expect(lines[3]).ToNot(ContainSubstring("* "))
+					}
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
+					if ns != "" {
+						Expect(lines[3]).To(ContainSubstring(fmt.Sprintf("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: %s)", ns)))
+					} else {
+						Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+						Expect(lines[3]).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					}
+					Expect(lines[3]).To(ContainSubstring("Dev"))
+				},
+			},
+			{
+				title:                "creating a component with a binding as environment variables",
+				devfile:              helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-envvars.yaml"),
+				isServiceNsSupported: true,
+				assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
+					prefix := ""
+					if list {
+						prefix = "0."
+					}
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
+					if ns != "" {
+						helper.JsonPathContentIs(stdout, prefix+"spec.services.0.namespace", ns)
+					} else {
+						helper.JsonPathDoesNotExist(stdout, prefix+"spec.services.0.namespace")
+					}
+					helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "true")
+					helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "false")
+					helper.JsonPathContentIs(stdout, prefix+"status.bindingFiles", "")
+					helper.JsonPathContentContain(stdout, prefix+"status.bindingEnvVars", "PASSWORD")
+					helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
+				},
+				assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
+					if list {
+						Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
+					}
+					Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
+					if ns != "" {
+						Expect(stdout).To(ContainSubstring(fmt.Sprintf("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: %s)", ns)))
+					} else {
+						Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+						Expect(stdout).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					}
+					Expect(stdout).To(ContainSubstring("Bind as files: false"))
+					Expect(stdout).To(ContainSubstring("Detect binding resources: true"))
+					Expect(stdout).To(ContainSubstring("PASSWORD"))
+					Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
+				},
+				assertListJsonOutput: func(devfile bool, stdout, stderr string) {
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
+					if ns != "" {
+						helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.namespace", ns)
+					} else {
+						helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.services.0.namespace")
+					}
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "true")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "false")
+					helper.JsonPathContentIs(stdout, "bindings.0.status.bindingFiles", "")
+					helper.JsonPathContentContain(stdout, "bindings.0.status.bindingEnvVars", "PASSWORD")
+					if devfile {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
+					} else {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
+					}
+					helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
+				},
+				assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
+					lines := strings.Split(stdout, "\n")
+					Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
+					if devfile {
+						Expect(lines[3]).To(ContainSubstring("* "))
+					} else {
+						Expect(lines[3]).ToNot(ContainSubstring("* "))
+					}
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
+					if ns != "" {
+						Expect(lines[3]).To(ContainSubstring(fmt.Sprintf("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: %s)", ns)))
+					} else {
+						Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+						Expect(lines[3]).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					}
+					Expect(lines[3]).To(ContainSubstring("Dev"))
+				},
+			},
+			{
+				title:                "creating a component with a spec binding",
+				devfile:              helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-spec-service-binding.yaml"),
+				isServiceNsSupported: false,
+				assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
+					prefix := ""
+					if list {
+						prefix = "0."
+					}
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
+					helper.JsonPathDoesNotExist(stdout, prefix+"spec.services.0.namespace")
+					helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "false")
+					helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
+					helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
+					helper.JsonPathContentIs(stdout, prefix+"status.bindingEnvVars", "")
+					helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
+				},
+				assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
+					if list {
+						Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
+					}
+					Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
+					Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+					Expect(stdout).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					Expect(stdout).To(ContainSubstring("Bind as files: true"))
+					Expect(stdout).To(ContainSubstring("Detect binding resources: false"))
+					Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
+					Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
+				},
+				assertListJsonOutput: func(devfile bool, stdout, stderr string) {
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
+					helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.services.0.namespace")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "false")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
+					helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
+					helper.JsonPathContentIs(stdout, "bindings.0.status.bindingEnvVars", "")
+					if devfile {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
+					} else {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
+					}
+					helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
+				},
+				assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
+					lines := strings.Split(stdout, "\n")
+					Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
+					if devfile {
+						Expect(lines[3]).To(ContainSubstring("* "))
+					} else {
+						Expect(lines[3]).ToNot(ContainSubstring("* "))
+					}
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
+					Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+					Expect(lines[3]).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					Expect(lines[3]).To(ContainSubstring("Dev"))
+				},
+			},
+			{
+				title:                "creating a component with a spec binding and envvars",
+				devfile:              helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-spec-service-binding-envvars.yaml"),
+				isServiceNsSupported: false,
+				assertDescribeJsonOutput: func(list bool, stdout, stderr string) {
+					prefix := ""
+					if list {
+						prefix = "0."
+					}
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, prefix+"name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, prefix+"spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, prefix+"spec.services.0.name", "cluster-sample")
+					helper.JsonPathDoesNotExist(stdout, prefix+"spec.services.0.namespace")
+					helper.JsonPathContentIs(stdout, prefix+"spec.detectBindingResources", "false")
+					helper.JsonPathContentIs(stdout, prefix+"spec.bindAsFiles", "true")
+					helper.JsonPathContentContain(stdout, prefix+"status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
+					helper.JsonPathContentContain(stdout, prefix+"status.bindingEnvVars", "PASSWD")
+					helper.JsonPathDoesNotExist(stdout, prefix+"spec.namingStrategy")
+				},
+				assertDescribeHumanReadableOutput: func(list bool, stdout, stderr string) {
+					if list {
+						Expect(stdout).To(ContainSubstring("ServiceBinding used by the current component"))
+					}
+					Expect(stdout).To(ContainSubstring("Service Binding Name: my-nodejs-app-cluster-sample"))
+					Expect(stdout).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+					Expect(stdout).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					Expect(stdout).To(ContainSubstring("Bind as files: true"))
+					Expect(stdout).To(ContainSubstring("Detect binding resources: false"))
+					Expect(stdout).To(ContainSubstring("${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password"))
+					Expect(stdout).To(ContainSubstring("PASSWD"))
+					Expect(stdout).ToNot(ContainSubstring("Naming strategy:"))
+				},
+				assertListJsonOutput: func(devfile bool, stdout, stderr string) {
+					Expect(stderr).To(BeEmpty())
+					Expect(helper.IsJSON(stdout)).To(BeTrue())
+					helper.JsonPathContentIs(stdout, "bindings.0.name", "my-nodejs-app-cluster-sample")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.kind", "Deployment")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.name", "my-nodejs-app-app")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.application.apiVersion", "apps/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.apiVersion", "postgresql.k8s.enterprisedb.io/v1")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.kind", "Cluster")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.services.0.name", "cluster-sample")
+					helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.services.0.namespace")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.detectBindingResources", "false")
+					helper.JsonPathContentIs(stdout, "bindings.0.spec.bindAsFiles", "true")
+					helper.JsonPathContentContain(stdout, "bindings.0.status.bindingFiles", "${SERVICE_BINDING_ROOT}/my-nodejs-app-cluster-sample/password")
+					helper.JsonPathContentContain(stdout, "bindings.0.status.bindingEnvVars", "PASSWD")
+					if devfile {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.#", "1")
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile.0", "my-nodejs-app-cluster-sample")
+					} else {
+						helper.JsonPathContentIs(stdout, "bindingsInDevfile", "")
+					}
+					helper.JsonPathDoesNotExist(stdout, "bindings.0.spec.namingStrategy")
+				},
+				assertListHumanReadableOutput: func(devfile bool, stdout, stderr string) {
+					lines := strings.Split(stdout, "\n")
+					Expect(lines[0]).To(ContainSubstring(fmt.Sprintf("Listing ServiceBindings from the namespace %q", commonVar.Project)))
+					if devfile {
+						Expect(lines[3]).To(ContainSubstring("* "))
+					} else {
+						Expect(lines[3]).ToNot(ContainSubstring("* "))
+					}
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-cluster-sample"))
+					Expect(lines[3]).To(ContainSubstring("my-nodejs-app-app (Deployment)"))
+					Expect(lines[3]).To(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io)"))
+					Expect(lines[3]).ToNot(ContainSubstring("cluster-sample (Cluster.postgresql.k8s.enterprisedb.io) (namespace: "))
+					Expect(lines[3]).To(ContainSubstring("Dev"))
+				},
+			},
+		} {
+			// this is a workaround to ensure that for loop works well with `It` blocks
+			ctx := ctx
+			When(fmt.Sprintf("%s (service in namespace %q)", ctx.title, ns), func() {
+				cmpName := "my-nodejs-app"
+				BeforeEach(func() {
+					helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", ctx.devfile).ShouldPass()
+
+					if ctx.isServiceNsSupported && ns != "" {
+						ns = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+
+						commonVar.CliRunner.SetProject(commonVar.Project)
+
+						helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"),
+							"name: cluster-sample",
+							fmt.Sprintf(`name: cluster-sample
+          namespace: %s`, ns))
+					}
+				})
+
+				AfterEach(func() {
+					if ctx.isServiceNsSupported && ns != "" {
+						commonVar.CliRunner.DeleteNamespaceProject(ns, false)
+					}
+				})
+
+				When("Starting a Pg service", func() {
+					BeforeEach(func() {
+						// Ensure that the operators are installed
+						commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")
+						commonVar.CliRunner.EnsureOperatorIsInstalled("cloud-native-postgresql")
+						Eventually(func() string {
+							out, _ := commonVar.CliRunner.GetBindableKinds()
+							return out
+						}, 120, 3).Should(ContainSubstring("Cluster"))
+						addBindableKind := commonVar.CliRunner.Run("apply", "-f", helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
+						Expect(addBindableKind.ExitCode()).To(BeEquivalentTo(0))
+
+						if ctx.isServiceNsSupported && ns != "" {
+							addBindableKindInOtherNs := commonVar.CliRunner.Run("-n", ns, "apply", "-f",
+								helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
+							Expect(addBindableKindInOtherNs.ExitCode()).To(BeEquivalentTo(0))
+
+							helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"),
+								"name: cluster-sample",
+								fmt.Sprintf(`name: cluster-sample
+          namespace: %s`, ns))
+						}
+					})
+
+					When("running dev session", func() {
+						var session helper.DevSession
+						BeforeEach(func() {
+							var err error
+							session, _, _, _, err = helper.StartDevMode()
+							Expect(err).ToNot(HaveOccurred())
+						})
+
+						AfterEach(func() {
+							session.Kill()
+							session.WaitEnd()
+						})
+
+						It("should describe the binding", func() {
+							By("JSON output", func() {
+								res := helper.Cmd("odo", "describe", "binding", "-o", "json").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								ctx.assertDescribeJsonOutput(true, stdout, stderr)
+							})
+							By("human readable output", func() {
+								res := helper.Cmd("odo", "describe", "binding").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								ctx.assertDescribeHumanReadableOutput(true, stdout, stderr)
+							})
+
+							By("JSON output from another directory with name flag", func() {
+								err := os.Chdir("/")
+								Expect(err).ToNot(HaveOccurred())
+								res := helper.Cmd("odo", "describe", "binding", "--name", "my-nodejs-app-cluster-sample", "-o", "json").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								ctx.assertDescribeJsonOutput(false, stdout, stderr)
+							})
+							By("human readable output from another directory with name flag", func() {
+								err := os.Chdir("/")
+								Expect(err).ToNot(HaveOccurred())
+								res := helper.Cmd("odo", "describe", "binding", "--name", "my-nodejs-app-cluster-sample").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								ctx.assertDescribeHumanReadableOutput(false, stdout, stderr)
+							})
+
+						})
+
+						It("should list the binding", func() {
+							By("JSON output", func() {
+								res := helper.Cmd("odo", "list", "binding", "-o", "json").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								if ctx.assertListJsonOutput != nil {
+									ctx.assertListJsonOutput(true, stdout, stderr)
+								}
+							})
+							By("human readable output", func() {
+								res := helper.Cmd("odo", "list", "binding").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								if ctx.assertListHumanReadableOutput != nil {
+									ctx.assertListHumanReadableOutput(true, stdout, stderr)
+								}
+							})
+
+							By("JSON output from another directory", func() {
+								err := os.Chdir("/")
+								Expect(err).ToNot(HaveOccurred())
+								res := helper.Cmd("odo", "list", "binding", "-o", "json").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								if ctx.assertListJsonOutput != nil {
+									ctx.assertListJsonOutput(false, stdout, stderr)
+								}
+							})
+							By("human readable output from another directory with name flag", func() {
+								err := os.Chdir("/")
+								Expect(err).ToNot(HaveOccurred())
+								res := helper.Cmd("odo", "list", "binding").ShouldPass()
+								stdout, stderr := res.Out(), res.Err()
+								if ctx.assertListHumanReadableOutput != nil {
+									ctx.assertListHumanReadableOutput(false, stdout, stderr)
+								}
+							})
+						})
+					})
+				})
+			})
+		}
 	}
 })

--- a/tests/integration/interactive_add_binding_test.go
+++ b/tests/integration/interactive_add_binding_test.go
@@ -282,6 +282,18 @@ var _ = Describe("odo add binding interactive command tests", func() {
 				Expect(err).To(BeNil())
 				components := helper.GetDevfileComponents(filepath.Join(commonVar.Context, "devfile.yaml"), bindingName)
 				Expect(components).ToNot(BeNil())
+				Expect(components).To(HaveLen(1))
+				cmp := components[0]
+				Expect(cmp.Kubernetes).ToNot(BeNil())
+				Expect(cmp.Kubernetes.Inlined).To(ContainSubstring(fmt.Sprintf(`
+  services:
+  - group: postgresql.k8s.enterprisedb.io
+    id: mynode-cluster-sample
+    kind: Cluster
+    name: cluster-sample
+    namespace: %s
+    resource: clusters
+    version: v1`, otherNS)))
 			})
 
 		})
@@ -579,7 +591,7 @@ var _ = Describe("odo add binding interactive command tests", func() {
 
 				_, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
 					outputFile := "binding.yaml"
-					expected := `spec:
+					expected := fmt.Sprintf(`spec:
   application:
     group: apps
     kind: Deployment
@@ -592,8 +604,9 @@ var _ = Describe("odo add binding interactive command tests", func() {
     id: nginx-cluster-sample
     kind: Cluster
     name: cluster-sample
+    namespace: %s
     resource: clusters
-    version: v1`
+    version: v1`, otherNS)
 
 					helper.ExpectString(ctx, "Do you want to list services from:")
 					helper.SendLine(ctx, "all accessible namespaces")


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This PR makes it possible to select or specify any other namespace when listing the service instances to use for adding a new binding.
For consistency, this supports both interactive and non-interactive modes. And output / docs for `odo describe binding` and `odo list binding` (and their JSON counterparts) have been updated to include information about the service namespace, if available.

**Which issue(s) this PR fixes:**
Fixes #5820

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-5936--odo-docusaurus-preview.netlify.app/) 

**How to test changes / Special notes to the reviewer:**
- Non-Interactive mode: new `--service-namespace` flag added to `odo add binding`
- Interactive mode: new questions added when running `odo add binding`. They allow picking the namespace from which services instances will be listed
  - Current namespace
[![asciicast](https://asciinema.org/a/507965.png)](https://asciinema.org/a/507965)

  - All accessible namespaces: note that if the user does not have the permissions to list namespaces/projects, a simple warning is displayed, and they are prompted to enter the namespace manually instead.
[![asciicast](https://asciinema.org/a/507966.png)](https://asciinema.org/a/507966)