### PR TITLE
Enhance error message when user runs from a non-component directory

### DIFF
--- a/pkg/odo/genericclioptions/context_test.go
+++ b/pkg/odo/genericclioptions/context_test.go
@@ -312,15 +312,28 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "no env file",
+			name: "no env file; non-empty directory",
 			input: input{
 				needDevfile: false,
 				isOffline:   true,
 				workingDir:  filepath.Join(prefixDir, "myapp"),
 				populateWorkingDir: func(fs filesystem.Filesystem) {
+					_ = fs.WriteFile(filepath.Join(prefixDir, "myapp", "main.go"), []byte{}, 0644)
 				},
 			},
-			expectedErr: "The current directory does not represent an odo component",
+			expectedErr: "Use \"odo dev\" to initialize an odo component for this folder and deploy it on cluster",
+		},
+		{
+			name: "no env file; empty directory",
+			input: input{
+				needDevfile: false,
+				isOffline:   true,
+				workingDir:  filepath.Join(prefixDir, "myapp"),
+				populateWorkingDir: func(fs filesystem.Filesystem) {
+					_ = fs.MkdirAll(filepath.Join(prefixDir, "myapp"), 0755)
+				},
+			},
+			expectedErr: "Use \"odo init\" to initialize an odo component in the folder.",
 		},
 	}
 

--- a/pkg/odo/genericclioptions/localprovider.go
+++ b/pkg/odo/genericclioptions/localprovider.go
@@ -2,9 +2,12 @@ package genericclioptions
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 // GetValidEnvInfo accesses the environment file
@@ -33,15 +36,24 @@ func GetValidEnvInfo(cmdline cmdline.Cmdline) (*envinfo.EnvSpecificInfo, error) 
 
 	// Check to see if the environment file exists
 	if !envInfo.Exists() {
+		exitMessage := `The current directory does not represent an odo component. 
+
+To get started,%s
+  * Open this folder in your favorite IDE and start editing, your changes will be reflected directly on the cluster.
+
+Visit https://odo.dev for more information.`
+
+		if isEmpty, _ := location.DirIsEmpty(filesystem.DefaultFs{}, componentContext); isEmpty {
+			exitMessage = fmt.Sprintf(exitMessage, `
+  * Create and move to a new directory
+  * Use "odo init" to initialize an odo component in the folder.
+  * Use "odo dev" to deploy it on cluster.`)
+		} else {
+			exitMessage = fmt.Sprintf(exitMessage, `
+  * Use "odo dev" to initialize an odo component for this folder and deploy it on cluster.`)
+		}
 		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
-		return nil, errors.New(`The current directory does not represent an odo component. 
-
-To get started,
-  * Create and move to a new directory, or use an existing one.
-  * Run "odo init" from the directory to initialize an odo component.
-  * Start editing the component in an IDE and run "odo dev" to see your changes get reflected on the cluster.
-
-Visit https://odo.dev for more information.`)
+		return nil, errors.New(exitMessage)
 		//revive:enable:error-strings
 	}
 

--- a/pkg/odo/genericclioptions/localprovider.go
+++ b/pkg/odo/genericclioptions/localprovider.go
@@ -35,7 +35,7 @@ func GetValidEnvInfo(cmdline cmdline.Cmdline) (*envinfo.EnvSpecificInfo, error) 
 	if !envInfo.Exists() {
 		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
 		return nil, errors.New(`The current directory does not represent an odo component.
-To start editing your component, use "odo dev" and open this folder in your favorite IDE. Changes will be directly reflected on the cluster.
+If you are working from an empty directory, use "odo init" to get started, else start editing your component, use "odo dev" and open this folder in your favorite IDE. Changes will be directly reflected on the cluster.
 To deploy your component to a cluster use "odo deploy".
 Or switch to directory with a component.`)
 		//revive:enable:error-strings

--- a/pkg/odo/genericclioptions/localprovider.go
+++ b/pkg/odo/genericclioptions/localprovider.go
@@ -34,10 +34,14 @@ func GetValidEnvInfo(cmdline cmdline.Cmdline) (*envinfo.EnvSpecificInfo, error) 
 	// Check to see if the environment file exists
 	if !envInfo.Exists() {
 		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
-		return nil, errors.New(`The current directory does not represent an odo component.
-If you are working from an empty directory, use "odo init" to get started, else start editing your component, use "odo dev" and open this folder in your favorite IDE. Changes will be directly reflected on the cluster.
-To deploy your component to a cluster use "odo deploy".
-Or switch to directory with a component.`)
+		return nil, errors.New(`The current directory does not represent an odo component. 
+
+To get started,
+  * Create and move to a new directory, or use an existing one.
+  * Run "odo init" from the directory to initialize an odo component.
+  * Start editing the component in an IDE and run "odo dev" to see your changes get reflected on the cluster.
+
+Visit https://odo.dev for more information.`)
 		//revive:enable:error-strings
 	}
 

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -29,6 +29,32 @@ var _ = Describe("odo delete command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
+	When("running odo delete from a directory that does not contain a .odo/env/env.yaml file", func() {
+		var files []string
+		BeforeEach(func() {
+			files = helper.ListFilesInDir(commonVar.Context)
+			Expect(files).ToNot(ContainElement(".odo"))
+		})
+		When("the directory is empty", func() {
+			BeforeEach(func() {
+				Expect(len(files)).To(BeZero())
+			})
+			It("should fail", func() {
+				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
+				helper.MatchAllInOutput(errOut, []string{"The current directory does not represent an odo component", "Use \"odo init\" to initialize an odo component in the folder."})
+			})
+		})
+		When("the directory is not empty", func() {
+			BeforeEach(func() {
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			})
+			It("should fail", func() {
+				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
+				helper.MatchAllInOutput(errOut, []string{"The current directory does not represent an odo component", "Use \"odo dev\" to initialize an odo component for this folder and deploy it on cluster."})
+			})
+		})
+	})
+
 	for _, ctx := range []struct {
 		title       string
 		devfileName string
@@ -63,12 +89,6 @@ var _ = Describe("odo delete command tests", func() {
 				if ctx.setupFunc != nil {
 					ctx.setupFunc()
 				}
-			})
-			It("should fail when the directory does not contain a .odo/env.yaml file", func() {
-				files := helper.ListFilesInDir(commonVar.Context)
-				Expect(files).ToNot(ContainElement(".odo"))
-				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
-				Expect(errOut).To(ContainSubstring("The current directory does not represent an odo component"))
 			})
 			When("the components are not deployed", func() {
 				var stdOut string


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
Enhance error message when user runs from a non-component directory
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5987


**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. Run `odo delete component` or any other command from an empty directory.

The error message is long and could use an improvement, so I am looking for suggestions.