### PR TITLE
Refactor color througout interactive mode and dev

### DIFF
--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
-	"github.com/fatih/color"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/init/asker"
@@ -210,7 +209,6 @@ func (o *InteractiveBackend) PersonalizeDevfileConfig(devfileobj parser.DevfileO
 }
 
 func PrintConfiguration(config asker.DevfileConfiguration) {
-	color.New(color.Bold, color.FgGreen).Println("Current component configuration:")
 
 	var keys []string
 	for key := range config {
@@ -220,18 +218,24 @@ func PrintConfiguration(config asker.DevfileConfiguration) {
 
 	for _, key := range keys {
 		container := config[key]
-		color.Green("Container %q:", key)
-		color.Green("  Opened ports:")
+		log.Sectionf("Container Configuration %q:", key)
 
-		for _, port := range container.Ports {
-			color.New(color.Bold, color.FgWhite).Printf("   - %s\n", port)
+		fmt.Printf("  OPEN PORTS:\n")
+
+		for _, value := range container.Ports {
+			fmt.Printf("    - %s\n", value)
 		}
 
-		color.Green("  Environment variables:")
+		fmt.Println("  ENVIRONMENT VARIABLES:")
+
 		for key, value := range container.Envs {
-			color.New(color.Bold, color.FgWhite).Printf("   - %s = %s\n", key, value)
+			fmt.Printf("    - %s = %s\n", key, value)
 		}
+
 	}
+
+	// Make sure we add a newline at the end
+	fmt.Println()
 }
 
 func getPortsAndEnvVar(obj parser.DevfileObj) (asker.DevfileConfiguration, error) {

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -220,16 +220,18 @@ func PrintConfiguration(config asker.DevfileConfiguration) {
 		container := config[key]
 		log.Sectionf("Container Configuration %q:", key)
 
-		fmt.Printf("  OPEN PORTS:\n")
+		stdout := log.GetStdout()
+
+		fmt.Fprintf(stdout, "  OPEN PORTS:\n")
 
 		for _, value := range container.Ports {
-			fmt.Printf("    - %s\n", value)
+			fmt.Fprintf(stdout, "    - %s\n", value)
 		}
 
-		fmt.Println("  ENVIRONMENT VARIABLES:")
+		fmt.Fprintf(stdout, "  ENVIRONMENT VARIABLES:\n")
 
 		for key, value := range container.Envs {
-			fmt.Printf("    - %s = %s\n", key, value)
+			fmt.Fprintf(stdout, "    - %s = %s\n", key, value)
 		}
 
 	}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -388,6 +388,20 @@ func Sbold(s string) string {
 	return bold(fmt.Sprint(s))
 }
 
+// Bold will print out a bolded string
+func Bold(s string) {
+	if !IsJSON() {
+		bold := color.New(color.Bold).SprintFunc()
+		fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintln(s)))
+	}
+}
+
+// BoldColor will print out a bolded string with a color (that's passed in)
+func SboldColor(c color.Attribute, s string) string {
+	chosenColor := color.New(c).SprintFunc()
+	return chosenColor(fmt.Sprintln(Sbold(s)))
+}
+
 // Describef will print out the first variable as BOLD and then the second not..
 // this is intended to be used with `odo describe` and other outputs that list
 // a lot of information

--- a/pkg/portForward/writer.go
+++ b/pkg/portForward/writer.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-
 	"github.com/redhat-developer/odo/pkg/api"
+	"github.com/redhat-developer/odo/pkg/log"
 
 	"k8s.io/klog"
 )
@@ -37,11 +37,6 @@ func NewPortWriter(buffer io.Writer, len int, mapping map[string][]int) *PortWri
 
 func (o *PortWriter) Write(buf []byte) (n int, err error) {
 
-	// Set the colours to green (to indicate that the port is OPEN)
-	// as well as bold. So it stands our that the application is currently
-	// being port forwarded.
-	color.Set(color.FgGreen, color.Bold)
-	defer color.Unset() // Use it in your function
 	s := string(buf)
 	if strings.HasPrefix(s, "Forwarding from 127.0.0.1") {
 
@@ -52,7 +47,8 @@ func (o *PortWriter) Write(buf []byte) (n int, err error) {
 			klog.V(4).Infof("unable to get forwarded port: %v", err)
 		}
 
-		fmt.Fprintf(o.buffer, " - %s", s)
+		// Also set the colour to bolded green for easier readability
+		fmt.Fprintf(o.buffer, " -  %s", log.SboldColor(color.FgGreen, s))
 		o.len--
 		if o.len == 0 {
 			o.end <- true


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind cleanup

**What does this PR do / why we need it:**

This PR fixes the following:
- Updates the interactive mode so it's better looking when outputting
  configuration so it's similar to the rest of the output:

```sh
? Is this correct? Yes
 ✓  Downloading devfile "nodejs" from registry "DefaultDevfileRegistry" [1s]

↪ Container Configuration "runtime":
  OPEN PORTS:
    - 3000
  ENVIRONMENT VARIABLES:

? Select container for which you want to change configuration? runtime
? What configuration do you want change? Delete port "3000"
? What configuration do you want change? NOTHING - configuration is correct

↪ Container Configuration "runtime":
  OPEN PORTS:
  ENVIRONMENT VARIABLES:

? Select container for which you want to change configuration?  [Use arrows to move, type to filter]
  runtime
> NONE - configuration is correct
```

- Removes issue of fgGreen not appearing correctly because of direct use
  of `color` instead of log/status.go. This is due to color not
  detecting if the terminal supports the color, which is done in
  `log/status.go` instead.

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5843

**How to test changes / Special notes to the reviewer:**