### PR TITLE
Fetch pods first; use channel instead of slice

### DIFF
--- a/pkg/kclient/all.go
+++ b/pkg/kclient/all.go
@@ -28,7 +28,9 @@ func (c *Client) GetAllResourcesFromSelector(selector string, ns string) ([]unst
 func getAllResources(client dynamic.Interface, apis []apiResource, ns string, selector string) ([]unstructured.Unstructured, error) {
 	var out []unstructured.Unstructured
 	outChan := make(chan []unstructured.Unstructured)
+	defer close(outChan)
 	errChan := make(chan struct{}) // use this to ensure that go routine doesn't keep waiting on outChan
+	defer close(errChan)
 
 	var apisOfInterest []apiResource
 	for _, api := range apis {

--- a/pkg/kclient/all.go
+++ b/pkg/kclient/all.go
@@ -43,6 +43,7 @@ func getAllResources(client dynamic.Interface, apis []apiResource, ns string, se
 	klog.V(2).Infof("starting to concurrently query %d APIs", len(apis))
 
 	for _, api := range apisOfInterest {
+		api := api // shadowing because go vet complains "loop variable api captured by func literal"
 		group.Go(func() error {
 			klog.V(4).Infof("[query api] start: %s", api.GroupVersionResource())
 			v, err := queryAPI(client, api, ns, selector)

--- a/pkg/kclient/all.go
+++ b/pkg/kclient/all.go
@@ -40,7 +40,7 @@ func getAllResources(client dynamic.Interface, apis []apiResource, ns string, se
 	}
 
 	start := time.Now()
-	klog.V(2).Infof("starting to query %d APIs in concurrently", len(apis))
+	klog.V(2).Infof("starting to concurrently query %d APIs", len(apis))
 
 	var errResult error
 	for _, api := range apisOfInterest {

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -69,8 +69,7 @@ func (c *Client) GetOneDeploymentFromSelector(selector string) (*appsv1.Deployme
 	return &deployments[0], nil
 }
 
-// GetDeploymentFromSelector returns an array of Deployment resources which
-// match the given selector
+// GetDeploymentFromSelector returns an array of Deployment resources which match the given selector
 func (c *Client) GetDeploymentFromSelector(selector string) ([]appsv1.Deployment, error) {
 	var deploymentList *appsv1.DeploymentList
 	var err error

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -113,6 +113,7 @@ type ClientInterface interface {
 	GetOnePodFromSelector(selector string) (*corev1.Pod, error)
 	GetPodLogs(podName, containerName string, followLog bool) (io.ReadCloser, error)
 	GetAllPodsInNamespace() (*corev1.PodList, error)
+	GetPodsMatchingSelector(selector string) (*corev1.PodList, error)
 
 	// port_forwarding.go
 	// SetupPortForwarding creates port-forwarding for the pod on the port pairs provided in the

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -828,6 +828,21 @@ func (mr *MockClientInterfaceMockRecorder) GetPodUsingComponentName(componentNam
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodUsingComponentName", reflect.TypeOf((*MockClientInterface)(nil).GetPodUsingComponentName), componentName)
 }
 
+// GetPodsMatchingSelector mocks base method.
+func (m *MockClientInterface) GetPodsMatchingSelector(selector string) (*v11.PodList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodsMatchingSelector", selector)
+	ret0, _ := ret[0].(*v11.PodList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPodsMatchingSelector indicates an expected call of GetPodsMatchingSelector.
+func (mr *MockClientInterfaceMockRecorder) GetPodsMatchingSelector(selector interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodsMatchingSelector", reflect.TypeOf((*MockClientInterface)(nil).GetPodsMatchingSelector), selector)
+}
+
 // GetProject mocks base method.
 func (m *MockClientInterface) GetProject(projectName string) (*v1.Project, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -244,3 +244,7 @@ func (c *Client) GetPodLogs(podName, containerName string, followLog bool) (io.R
 func (c *Client) GetAllPodsInNamespace() (*corev1.PodList, error) {
 	return c.KubeClient.CoreV1().Pods(c.Namespace).List(context.TODO(), metav1.ListOptions{})
 }
+
+func (c *Client) GetPodsMatchingSelector(selector string) (*corev1.PodList, error) {
+	return c.KubeClient.CoreV1().Pods(c.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+}

--- a/pkg/storage/mock_Client.go
+++ b/pkg/storage/mock_Client.go
@@ -5,34 +5,35 @@
 package storage
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockClient) Create(arg0 Storage) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0)
@@ -40,13 +41,13 @@ func (m *MockClient) Create(arg0 Storage) error {
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockClientMockRecorder) Create(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), arg0)
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockClient) Delete(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0)
@@ -54,13 +55,13 @@ func (m *MockClient) Delete(arg0 string) error {
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockClientMockRecorder) Delete(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), arg0)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockClient) List() (StorageList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
@@ -69,7 +70,7 @@ func (m *MockClient) List() (StorageList, error) {
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockClientMockRecorder) List() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List))


### PR DESCRIPTION
/kind bug

**What does this PR do / why we need it:**
We first fetch the pods matching the selector so that we can quickly start showing the logs to the user. For a component created using [this devfile in test suite](https://github.com/redhat-developer/odo/blob/main/tests/examples/source/devfiles/nodejs/devfile-deploy-functional-pods.yaml) and running in both Dev and Deploy modes, performance improvement is as below:

```sh
# odo built using the main branch
$ odo-main logs | grep "===="
============================= 2.322569471s =============================
============================= 2.614284155s =============================
============================= 6.419786304s =============================
============================= 6.727155955s =============================

# odo built using this PR's branch
$ odo-pods-first logs | grep "====" 
============================= 1.475623872s =============================
============================= 1.781928233s =============================
============================= 6.903285785s =============================
============================= 7.182508784s =============================

```

I added logic to grab the deployments from the cluster and then match pods to those to see if there could be further improvement, but it's worsening:
```sh
$ odo-get-deployments logs | grep "===="
============================= 1.575954862s =============================
============================= 1.873502308s =============================
============================= 8.719334078s =============================
============================= 9.051154327s =============================
```

**Which issue(s) this PR fixes:**
Fixes #5872

Marking the issue fixed since there aren't any other ideas that we have to improve the performance at the moment.

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
* Create a component using the devfile mentioned above
* Use below diff to benchmark the performance:
  ```diff
  $ git diff --unified=0 
  diff --git a/pkg/odo/cli/logs/logs.go b/pkg/odo/cli/logs/logs.go
  index 6779c5173..04741027a 100644
  --- a/pkg/odo/cli/logs/logs.go
  +++ b/pkg/odo/cli/logs/logs.go
  @@ -15,0 +16 @@ import (
  +       "time"
  @@ -40,0 +42 @@ type LogsOptions struct {
  +       start         time.Time
  @@ -68,0 +71 @@ func (o *LogsOptions) SetClientset(clientset *clientset.Clientset) {
  +       o.start = time.Now()
  @@ -160,0 +164 @@ func (o *LogsOptions) Run(_ context.Context) error {
  +                               fmt.Println("=============================", time.Since(o.start), "=============================")
  ```