### PR TITLE
Fix: (odo list) Empty parenthesis for odo version if component is not on the cluster

### DIFF
--- a/pkg/odo/cli/list/component/list.go
+++ b/pkg/odo/cli/list/component/list.go
@@ -192,18 +192,13 @@ func HumanReadableOutput(list api.ResourcesList) {
 		// If we find our local unpushed component, let's change the output appropriately.
 		if list.ComponentInDevfile == comp.Name {
 			name = fmt.Sprintf("* %s", name)
-
-			if comp.ManagedBy == "" {
-				managedBy = "odo"
-			}
 		}
-
+		if comp.ManagedByVersion != "" {
+			managedBy += fmt.Sprintf(" (%s)", comp.ManagedByVersion)
+		}
 		// If we are managing that component, output it as blue (our logo colour) to indicate it's used by odo
-		if managedBy == "odo" {
-			managedBy = text.Colors{text.FgBlue}.Sprintf("odo (%s)", comp.ManagedByVersion)
-		} else if managedBy != "" && comp.ManagedByVersion != "" {
-			// this is done to maintain the color of the output
-			managedBy += fmt.Sprintf("(%s)", comp.ManagedByVersion)
+		if comp.ManagedBy == "odo" {
+			managedBy = text.Colors{text.FgBlue}.Sprintf(managedBy)
 		}
 
 		t.AppendRow(table.Row{name, componentType, mode, managedBy})


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #6061


**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `mkdir /tmp/101; cd /tmp/101`
2. `odo init --devfile go --name my-go --starter go-starter`
3. `odo list` should not show empty parenthesis for odo version