### PR TITLE
Troubleshoot IBM Cloud Windows tests failing

### DIFF
--- a/tests/helper/helper_cmd_wrapper.go
+++ b/tests/helper/helper_cmd_wrapper.go
@@ -31,6 +31,7 @@ func Cmd(program string, args ...string) *CmdWrapper {
 	prefix := fmt.Sprintf("[%s] ", filepath.Base(program))
 	prefixWriter := gexec.NewPrefixedWriter(prefix, GinkgoWriter)
 	command := exec.Command(program, args...)
+	setSysProcAttr(command)
 	return &CmdWrapper{
 		Cmd:     command,
 		program: program,


### PR DESCRIPTION
On Windows, when sending the Ctrl-C signal to the `odo dev` process to stop it, we firt need to set a specific attribute on the process (`CREATE_NEW_PROCESS_GROUP`), or the parent process will also receive the signal.

By changing from `CmdRunner()` to `Cmd().Runner()` in commit (https://github.com/redhat-developer/odo/commit/224069cd68f4a03f4b5b17009fb4ca42ef8c5d89), `setSysProcAttr` in `CmdRunner()` is not called anymore.
