### PR TITLE
Allow specifying message to end the spinner with

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/commandhandler.go
+++ b/pkg/devfile/adapters/kubernetes/component/commandhandler.go
@@ -55,7 +55,7 @@ func (a *adapterHandler) Execute(devfileCmd devfilev1.Command) error {
 				// Creating with no spin because the command could be long-running, and we cannot determine when it will end.
 				s.Start(fmt.Sprintf("Executing the application (command: %s)", devfileCmd.Id), true)
 			case remotecmd.Stopped, remotecmd.Errored:
-				s.EndWithStatus(fmt.Sprintf("Finished executing the long running application (command: %s)", devfileCmd.Id), status == remotecmd.Stopped)
+				s.EndWithStatus(fmt.Sprintf("Finished executing the application (command: %s)", devfileCmd.Id), status == remotecmd.Stopped)
 				if err != nil {
 					klog.V(2).Infof("error while running background command: %v", err)
 				}

--- a/pkg/devfile/adapters/kubernetes/component/commandhandler.go
+++ b/pkg/devfile/adapters/kubernetes/component/commandhandler.go
@@ -55,7 +55,7 @@ func (a *adapterHandler) Execute(devfileCmd devfilev1.Command) error {
 				// Creating with no spin because the command could be long-running, and we cannot determine when it will end.
 				s.Start(fmt.Sprintf("Executing the application (command: %s)", devfileCmd.Id), true)
 			case remotecmd.Stopped, remotecmd.Errored:
-				s.End(status == remotecmd.Stopped)
+				s.EndWithStatus(fmt.Sprintf("Finished executing the long running application (command: %s)", devfileCmd.Id), status == remotecmd.Stopped)
 				if err != nil {
 					klog.V(2).Infof("error while running background command: %v", err)
 				}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -221,6 +221,15 @@ func (s *Status) End(success bool) {
 	s.status = ""
 }
 
+// EndWithStatus is similar to End, but lets the user specify a custom message/status while ending
+func (s *Status) EndWithStatus(status string, success bool) {
+	if status == "" {
+		return
+	}
+	s.status = status
+	s.End(success)
+}
+
 // Printf will output in an appropriate "information" manner; for e.g.
 // • <message>
 func Printf(format string, a ...interface{}) {


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <shahdharmit@gmail.com>


**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
It fixes the UX that would lead a user to think that there was some error in executing the `run` command

**Which issue(s) this PR fixes:**
Fixes #5881

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
* Run `odo dev`
* Change a code file in the directory; odo should not exhibit the erroneous UX
* Stop `odo dev` with `Ctrl+C`; odo should not exhibit the erroneous UX