### PR TITLE
Limit the total number of Dependabot PRs to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
 - package-ecosystem: "gomod"
   directory: "/"
   # Set this to 0 to disable version updates
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 1
   commit-message:
     prefix: "Go"
   schedule:
@@ -28,7 +28,7 @@ updates:
 - package-ecosystem: "npm"
   directory: "/docs/website"
   # Set this to 0 to disable version updates
-  open-pull-requests-limit: 2
+  open-pull-requests-limit: 1
   commit-message:
     prefix: "Website"
   schedule:


### PR DESCRIPTION
**What type of PR is this:**
/kind task

**What does this PR do / why we need it:**
To help alleviate the review burden on PRs, this PR reduces the number of PRs created by Dependabot to a maximum of 2 (1 for `go.mod` related PRs, and 1 for NPM packages).
This was discussed in the Retrospective meeting.

**Which issue(s) this PR fixes:**
None

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
