### PR TITLE
Do not get project from env.yaml file

### DIFF
--- a/docs/website/docs/command-reference/create-namespace.md
+++ b/docs/website/docs/command-reference/create-namespace.md
@@ -6,10 +6,6 @@ title: odo create namespace
 
 Any new namespace created with this command will also be set as the current active namespace, this applies to project as well.
 
-:::note
-Executing this command inside a component directory will not update the namespace or project of the existing component.
-:::
-
 To create a namespace you can run `odo create namespace <name>`:
 ```shell
 odo create namespace mynamespace

--- a/docs/website/docs/command-reference/delete-namespace.md
+++ b/docs/website/docs/command-reference/delete-namespace.md
@@ -29,11 +29,6 @@ This command is smart enough to detect the resources supported by your cluster a
 So you can run `odo delete project` on a Kubernetes cluster, and it will delete a Namespace resource, or you can run `odo delete namespace` on an OpenShift cluster, it will delete a Project resource.
 :::
 
-
-:::note
-Running `odo delete <namespace/project>` to delete namespace/project does not ensure that a component using it will also get updated. See [odo dev#env-file](./dev.md#env-file) or [odo deploy#env-file](./deploy.md#env-file) for more information.
-:::
-
 ## Available Flags
 * `-f`, `--force` - Use this flag to avoid being prompted for confirmation.
 * `--wait` - Use this flag to wait until the namespace no longer exists

--- a/docs/website/docs/command-reference/deploy.md
+++ b/docs/website/docs/command-reference/deploy.md
@@ -73,16 +73,3 @@ The Devfile can define variables to make the Devfile parameterizable. The Devfil
 can override the values for variables from the command line when running `odo deploy`, using the `--var` and `--var-file` options.
 
 See [Substituting variables in odo dev](dev.md#substituting-variables) for more information.
-
-## Env File
-
-When `odo deploy` is executed, a `.odo/env/env.yaml` file is created if it does not exist. It stores the namespace/project that will be used by the component, and its default value is set to currently active namespace/project.
-
-```yaml
-ComponentSettings:
-  Project: myproject
-```
-
-:::note
-Creating, deleting or setting a namespace/project will not modify this value. To use a different namespace/project, user will have to manually change `.ComponentSettings.Project` value, or delete the `.odo` directory.
-:::

--- a/docs/website/docs/command-reference/dev.md
+++ b/docs/website/docs/command-reference/dev.md
@@ -417,13 +417,9 @@ This state file contains the forwarded ports:
 
 ## Env File
 
-When `odo dev` is executed, a `.odo/env/env.yaml` file is created if it does not exist. It stores the namespace/project that will be used by the component, and its default value is set to currently active namespace/project.
+When `odo dev` is executed, a `.odo/env/env.yaml` file is created if it does not exist. It stores the namespace/project that will be used by the component during the dev session. The value is removed from the file at the end of the session.
 
 ```yaml
 ComponentSettings:
   Project: myproject
 ```
-
-:::note
-Creating, deleting or setting a namespace/project will not modify this value. To use a different namespace/project, user will have to manually change `.ComponentSettings.Project` value, or delete the `.odo` directory.
-:::

--- a/docs/website/docs/command-reference/set-namespace.md
+++ b/docs/website/docs/command-reference/set-namespace.md
@@ -4,10 +4,6 @@ title: odo set namespace
 
 `odo set namespace` lets you set a namespace/project as the current active one in your local `kubeconfig` configuration.
 
-:::note
-Executing this command inside a component directory will not update the namespace or project of the existing component.
-:::
-
 To set the current active namespace you can run `odo set namespace <name>`:
 ```console
 odo set namespace mynamespace

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -100,7 +100,7 @@ func (a Adapter) Push(parameters adapters.PushParameters, componentStatus *watch
 		return err
 	}
 
-	err = dfutil.ValidateK8sResourceName("component namespace", parameters.EnvSpecificInfo.GetNamespace())
+	err = dfutil.ValidateK8sResourceName("component namespace", a.kubeClient.GetCurrentNamespace())
 	if err != nil {
 		return err
 	}

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -307,19 +307,9 @@ func (esi *EnvSpecificInfo) SetRunMode(runMode RUNMode) error {
 	return esi.writeToFile()
 }
 
-// GetNamespace returns component namespace
-func (ei *EnvInfo) GetNamespace() string {
-	return ei.componentSettings.Project
-}
-
 // GetApplication returns the application name
 func (ei *EnvInfo) GetApplication() string {
 	return ei.componentSettings.AppName
-}
-
-// MatchComponent matches a component information provided by a devfile component with the local env info
-func (ei *EnvInfo) MatchComponent(name, app, namespace string) bool {
-	return name == ei.GetName() && app == ei.GetApplication() && namespace == ei.GetNamespace()
 }
 
 // SetDevfileObj sets the devfileObj for the envinfo

--- a/pkg/localConfigProvider/localConfigProvider.go
+++ b/pkg/localConfigProvider/localConfigProvider.go
@@ -24,7 +24,6 @@ type LocalContainer struct {
 type LocalConfigProvider interface {
 	GetApplication() string
 	GetName() string
-	GetNamespace() string
 	GetDebugPort() int
 	GetContainers() ([]LocalContainer, error)
 

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -70,7 +70,7 @@ func (o *ComponentOptions) Complete(cmdline cmdline.Cmdline, args []string) (err
 		if err != nil {
 			return err
 		}
-		// this ensures that the namespace set in env.yaml is used
+		// this ensures that the current namespace is used
 		o.clientset.KubernetesClient.SetNamespace(o.GetProject())
 		return nil
 	}

--- a/pkg/odo/cli/delete/component/component_test.go
+++ b/pkg/odo/cli/delete/component/component_test.go
@@ -245,6 +245,7 @@ func populateWorkingDir(fs filesystem.Filesystem, workingDir, compName, projectN
 // prepareKubeClient prepares the mock kclient.ClientInterface3 and returns it
 func prepareKubeClient(ctrl *gomock.Controller, projectName string) kclient.ClientInterface {
 	kubeClient := kclient.NewMockClientInterface(ctrl)
+	kubeClient.EXPECT().GetCurrentNamespace().Return(projectName)
 	kubeClient.EXPECT().GetNamespaceNormal(projectName).Return(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		return err
 	}
 	if isEmptyDir {
-		return errors.New("this command cannot run in an empty directory, run the command in a directory containing source code or initialize using 'odo init'")
+		return genericclioptions.NewNoDevfileError(o.contextDir)
 	}
 
 	initFlags := o.clientset.InitClient.GetFlags(cmdline.GetFlags())

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/devfile/location"
-	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
@@ -22,7 +21,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/version"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -105,35 +103,7 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		return err
 	}
 
-	// ENV.YAML
-	//
-	// Set the appropriate variables in the env.yaml file
-	//
-	// TODO: Eventually refactor with code in dev/dev.go
-
-	envfileinfo, err := envinfo.NewEnvSpecificInfo("")
-	if err != nil {
-		return fmt.Errorf("unable to retrieve configuration information: %w", err)
-	}
-
-	// If the env.yaml does not exist, we will save the project name
-	if !envfileinfo.Exists() {
-		err = envfileinfo.SetComponentSettings(envinfo.ComponentSettings{Project: o.GetProject()})
-		if err != nil {
-			return fmt.Errorf("failed to write new env.yaml file: %w", err)
-		}
-	} else if envfileinfo.Exists() && envfileinfo.GetComponentSettings().Project != o.GetProject() {
-		// If the env.yaml exists and the project is set incorrectly, we'll override it.
-		klog.V(4).Info("Overriding project name in env.yaml as it's set incorrectly, new project name: ", o.GetProject())
-		err = envfileinfo.SetConfiguration("project", o.GetProject())
-		if err != nil {
-			return fmt.Errorf("failed to update project in env.yaml file: %w", err)
-		}
-	}
-
-	// END ENV.YAML
-
-	// this ensures that odo deploy uses the namespace set in env.yaml
+	// this ensures that odo deploy uses the current namespace
 	o.clientset.KubernetesClient.SetNamespace(o.GetProject())
 	return
 }

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -315,11 +315,31 @@ func (o *DevOptions) HandleSignal() error {
 	select {}
 }
 
-func (o *DevOptions) Cleanup(err error) {
+func (o *DevOptions) Cleanup(commandError error) {
+	err := unsetProjectInEnvfile()
 	if err != nil {
+		klog.V(4).Infof("Error unsetting project into env.yaml file")
+	}
+
+	if commandError != nil {
 		devFileObj := o.Context.EnvSpecificInfo.GetDevfileObj()
 		_ = o.clientset.WatchClient.CleanupDevResources(devFileObj, log.GetStdout())
 	}
+}
+
+func unsetProjectInEnvfile() error {
+	envfileinfo, err := envinfo.NewEnvSpecificInfo("")
+	if err != nil {
+		return err
+	}
+
+	if envfileinfo.Exists() {
+		err = envfileinfo.SetConfiguration("project", "")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // NewCmdDev implements the odo dev command

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -2,7 +2,6 @@ package dev
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -122,7 +121,7 @@ func (o *DevOptions) Complete(cmdline cmdline.Cmdline, args []string) error {
 		return err
 	}
 	if isEmptyDir {
-		return errors.New("this command cannot run in an empty directory, run the command in a directory containing source code or initialize using 'odo init'")
+		return genericclioptions.NewNoDevfileError(o.contextDir)
 	}
 	initFlags := o.clientset.InitClient.GetFlags(cmdline.GetFlags())
 	err = o.clientset.InitClient.InitDevfile(initFlags, o.contextDir,

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -304,7 +304,7 @@ func (o *Handler) regenerateComponentAdapterFromWatchParams(parameters watch.Wat
 			Devfile:       devObj,
 			FS:            o.clientset.FS,
 		},
-		parameters.EnvSpecificInfo.GetNamespace(),
+		o.clientset.KubernetesClient.GetCurrentNamespace(),
 	), nil
 }
 

--- a/pkg/odo/cli/set/namespace/namespace.go
+++ b/pkg/odo/cli/set/namespace/namespace.go
@@ -7,14 +7,12 @@ import (
 
 	dfutil "github.com/devfile/library/pkg/util"
 
-	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 
-	"k8s.io/klog"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"
@@ -24,13 +22,11 @@ const RecommendedCommandName = "namespace"
 
 var (
 	setExample = ktemplates.Examples(`
-	# Set the specified namespace as the current active namespace in the config
+	# Set the specified namespace as the current active namespace in your local kubeconfig configuration
 	%[1]s my-namespace
 	`)
 
 	setLongDesc = ktemplates.LongDesc(`Set the current active namespace.
-	
-	If executed inside a component directory, this command will not update the namespace of the existing component.
 	`)
 
 	setShortDesc = `Set the current active namespace`
@@ -89,17 +85,7 @@ func (so *SetOptions) Validate() error {
 
 // Run runs the 'set namespace' command
 func (so *SetOptions) Run(ctx context.Context) error {
-	devfilePresent, err := location.DirectoryContainsDevfile(so.clientset.FS, so.contextDir)
-	if err != nil {
-		// Purposely ignoring the error, as it is not mandatory for this command
-		klog.V(2).Infof("Unexpected error while checking if running inside a component directory: %v", err)
-	}
-	if devfilePresent {
-		log.Warningf("This is being executed inside a component directory. This will not update the %s of the existing component",
-			so.commandName)
-	}
-
-	err = so.clientset.ProjectClient.SetCurrent(so.namespaceName)
+	err := so.clientset.ProjectClient.SetCurrent(so.namespaceName)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cmdline/cmdline.go
+++ b/pkg/odo/cmdline/cmdline.go
@@ -24,9 +24,6 @@ type Cmdline interface {
 	// IsFlagSet returns true if the flag is explicitely set
 	IsFlagSet(flagName string) bool
 
-	// CheckIfConfigurationNeeded checks against a set of commands that need configuration.
-	CheckIfConfigurationNeeded() (bool, error)
-
 	// Context returns the context attached to the command
 	Context() context.Context
 

--- a/pkg/odo/cmdline/cobra.go
+++ b/pkg/odo/cmdline/cobra.go
@@ -87,57 +87,6 @@ func (o *Cobra) FlagValueIfSet(flagName string) string {
 	return flag
 }
 
-// CheckIfConfigurationNeeded checks against a set of commands that need configuration.
-func (o *Cobra) CheckIfConfigurationNeeded() (bool, error) {
-	// Here we will check for parent commands, if the match a certain criteria, we will skip
-	// using the configuration.
-	//
-	// For example, `odo init` should NOT check to see if there is actually a configuration yet.
-	if o.cmd.HasParent() {
-
-		// Find the first child of the command, as some groups are allowed even with non existent configuration
-		firstChildCommand := getFirstChildOfCommand(o.cmd)
-
-		// This should *never* happen, but added just to be safe
-		if firstChildCommand == nil {
-			return false, errors.New("unable to get first child of command")
-		}
-
-		// Gather necessary preliminary information
-		componentNameFlagValue := o.FlagValueIfSet(util.ComponentNameFlagName)
-		// if command is `odo delete component` and name flag is not used, require configuration
-		if firstChildCommand.Name() == "delete" && o.cmd.Name() == "component" && len(componentNameFlagValue) == 0 {
-			return true, nil
-		}
-		// if command is `odo build-images`, require configuration
-		if o.cmd.Name() == "build-images" {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// getFirstChildOfCommand gets the first child command of the root command of command
-func getFirstChildOfCommand(command *cobra.Command) *cobra.Command {
-	// If command does not have a parent no point checking
-	if command.HasParent() {
-		// Get the root command and set current command and its parent
-		rootCommand := command.Root()
-		parentCommand := command.Parent()
-		mainCommand := command
-		for {
-			// if parent is root, then we have our first child in c
-			if parentCommand == rootCommand {
-				return mainCommand
-			}
-			// Traverse backwards making current command as the parent and parent as the grandparent
-			mainCommand = parentCommand
-			parentCommand = mainCommand.Parent()
-		}
-	}
-	return nil
-}
-
 func (o *Cobra) GetKubeClient() (kclient.ClientInterface, error) {
 	return kclient.New()
 }

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -145,7 +145,7 @@ func New(parameters CreateParameters) (*Context, error) {
 		} else {
 			return &Context{
 				internalCxt: ctx,
-			}, NewNoDevfileError(parameters.componentContext)
+			}, NewNoDevfileError(".")
 		}
 	}
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -145,7 +145,7 @@ func New(parameters CreateParameters) (*Context, error) {
 		} else {
 			return &Context{
 				internalCxt: ctx,
-			}, NoDevfileError{}
+			}, NewNoDevfileError(parameters.componentContext)
 		}
 	}
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -101,7 +101,7 @@ func New(parameters CreateParameters) (*Context, error) {
 	}
 	ctx.LocalConfigProvider = ctx.EnvSpecificInfo
 
-	ctx.project = resolveProject(parameters.cmdline, ctx.EnvSpecificInfo)
+	ctx.project = resolveProject(parameters.cmdline)
 
 	ctx.application = resolveApp(parameters.cmdline, ctx.EnvSpecificInfo, parameters.appIfNeeded)
 
@@ -116,7 +116,7 @@ func New(parameters CreateParameters) (*Context, error) {
 		if err != nil {
 			return nil, err
 		}
-		if e := ctx.resolveProjectAndNamespace(parameters.cmdline, ctx.EnvSpecificInfo); e != nil {
+		if e := ctx.resolveProjectAndNamespace(parameters.cmdline); e != nil {
 			return nil, e
 		}
 

--- a/pkg/odo/genericclioptions/context_test.go
+++ b/pkg/odo/genericclioptions/context_test.go
@@ -181,7 +181,7 @@ func TestNew(t *testing.T) {
 			expectedErr: "",
 			expected: &Context{
 				internalCxt: internalCxt{
-					project:     "a-project",
+					project:     "",
 					application: "an-app-name",
 					component:   "a-name",
 					// empty when no devfile

--- a/pkg/odo/genericclioptions/context_test.go
+++ b/pkg/odo/genericclioptions/context_test.go
@@ -241,7 +241,7 @@ func TestNew(t *testing.T) {
 					_ = fs.WriteFile(filepath.Join(prefixDir, "myapp", ".odo", "env", "env.yaml"), []byte{}, 0644)
 				},
 			},
-			expectedErr: "no devfile found",
+			expectedErr: "The current directory does not represent an odo component",
 			expected: &Context{
 				internalCxt: internalCxt{
 					project:          "myproject",

--- a/pkg/odo/genericclioptions/context_test.go
+++ b/pkg/odo/genericclioptions/context_test.go
@@ -311,30 +311,6 @@ func TestNew(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "no env file; non-empty directory",
-			input: input{
-				needDevfile: false,
-				isOffline:   true,
-				workingDir:  filepath.Join(prefixDir, "myapp"),
-				populateWorkingDir: func(fs filesystem.Filesystem) {
-					_ = fs.WriteFile(filepath.Join(prefixDir, "myapp", "main.go"), []byte{}, 0644)
-				},
-			},
-			expectedErr: "Use \"odo dev\" to initialize an odo component for this folder and deploy it on cluster",
-		},
-		{
-			name: "no env file; empty directory",
-			input: input{
-				needDevfile: false,
-				isOffline:   true,
-				workingDir:  filepath.Join(prefixDir, "myapp"),
-				populateWorkingDir: func(fs filesystem.Filesystem) {
-					_ = fs.MkdirAll(filepath.Join(prefixDir, "myapp"), 0755)
-				},
-			},
-			expectedErr: "Use \"odo init\" to initialize an odo component in the folder.",
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/odo/genericclioptions/errors.go
+++ b/pkg/odo/genericclioptions/errors.go
@@ -1,11 +1,39 @@
 package genericclioptions
 
+import (
+	"fmt"
+
+	"github.com/redhat-developer/odo/pkg/devfile/location"
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+)
+
 var _ error = NoDevfileError{}
 
-type NoDevfileError struct{}
+type NoDevfileError struct {
+	context string
+}
+
+func NewNoDevfileError(context string) NoDevfileError {
+	return NoDevfileError{
+		context: context,
+	}
+}
 
 func (o NoDevfileError) Error() string {
-	return "no devfile found"
+	message := `The current directory does not represent an odo component. 
+To get started:%s
+  * Open this folder in your favorite IDE and start editing, your changes will be reflected directly on the cluster.
+Visit https://odo.dev for more information.`
+
+	if isEmpty, _ := location.DirIsEmpty(filesystem.DefaultFs{}, o.context); isEmpty {
+		message = fmt.Sprintf(message, `
+  * Use "odo init" to initialize an odo component in the folder.
+  * Use "odo dev" to deploy it on cluster.`)
+	} else {
+		message = fmt.Sprintf(message, `
+  * Use "odo dev" to initialize an odo component for this folder and deploy it on cluster.`)
+	}
+	return message
 }
 
 func IsNoDevfileError(err error) bool {

--- a/pkg/odo/genericclioptions/localprovider.go
+++ b/pkg/odo/genericclioptions/localprovider.go
@@ -1,13 +1,8 @@
 package genericclioptions
 
 import (
-	"errors"
-	"fmt"
-
-	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/envinfo"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
-	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
 // GetValidEnvInfo accesses the environment file
@@ -22,39 +17,6 @@ func GetValidEnvInfo(cmdline cmdline.Cmdline) (*envinfo.EnvSpecificInfo, error) 
 	envInfo, err := envinfo.NewEnvSpecificInfo(componentContext)
 	if err != nil {
 		return nil, err
-	}
-
-	// Now we check to see if we can skip gathering the information.
-	// Return if we can skip gathering configuration information
-	configIsNeeded, err := cmdline.CheckIfConfigurationNeeded()
-	if err != nil {
-		return nil, err
-	}
-	if !configIsNeeded {
-		return envInfo, nil
-	}
-
-	// Check to see if the environment file exists
-	if !envInfo.Exists() {
-		exitMessage := `The current directory does not represent an odo component. 
-
-To get started,%s
-  * Open this folder in your favorite IDE and start editing, your changes will be reflected directly on the cluster.
-
-Visit https://odo.dev for more information.`
-
-		if isEmpty, _ := location.DirIsEmpty(filesystem.DefaultFs{}, componentContext); isEmpty {
-			exitMessage = fmt.Sprintf(exitMessage, `
-  * Create and move to a new directory
-  * Use "odo init" to initialize an odo component in the folder.
-  * Use "odo dev" to deploy it on cluster.`)
-		} else {
-			exitMessage = fmt.Sprintf(exitMessage, `
-  * Use "odo dev" to initialize an odo component for this folder and deploy it on cluster.`)
-		}
-		//revive:disable:error-strings This is a top-level error message displayed as is to the end user
-		return nil, errors.New(exitMessage)
-		//revive:enable:error-strings
 	}
 
 	return envInfo, nil

--- a/pkg/odo/genericclioptions/resolve.go
+++ b/pkg/odo/genericclioptions/resolve.go
@@ -27,15 +27,12 @@ func (o *internalCxt) resolveProjectAndNamespace(cmdline cmdline.Cmdline, config
 		}
 		namespace = projectFlag
 	} else {
-		namespace = configProvider.GetNamespace()
-		if namespace == "" {
-			namespace = o.KClient.GetCurrentNamespace()
-			if len(namespace) <= 0 {
-				errFormat := "Could not get current namespace. Please create or set a namespace\n"
-				err := checkProjectCreateOrDeleteOnlyOnInvalidNamespace(cmdline, errFormat)
-				if err != nil {
-					return err
-				}
+		namespace = o.KClient.GetCurrentNamespace()
+		if len(namespace) <= 0 {
+			errFormat := "Could not get current namespace. Please create or set a namespace\n"
+			err := checkProjectCreateOrDeleteOnlyOnInvalidNamespace(cmdline, errFormat)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -91,11 +88,7 @@ func resolveComponent(cmdline cmdline.Cmdline, localConfiguration localConfigPro
 }
 
 func resolveProject(cmdline cmdline.Cmdline, localConfiguration localConfigProvider.LocalConfigProvider) string {
-	projectFlag := cmdline.FlagValueIfSet(util.ProjectFlagName)
-	if projectFlag != "" {
-		return projectFlag
-	}
-	return localConfiguration.GetNamespace()
+	return cmdline.FlagValueIfSet(util.ProjectFlagName)
 }
 
 // checkComponentExistsOrFail checks if the specified component exists with the given context and returns error if not.

--- a/pkg/odo/genericclioptions/resolve.go
+++ b/pkg/odo/genericclioptions/resolve.go
@@ -12,18 +12,14 @@ import (
 )
 
 // resolveProjectAndNamespace resolve project in Context and namespace in Kubernetes and OpenShift clients
-func (o *internalCxt) resolveProjectAndNamespace(cmdline cmdline.Cmdline, configProvider localConfigProvider.LocalConfigProvider) error {
+func (o *internalCxt) resolveProjectAndNamespace(cmdline cmdline.Cmdline) error {
 	var namespace string
 	projectFlag := cmdline.FlagValueIfSet(util.ProjectFlagName)
 	if len(projectFlag) > 0 {
 		// if namespace flag was set, check that the specified namespace exists and use it
 		_, err := o.KClient.GetNamespaceNormal(projectFlag)
-
-		// do not error out when the user is running `odo project`
 		if err != nil {
-			if cmdline.GetParentName() != "project" {
-				return err
-			}
+			return err
 		}
 		namespace = projectFlag
 	} else {
@@ -87,7 +83,7 @@ func resolveComponent(cmdline cmdline.Cmdline, localConfiguration localConfigPro
 	return localConfiguration.GetName()
 }
 
-func resolveProject(cmdline cmdline.Cmdline, localConfiguration localConfigProvider.LocalConfigProvider) string {
+func resolveProject(cmdline cmdline.Cmdline) string {
 	return cmdline.FlagValueIfSet(util.ProjectFlagName)
 }
 

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -41,7 +41,7 @@ var _ = Describe("odo delete command tests", func() {
 			})
 			It("should fail", func() {
 				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
-				helper.MatchAllInOutput(errOut, []string{"The current directory does not represent an odo component", "Use \"odo init\" to initialize an odo component in the folder."})
+				helper.MatchAllInOutput(errOut, []string{"no devfile found"})
 			})
 		})
 		When("the directory is not empty", func() {
@@ -50,7 +50,7 @@ var _ = Describe("odo delete command tests", func() {
 			})
 			It("should fail", func() {
 				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
-				helper.MatchAllInOutput(errOut, []string{"The current directory does not represent an odo component", "Use \"odo dev\" to initialize an odo component for this folder and deploy it on cluster."})
+				helper.MatchAllInOutput(errOut, []string{"no devfile found"})
 			})
 		})
 	})
@@ -93,16 +93,6 @@ var _ = Describe("odo delete command tests", func() {
 			When("the components are not deployed", func() {
 				var stdOut string
 				BeforeEach(func() {
-					// Bootstrap the component with a .odo/env/env.yaml file
-					odoDir := filepath.Join(commonVar.Context, ".odo", "env")
-					helper.MakeDir(odoDir)
-					err := helper.CreateFileWithContent(filepath.Join(odoDir, "env.yaml"), fmt.Sprintf(`
-ComponentSettings:
-  Name: %s
-  Project: %s
-  AppName: app
-`, cmpName, commonVar.Project))
-					Expect(err).To(BeNil())
 					stdOut = helper.Cmd("odo", "delete", "component", "-f").ShouldPass().Out()
 				})
 				It("should output that there are no resources to be deleted", func() {
@@ -251,9 +241,8 @@ ComponentSettings:
 						By("deleting the service", func() {
 							Eventually(commonVar.CliRunner.Run(getSVCArgs...).Out.Contents(), 60, 3).ShouldNot(ContainSubstring(serviceName))
 						})
-						By("ensuring that devfile.yaml and .odo still exists", func() {
+						By("ensuring that devfile.yaml still exists", func() {
 							files := helper.ListFilesInDir(commonVar.Context)
-							Expect(files).To(ContainElement(".odo"))
 							Expect(files).To(ContainElement("devfile.yaml"))
 						})
 					})

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -41,7 +41,7 @@ var _ = Describe("odo delete command tests", func() {
 			})
 			It("should fail", func() {
 				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
-				helper.MatchAllInOutput(errOut, []string{"no devfile found"})
+				helper.MatchAllInOutput(errOut, []string{"The current directory does not represent an odo component"})
 			})
 		})
 		When("the directory is not empty", func() {
@@ -50,7 +50,7 @@ var _ = Describe("odo delete command tests", func() {
 			})
 			It("should fail", func() {
 				errOut := helper.Cmd("odo", "delete", "component", "-f").ShouldFail().Err()
-				helper.MatchAllInOutput(errOut, []string{"no devfile found"})
+				helper.MatchAllInOutput(errOut, []string{"The current directory does not represent an odo component"})
 			})
 		})
 	})

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -260,42 +260,6 @@ ComponentSettings:
 				})
 
 			})
-			When("component is deployed to the cluster in the namespace set in env.yaml which is not the same as the current active namespace", func() {
-				var projectName string
-				BeforeEach(func() {
-					// deploy the component to the cluster
-					session := helper.CmdRunner("odo", "dev", "--random-ports")
-					defer session.Kill()
-					helper.WaitForOutputToContain("Press Ctrl+c to exit", 180, 10, session)
-					Expect(string(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents())).To(ContainSubstring(cmpName))
-
-					helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
-					Expect(string(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents())).To(ContainSubstring(deploymentName))
-					Expect(string(commonVar.CliRunner.Run(getSVCArgs...).Out.Contents())).To(ContainSubstring(serviceName))
-
-					// create and set a new namespace
-					projectName = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
-				})
-				AfterEach(func() {
-					commonVar.CliRunner.DeleteNamespaceProject(projectName, false)
-				})
-				When("the component is deleted", func() {
-					BeforeEach(func() {
-						helper.Cmd("odo", "delete", "component", "-f").ShouldPass().Out()
-					})
-					It("should have deleted the component", func() {
-						By("deleting the component", func() {
-							Eventually(string(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents()), 60, 3).ShouldNot(ContainSubstring(cmpName))
-						})
-						By("deleting the deployment", func() {
-							Eventually(string(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents()), 60, 3).ShouldNot(ContainSubstring(deploymentName))
-						})
-						By("deleting the service", func() {
-							Eventually(string(commonVar.CliRunner.Run(getSVCArgs...).Out.Contents()), 60, 3).ShouldNot(ContainSubstring(serviceName))
-						})
-					})
-				})
-			})
 		})
 	}
 

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -40,7 +40,7 @@ var _ = Describe("odo describe component command tests", func() {
 			stdout, stderr := res.Out(), res.Err()
 			Expect(helper.IsJSON(stderr)).To(BeTrue())
 			Expect(stdout).To(BeEmpty())
-			helper.JsonPathContentContain(stderr, "message", "no devfile found")
+			helper.JsonPathContentContain(stderr, "message", "The current directory does not represent an odo component")
 		})
 
 		By("running odo describe component -o json with an unknown name", func() {
@@ -62,7 +62,7 @@ var _ = Describe("odo describe component command tests", func() {
 			res := helper.Cmd("odo", "describe", "component").ShouldFail()
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stdout).To(BeEmpty())
-			Expect(stderr).To(ContainSubstring("no devfile found"))
+			Expect(stderr).To(ContainSubstring("The current directory does not represent an odo component"))
 		})
 
 		By("running odo describe component with an unknown name", func() {

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -51,7 +51,7 @@ var _ = Describe("odo dev command tests", func() {
 
 		It("should error", func() {
 			output := helper.Cmd("odo", "dev", "--random-ports").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
+			Expect(output).To(ContainSubstring("The current directory does not represent an odo component"))
 
 		})
 	})

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -237,6 +237,11 @@ var _ = Describe("odo dev command tests", func() {
 					errout := commonVar.CliRunner.Run("get", "deployment", "-n", commonVar.Project).Err.Contents()
 					Expect(string(errout)).ToNot(ContainSubstring(deploymentName))
 				})
+
+				It("should unset project from env.yaml file", func() {
+					Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeTrue())
+					helper.FileShouldNotContainSubstring(".odo/env/env.yaml", "Project")
+				})
 			})
 		})
 

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -226,29 +226,6 @@ var _ = Describe("odo dev command tests", func() {
 				devSession.WaitEnd()
 			})
 
-			When("deleting previous deployment and switching kubeconfig to another namespace", func() {
-				var otherNS string
-				BeforeEach(func() {
-					devSession.Stop()
-					devSession.WaitEnd()
-					otherNS = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
-				})
-
-				AfterEach(func() {
-					commonVar.CliRunner.DeleteNamespaceProject(otherNS, false)
-				})
-
-				It("should run odo dev on initial namespace", func() {
-					err := helper.RunDevMode(nil, nil, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {
-						output := commonVar.CliRunner.Run("get", "deployment").Err.Contents()
-						Expect(string(output)).To(ContainSubstring("No resources found in " + otherNS + " namespace."))
-
-						output = commonVar.CliRunner.Run("get", "deployment", "-n", commonVar.Project).Out.Contents()
-						Expect(string(output)).To(ContainSubstring(cmpName))
-					})
-					Expect(err).ToNot(HaveOccurred())
-				})
-			})
 			When("odo dev is stopped", func() {
 				BeforeEach(func() {
 					devSession.Stop()

--- a/tests/integration/cmd_devfile_build_images_test.go
+++ b/tests/integration/cmd_devfile_build_images_test.go
@@ -181,16 +181,6 @@ var _ = Describe("odo devfile build-images command tests", func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-outerloop.yaml"),
 					path.Join(commonVar.Context, "devfile.yaml"))
-				// Bootstrap the component with a .odo/env/env.yaml file
-				odoDir := filepath.Join(commonVar.Context, ".odo", "env")
-				helper.MakeDir(odoDir)
-				err := helper.CreateFileWithContent(filepath.Join(odoDir, "env.yaml"), fmt.Sprintf(`
-ComponentSettings:
-  Name: nodejs-prj1-api-abhz
-  Project: %s
-  AppName: app
-`, commonVar.Project))
-				Expect(err).To(BeNil())
 			})
 
 			When("remote server returns an error", func() {

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -38,7 +38,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 
 		It("should error", func() {
 			output := helper.Cmd("odo", "deploy").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("this command cannot run in an empty directory"))
+			Expect(output).To(ContainSubstring("The current directory does not represent an odo component"))
 
 		})
 	})

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -23,7 +23,6 @@ var _ = Describe("odo devfile deploy command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
 		helper.Chdir(commonVar.Context)
-		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
 	})
 
 	// This is run after every Spec (It)
@@ -83,9 +82,6 @@ var _ = Describe("odo devfile deploy command tests", func() {
 				var stdout string
 				BeforeEach(func() {
 					stdout = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
-					// An ENV file should have been created indicating current namespace
-					Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeTrue())
-					helper.FileShouldContainSubstring(".odo/env/env.yaml", "Project: "+commonVar.Project)
 				})
 				It("should succeed", func() {
 					By("building and pushing image to registry", func() {

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -69,7 +69,6 @@ var _ = Describe("odo devfile deploy command tests", func() {
 
 		When(ctx.title, func() {
 			// from devfile
-			cmpName := "nodejs-prj1-api-abhz"
 			deploymentName := "my-component"
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
@@ -106,34 +105,6 @@ var _ = Describe("odo devfile deploy command tests", func() {
 					Expect(err).ToNot(HaveOccurred())
 					session.Kill()
 					session.WaitEnd()
-				})
-
-				When("deleting previous deployment and switching kubeconfig to another namespace", func() {
-					var otherNS string
-					BeforeEach(func() {
-						helper.Cmd("odo", "delete", "component", "--name", cmpName, "-f").ShouldPass()
-						output := commonVar.CliRunner.Run("get", "deployment", "-n", commonVar.Project).Err.Contents()
-						Expect(string(output)).To(
-							ContainSubstring("No resources found in " + commonVar.Project + " namespace."))
-
-						otherNS = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
-					})
-
-					AfterEach(func() {
-						commonVar.CliRunner.DeleteNamespaceProject(otherNS, false)
-					})
-
-					It("should run odo deploy on initial namespace", func() {
-						helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
-
-						output := commonVar.CliRunner.Run("get", "deployment").Err.Contents()
-						Expect(string(output)).To(
-							ContainSubstring("No resources found in " + otherNS + " namespace."))
-
-						output = commonVar.CliRunner.Run("get", "deployment", "-n", commonVar.Project).Out.Contents()
-						Expect(string(output)).To(ContainSubstring(deploymentName))
-					})
-
 				})
 
 				When("running and stopping odo dev", func() {

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -155,20 +155,17 @@ ComponentSettings:
 				})
 
 				It(fmt.Sprintf("should set the %s", commandName), func() {
-					var stdout, stderr string
+					var stdout string
 					By("setting the current active "+commandName, func() {
 						Expect(commonVar.CliRunner.GetActiveNamespace()).ToNot(Equal(activeNs))
 						cmd := helper.Cmd("odo", "set", commandName, activeNs).ShouldPass()
 						Expect(commonVar.CliRunner.GetActiveNamespace()).To(Equal(activeNs))
-						stdout, stderr = cmd.OutAndErr()
+						stdout, _ = cmd.OutAndErr()
 					})
 
 					By("displaying warning message", func() {
 						Expect(stdout).To(
 							ContainSubstring(fmt.Sprintf("Current active %s set to %q", commandName, activeNs)))
-						Expect(stderr).To(
-							ContainSubstring(fmt.Sprintf("This is being executed inside a component directory. "+
-								"This will not update the %s of the existing component", commandName)))
 					})
 
 					By("not changing the namespace of the existing component", func() {


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

- set current namespace in env.yaml file when starting `odo dev`, remove it when cleanup
- do not read project from env.yaml file when running `odo dev` (or any other command)
- env.yaml file is not created when running `odo deploy`
- the existence of env.yaml file is not checked when running `odo delete component`, `odo build-images` (or any other command)

**Which issue(s) this PR fixes:**

Fixes #6018
Fixes #6027

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
