### PR TITLE
 Add extra output when init project using odo dev or deploy

### DIFF
--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/odo/cli/messages"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
@@ -81,8 +82,8 @@ func (o *DeployOptions) Complete(cmdline cmdline.Cmdline, args []string) (err er
 		func(interactiveMode bool) {
 			scontext.SetInteractive(cmdline.Context(), interactiveMode)
 			if interactiveMode {
-				fmt.Println("The current directory already contains source code. " +
-					"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
+				log.Title(messages.DeployInitializeExistingComponent, messages.SourceCodeDetected, "odo version: "+version.VERSION)
+				log.Info("\n" + messages.InteractiveModeEnabled)
 			}
 		},
 		func(newDevfileObj parser.DevfileObj) error {

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -161,7 +161,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 	)
 
 	// Output what the command is doing / information
-	log.Title("Developing using the "+componentName+" Devfile",
+	log.Title("Developing using the \""+componentName+"\" Devfile",
 		"Namespace: "+o.GetProject(),
 		"odo version: "+version.VERSION)
 

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"github.com/redhat-developer/odo/pkg/log"
 	clierrors "github.com/redhat-developer/odo/pkg/odo/cli/errors"
+	"github.com/redhat-developer/odo/pkg/odo/cli/messages"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
@@ -114,8 +115,8 @@ func (o *DevOptions) Complete(cmdline cmdline.Cmdline, args []string) error {
 		func(interactiveMode bool) {
 			scontext.SetInteractive(cmdline.Context(), interactiveMode)
 			if interactiveMode {
-				fmt.Println("The current directory already contains source code. " +
-					"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project.")
+				log.Title(messages.InitializeExistingComponent, messages.SourceCodeDetected, "odo version: "+version.VERSION)
+				log.Info("\n" + messages.InteractiveModeEnabled)
 			}
 		},
 		func(newDevfileObj parser.DevfileObj) error {

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -115,7 +115,7 @@ func (o *DevOptions) Complete(cmdline cmdline.Cmdline, args []string) error {
 		func(interactiveMode bool) {
 			scontext.SetInteractive(cmdline.Context(), interactiveMode)
 			if interactiveMode {
-				log.Title(messages.InitializeExistingComponent, messages.SourceCodeDetected, "odo version: "+version.VERSION)
+				log.Title(messages.DevInitializeExistingComponent, messages.SourceCodeDetected, "odo version: "+version.VERSION)
 				log.Info("\n" + messages.InteractiveModeEnabled)
 			}
 		},

--- a/pkg/odo/cli/messages/messages.go
+++ b/pkg/odo/cli/messages/messages.go
@@ -5,3 +5,4 @@ const InteractiveModeEnabled = "Interactive mode enabled, please answer the foll
 const InitializingNewComponent = "Initializing new component"
 const SourceCodeDetected = "Files: Source code detected, a Devfile will be determined based upon source code autodetection"
 const NoSourceCodeDetected = "Files: No source code detected, a starter project will be created in the current directory"
+const InitializeExistingComponent = "Dev mode ran, but no Devfile was found. Initializing a Devfile in the current directory"

--- a/pkg/odo/cli/messages/messages.go
+++ b/pkg/odo/cli/messages/messages.go
@@ -2,8 +2,8 @@
 package messages
 
 const InteractiveModeEnabled = "Interactive mode enabled, please answer the following questions:"
-const InitializingNewComponent = "Initializing new component"
+const InitializingNewComponent = "Initializing a new component"
 const SourceCodeDetected = "Files: Source code detected, a Devfile will be determined based upon source code autodetection"
 const NoSourceCodeDetected = "Files: No source code detected, a starter project will be created in the current directory"
-const DevInitializeExistingComponent = "Dev mode ran, but no Devfile was found. Initializing a Devfile in the current directory"
-const DeployInitializeExistingComponent = "Deploy mode ran, but no Devfile was found. Initializing a Devfile in the current directory"
+const DevInitializeExistingComponent = "Dev mode ran, but no Devfile was found. Initializing a component in the current directory"
+const DeployInitializeExistingComponent = "Deploy mode ran, but no Devfile was found. Initializing a component in the current directory"

--- a/pkg/odo/cli/messages/messages.go
+++ b/pkg/odo/cli/messages/messages.go
@@ -5,4 +5,5 @@ const InteractiveModeEnabled = "Interactive mode enabled, please answer the foll
 const InitializingNewComponent = "Initializing new component"
 const SourceCodeDetected = "Files: Source code detected, a Devfile will be determined based upon source code autodetection"
 const NoSourceCodeDetected = "Files: No source code detected, a starter project will be created in the current directory"
-const InitializeExistingComponent = "Dev mode ran, but no Devfile was found. Initializing a Devfile in the current directory"
+const DevInitializeExistingComponent = "Dev mode ran, but no Devfile was found. Initializing a Devfile in the current directory"
+const DeployInitializeExistingComponent = "Deploy mode ran, but no Devfile was found. Initializing a Devfile in the current directory"

--- a/tests/integration/interactive_deploy_test.go
+++ b/tests/integration/interactive_deploy_test.go
@@ -145,8 +145,7 @@ var _ = Describe("odo deploy interactive command tests", func() {
 			lines, err := helper.ExtractLines(output)
 			Expect(err).To(BeNil())
 			Expect(lines).To(Not(BeEmpty()))
-			Expect(lines[0]).To(Equal("The current directory already contains source code. " +
-				"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project."))
+			Expect(lines[1]).To(ContainSubstring("Deploy mode ran, but no Devfile was found. Initializing a Devfile in the current directory"))
 		})
 	})
 })

--- a/tests/integration/interactive_deploy_test.go
+++ b/tests/integration/interactive_deploy_test.go
@@ -145,7 +145,7 @@ var _ = Describe("odo deploy interactive command tests", func() {
 			lines, err := helper.ExtractLines(output)
 			Expect(err).To(BeNil())
 			Expect(lines).To(Not(BeEmpty()))
-			Expect(lines[1]).To(ContainSubstring("Deploy mode ran, but no Devfile was found. Initializing a Devfile in the current directory"))
+			Expect(lines[1]).To(ContainSubstring("Deploy mode ran, but no Devfile was found. Initializing a component in the current directory"))
 		})
 	})
 })

--- a/tests/integration/interactive_dev_test.go
+++ b/tests/integration/interactive_dev_test.go
@@ -142,8 +142,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 			lines, err := helper.ExtractLines(output)
 			Expect(err).To(BeNil())
 			Expect(lines).To(Not(BeEmpty()))
-			Expect(lines[0]).To(Equal("The current directory already contains source code. " +
-				"odo will try to autodetect the language and project type in order to select the best suited Devfile for your project."))
+			Expect(lines[1]).To(ContainSubstring("Dev mode ran, but no Devfile was found. Initializing a Devfile in the current directory"))
 		})
 	})
 

--- a/tests/integration/interactive_dev_test.go
+++ b/tests/integration/interactive_dev_test.go
@@ -142,7 +142,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 			lines, err := helper.ExtractLines(output)
 			Expect(err).To(BeNil())
 			Expect(lines).To(Not(BeEmpty()))
-			Expect(lines[1]).To(ContainSubstring("Dev mode ran, but no Devfile was found. Initializing a Devfile in the current directory"))
+			Expect(lines[1]).To(ContainSubstring("Dev mode ran, but no Devfile was found. Initializing a component in the current directory"))
 		})
 	})
 


### PR DESCRIPTION
Add extra output when init project using odo dev

<!--
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->
/kind cleanup

**What does this PR do / why we need it:**

Updates the messaging when you run `odo dev` and there is no
`devfile.yaml` available. Outputs more information that makes it similar
to running `odo dev` or `odo init`

**Which issue(s) this PR fixes:**
<!--
Specifying the issue will automatically close it when this PR is merged
-->

Fixes https://github.com/redhat-developer/odo/issues/5679

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
