### PR TITLE
WIP set service account for dev container via component attributes

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -458,6 +458,27 @@ func (a *Adapter) createOrUpdateComponent(
 	if err != nil {
 		return nil, false, err
 	}
+
+	// Set service account if component has attribute `serviceAccountName`
+	var serviceAccountName string
+	components, _ := a.Devfile.Data.GetComponents(parsercommon.DevfileOptions{})
+	for _, component := range components {
+		for _, container := range containers {
+			if component.Name == container.Name {
+				var err *error
+				if component.Attributes.Exists("serviceAccountName") {
+					serviceAccountName = component.Attributes.GetString("serviceAccountName", err)
+					if err != nil {
+						return nil, false, *err
+					}
+				} else {
+					serviceAccountName = "default"
+				}
+			}
+		}
+	}
+	deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+
 	klog.V(2).Infof("Creating deployment %v", deployment.Spec.Template.GetName())
 	klog.V(2).Infof("The component name is %v", componentName)
 	if componentExists {


### PR DESCRIPTION
Signed-off-by: Vinny Sabatini <vincent.sabatini@kohls.com>

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

Allow users to specify what Kubernetes service account the pod should run as for an `odo dev` session.
This is generally useful if you want your workload to have additional permissions within a Kubernetes cluster
and you do not want to grant additional access to the default service account.

If the attribute is not set, the `default` service account will be used.

**Which issue(s) this PR fixes:**

Fixes #5977

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

- In your Kubernetes cluster, create a service account
- In your devfile, set `.components.attributes.serviceAccountName` for your container component to the name of the service account you created
  ```yaml
  components:
  - attributes:
      serviceAccountName: my-service-account
    container:
      dedicatedPod: false
      endpoints:
      - name: http
        secure: false
        targetPort: 8080
      image: quay.io/devfile/golang:latest
      memoryLimit: 1024Mi
      mountSources: true
    name: runtime
  ```
- Start `odo dev`
- Check `.spec.template.spec.serviceAccountName` on the deployment, or `.spec.serviceAccountName` of the running pod