### PR TITLE
Show Kubernetes cluster version in odo version

### DIFF
--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	dfutil "github.com/devfile/library/pkg/util"
-
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog"
 )
@@ -60,7 +61,7 @@ func (c *Client) GetServerVersion(timeout time.Duration) (*ServerInfo, error) {
 
 	// fail fast if user is not connected (same logic as `oc whoami`)
 	_, err = c.userClient.Users().Get(context.TODO(), "~", metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return nil, err
 	}
 

--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -9,9 +9,6 @@ import (
 	"time"
 
 	dfutil "github.com/devfile/library/pkg/util"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog"
 )
@@ -59,25 +56,17 @@ func (c *Client) GetServerVersion(timeout time.Duration) (*ServerInfo, error) {
 		return nil, errors.New("unable to connect to OpenShift cluster, it may be down")
 	}
 
-	// fail fast if user is not connected (same logic as `oc whoami`)
-	_, err = c.userClient.Users().Get(context.TODO(), "~", metav1.GetOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		return nil, err
-	}
-
 	// This will fetch the information about OpenShift Version
 	coreGet := c.GetClient().CoreV1().RESTClient().Get()
 	rawOpenShiftVersion, err := coreGet.AbsPath("/version/openshift").Do(context.TODO()).Raw()
 	if err != nil {
-		// when using Minishift (or plain 'oc cluster up' for that matter) with OKD 3.11, the version endpoint is missing...
-		klog.V(3).Infof("Unable to get OpenShift Version - endpoint '/version/openshift' doesn't exist")
-	} else {
-		var openShiftVersion version.Info
-		if e := json.Unmarshal(rawOpenShiftVersion, &openShiftVersion); e != nil {
-			return nil, fmt.Errorf("unable to unmarshal OpenShift version %v: %w", string(rawOpenShiftVersion), e)
-		}
-		info.OpenShiftVersion = openShiftVersion.GitVersion
+		return nil, fmt.Errorf("unable to get OpenShift Version: %w", err)
 	}
+	var openShiftVersion version.Info
+	if e := json.Unmarshal(rawOpenShiftVersion, &openShiftVersion); e != nil {
+		return nil, fmt.Errorf("unable to unmarshal OpenShift version %v: %w", string(rawOpenShiftVersion), e)
+	}
+	info.OpenShiftVersion = openShiftVersion.GitVersion
 
 	// This will fetch the information about Kubernetes Version
 	rawKubernetesVersion, err := coreGet.AbsPath("/version").Do(context.TODO()).Raw()

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -74,7 +74,7 @@ func (o *VersionOptions) Complete(cmdline cmdline.Cmdline, args []string) (err e
 			}
 			o.serverInfo, err = client.GetServerVersion(timeout)
 			if err != nil {
-				klog.V(4).Info("an error occured while fetching server version", err)
+				klog.V(4).Info("unable to fetch the server version: ", err)
 			}
 		}
 	}

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -72,7 +72,10 @@ func (o *VersionOptions) Complete(cmdline cmdline.Cmdline, args []string) (err e
 				// when the value is not readable from preference
 				timeout = preference.DefaultTimeout
 			}
-			o.serverInfo, _ = client.GetServerVersion(timeout)
+			o.serverInfo, err = client.GetServerVersion(timeout)
+			if err != nil {
+				klog.V(4).Info("an error occured while fetching server version", err)
+			}
 		}
 	}
 	return nil

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"regexp"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -114,12 +112,9 @@ var _ = Describe("odo generic", func() {
 		})
 
 		It("should show the version of odo major components including server login URL", func() {
-			reOdoVersion := regexp.MustCompile(`^odo\s*v[0-9]+.[0-9]+.[0-9]+(?:-\w+)?\s*\(\w+\)`)
-			odoVersionStringMatch := reOdoVersion.MatchString(odoVersion)
-			Expect(odoVersionStringMatch).Should(BeTrue())
-			rekubernetesVersion := regexp.MustCompile(`Kubernetes:\s*v[0-9]+.[0-9]+.[0-9]+((-\w+\.[0-9]+)?\+\w+)?`)
-			kubernetesVersionStringMatch := rekubernetesVersion.MatchString(odoVersion)
-			Expect(kubernetesVersionStringMatch).Should(BeTrue())
+			reOdoVersion := `^odo\s*v[0-9]+.[0-9]+.[0-9]+(?:-\w+)?\s*\(\w+\)`
+			rekubernetesVersion := `Kubernetes:\s*v[0-9]+.[0-9]+.[0-9]+((-\w+\.[0-9]+)?\+\w+)?`
+			Expect(odoVersion).Should(SatisfyAll(MatchRegexp(reOdoVersion), MatchRegexp(rekubernetesVersion)))
 			serverURL := oc.GetCurrentServerURL()
 			Expect(odoVersion).Should(ContainSubstring("Server: " + serverURL))
 		})

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
@@ -116,13 +117,11 @@ var _ = Describe("odo generic", func() {
 			reOdoVersion := regexp.MustCompile(`^odo\s*v[0-9]+.[0-9]+.[0-9]+(?:-\w+)?\s*\(\w+\)`)
 			odoVersionStringMatch := reOdoVersion.MatchString(odoVersion)
 			Expect(odoVersionStringMatch).Should(BeTrue())
-			if !helper.IsKubernetesCluster() {
-				rekubernetesVersion := regexp.MustCompile(`Kubernetes:\s*v[0-9]+.[0-9]+.[0-9]+((-\w+\.[0-9]+)?\+\w+)?`)
-				kubernetesVersionStringMatch := rekubernetesVersion.MatchString(odoVersion)
-				Expect(kubernetesVersionStringMatch).Should(BeTrue())
-				serverURL := oc.GetCurrentServerURL()
-				Expect(odoVersion).Should(ContainSubstring("Server: " + serverURL))
-			}
+			rekubernetesVersion := regexp.MustCompile(`Kubernetes:\s*v[0-9]+.[0-9]+.[0-9]+((-\w+\.[0-9]+)?\+\w+)?`)
+			kubernetesVersionStringMatch := rekubernetesVersion.MatchString(odoVersion)
+			Expect(kubernetesVersionStringMatch).Should(BeTrue())
+			serverURL := oc.GetCurrentServerURL()
+			Expect(odoVersion).Should(ContainSubstring("Server: " + serverURL))
 		})
 	})
 

--- a/tests/integration/loginlogout/cmd_login_logout_test.go
+++ b/tests/integration/loginlogout/cmd_login_logout_test.go
@@ -39,6 +39,11 @@ var _ = Describe("odo login and logout command tests", func() {
 		})
 	})
 
+	It("should show cluster version when not logged in", func() {
+		version := helper.Cmd("odo", "version").ShouldPass().Out()
+		helper.MatchAllInOutput(version, []string{"odo", "Server", "Kubernetes"})
+	})
+
 	Context("when running login tests", func() {
 		It("should successful with correct credentials and fails with incorrect token", func() {
 			// skip if requested


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5650


**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. Start a kubernetes cluster.
2. Run `odo version`. It should display kubernetes version and Server URL.
```sh
$ odo version
odo v3.0.0-rc1 (6c6f8ef5ad)

Server: https://192.168.49.2:8443
Kubernetes: v1.23.3
```