### PR TITLE
Fix default value for `Ephemeral` in documentation

### DIFF
--- a/docs/website/docs/overview/configure.md
+++ b/docs/website/docs/overview/configure.md
@@ -101,7 +101,7 @@ Unsetting a preference key sets it to an empty value in the preference file. odo
 | Timeout            | Timeout for Kubernetes server connection check                                 | 1 second    |
 | PushTimeout        | Timeout for waiting for a component to start                                   | 240 seconds |
 | RegistryCacheTime  | For how long (in minutes) odo will cache information from the Devfile registry | 4 Minutes   |
-| Ephemeral          | Control whether odo should create a emptyDir volume to store source code       | True        |
+| Ephemeral          | Control whether odo should create a emptyDir volume to store source code       | False       |
 | ConsentTelemetry   | Control whether odo can collect telemetry for the user's odo usage             | False       |
 
 


### PR DESCRIPTION
**What type of PR is this:**
/kind documentation

**What does this PR do / why we need it:**
Since #5795, the default value for 'Ephemeral' is now `False`, but the documentation was outdated.

**Which issue(s) this PR fixes:**
No issue related

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
