### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/envinfo/envinfo_test.go
+++ b/pkg/envinfo/envinfo_test.go
@@ -17,7 +17,7 @@ func TestSetEnvInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempEnvFile.Close()
-	os.Setenv(envInfoEnvName, tempEnvFile.Name())
+	t.Setenv(envInfoEnvName, tempEnvFile.Name())
 	testDebugPort := 5005
 	invalidParam := "invalidParameter"
 
@@ -85,7 +85,7 @@ func TestUnsetEnvInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempEnvFile.Close()
-	os.Setenv(envInfoEnvName, tempEnvFile.Name())
+	t.Setenv(envInfoEnvName, tempEnvFile.Name())
 	testDebugPort := 15005
 	invalidParam := "invalidParameter"
 

--- a/pkg/odo/genericclioptions/context_test.go
+++ b/pkg/odo/genericclioptions/context_test.go
@@ -344,7 +344,7 @@ func TestNew(t *testing.T) {
 			os.RemoveAll(prefixDir)
 			// the second one to cleanup after execution
 			defer os.RemoveAll(prefixDir)
-			os.Setenv("KUBECONFIG", filepath.Join(prefixDir, ".kube", "config"))
+			t.Setenv("KUBECONFIG", filepath.Join(prefixDir, ".kube", "config"))
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/pkg/preference/implem_test.go
+++ b/pkg/preference/implem_test.go
@@ -19,7 +19,7 @@ func TestNew(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 
 	tests := []struct {
 		name    string
@@ -77,7 +77,7 @@ func TestGetPushTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 
 	nonzeroValue := 5 * time.Second
 
@@ -123,7 +123,7 @@ func TestGetTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 	zeroValue := 0 * time.Second
 	nonzeroValue := 5 * time.Second
 	tests := []struct {
@@ -179,7 +179,7 @@ func TestSetConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 	trueValue := true
 	falseValue := false
 	minValue := minimumDurationValue
@@ -407,7 +407,7 @@ func TestConsentTelemetry(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 	trueValue := true
 	falseValue := false
 
@@ -463,7 +463,7 @@ func TestGetupdateNotification(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 	trueValue := true
 	falseValue := false
 
@@ -692,7 +692,7 @@ func TestGetConsentTelemetry(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 	trueValue := true
 	falseValue := false
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -36,8 +36,7 @@ OdoSettings:
 		t.Error(err)
 	}
 
-	os.Setenv(preference.GlobalConfigEnvName, tempConfigFile.Name())
-	defer os.Unsetenv(preference.GlobalConfigEnvName)
+	t.Setenv(preference.GlobalConfigEnvName, tempConfigFile.Name())
 
 	tests := []struct {
 		name         string

--- a/pkg/registry/utils_test.go
+++ b/pkg/registry/utils_test.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 
@@ -20,7 +19,7 @@ func TestIsSecure(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempConfigFile.Close()
-	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	t.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
 
 	tests := []struct {
 		name              string

--- a/pkg/segment/integrations_test.go
+++ b/pkg/segment/integrations_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/devfile/registry-support/registry-library/library"
@@ -18,11 +17,7 @@ func TestGetRegistryOptions(t *testing.T) {
 	}
 	defer tempConfigFile.Close()
 
-	err = os.Setenv(preference.GlobalConfigEnvName, tempConfigFile.Name())
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(preference.GlobalConfigEnvName, tempConfigFile.Name())
 
 	tests := []struct {
 		testName string

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -231,7 +231,7 @@ func TestIsTelemetryEnabled(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		os.Setenv(DisableTelemetryEnv, tt.envVar)
+		t.Setenv(DisableTelemetryEnv, tt.envVar)
 		ctrl := gomock.NewController(t)
 		cfg := preference.NewMockClient(ctrl)
 		cfg.EXPECT().GetConsentTelemetry().Return(tt.preferenceValue).AnyTimes()


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
