### PR TITLE
Allow using remote Dockerfiles (HTTP(S) only) for building images

### DIFF
--- a/docs/website/docs/command-reference/build-images.md
+++ b/docs/website/docs/command-reference/build-images.md
@@ -16,10 +16,11 @@ components:
   name: component-built-from-dockerfile
 ```
 
-The `uri` field indicates the relative path of the Dockerfile to use, relative to the directory containing the `devfile.yaml`. The devfile specification indicates that `uri` could also be an HTTP URL, but this case is not supported by odo yet.
+The `uri` field indicates the relative path of the Dockerfile to use, relative to the directory containing the `devfile.yaml`. 
+As indicated in the Devfile specification, `uri` could also be an HTTP or HTTPS URL.
 
 The `buildContext` indicates the directory used as build context. The default value is `${PROJECT_SOURCE}`.
 
 For each image component, odo executes either `podman` or `docker` (the first one found, in this order), to build the image with the specified Dockerfile, build context and arguments.
 
-If the `--push` flag is passed to the command, the images are be pushed to their registries after they are built.
+If the `--push` flag is passed to the command, the images will be pushed to their registries after they are built.

--- a/docs/website/docs/command-reference/deploy.md
+++ b/docs/website/docs/command-reference/deploy.md
@@ -65,6 +65,8 @@ components:
                   image: {{CONTAINER_IMAGE}}
 ```
 
+Note that the `uri` for the Dockerfile could also be an HTTP or HTTPS URL.
+
 ## Sustituting variables
 
 The Devfile can define variables to make the Devfile parameterizable. The Devfile can define values for these variables, and you 

--- a/pkg/deploy/interface.go
+++ b/pkg/deploy/interface.go
@@ -7,6 +7,8 @@ import (
 )
 
 type Client interface {
-	// Deploy resources from a devfile located in path, for the specified appName
+	// Deploy resources from a devfile located in path, for the specified appName.
+	// The filesystem specified is used to download and store the Dockerfiles needed to build the necessary container images,
+	// in case such Dockerfiles are referenced as remote URLs in the Devfile.
 	Deploy(fs filesystem.Filesystem, devfileObj parser.DevfileObj, path string, appName string) error
 }

--- a/pkg/deploy/interface.go
+++ b/pkg/deploy/interface.go
@@ -1,8 +1,12 @@
 package deploy
 
-import "github.com/devfile/library/pkg/devfile/parser"
+import (
+	"github.com/devfile/library/pkg/devfile/parser"
+
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+)
 
 type Client interface {
 	// Deploy resources from a devfile located in path, for the specified appName
-	Deploy(devfileObj parser.DevfileObj, path string, appName string) error
+	Deploy(fs filesystem.Filesystem, devfileObj parser.DevfileObj, path string, appName string) error
 }

--- a/pkg/deploy/mock.go
+++ b/pkg/deploy/mock.go
@@ -9,6 +9,7 @@ import (
 
 	parser "github.com/devfile/library/pkg/devfile/parser"
 	gomock "github.com/golang/mock/gomock"
+	filesystem "github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 // MockClient is a mock of Client interface.
@@ -35,15 +36,15 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Deploy mocks base method.
-func (m *MockClient) Deploy(devfileObj parser.DevfileObj, path, appName string) error {
+func (m *MockClient) Deploy(fs filesystem.Filesystem, devfileObj parser.DevfileObj, path, appName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Deploy", devfileObj, path, appName)
+	ret := m.ctrl.Call(m, "Deploy", fs, devfileObj, path, appName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Deploy indicates an expected call of Deploy.
-func (mr *MockClientMockRecorder) Deploy(devfileObj, path, appName interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Deploy(fs, devfileObj, path, appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockClient)(nil).Deploy), devfileObj, path, appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockClient)(nil).Deploy), fs, devfileObj, path, appName)
 }

--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -124,7 +124,10 @@ func resolveDockerfile(fs filesystem.Filesystem, uri string) (string, bool, erro
 func getShellCommand(cmdName string, image *devfile.ImageComponent, devfilePath string, dockerfilePath string) []string {
 	var shellCmd []string
 	imageName := image.ImageName
-	dockerfile := filepath.Join(devfilePath, dockerfilePath)
+	dockerfile := dockerfilePath
+	if !filepath.IsAbs(dockerfile) {
+		dockerfile = filepath.Join(devfilePath, dockerfilePath)
+	}
 	buildpath := image.Dockerfile.BuildContext
 	if buildpath == "" {
 		buildpath = devfilePath

--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -35,7 +35,7 @@ func NewDockerCompatibleBackend(name string, fs filesystem.Filesystem) *DockerCo
 // Build an image, as defined in devfile, using a Docker compatible CLI
 func (o *DockerCompatibleBackend) Build(image *devfile.ImageComponent, devfilePath string) error {
 
-	dockerfile, isTemp, err := resolveDockerfile(o.fs, image.Dockerfile.Uri)
+	dockerfile, isTemp, err := resolveAndDownloadDockerfile(o.fs, image.Dockerfile.Uri)
 	if isTemp {
 		defer func(path string) {
 			if e := o.fs.Remove(path); e != nil {

--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -20,25 +20,21 @@ import (
 // DockerCompatibleBackend uses a CLI compatible with the docker CLI (at least docker itself and podman)
 type DockerCompatibleBackend struct {
 	name string
-	fs   filesystem.Filesystem
 }
 
 var _ Backend = (*DockerCompatibleBackend)(nil)
 
-func NewDockerCompatibleBackend(name string, fs filesystem.Filesystem) *DockerCompatibleBackend {
-	return &DockerCompatibleBackend{
-		name: name,
-		fs:   fs,
-	}
+func NewDockerCompatibleBackend(name string) *DockerCompatibleBackend {
+	return &DockerCompatibleBackend{name: name}
 }
 
 // Build an image, as defined in devfile, using a Docker compatible CLI
-func (o *DockerCompatibleBackend) Build(image *devfile.ImageComponent, devfilePath string) error {
+func (o *DockerCompatibleBackend) Build(fs filesystem.Filesystem, image *devfile.ImageComponent, devfilePath string) error {
 
-	dockerfile, isTemp, err := resolveAndDownloadDockerfile(o.fs, image.Dockerfile.Uri)
+	dockerfile, isTemp, err := resolveAndDownloadDockerfile(fs, image.Dockerfile.Uri)
 	if isTemp {
 		defer func(path string) {
-			if e := o.fs.Remove(path); e != nil {
+			if e := fs.Remove(path); e != nil {
 				klog.V(3).Infof("could not remove temporary Dockerfile at path %q: %v", path, err)
 			}
 		}(dockerfile)

--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -87,17 +87,17 @@ func (o *DockerCompatibleBackend) Build(image *devfile.ImageComponent, devfilePa
 	return nil
 }
 
-// resolveDockerfile resolves the specified Dockerfile URI.
+// resolveAndDownloadDockerfile resolves and downloads (if needed) the specified Dockerfile URI.
 // For now, it only supports resolving HTTP(S) URIs, in which case it downloads the remote file
 // to a temporary file. The path to that temporary file is then returned.
 //
 // In all other cases, the specified URI path is returned as is.
 // This means that non-HTTP(S) URIs will *not* get resolved, but will be returned as is.
 //
-// In addition to the path, a boolean and a potential error is returned. The boolean indicates whether
+// In addition to the path, a boolean and a potential error are returned. The boolean indicates whether
 // the returned path is a temporary one; in such case, it is the caller's responsibility to delete this file
-// once it is done working with the file.
-func resolveDockerfile(fs filesystem.Filesystem, uri string) (string, bool, error) {
+// once it is done working with it.
+func resolveAndDownloadDockerfile(fs filesystem.Filesystem, uri string) (string, bool, error) {
 	uriLower := strings.ToLower(uri)
 	if strings.HasPrefix(uriLower, "http://") || strings.HasPrefix(uriLower, "https://") {
 		s := log.Spinner("Downloading Dockerfile")

--- a/pkg/devfile/image/docker_compatible_test.go
+++ b/pkg/devfile/image/docker_compatible_test.go
@@ -113,6 +113,26 @@ func TestGetShellCommand(t *testing.T) {
 				"cli", "build", "-t", "registry.io/myimagename:tag", "-f", filepath.Join(devfilePath, "Dockerfile.rhel"), devfilePath,
 			},
 		},
+		{
+			name:    "using an absolute Dockerfile path",
+			cmdName: "cli",
+			image: &devfile.ImageComponent{
+				Image: devfile.Image{
+					ImageName: "registry.io/myimagename:tag",
+					ImageUnion: devfile.ImageUnion{
+						Dockerfile: &devfile.DockerfileImage{
+							DockerfileSrc: devfile.DockerfileSrc{
+								Uri: filepath.Join("/", "path", "to", "Dockerfile.rhel"),
+							},
+						},
+					},
+				},
+			},
+			devfilePath: devfilePath,
+			want: []string{
+				"cli", "build", "-t", "registry.io/myimagename:tag", "-f", filepath.Join("/", "path", "to", "Dockerfile.rhel"), devfilePath,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/devfile/image/docker_compatible_test.go
+++ b/pkg/devfile/image/docker_compatible_test.go
@@ -117,7 +117,7 @@ func TestGetShellCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getShellCommand(tt.cmdName, tt.image, tt.devfilePath)
+			got := getShellCommand(tt.cmdName, tt.image, tt.devfilePath, tt.image.Dockerfile.Uri)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s:\n  Expected %v,\n       got %v", tt.name, tt.want, got)
 			}

--- a/pkg/devfile/image/docker_compatible_test.go
+++ b/pkg/devfile/image/docker_compatible_test.go
@@ -145,7 +145,7 @@ func TestGetShellCommand(t *testing.T) {
 	}
 }
 
-func Test_resolveDockerfile(t *testing.T) {
+func Test_resolveAndDownloadDockerfile(t *testing.T) {
 	fakeFs := filesystem.NewFakeFs()
 
 	for _, tt := range []struct {
@@ -195,7 +195,7 @@ func Test_resolveDockerfile(t *testing.T) {
 			if server != nil {
 				defer server.Close()
 			}
-			got, gotIsTemp, err := resolveDockerfile(fakeFs, uri)
+			got, gotIsTemp, err := resolveAndDownloadDockerfile(fakeFs, uri)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s:\n  Expected error %v,\n       got %v", tt.name, tt.wantErr, err)
 			}

--- a/pkg/devfile/image/docker_compatible_test.go
+++ b/pkg/devfile/image/docker_compatible_test.go
@@ -1,11 +1,17 @@
 package image
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	devfile "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 func TestGetShellCommand(t *testing.T) {
@@ -113,6 +119,78 @@ func TestGetShellCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := getShellCommand(tt.cmdName, tt.image, tt.devfilePath)
 			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%s:\n  Expected %v,\n       got %v", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_resolveDockerfile(t *testing.T) {
+	fakeFs := filesystem.NewFakeFs()
+
+	for _, tt := range []struct {
+		name       string
+		uriFunc    func() (*httptest.Server, string)
+		wantErr    bool
+		wantIsTemp bool
+		want       string
+	}{
+		{
+			name:    "local file",
+			uriFunc: func() (*httptest.Server, string) { return nil, "Dockerfile" },
+			want:    "Dockerfile",
+		},
+		{
+			name:    "remote file (non-HTTP)",
+			uriFunc: func() (*httptest.Server, string) { return nil, "ftp://example.com/Dockerfile" },
+			want:    "ftp://example.com/Dockerfile",
+		},
+		{
+			name: "remote file with error (HTTP)",
+			uriFunc: func() (*httptest.Server, string) {
+				s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				}))
+				return s, s.URL + "/404"
+			},
+			wantErr:    true,
+			wantIsTemp: true,
+		},
+		{
+			name: "remote file (HTTP)",
+			uriFunc: func() (*httptest.Server, string) {
+				s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					fmt.Fprintln(w, "FROM alpine:3.6")
+					fmt.Fprintln(w, "RUN echo Hello World")
+					fmt.Fprintln(w, "ENTRYPOINT [\"/bin/tail\"]")
+					fmt.Fprintln(w, "CMD [\"-f\", \"/dev/null\"]")
+				}))
+				return s, s.URL
+			},
+			wantIsTemp: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server, uri := tt.uriFunc()
+			if server != nil {
+				defer server.Close()
+			}
+			got, gotIsTemp, err := resolveDockerfile(fakeFs, uri)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s:\n  Expected error %v,\n       got %v", tt.name, tt.wantErr, err)
+			}
+			if gotIsTemp != tt.wantIsTemp {
+				t.Errorf("%s:\n  For 'isTemp', expected %v,\n       got %v", tt.name, tt.wantIsTemp, gotIsTemp)
+			}
+			if gotIsTemp {
+				defer func(fs filesystem.Filesystem, name string) {
+					_ = fs.Remove(name)
+				}(fakeFs, got)
+				// temp file is created, so we can't compare the path, but we can check the path is not blank
+				if strings.TrimSpace(got) == "" {
+					t.Errorf("%s:\n  Expected non-blank path,\n       got blank path: %s", tt.name, got)
+				}
+			} else if got != tt.want {
 				t.Errorf("%s:\n  Expected %v,\n       got %v", tt.name, tt.want, got)
 			}
 		})

--- a/pkg/devfile/image/image.go
+++ b/pkg/devfile/image/image.go
@@ -18,7 +18,7 @@ import (
 // Backend is in interface that must be implemented by container runtimes
 type Backend interface {
 	// Build the image as defined in the devfile.
-	// The filesystem specified will be used to download and store the Dockerfile it is referenced as a remote URL.
+	// The filesystem specified will be used to download and store the Dockerfile if it is referenced as a remote URL.
 	Build(fs filesystem.Filesystem, image *devfile.ImageComponent, devfilePath string) error
 	// Push the image to its registry as defined in the devfile
 	Push(image string) error

--- a/pkg/devfile/image/image_test.go
+++ b/pkg/devfile/image/image_test.go
@@ -8,6 +8,8 @@ import (
 
 	devfile "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	gomock "github.com/golang/mock/gomock"
+
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 func TestBuildPushImage(t *testing.T) {
@@ -208,7 +210,7 @@ func TestSelectBackend(t *testing.T) {
 			defer func() { getEnvFunc = os.Getenv }()
 			lookPathCmd = tt.lookPathCmd
 			defer func() { lookPathCmd = exec.LookPath }()
-			backend, err := selectBackend()
+			backend, err := selectBackend(filesystem.NewFakeFs())
 			if tt.wantErr != (err != nil) {
 				t.Errorf("%s: Error result wanted %v, got %v", tt.name, tt.wantErr, err != nil)
 			}

--- a/pkg/devfile/image/mock_Backend.go
+++ b/pkg/devfile/image/mock_Backend.go
@@ -9,6 +9,7 @@ import (
 
 	v1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	gomock "github.com/golang/mock/gomock"
+	filesystem "github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 // MockBackend is a mock of Backend interface.
@@ -35,17 +36,17 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 }
 
 // Build mocks base method.
-func (m *MockBackend) Build(image *v1alpha2.ImageComponent, devfilePath string) error {
+func (m *MockBackend) Build(fs filesystem.Filesystem, image *v1alpha2.ImageComponent, devfilePath string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Build", image, devfilePath)
+	ret := m.ctrl.Call(m, "Build", fs, image, devfilePath)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockBackendMockRecorder) Build(image, devfilePath interface{}) *gomock.Call {
+func (mr *MockBackendMockRecorder) Build(fs, image, devfilePath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockBackend)(nil).Build), image, devfilePath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockBackend)(nil).Build), fs, image, devfilePath)
 }
 
 // Push mocks base method.

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/devfile/library/pkg/devfile/parser"
 
@@ -18,9 +20,6 @@ import (
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/vars"
 	"github.com/redhat-developer/odo/pkg/version"
-
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -154,7 +153,7 @@ func (o *DeployOptions) Run(ctx context.Context) error {
 		"odo version: "+version.VERSION)
 
 	// Run actual deploy command to be used
-	err := o.clientset.DeployClient.Deploy(devfileObj, path, appName)
+	err := o.clientset.DeployClient.Deploy(o.clientset.FS, devfileObj, path, appName)
 
 	if err == nil {
 		log.Info("\nYour Devfile has been successfully deployed")


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This PR adds support for remote Dockerfiles (specified via an HTTP or HTTPS URL) when running `odo build-images` or `odo deploy`.

**Which issue(s) this PR fixes:**
Fixes #5450

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-5976--odo-docusaurus-preview.netlify.app/)

**How to test changes / Special notes to the reviewer:**
See the reproduction steps provided in #5450 for functional testing.

From the code perspective, commits in this branch are atomic and self-contained. This PR can be reviewed on a commit-by-commit basis.