### PR TITLE
Add blog post for v3.0.0-beta1 release

### DIFF
--- a/docs/website/blog/2022-07-01-odo-v3-beta1.md
+++ b/docs/website/blog/2022-07-01-odo-v3-beta1.md
@@ -18,15 +18,15 @@ slug: odo-v3-beta1-release
 Check this Playlist for an overview of the most notable changes in this release:
 https://www.youtube.com/watch?v=yTUk_rx3aP8&list=PLGMB2PY4SNOrBQabcLZ_M5rN8l5u0B_cw
 
-#### Ability to show (and stream) logs of running component, with “odo logs” and “odo logs –follow” ([#5622](https://github.com/redhat-developer/odo/issues/5622), [#5715](https://github.com/redhat-developer/odo/issues/5715))
+#### Ability to show (and stream) logs of running component, with `odo logs` and `odo logs –follow` ([#5622](https://github.com/redhat-developer/odo/issues/5622), [#5715](https://github.com/redhat-developer/odo/issues/5715))
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BjmUPUVupG0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-#### Substituting variables into the Devfile from the CLI when running “odo dev” or “odo deploy” ([#5489](https://github.com/redhat-developer/odo/issues/5489))
+#### Substituting variables into the Devfile from the CLI when running `odo dev` or `odo deploy` ([#5489](https://github.com/redhat-developer/odo/issues/5489))
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/yTUk_rx3aP8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-#### Support for composite run and debug Devfile commands when running “odo dev” ([#5054](https://github.com/redhat-developer/odo/issues/5054))
+#### Support for composite run and debug Devfile commands when running `odo dev` ([#5054](https://github.com/redhat-developer/odo/issues/5054))
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/IK2lrDUGOMk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -34,17 +34,17 @@ https://www.youtube.com/watch?v=yTUk_rx3aP8&list=PLGMB2PY4SNOrBQabcLZ_M5rN8l5u0B
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/xJVRMCBPV44" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-#### “Bind as files” UI update when running “odo add binding” ([#5770](https://github.com/redhat-developer/odo/issues/5770))
+#### “Bind as files” UI update when running `odo add binding` ([#5770](https://github.com/redhat-developer/odo/issues/5770))
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/7ZVjoLR8H0k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> 
 
-#### Ability to unbind ServiceBindings from the Devfile, with “odo remove binding” ([#5693](https://github.com/redhat-developer/odo/issues/5693))
+#### Ability to unbind ServiceBindings from the Devfile, with `odo remove binding` ([#5693](https://github.com/redhat-developer/odo/issues/5693))
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/oWMwcF-oQtE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### Bug fixes
 - Better support for command and args fields in Devfile container components: odo no longer overrides the container command with Supervisord ([#5648](https://github.com/redhat-developer/odo/issues/5648))
-- Devfile Volume components shown when personalizing Devfile configuration via “odo init” ([#5779](https://github.com/redhat-developer/odo/issues/5779))
+- Devfile Volume components shown when personalizing Devfile configuration via `odo init` ([#5779](https://github.com/redhat-developer/odo/issues/5779))
 
 ### odo.dev
 - Main site switched to 3.0.0 documentation
@@ -58,32 +58,32 @@ As with every release, you can find the full list of changes and bug fixes on th
 
 ### Features/Enhancements
 
-* odo remove binding by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5787
+* `odo remove binding` by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5787
 * Add `odo logs` by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5760
 * Substituting variables into the devfile from the CLI by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5749
 * Add support for `command`/`args` fields in `container` components by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5768
-* Adds odo logs for Deploy mode by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5825
-* odo list binding by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5823
-* Remove odo preference registry update command by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5853
+* Add `odo logs` for Deploy mode by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5825
+* `odo list binding` by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5823
+* Remove `odo preference registry update` command by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5853
 * Preference cleanup (1/n) by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5822
-* odo add binding without devfile.yaml by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5858
+* `odo add binding` without devfile.yaml by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5858
 * Adds support to follow/tail/stream odo logs by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5846
-* Change ephemeral default to false by [@kadel](https://github.com/kadel) in https://github.com/redhat-developer/odo/pull/5795
+* Change ephemeral default to `false` by [@kadel](https://github.com/kadel) in https://github.com/redhat-developer/odo/pull/5795
 * Add support for composite run/debug commands by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5841
-* Update preference view to show list of devfile registries by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5850
-* Add preference add and remove commands by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5873
+* Update `odo preference view` to show list of devfile registries by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5850
+* Add `odo preference add` and `odo preference remove` commands by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5873
 * Add `run-command` flag to `odo dev` to run non-default Run command by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5878
 * Add `build-command` flag to `odo dev` to run non-default Build command by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5891
 
 ### Bugs
 
-* Use latest alizer library version, including .net detection by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5804
-* ignore dynamic resource when not found by [@vinny-sabatini](https://github.com/vinny-sabatini) in https://github.com/redhat-developer/odo/pull/5815
+* Use latest alizer library version, including .NET detection by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5804
+* Ignore dynamic resource when not found by [@vinny-sabatini](https://github.com/vinny-sabatini) in https://github.com/redhat-developer/odo/pull/5815
 * Fix: configuration shows volumes as containers by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5807
 * Wait for deployment rollout only when binding created / modified by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5785
-* odo add binding - Bind as files UI update by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5817
-* When typing odo foobar --help should error out with invalid command by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5813
-* Fix misleading add binding  error message by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5887
+* `odo add binding` - Bind as files UI update by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5817
+* Typing `odo foobar --help` should error out with invalid command by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5813
+* Fix misleading `add binding` error message by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5887
 
 ### Documentation
 
@@ -100,11 +100,11 @@ As with every release, you can find the full list of changes and bug fixes on th
 
 ### Testing/CI
 
-* Add unit test for odo add binding by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5790
+* Add unit test for `odo add binding` by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5790
 * add e2e tests by [@anandrkskd](https://github.com/anandrkskd) in https://github.com/redhat-developer/odo/pull/5778
 * Fix parametrized integration tests by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5826
 * Fix flaky `kubeexec` unit test case with env vars by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5845
-* Check if all Pods are running in odo logs tests by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5851
+* Check if all Pods are running in `odo logs` tests by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5851
 * Install script for operators on Kubernetes + Activate tests with operatoes on Kubernetes by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5861
 * Eventually list namespaces for test by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5837
 * Enable Dependabot by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5827

--- a/docs/website/blog/2022-07-01-odo-v3-beta1.md
+++ b/docs/website/blog/2022-07-01-odo-v3-beta1.md
@@ -1,0 +1,115 @@
+---
+title: odo v3.0.0-beta1 Released
+author: Armel Soro
+author_url: https://github.com/rm3l
+author_image_url: https://github.com/rm3l.png
+tags: ["release"]
+slug: odo-v3-beta1-release
+---
+
+`3.0.0-beta1` of odo has been released!
+
+<!--truncate-->
+
+## Notable Changes
+
+### Features
+
+Check this Playlist for an overview of the most notable changes in this release:
+https://www.youtube.com/watch?v=yTUk_rx3aP8&list=PLGMB2PY4SNOrBQabcLZ_M5rN8l5u0B_cw
+
+#### Ability to show (and stream) logs of running component, with “odo logs” and “odo logs –follow” ([#5622](https://github.com/redhat-developer/odo/issues/5622), [#5715](https://github.com/redhat-developer/odo/issues/5715))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/BjmUPUVupG0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### Substituting variables into the Devfile from the CLI when running “odo dev” or “odo deploy” ([#5489](https://github.com/redhat-developer/odo/issues/5489))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/yTUk_rx3aP8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### Support for composite run and debug Devfile commands when running “odo dev” ([#5054](https://github.com/redhat-developer/odo/issues/5054))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/IK2lrDUGOMk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### Ability to list existing Service Bindings and interactively generate Service Binding from a directory with no Devfile ([#5635](https://github.com/redhat-developer/odo/issues/5635), [#5772](https://github.com/redhat-developer/odo/issues/5772))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/xJVRMCBPV44" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### “Bind as files” UI update when running “odo add binding” ([#5770](https://github.com/redhat-developer/odo/issues/5770))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/7ZVjoLR8H0k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> 
+
+#### Ability to unbind ServiceBindings from the Devfile, with “odo remove binding” ([#5693](https://github.com/redhat-developer/odo/issues/5693))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/oWMwcF-oQtE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Bug fixes
+- Better support for command and args fields in Devfile container components: odo no longer overrides the container command with Supervisord ([#5648](https://github.com/redhat-developer/odo/issues/5648))
+- Devfile Volume components shown when personalizing Devfile configuration via “odo init” ([#5779](https://github.com/redhat-developer/odo/issues/5779))
+
+### odo.dev
+- Main site switched to 3.0.0 documentation
+- Blog post about binding an external service with odo v3 ([link](https://odo.dev/blog/binding-database-service-without-sbo))
+- Homebrew installation details ([#5801](https://github.com/redhat-developer/odo/issues/5801))
+
+
+## Detailed Changelog
+
+As with every release, you can find the full list of changes and bug fixes on the [GitHub release page](https://github.com/redhat-developer/odo/releases/tag/v3.0.0-beta1)
+
+### Features/Enhancements
+
+* odo remove binding by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5787
+* Add `odo logs` by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5760
+* Substituting variables into the devfile from the CLI by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5749
+* Add support for `command`/`args` fields in `container` components by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5768
+* Adds odo logs for Deploy mode by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5825
+* odo list binding by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5823
+* Remove odo preference registry update command by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5853
+* Preference cleanup (1/n) by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5822
+* odo add binding without devfile.yaml by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5858
+* Adds support to follow/tail/stream odo logs by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5846
+* Change ephemeral default to false by [@kadel](https://github.com/kadel) in https://github.com/redhat-developer/odo/pull/5795
+* Add support for composite run/debug commands by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5841
+* Update preference view to show list of devfile registries by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5850
+* Add preference add and remove commands by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5873
+* Add `run-command` flag to `odo dev` to run non-default Run command by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5878
+* Add `build-command` flag to `odo dev` to run non-default Build command by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5891
+
+### Bugs
+
+* Use latest alizer library version, including .net detection by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5804
+* ignore dynamic resource when not found by [@vinny-sabatini](https://github.com/vinny-sabatini) in https://github.com/redhat-developer/odo/pull/5815
+* Fix: configuration shows volumes as containers by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5807
+* Wait for deployment rollout only when binding created / modified by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5785
+* odo add binding - Bind as files UI update by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5817
+* When typing odo foobar --help should error out with invalid command by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5813
+* Fix misleading add binding  error message by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5887
+
+### Documentation
+
+* update links to v3 binary by [@anandrkskd](https://github.com/anandrkskd) in https://github.com/redhat-developer/odo/pull/5805
+* Add 3.0.0 link to homepage, and fix alpha title by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5810
+* Update README.md by [@kadel](https://github.com/kadel) in https://github.com/redhat-developer/odo/pull/5835
+* Add Homebrew installation details by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5812
+* Add blog post about binding an external service by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5828
+* Fix CLI info regarding Springboot quickstart by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5849
+* Add DCO documentation by [@fbricon](https://github.com/fbricon) in https://github.com/redhat-developer/odo/pull/5864
+* Add missing documentation on SBO installation by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5855
+* Make 3.0.0 the default on the site by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5857
+* Remove "unmaintained" banner for 2.5.0 by [@cdrage](https://github.com/cdrage) in https://github.com/redhat-developer/odo/pull/5884
+
+### Testing/CI
+
+* Add unit test for odo add binding by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5790
+* add e2e tests by [@anandrkskd](https://github.com/anandrkskd) in https://github.com/redhat-developer/odo/pull/5778
+* Fix parametrized integration tests by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5826
+* Fix flaky `kubeexec` unit test case with env vars by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5845
+* Check if all Pods are running in odo logs tests by [@dharmit](https://github.com/dharmit) in https://github.com/redhat-developer/odo/pull/5851
+* Install script for operators on Kubernetes + Activate tests with operatoes on Kubernetes by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5861
+* Eventually list namespaces for test by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5837
+* Enable Dependabot by [@rm3l](https://github.com/rm3l) in https://github.com/redhat-developer/odo/pull/5827
+
+### Other merged pull requests
+
+* Update OWNERS files by [@valaparthvi](https://github.com/valaparthvi) in https://github.com/redhat-developer/odo/pull/5808
+* Bump to version v3.0.0-beta1 by [@feloy](https://github.com/feloy) in https://github.com/redhat-developer/odo/pull/5903


### PR DESCRIPTION
**What type of PR is this:**

/kind documentation

**What does this PR do / why we need it:**
This adds a blog post for the previous v3.0.0-beta1 release.

For simplicity, I've copied the changelog associated with this release. And I also picked the points mentioned during the Sprint Demos as "most notable changes" along with the relevant videos. I've also included the link to the corresponding [playlist](https://www.youtube.com/playlist?list=PLGMB2PY4SNOrBQabcLZ_M5rN8l5u0B_cw).

A separate PR will follow up for v3.0.0-beta2 once it is completely released.

**Which issue(s) this PR fixes:**
Fixes #5904

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
Preview: https://deploy-preview-5956--odo-docusaurus-preview.netlify.app/blog/odo-v3-beta1-release