### PR TITLE
Fix message for interactive odo delete project

### DIFF
--- a/pkg/odo/cli/delete/namespace/namespace.go
+++ b/pkg/odo/cli/delete/namespace/namespace.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
-	"github.com/spf13/cobra"
-	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
@@ -83,7 +84,7 @@ func (do *DeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the 'odo delete namespace' command
 func (do *DeleteOptions) Run(ctx context.Context) error {
-	if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete namespace %q?", do.namespaceName)) {
+	if do.forceFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %s %q?", do.commandName, do.namespaceName)) {
 		// Create the "spinner"
 		s := &log.Status{}
 
@@ -105,7 +106,7 @@ func (do *DeleteOptions) Run(ctx context.Context) error {
 
 		return nil
 	}
-	log.Error("Aborting namespace deletion")
+	log.Errorf("Aborting %s deletion", do.commandName)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
/area UX
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR fixes `odo delete project` command to use `project` instead of `namespace` in it's interactive messages.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
There should be no reference to namespace while deleting project.
```sh
$ odo delete project myproject
? Are you sure you want to delete project "myproject2"? Yes
 ✓  Project "myproject2" deleted
```

```sh
$ odo delete project myproject
? Are you sure you want to delete project "myproject2"? No
 ✗  Aborting project deletion
```

Note: Deleting a non-existent project still shows namespace in the unwrapped errors, but the purpose of this PR is to ensure that any message by odo should have `project` instead of `namespace` or whatever alias is used.