### PR TITLE
Display "Interactive mode enabled" only when running `odo init` interactively

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -238,6 +238,13 @@ func Printf(format string, a ...interface{}) {
 	}
 }
 
+// Println will output a new line when applicable
+func Println() {
+	if !IsJSON() {
+		fmt.Fprintln(GetStdout())
+	}
+}
+
 // Success will output in an appropriate "success" manner
 //  ✓  <message>
 func Success(a ...interface{}) {

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -185,7 +185,9 @@ func (o *InitOptions) run(ctx context.Context) (devfileObj parser.DevfileObj, pa
 		infoOutput = messages.SourceCodeDetected
 	}
 	log.Title(messages.InitializingNewComponent, infoOutput, "odo version: "+version.VERSION)
-	log.Info("\nInteractive mode enabled, please answer the following questions:")
+	if len(o.flags) == 0 {
+		log.Infof("\n%s", messages.InteractiveModeEnabled)
+	}
 
 	devfileObj, devfilePath, err := o.clientset.InitClient.SelectAndPersonalizeDevfile(o.flags, o.contextDir)
 	if err != nil {

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -185,8 +185,9 @@ func (o *InitOptions) run(ctx context.Context) (devfileObj parser.DevfileObj, pa
 		infoOutput = messages.SourceCodeDetected
 	}
 	log.Title(messages.InitializingNewComponent, infoOutput, "odo version: "+version.VERSION)
+	log.Println()
 	if len(o.flags) == 0 {
-		log.Infof("\n%s", messages.InteractiveModeEnabled)
+		log.Info(messages.InteractiveModeEnabled)
 	}
 
 	devfileObj, devfilePath, err := o.clientset.InitClient.SelectAndPersonalizeDevfile(o.flags, o.contextDir)

--- a/pkg/odo/cli/messages/messages.go
+++ b/pkg/odo/cli/messages/messages.go
@@ -1,7 +1,7 @@
+// Package messages contains the various "outputs" that we use in both the CLI and test cases.
 package messages
 
-// Below are various "outputs" that we use in both the CLI and test cases, so we must
-// put them in a common place
+const InteractiveModeEnabled = "Interactive mode enabled, please answer the following questions:"
 const InitializingNewComponent = "Initializing new component"
 const SourceCodeDetected = "Files: Source code detected, a Devfile will be determined based upon source code autodetection"
 const NoSourceCodeDetected = "Files: No source code detected, a starter project will be created in the current directory"

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -41,6 +41,10 @@ var _ = Describe("odo init interactive command tests", func() {
 		command := []string{"odo", "init", "-v", "4"}
 		output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
 
+			By("showing the interactive mode notice message", func() {
+				helper.ExpectString(ctx, messages.InteractiveModeEnabled)
+			})
+
 			helper.ExpectString(ctx, "Select language")
 			helper.SendLine(ctx, "go")
 
@@ -92,6 +96,10 @@ var _ = Describe("odo init interactive command tests", func() {
 
 		command := []string{"odo", "init"}
 		output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
+
+			By("showing the interactive mode notice message", func() {
+				helper.ExpectString(ctx, messages.InteractiveModeEnabled)
+			})
 
 			helper.ExpectString(ctx, "Select language")
 			helper.SendLine(ctx, "go")


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
Fixes #5957

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Running `odo init` non-interactively should no longer display the "Interactive mode enabled, please answer the following questions" message.