### PR TITLE
Remove green bold from port forwarding

### DIFF
--- a/pkg/portForward/writer.go
+++ b/pkg/portForward/writer.go
@@ -8,9 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
-
 	"github.com/redhat-developer/odo/pkg/api"
+	"github.com/redhat-developer/odo/pkg/log"
 
 	"k8s.io/klog"
 )
@@ -37,11 +36,6 @@ func NewPortWriter(buffer io.Writer, len int, mapping map[string][]int) *PortWri
 
 func (o *PortWriter) Write(buf []byte) (n int, err error) {
 
-	// Set the colours to green (to indicate that the port is OPEN)
-	// as well as bold. So it stands our that the application is currently
-	// being port forwarded.
-	color.Set(color.FgGreen, color.Bold)
-	defer color.Unset() // Use it in your function
 	s := string(buf)
 	if strings.HasPrefix(s, "Forwarding from 127.0.0.1") {
 
@@ -52,7 +46,7 @@ func (o *PortWriter) Write(buf []byte) (n int, err error) {
 			klog.V(4).Infof("unable to get forwarded port: %v", err)
 		}
 
-		fmt.Fprintf(o.buffer, " - %s", s)
+		fmt.Fprintf(o.buffer, " -  %s", log.Sbold(s))
 		o.len--
 		if o.len == 0 {
 			o.end <- true


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind bug

**What does this PR do / why we need it:**

Fixes the problem of port information not showing on light terminals.
This changes the ports being shown as bolded rather than green (and
bolded).

Confirmed to work on both light and dark terminal colours

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5843

**PR acceptance criteria:**

- [X] Unit test
- [X] Integration test
- [X] Documentation

N/A

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>