### PR TITLE
Use GitHub actions to build website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/website/**'
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs/website
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: ./docs/website/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./docs/website/build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -27,3 +27,9 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build website
         run: yarn build
+
+      - name: Deploy
+        uses: shlinkio/deploy-preview-action@v1.0.1
+        with:
+          branch: gh-pages # The branch from where the GitHub Pages are served (defaults to preview-env)
+          folder: ./docs/website/build # The folder where the artifacts to publish are (defaults to the project root)

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,29 @@
+name: Test a PR
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/website/**'
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs/website
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: ./docs/website/yarn.lock
+
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -56,7 +56,7 @@ export default function Home(): JSX.Element {
           <div className="container text--center margin-top--md">
             <div className="row">
               <div className="col col--5 col--offset-1">
-                    <video className={styles.loopVideo} autoPlay loop muted><source src="/video/container_ship.webm" type="video/webm"/></video>
+                  <video className={styles.loopVideo} autoPlay loop muted><source src={useBaseUrl('/video/container_ship.webm')} type="video/webm"/></video>
                 <h2 className={clsx(styles.featureHeading)}>
                   Deploy on <b className={styles.kubernetesFont}>Kubernetes</b> and <b className={styles.openshiftFont}>OpenShift</b>
                 </h2>
@@ -65,7 +65,7 @@ export default function Home(): JSX.Element {
                 </p>
               </div>
               <div className="col col--5">
-                    <video className={styles.loopVideo} autoPlay loop muted><source src="/video/coding.webm" type="video/webm"/></video>
+                  <video className={styles.loopVideo} autoPlay loop muted><source src={useBaseUrl("/video/coding.webm")} type="video/webm"/></video>
                 <h2 className={clsx(styles.featureHeading)}>
                   Push code fast and often
                 </h2>


### PR DESCRIPTION
**What type of PR is this:**

/kind feature
/kind documentation

**What does this PR do / why we need it:**
This PR builds odo website using GH actions each time there's a change in `docs/website` directory. It won't run the particular GH actions when the PR doesn't change anything under `docs/website` directory.

It also automatically updates the `gh-pages` git branch of the repo. There's no manual intervention required for it. 

The website built this way will be deployed at redhat-developer.github.io/odo. Note that after this PR merges, the CSS on this link is going to be broken till we change the `baseUrl` like in [this commit](https://github.com/dharmit/odo/pull/4/commits/727ed100f18e63e4dfb8d6d555c389c54c7dedcd).

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes # N/A. 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
An additional test has been added to this PR as a result of this PR. Look for - ` Test a PR / Test deployment (pull_request)`.