### PR TITLE
Try to reload config when disconnected from the cluster

### DIFF
--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -76,6 +76,7 @@ type ClientInterface interface {
 	SetDiscoveryInterface(client discovery.DiscoveryInterface)
 	IsResourceSupported(apiGroup, apiVersion, resourceName string) (bool, error)
 	IsSSASupported() bool
+	Refresh() (newConfig bool, err error)
 
 	// namespace.go
 	GetCurrentNamespace() string

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -1236,6 +1236,21 @@ func (mr *MockClientInterfaceMockRecorder) PodWatcher(ctx, selector interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PodWatcher", reflect.TypeOf((*MockClientInterface)(nil).PodWatcher), ctx, selector)
 }
 
+// Refresh mocks base method.
+func (m *MockClientInterface) Refresh() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Refresh")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Refresh indicates an expected call of Refresh.
+func (mr *MockClientInterfaceMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockClientInterface)(nil).Refresh))
+}
+
 // RunLogout mocks base method.
 func (m *MockClientInterface) RunLogout(stdout io.Writer) error {
 	m.ctrl.T.Helper()

--- a/pkg/kclient/refresh.go
+++ b/pkg/kclient/refresh.go
@@ -1,0 +1,67 @@
+package kclient
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Refresh re-creates a new Kubernetes client and checks if the Config changes
+// If config changed, updates the Kubernetes client with the new configuration and returns true
+// If the namespace or cluster of the current context has changed since the last time
+// the config has been loaded, the function will not update the configuration
+func (c *Client) Refresh() (bool, error) {
+	newClient, err := New()
+	if err != nil {
+		return false, err
+	}
+
+	oldCluster, oldNs, err := getContext(c)
+	if err != nil {
+		return false, err
+	}
+	newCluster, newNs, err := getContext(newClient)
+	if err != nil {
+		return false, err
+	}
+
+	if oldCluster != newCluster {
+		return false, fmt.Errorf("cluster changed (%q -> %q), won't refresh the configuration", oldCluster, newCluster)
+	}
+	if oldNs != newNs {
+		return false, fmt.Errorf("namespace changed (%q -> %q), won't refresh the configuration", oldNs, newNs)
+	}
+
+	updated, err := isConfigUpdated(c.GetConfig(), newClient.GetConfig())
+	if err != nil {
+		return false, err
+	}
+
+	if updated {
+		*c = *newClient
+	}
+	return updated, nil
+}
+
+func getContext(c *Client) (cluster string, namespace string, err error) {
+	raw, err := c.GetConfig().RawConfig()
+	if err != nil {
+		return "", "", err
+	}
+
+	currentCtx := raw.Contexts[raw.CurrentContext]
+	return currentCtx.Cluster, currentCtx.Namespace, nil
+}
+
+func isConfigUpdated(oldC, newC clientcmd.ClientConfig) (bool, error) {
+	oldRaw, err := oldC.RawConfig()
+	if err != nil {
+		return false, err
+	}
+	newRaw, err := newC.RawConfig()
+	if err != nil {
+		return false, err
+	}
+	return !reflect.DeepEqual(oldRaw, newRaw), nil
+}

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -27,6 +27,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog"
@@ -175,7 +176,7 @@ func (o *WatchClient) WatchAndPush(out io.Writer, parameters WatchParameters, ct
 	}
 
 	o.keyWatcher = getKeyWatcher(ctx, out)
-	return o.eventWatcher(ctx, parameters, out, evaluateFileChanges, processEvents, componentStatus)
+	return o.eventWatcher(ctx, parameters, out, evaluateFileChanges, o.processEvents, componentStatus)
 }
 
 // eventWatcher loops till the context's Done channel indicates it to stop looping, at which point it performs cleanup.
@@ -424,7 +425,7 @@ func evaluateFileChanges(events []fsnotify.Event, path string, fileIgnores []str
 	return changedFiles, deletedPaths
 }
 
-func processEvents(
+func (o *WatchClient) processEvents(
 	changedFiles, deletedPaths []string,
 	parameters WatchParameters,
 	out io.Writer,
@@ -461,12 +462,19 @@ func processEvents(
 			return nil, err
 		}
 		klog.V(4).Infof("Error from Push: %v", err)
-		if parameters.WatchFiles {
-			// Log and output, but intentionally not exiting on error here.
-			// We don't want to break watch when push failed, it might be fixed with the next change.
-			fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
+		// Log and output, but intentionally not exiting on error here.
+		// We don't want to break watch when push failed, it might be fixed with the next push.
+		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
+			fmt.Fprintf(out, "Error connecting to the cluster. Please log in again\n\n")
+			var refreshed bool
+			refreshed, err = o.kubeClient.Refresh()
+			if err != nil {
+				fmt.Fprintf(out, "Error updating Kubernetes config: %s\n", err)
+			} else if refreshed {
+				fmt.Fprintf(out, "Updated Kubernetes config\n")
+			}
 		} else {
-			return nil, err
+			fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
 		}
 		wait := backoff.Delay()
 		return &wait, nil
@@ -484,7 +492,11 @@ func (o *WatchClient) CleanupDevResources(devfileObj parser.DevfileObj, componen
 	fmt.Fprintln(out, "Cleaning resources, please wait")
 	isInnerLoopDeployed, resources, err := o.deleteClient.ListResourcesToDeleteFromDevfile(devfileObj, "app", componentName, labels.ComponentDevMode)
 	if err != nil {
-		fmt.Fprintf(out, "failed to delete inner loop resources: %v", err)
+		if kerrors.IsUnauthorized(err) {
+			fmt.Fprintf(out, "Error connecting to the cluster, the resources were not cleaned up.\nPlease log in again and cleanup the resource with `odo delete component`\n\n")
+		} else {
+			fmt.Fprintf(out, "Failed to delete inner loop resources: %v\n", err)
+		}
 		return err
 	}
 	// if innerloop deployment resource is present, then execute preStop events

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -474,7 +474,11 @@ func (o *WatchClient) processEvents(
 				fmt.Fprintf(out, "Updated Kubernetes config\n")
 			}
 		} else {
-			fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
+			if parameters.WatchFiles {
+				fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
+			} else {
+				return nil, err
+			}
 		}
 		wait := backoff.Delay()
 		return &wait, nil

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -496,7 +496,7 @@ func (o *WatchClient) CleanupDevResources(devfileObj parser.DevfileObj, componen
 	fmt.Fprintln(out, "Cleaning resources, please wait")
 	isInnerLoopDeployed, resources, err := o.deleteClient.ListResourcesToDeleteFromDevfile(devfileObj, "app", componentName, labels.ComponentDevMode)
 	if err != nil {
-		if kerrors.IsUnauthorized(err) {
+		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
 			fmt.Fprintf(out, "Error connecting to the cluster, the resources were not cleaned up.\nPlease log in again and cleanup the resource with `odo delete component`\n\n")
 		} else {
 			fmt.Fprintf(out, "Failed to delete inner loop resources: %v\n", err)


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

1. When disconnected from the cluster and `odo dev` is interrupted with Ctrl-c, this message is displayed:
```
Error connecting to the cluster, the resources were not cleaned up.
Please log in again and cleanup the resource with `odo delete component
```

2. When disconnected from the cluster, `odo dev` tries to reload the configuration from kubeconfig file.
- If a change of namespace or cluster in the current context is detected, the configuration is not updated. The user can still update the current namespace / cluster 
- if the namespace and cluster are the same, the new configuration is loaded, and `odo dev` continues with it

```
Keyboard Commands:
[Ctrl+c] - Exit and delete resources from the cluster
     [p] - Manually apply local changes to the application on the cluster
pPushing files...

Error connecting to the cluster. Please log in again

Error updating Kubernetes config: namespace changed ("prj3" -> "prj4"), won't refresh the configuration
Error connecting to the cluster. Please log in again

[...]
 Keyboard Commands:
[Ctrl+c] - Exit and delete resources from the cluster
     [p] - Manually apply local changes to the application on the cluster
pPushing files...

Error connecting to the cluster. Please log in again

Error updating Kubernetes config: cluster changed ("api-crc-testing:6443" -> "kubernetes"), won't refresh the configuration
Error connecting to the cluster. Please log in again

Error updating Kubernetes config: cluster changed ("api-crc-testing:6443" -> "kubernetes"), won't refresh the configuration
Error connecting to the cluster. Please log in again

[...]

Error connecting to the cluster. Please log in again

Updated Kubernetes config
 •  Waiting for Kubernetes resources  ...
 ✓  Syncing files into the container [1ms]

↪ Dev mode
 Status:
 Watching for changes in the current directory /home/phmartin/Documents/tests/go

 Keyboard Commands:
[Ctrl+c] - Exit and delete resources from the cluster
     [p] - Manually apply local changes to the application on the cluster

```

**Which issue(s) this PR fixes:**
Fixes #5668 

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

```
[terminal 1]
$ crc start
$ oc login -u developer https://api.crc.testing:6443
```

```
[terminal 2]
$ odo dev
[...]
↪ Dev mode
 Status:
 Watching for changes in the current directory /home/phmartin/Documents/tests/go

 Keyboard Commands:
[Ctrl+c] - Exit and delete resources from the cluster
     [p] - Manually apply local changes to the application on the cluster
```

```
[terminal 1]
$ oc logout
```

```
[terminal 2]
(repeat press [p] until the token is expired and error occurs)
pPushing files...

Error connecting to the cluster. Please log in again

Updated Kubernetes config
Error connecting to the cluster. Please log in again
[...]
```

```
[terminal 1]
$ oc login -u developer https://api.crc.testing:6443
```

```
[terminal 2]
Error connecting to the cluster. Please log in again

Updated Kubernetes config
 •  Waiting for Kubernetes resources  ...
 ✓  Syncing files into the container [1ms]

↪ Dev mode
 Status:
 Watching for changes in the current directory /home/phmartin/Documents/tests/go

 Keyboard Commands:
[Ctrl+c] - Exit and delete resources from the cluster
     [p] - Manually apply local changes to the application on the cluster
```
