### PR TITLE
Port-forward all endpoints regardless of exposure

### DIFF
--- a/pkg/libdevfile/libdevfile.go
+++ b/pkg/libdevfile/libdevfile.go
@@ -269,7 +269,7 @@ func execDevfileEvent(devfileObj parser.DevfileObj, events []string, handler Han
 	return nil
 }
 
-// GetContainerEndpointMapping returns a map of container names and slice of its endpoints (in int) with exposure status other than none
+// GetContainerEndpointMapping returns a map of container names and slice of its endpoints (in int)
 func GetContainerEndpointMapping(containers []v1alpha2.Component) map[string][]int {
 	ceMapping := make(map[string][]int)
 	for _, container := range containers {
@@ -284,9 +284,7 @@ func GetContainerEndpointMapping(containers []v1alpha2.Component) map[string][]i
 
 		endpoints := container.Container.Endpoints
 		for _, e := range endpoints {
-			if e.Exposure != v1alpha2.NoneEndpointExposure {
-				ceMapping[k] = append(ceMapping[k], e.TargetPort)
-			}
+			ceMapping[k] = append(ceMapping[k], e.TargetPort)
 		}
 	}
 	return ceMapping

--- a/pkg/libdevfile/libdevfile_test.go
+++ b/pkg/libdevfile/libdevfile_test.go
@@ -530,6 +530,17 @@ func TestGetContainerEndpointMapping(t *testing.T) {
 		},
 	})
 
+	containerWithOneNoneInternalEndpoint := generator.GetContainerComponent(generator.ContainerComponentParams{
+		Name: "container-none-endpoint",
+		Endpoints: []v1alpha2.Endpoint{
+			{
+				Name:       "debug",
+				TargetPort: 9099,
+				Exposure:   v1alpha2.NoneEndpointExposure,
+			},
+		},
+	})
+
 	tests := []struct {
 		name string
 		args args
@@ -552,16 +563,37 @@ func TestGetContainerEndpointMapping(t *testing.T) {
 		{
 			name: "multiple containers with varying types of endpoints",
 			args: args{
-				containers: []v1alpha2.Component{containerWithNoEndpoints, containerWithOnePublicEndpoint, containerWithOneInternalEndpoint},
+				containers: []v1alpha2.Component{
+					containerWithNoEndpoints,
+					containerWithOnePublicEndpoint,
+					containerWithOneInternalEndpoint,
+					containerWithOneNoneInternalEndpoint,
+				},
 			},
-			want: map[string][]int{containerWithNoEndpoints.Name: {}, containerWithOnePublicEndpoint.Name: {8080}, containerWithOneInternalEndpoint.Name: {9090}},
+			want: map[string][]int{
+				containerWithNoEndpoints.Name:             {},
+				containerWithOnePublicEndpoint.Name:       {8080},
+				containerWithOneInternalEndpoint.Name:     {9090},
+				containerWithOneNoneInternalEndpoint.Name: {9099},
+			},
 		},
 		{
 			name: "invalid input - one image component with rest being containers",
 			args: args{
-				containers: []v1alpha2.Component{containerWithNoEndpoints, containerWithOnePublicEndpoint, containerWithOneInternalEndpoint, imageComponent},
+				containers: []v1alpha2.Component{
+					containerWithNoEndpoints,
+					containerWithOnePublicEndpoint,
+					containerWithOneInternalEndpoint,
+					containerWithOneNoneInternalEndpoint,
+					imageComponent,
+				},
 			},
-			want: map[string][]int{containerWithNoEndpoints.Name: {}, containerWithOnePublicEndpoint.Name: {8080}, containerWithOneInternalEndpoint.Name: {9090}},
+			want: map[string][]int{
+				containerWithNoEndpoints.Name:             {},
+				containerWithOnePublicEndpoint.Name:       {8080},
+				containerWithOneInternalEndpoint.Name:     {9090},
+				containerWithOneNoneInternalEndpoint.Name: {9099},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -307,7 +307,7 @@ func NewCmdDev(name, fullName string) *cobra.Command {
 		Use:   name,
 		Short: "Deploy component to development cluster",
 		Long: `odo dev is a long running command that will automatically sync your source to the cluster.
-It forwards endpoints with exposure values 'public' or 'internal' to a port on localhost.`,
+It forwards endpoints with any exposure values ('public', 'internal' or 'none') to a port on localhost.`,
 		Example: fmt.Sprintf(devExample, fullName),
 		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
This removes the condition that caused endpoints with `exposure: none` to be ignored. Now `odo dev` should port-forward all endpoints, regardless of their exposures.
This is needed as part of #5988: a separate PR in the Devfile registry will add endpoints for debug ports to all relevant Devfiles.

**Which issue(s) this PR fixes:**
ref #5988

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Endpoints with `exposure: none` should be port-forwarded, just like any other endpoint.