### PR TITLE
[flaky test] Move DetectName to method in alizer package

### DIFF
--- a/pkg/alizer/alizer.go
+++ b/pkg/alizer/alizer.go
@@ -47,13 +47,6 @@ func (o *Alizer) DetectFramework(path string) (recognizer.DevFileType, api.Regis
 	return types[typ], components.Items[typ].Registry, nil
 }
 
-func GetDevfileLocationFromDetection(typ recognizer.DevFileType, registry api.Registry) *api.DevfileLocation {
-	return &api.DevfileLocation{
-		Devfile:         typ.Name,
-		DevfileRegistry: registry.Name,
-	}
-}
-
 // DetectName retrieves the name of the project (if available)
 // If source code is detected:
 // 1. Detect the name (pom.xml for java, package.json for nodejs, etc.)
@@ -69,7 +62,7 @@ func GetDevfileLocationFromDetection(typ recognizer.DevFileType, registry api.Re
 // components, err := recognizer.DetectComponents("./")
 
 // In order to detect the name, the name will first try to find out the name based on the program (pom.xml, etc.) but then if not, it will use the dir name.
-func DetectName(path string) (string, error) {
+func (o *Alizer) DetectName(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("path is empty")
 	}
@@ -119,4 +112,11 @@ func DetectName(path string) (string, error) {
 	}
 
 	return name, nil
+}
+
+func GetDevfileLocationFromDetection(typ recognizer.DevFileType, registry api.Registry) *api.DevfileLocation {
+	return &api.DevfileLocation{
+		Devfile:         typ.Name,
+		DevfileRegistry: registry.Name,
+	}
 }

--- a/pkg/alizer/alizer_test.go
+++ b/pkg/alizer/alizer_test.go
@@ -180,7 +180,11 @@ func TestDetectName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			name, err := DetectName(tt.args.path)
+			ctrl := gomock.NewController(t)
+			registryClient := registry.NewMockClient(ctrl)
+			alizerClient := NewAlizerClient(registryClient)
+
+			name, err := alizerClient.DetectName(tt.args.path)
 
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)

--- a/pkg/alizer/interface.go
+++ b/pkg/alizer/interface.go
@@ -7,4 +7,5 @@ import (
 
 type Client interface {
 	DetectFramework(path string) (recognizer.DevFileType, api.Registry, error)
+	DetectName(path string) (string, error)
 }

--- a/pkg/alizer/mock.go
+++ b/pkg/alizer/mock.go
@@ -50,3 +50,18 @@ func (mr *MockClientMockRecorder) DetectFramework(path interface{}) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectFramework", reflect.TypeOf((*MockClient)(nil).DetectFramework), path)
 }
+
+// DetectName mocks base method.
+func (m *MockClient) DetectName(path string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetectName", path)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DetectName indicates an expected call of DetectName.
+func (mr *MockClientMockRecorder) DetectName(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectName", reflect.TypeOf((*MockClient)(nil).DetectName), path)
+}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -57,7 +57,8 @@ func GatherName(contextDir string, devfileObj *parser.DevfileObj) (string, error
 			// Use Alizer if Devfile has no (optional) metadata.name field.
 			// We need to pass in the Devfile base directory (not the path to the devfile.yaml).
 			// Name returned by alizer.DetectName is expected to be already sanitized.
-			return alizer.DetectName(filepath.Dir(devfileObj.Ctx.GetAbsPath()))
+			alizerClient := alizer.Alizer{} // TODO(feloy) fix with DI
+			return alizerClient.DetectName(filepath.Dir(devfileObj.Ctx.GetAbsPath()))
 		}
 	} else {
 		// Fallback to the context dir name

--- a/pkg/init/backend/alizer.go
+++ b/pkg/init/backend/alizer.go
@@ -58,7 +58,7 @@ func (o *AlizerBackend) PersonalizeName(devfile parser.DevfileObj, flags map[str
 	if path == "" {
 		return "", fmt.Errorf("cannot determine the absolute path of the directory")
 	}
-	return alizer.DetectName(path)
+	return o.alizerClient.DetectName(path)
 }
 
 func (o *AlizerBackend) PersonalizeDevfileConfig(devfile parser.DevfileObj) (parser.DevfileObj, error) {

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -29,14 +29,16 @@ const (
 type InteractiveBackend struct {
 	askerClient    asker.Asker
 	registryClient registry.Client
+	alizerClient   alizer.Client
 }
 
 var _ InitBackend = (*InteractiveBackend)(nil)
 
-func NewInteractiveBackend(askerClient asker.Asker, registryClient registry.Client) *InteractiveBackend {
+func NewInteractiveBackend(askerClient asker.Asker, registryClient registry.Client, alizerClient alizer.Client) *InteractiveBackend {
 	return &InteractiveBackend{
 		askerClient:    askerClient,
 		registryClient: registryClient,
+		alizerClient:   alizerClient,
 	}
 }
 
@@ -123,7 +125,7 @@ func (o *InteractiveBackend) PersonalizeName(devfile parser.DevfileObj, flags ma
 	baseDir := filepath.Dir(path)
 
 	// Detect the name
-	name, err := alizer.DetectName(baseDir)
+	name, err := o.alizerClient.DetectName(baseDir)
 	if err != nil {
 		return "", fmt.Errorf("detecting name using alizer: %w", err)
 	}

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -44,7 +44,7 @@ func NewInitClient(fsys filesystem.Filesystem, preferenceClient preference.Clien
 	askerClient := asker.NewSurveyAsker()
 	return &InitClient{
 		flagsBackend:       backend.NewFlagsBackend(preferenceClient),
-		interactiveBackend: backend.NewInteractiveBackend(askerClient, registryClient),
+		interactiveBackend: backend.NewInteractiveBackend(askerClient, registryClient, alizerClient),
 		alizerBackend:      backend.NewAlizerBackend(askerClient, alizerClient),
 		fsys:               fsys,
 		preferenceClient:   preferenceClient,


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

Move the DetectName function to a method in the `pkg/alizer` method, to be able to mock it from `pkg/init/backend` package

**Which issue(s) this PR fixes:**

Fixes #6092 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
