### PR TITLE
Cleanup test to skip setup cluster steps if needed

### DIFF
--- a/tests/e2escenarios/e2e-test.go
+++ b/tests/e2escenarios/e2e-test.go
@@ -19,7 +19,7 @@ import (
 var _ = Describe("E2E Test", func() {
 	var commonVar helper.CommonVar
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 	})
 	var _ = AfterEach(func() {
 		helper.CommonAfterEach(commonVar)

--- a/tests/e2escenarios/e2e_devfile_test.go
+++ b/tests/e2escenarios/e2e_devfile_test.go
@@ -24,7 +24,7 @@ var _ = Describe("odo devfile supported tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		projectDirPath = commonVar.Context + projectDir

--- a/tests/integration/cmd_add_binding_test.go
+++ b/tests/integration/cmd_add_binding_test.go
@@ -16,7 +16,7 @@ var _ = Describe("odo add binding command tests", func() {
 	var err error
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 		// Ensure that the operators are installed
 		commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")

--- a/tests/integration/cmd_analyze_test.go
+++ b/tests/integration/cmd_analyze_test.go
@@ -14,7 +14,7 @@ var _ = Describe("odo analyze command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo delete command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		getDeployArgs = []string{"get", "deployment", "-n", commonVar.Project}

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -16,7 +16,7 @@ var _ = Describe("odo describe component command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 		cmpName = helper.RandString(6)
 	})

--- a/tests/integration/cmd_describe_list_binding_test.go
+++ b/tests/integration/cmd_describe_list_binding_test.go
@@ -16,7 +16,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo dev debug command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -30,7 +30,7 @@ var _ = Describe("odo dev command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())

--- a/tests/integration/cmd_devfile_build_images_test.go
+++ b/tests/integration/cmd_devfile_build_images_test.go
@@ -15,7 +15,7 @@ var _ = Describe("odo devfile build-images command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -18,7 +18,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
 	})

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -21,7 +21,7 @@ var _ = Describe("odo devfile init command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
 	})

--- a/tests/integration/cmd_devfile_list_test.go
+++ b/tests/integration/cmd_devfile_list_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo list with devfile", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -16,7 +16,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_logs_test.go
+++ b/tests/integration/cmd_logs_test.go
@@ -28,7 +28,7 @@ var _ = Describe("odo logs command tests", func() {
 	}
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -16,7 +16,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 	var commonVar helper.CommonVar
 
 	BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 	})
 
 	AfterEach(func() {

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -18,7 +18,7 @@ var _ = Describe("odo preference and config command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 	})
 
 	// Clean up after the test

--- a/tests/integration/cmd_remove_binding_test.go
+++ b/tests/integration/cmd_remove_binding_test.go
@@ -13,7 +13,7 @@ var _ = Describe("odo remove binding command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 		// Note: We do not add any operators here because `odo remove binding` is simply about removing the ServiceBinding from devfile.
 	})

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo generic", func() {
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
 		oc = helper.NewOcRunner("oc")
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 	})
 
 	// Clean up after the test

--- a/tests/integration/interactive_add_binding_test.go
+++ b/tests/integration/interactive_add_binding_test.go
@@ -23,7 +23,7 @@ var _ = Describe("odo add binding interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 
 		// We make EXPLICITLY sure that we are outputting with NO COLOR

--- a/tests/integration/interactive_deploy_test.go
+++ b/tests/integration/interactive_deploy_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo deploy interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/interactive_dev_test.go
+++ b/tests/integration/interactive_dev_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -26,7 +26,7 @@ var _ = Describe("odo init interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach()
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 		helper.Chdir(commonVar.Context)
 
 		// We make EXPLICITLY sure that we are outputting with NO COLOR


### PR DESCRIPTION
**What type of PR is this:**

/kind cleanup
/kind tests

**What does this PR do / why we need it:**
This PR will update the commonBeforeEach and CommonAfterEach to skip or to execute cluster related operation.
Now commonBeforeEach require bool argument, we can pass `helper.SetupClusterFalse` or `helper.SetupClusterTrue` as we require.

**Which issue(s) this PR fixes:**

Fixes #5868 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
