### PR TITLE
Add spinner ending for running command

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/commandhandler.go
+++ b/pkg/devfile/adapters/kubernetes/component/commandhandler.go
@@ -62,6 +62,7 @@ func (a *adapterHandler) Execute(devfileCmd devfilev1.Command) error {
 	// Spinner created but not started yet.
 	// It will be displayed when the statusHandlerFunc function is called with the "Starting" state.
 	spinner := log.NewStatus(log.GetStdout())
+	defer spinner.End(false)
 
 	// if we need to restart, issue the remote process handler command to stop all running commands first.
 	// We do not need to restart Hot reload capable commands.
@@ -122,6 +123,7 @@ func (a *adapterHandler) Execute(devfileCmd devfilev1.Command) error {
 		return err
 	}
 
+	spinner.End(true)
 	return a.checkRemoteCommandStatus(devfileCmd, a.podName,
 		fmt.Sprintf("Devfile command %q exited with an error status in %.0f second(s)", devfileCmd.Id, totalWaitTime))
 }


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind bug

**What does this PR do / why we need it:**

When running `odo dev`, it will never show that the command has
completed.

```sh
 ✓  Building your application in container on cluster (command: install) [3s]
 •  Executing the application (command: run)  ...
 -  Forwarding from 127.0.0.1:40001 -> 3000
```

`spinner.End` hadn't been added so it never shows at it ending.

This PR fixes that:

```sh
 ✓  Building your application in container on cluster (command: install) [3s]
 •  Executing the application (command: run)  ...
 ✓  Executing the application (command: run) [5s]
 ```

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

N/A

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>