### PR TITLE
Use devfile proxy for odo init --devfile-registry

### DIFF
--- a/docs/website/docs/overview/configure.md
+++ b/docs/website/docs/overview/configure.md
@@ -158,12 +158,13 @@ Options here are mostly used for debugging and testing `odo` behavior.
 
 ### Environment variables controlling odo behavior
 
-| Variable                   | Usage |
-| -------------------------- | ----- |
-| `PODMAN_CMD`               |   The command executed to run the local podman binary. `podman` by default    |
-| `DOCKER_CMD`               |  The command executed to run the local docker binary. `docker` by default     |
-| `ODO_BOOTSTRAPPER_IMAGE`   |       |
-| `ODO_LOG_LEVEL`            |       |
-| `ODO_DISABLE_TELEMETRY`    |       |
-| `GLOBALODOCONFIG`          |       |
-| `ODO_DEBUG_TELEMETRY_FILE` | Useful for debugging telemetry. When set it will save telemetry data to a file instead of sending it to the server. |
+| Variable                   | Usage                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `PODMAN_CMD`               | The command executed to run the local podman binary. `podman` by default                                              |
+| `DOCKER_CMD`               | The command executed to run the local docker binary. `docker` by default                                              |
+| `ODO_BOOTSTRAPPER_IMAGE`   |                                                                                                                       |
+| `ODO_LOG_LEVEL`            |                                                                                                                       |
+| `ODO_DISABLE_TELEMETRY`    |                                                                                                                       |
+| `GLOBALODOCONFIG`          |                                                                                                                       |
+| `ODO_DEBUG_TELEMETRY_FILE` | Useful for debugging telemetry. When set it will save telemetry data to a file instead of sending it to the server.   |
+| `DEVFILE_PROXY`            | Integration tests will use this address as Devfile registry instead of `https://registry.stage.devfile.io`            |

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -9,8 +11,13 @@ import (
 
 var _ = Describe("odo devfile registry command tests", func() {
 	const registryName string = "RegistryName"
+
 	// Use staging OCI-based registry for tests to avoid overload
-	const addRegistryURL string = "https://registry.stage.devfile.io"
+	var addRegistryURL string = "https://registry.stage.devfile.io"
+	proxy := os.Getenv("DEVFILE_PROXY")
+	if proxy != "" {
+		addRegistryURL = "http://" + proxy
+	}
 
 	var commonVar helper.CommonVar
 


### PR DESCRIPTION
**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**

This PR makes all tests use the devfile proxy, including the tests using `odo init --devfile-registry`
