### PR TITLE
Add blog post for `v3.0.0-beta2` release and update installation doc

### DIFF
--- a/docs/website/blog/2022-07-21-odo-v3-beta2.md
+++ b/docs/website/blog/2022-07-21-odo-v3-beta2.md
@@ -1,0 +1,89 @@
+---
+title: odo v3.0.0-beta2 Released
+author: Armel Soro
+author_url: https://github.com/rm3l
+author_image_url: https://github.com/rm3l.png
+tags: ["release"]
+slug: odo-v3-beta2-release
+---
+
+`3.0.0-beta2` of odo has been released!
+
+<!--truncate-->
+
+To install `odo`, follow our installation guide at [odo.dev](../docs/overview/installation)
+
+## Notable Changes
+
+Check this Playlist for an overview of the most notable changes in this release:
+https://www.youtube.com/playlist?list=PLGMB2PY4SNOoxZNN5Ye1mHC4kndPx3p6h
+
+### Features
+
+#### odo completion support ([#5856](https://github.com/redhat-developer/odo/pull/5856), [#5921](https://github.com/redhat-developer/odo/pull/5921))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/cnxycd81wh0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### Executing alternative 'build' and 'run' commands with 'odo dev' ([#5878](https://github.com/redhat-developer/odo/pull/5878), [#5891](https://github.com/redhat-developer/odo/pull/5891))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/1qjceo414cA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### Setting naming strategy when running 'odo add binding' ([#5912](https://github.com/redhat-developer/odo/pull/5912))
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/jvCUSO6uXfI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+#### `odo dev`: handle port forwarding after pod restart ([#5885](https://github.com/redhat-developer/odo/pull/5885))
+
+`odo dev` is now able to automatically handle port forwarding (and regenerate them if needed) after a pod restarts, 
+e.g., following a change in the Devfile that modifies the container component configuration while the dev session is running.
+
+### Bug fixes
+- Error for `odo add binding` is misleading when no supported operator is installed ([#5887](https://github.com/redhat-developer/odo/pull/5887))
+
+### odo.dev
+- Blog post on how to connect to a service without using the Service Binding Operator ([link](./binding-database-service-without-sbo/))
+
+## Detailed Changelog
+
+As with every release, you can find the full list of changes and bug fixes on the [GitHub release page](https://github.com/redhat-developer/odo/releases/tag/v3.0.0-beta2)
+
+**Features/Enhancements:**
+
+- Allow setting `namingStrategy` when using `odo add binding` [\#5912](https://github.com/redhat-developer/odo/pull/5912) ([rm3l](https://github.com/rm3l))
+- `odo dev`: handle port forwarding after pod restart [\#5885](https://github.com/redhat-developer/odo/pull/5885) ([feloy](https://github.com/feloy))
+
+**Documentation:**
+
+- Add documentation for `odo completion` [\#5921](https://github.com/redhat-developer/odo/pull/5921) ([cdrage](https://github.com/cdrage))
+- Bump odo version in installation docs [\#5919](https://github.com/redhat-developer/odo/pull/5919) ([valaparthvi](https://github.com/valaparthvi))
+- Blog: Connecting to a service without SBO [\#5915](https://github.com/redhat-developer/odo/pull/5915) ([valaparthvi](https://github.com/valaparthvi))
+- Add instruction to install odo via Maven plugin [\#5909](https://github.com/redhat-developer/odo/pull/5909) ([mcarlett](https://github.com/mcarlett))
+- adding Threat Model and corresponding md file [\#5902](https://github.com/redhat-developer/odo/pull/5902) ([rnapoles-rh](https://github.com/rnapoles-rh))
+
+**Testing/CI:**
+
+- Sbo nightly test [\#5946](https://github.com/redhat-developer/odo/pull/5946) ([anandrkskd](https://github.com/anandrkskd))
+- Cleanup test to skip setup cluster steps if needed [\#5945](https://github.com/redhat-developer/odo/pull/5945) ([anandrkskd](https://github.com/anandrkskd))
+- Migrate to Ginkgo v2  [\#5809](https://github.com/redhat-developer/odo/pull/5809) ([anandrkskd](https://github.com/anandrkskd))
+
+**Merged pull requests:**
+
+- Bump version to `v3.0.0-beta2` [\#5952](https://github.com/redhat-developer/odo/pull/5952) ([rm3l](https://github.com/rm3l))
+- Remove unused functions: `ComponentExist`, `PushedComponent` [\#5944](https://github.com/redhat-developer/odo/pull/5944) ([valaparthvi](https://github.com/valaparthvi))
+- download `golangci-lint` binary with test script [\#5934](https://github.com/redhat-developer/odo/pull/5934) ([anandrkskd](https://github.com/anandrkskd))
+- reduce test make targets, organize test file structure [\#5931](https://github.com/redhat-developer/odo/pull/5931) ([anandrkskd](https://github.com/anandrkskd))
+- Go: Bump `github.com/fatih/color` from `1.12.0` to `1.13.0` [\#5925](https://github.com/redhat-developer/odo/pull/5925) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Go: Bump `github.com/posener/complete` from `1.1.1` to `1.2.3` [\#5924](https://github.com/redhat-developer/odo/pull/5924) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Cleanup Adapter structure to not be used to pass parameters [\#5918](https://github.com/redhat-developer/odo/pull/5918) ([feloy](https://github.com/feloy))
+- Website: Bump `@tsconfig/docusaurus` from `1.0.4` to `1.0.6` in `/docs/website` [\#5917](https://github.com/redhat-developer/odo/pull/5917) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Simplify `pkg/devfile/adapters/...` packages [\#5914](https://github.com/redhat-developer/odo/pull/5914) ([feloy](https://github.com/feloy))
+- Website: Bump `@svgr/webpack` from `5.5.0` to `6.2.1` in `/docs/website` [\#5913](https://github.com/redhat-developer/odo/pull/5913) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Website: Bump `prism-react-renderer` from `1.3.1` to `1.3.5` in `/docs/website` [\#5911](https://github.com/redhat-developer/odo/pull/5911) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Website: Bump `glob-parent` from `5.1.2` to `6.0.2` in `/docs/website` [\#5910](https://github.com/redhat-developer/odo/pull/5910) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Use cached discovery client [\#5908](https://github.com/redhat-developer/odo/pull/5908) ([dharmit](https://github.com/dharmit))
+- Go: Bump `github.com/pborman/uuid` from `1.2.0` to `1.2.1` [\#5901](https://github.com/redhat-developer/odo/pull/5901) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Website: Bump `browserslist` from `4.19.3` to `4.21.1` in `/docs/website` [\#5897](https://github.com/redhat-developer/odo/pull/5897) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Website: Bump `@docusaurus/core` from `2.0.0-beta.16` to `2.0.0-beta.21` in `/docs/website` [\#5895](https://github.com/redhat-developer/odo/pull/5895) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Add assertions for types implementing interfaces [\#5893](https://github.com/redhat-developer/odo/pull/5893) ([feloy](https://github.com/feloy))
+- update documentation issue template [\#5859](https://github.com/redhat-developer/odo/pull/5859) ([kadel](https://github.com/kadel))
+- Fixes terminal completion command for odo [\#5856](https://github.com/redhat-developer/odo/pull/5856) ([cdrage](https://github.com/cdrage))

--- a/docs/website/docs/overview/installation.md
+++ b/docs/website/docs/overview/installation.md
@@ -31,12 +31,12 @@ Installing `odo` on `amd64` architecture:
 
 1. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-amd64 -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-amd64 -o odo
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-amd64.sha256 -o odo.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-amd64.sha256 -o odo.sha256
 echo "$(<odo.sha256)  odo" | shasum -a 256 --check
 ```
 
@@ -62,12 +62,12 @@ Installing `odo` on `arm64` architecture:
 
 1. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-arm64 -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-arm64 -o odo
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-arm64.sha256 -o odo.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-arm64.sha256 -o odo.sha256
 echo "$(<odo.sha256)  odo" | shasum -a 256 --check
 ```
 
@@ -93,12 +93,12 @@ Installing `odo` on `ppc64le` architecture:
 
 1. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-ppc64le -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-ppc64le -o odo
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-ppc64le.sha256 -o odo.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-ppc64le.sha256 -o odo.sha256
 echo "$(<odo.sha256)  odo" | shasum -a 256 --check
 ```
 
@@ -124,12 +124,12 @@ Installing `odo` on `s390x` architecture:
 
 1. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-s390x -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-s390x -o odo
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-linux-s390x.sha256 -o odo.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-linux-s390x.sha256 -o odo.sha256
 echo "$(<odo.sha256)  odo" | shasum -a 256 --check
 ```
 
@@ -169,12 +169,12 @@ Installing `odo` on `amd64` architecture:
 
 1. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-darwin-amd64 -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-darwin-amd64 -o odo
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-darwin-amd64.sha256 -o odo.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-darwin-amd64.sha256 -o odo.sha256
 echo "$(<odo.sha256)  odo" | shasum -a 256 --check
 ```
 
@@ -201,12 +201,12 @@ Installing `odo` on `arm64` architecture:
 
 1. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-darwin-arm64 -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-darwin-arm64 -o odo
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-darwin-arm64.sha256 -o odo.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-darwin-arm64.sha256 -o odo.sha256
 echo "$(<odo.sha256)  odo" | shasum -a 256 --check
 ```
 
@@ -257,12 +257,12 @@ odo version
 
 2. Download the latest release from the mirror:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-windows-amd64.exe -o odo.exe
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-windows-amd64.exe -o odo.exe
 ```
 
 2. (Optional) Verify the downloaded binary with the SHA-256 sum:
 ```shell
-curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta1/odo-windows-amd64.exe.sha256 -o odo.exe.sha256
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/odo-windows-amd64.exe.sha256 -o odo.exe.sha256
 # Visually compare the output of both files
 Get-FileHash odo.exe
 type odo.exe.sha256
@@ -304,7 +304,7 @@ The download can be executed using `download` goal which automatically retrieves
 ```shell
 mvn software.tnb:odo-downloader-maven-plugin:0.1.3:download \
   -Dodo.target.file=$HOME/bin/odo \
-  -Dodo.version=v3.0.0~beta1
+  -Dodo.version=v3.0.0~beta2
 ```
 
 ## IDE Installation

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -127,7 +127,7 @@ module.exports = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '3.0.0 (Beta 1) 🚧',
+              label: '3.0.0 (Beta 2) 🚧',
               badge: true,
               banner: 'none',
             },


### PR DESCRIPTION
**What type of PR is this:**
/kind documentation

**What does this PR do / why we need it:**
Now that the artifacts for our `v3.0.0-beta2` are [publicly available in the Content Gateway](https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v3.0.0~beta2/), this PR adds the blog post for this release.
It also updates the installation doc to use such version.

**Which issue(s) this PR fixes:**
Fixes #5905

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

- Updated
  - [Installation doc](https://deploy-preview-5966--odo-docusaurus-preview.netlify.app/docs/overview/installation)
- New
  - [Blog post](https://deploy-preview-5966--odo-docusaurus-preview.netlify.app/blog/odo-v3-beta2-release)