### PR TITLE
Fix help and doc for `odo completion zsh`

### DIFF
--- a/docs/website/docs/command-reference/completion.md
+++ b/docs/website/docs/command-reference/completion.md
@@ -43,7 +43,7 @@ source ~/.odo/completion.bash.inc
 Load into your current shell environment:
 
 ```sh
-source <(odo zsh)
+source <(odo completion zsh)
 ```
 
 Load persistently:

--- a/pkg/odo/cli/completion/completion.go
+++ b/pkg/odo/cli/completion/completion.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -31,7 +32,7 @@ var (
   # ZSH
 
 	## Load into your current shell environment
-  source <(odo zsh)
+  source <(%[1]s zsh)
 
 	## Load persistently
 	%[1]s zsh > "${fpath[1]}/_odo"


### PR DESCRIPTION
**What type of PR is this:**
/kind documentation
/kind bug
/area completion

**What does this PR do / why we need it:**
Replaces `odo zsh` (which does not exist) with `odo completion zsh` in doc and `odo help completion` output.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
