### PR TITLE
Improve --help page by separating commands to management commands

### DIFF
--- a/pkg/odo/cli/add/add.go
+++ b/pkg/odo/cli/add/add.go
@@ -19,7 +19,7 @@ func NewCmdAdd(name, fullName string) *cobra.Command {
 
 	bindingCmd := binding.NewCmdBinding(binding.BindingRecommendedCommandName, util.GetFullName(fullName, binding.BindingRecommendedCommandName))
 	createCmd.AddCommand(bindingCmd)
-	createCmd.Annotations = map[string]string{"command": "main"}
+	createCmd.Annotations = map[string]string{"command": "management"}
 	createCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return createCmd

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -72,6 +72,9 @@ Examples:
 Main Commands:{{range .Commands}}{{if eq .Annotations.command "main"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 
+Management Commands:{{range .Commands}}{{if eq .Annotations.command "management"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+
 OpenShift Commands:{{range .Commands}}{{if eq .Annotations.command "openshift"}}
   {{rpad .Name .NamePadding }} {{.Short}} {{end}}{{end}}
 

--- a/pkg/odo/cli/create/create.go
+++ b/pkg/odo/cli/create/create.go
@@ -23,7 +23,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf("%s\n",
 			namespaceCreateCmd.Example,
 		),
-		Annotations: map[string]string{"command": "main"},
+		Annotations: map[string]string{"command": "management"},
 	}
 
 	createCmd.AddCommand(namespaceCreateCmd)

--- a/pkg/odo/cli/delete/delete.go
+++ b/pkg/odo/cli/delete/delete.go
@@ -15,7 +15,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	var deleteCmd = &cobra.Command{
 		Use:         name,
 		Short:       "Delete resources",
-		Annotations: map[string]string{"command": "main"},
+		Annotations: map[string]string{"command": "management"},
 	}
 
 	componentCmd := component.NewCmdComponent(component.ComponentRecommendedCommandName,

--- a/pkg/odo/cli/describe/describe.go
+++ b/pkg/odo/cli/describe/describe.go
@@ -18,7 +18,7 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 	componentCmd := NewCmdComponent(ComponentRecommendedCommandName, util.GetFullName(fullName, ComponentRecommendedCommandName))
 	bindingCmd := NewCmdBinding(BindingRecommendedCommandName, util.GetFullName(fullName, BindingRecommendedCommandName))
 	describeCmd.AddCommand(componentCmd, bindingCmd)
-	describeCmd.Annotations = map[string]string{"command": "main"}
+	describeCmd.Annotations = map[string]string{"command": "management"}
 	describeCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return describeCmd

--- a/pkg/odo/cli/list/list.go
+++ b/pkg/odo/cli/list/list.go
@@ -190,7 +190,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 		Long:        "List all components in the current namespace.",
 		Example:     fmt.Sprintf(listExample, fullName),
 		Args:        cobra.NoArgs,
-		Annotations: map[string]string{"command": "main"},
+		Annotations: map[string]string{"command": "management"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/remove/remove.go
+++ b/pkg/odo/cli/remove/remove.go
@@ -19,7 +19,7 @@ func NewCmdRemove(name, fullName string) *cobra.Command {
 
 	bindingCmd := binding.NewCmdBinding(binding.BindingRecommendedCommandName, util.GetFullName(fullName, binding.BindingRecommendedCommandName))
 	removeCmd.AddCommand(bindingCmd)
-	removeCmd.Annotations = map[string]string{"command": "main"}
+	removeCmd.Annotations = map[string]string{"command": "management"}
 	removeCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return removeCmd

--- a/pkg/odo/cli/set/set.go
+++ b/pkg/odo/cli/set/set.go
@@ -24,7 +24,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf("%s\n",
 			namespaceSetCmd.Example,
 		),
-		Annotations: map[string]string{"command": "main"},
+		Annotations: map[string]string{"command": "management"},
 	}
 
 	setCmd.AddCommand(namespaceSetCmd)


### PR DESCRIPTION
<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind cleanup

**What does this PR do / why we need it:**

One thing I noticed is that all of our commands are clustered into one
section.

We mix both nouns and verbs together.

I've gone ahead and separated it into a different section so it's easier
to decipher what can be done, I've named the section "management
commands".

```sh
go/src/odo  improve-help-page-usage ✔                                                                                                                                                                                                                                                                                                                             2h18m
 /  \__     odo is a CLI tool for fast iterative application development
 \__/  \    deployed immediately to your kubernetes cluster.
 /  \__/    Find more information at https://odo.dev
 \__/

Usage:
  odo [flags]
  odo [command]

Examples:
  Initializing your component by taking your pick from multiple languages or frameworks:
  odo init

  After creating your initial component, start development with:
  odo dev

  Want to deploy after development? See it live with:
  odo deploy

Main Commands:
  build-images Build images
  deploy       Deploy components
  dev          Deploy component to development cluster
  init         Init bootstraps a new project
  logs         Show logs of all containers of the component
  registry     List all components from the Devfile registry

Management Commands:
  add          Add resources to devfile (binding)
  create       Perform create operation (namespace)
  delete       Delete resources (component, namespace)
  describe     Describe resource (binding, component)
  list         List all components in the current namespace (binding, namespace)
  remove       Remove resources from devfile (binding)
  set          Perform set operation (namespace)

OpenShift Commands:
  login        Login to cluster
  logout       Logout of the cluster

Utility Commands:
  analyze      Detect devfile to use based on files present in current directory
  completion   Add odo completion support to your development environment
  preference   Modifies preference settings (add, remove, set, unset, view)
  version      Print the client version information
```

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

N/A

**How to test changes / Special notes to the reviewer:**

Signed-off-by: Charlie Drage <charlie@charliedrage.com>