### PR TITLE
telemetry: start tracking flags usage

### DIFF
--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -94,6 +94,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 		klog.V(4).Infof("WARNING: debug telemetry, if enabled, will be logged in %s", debugTelemetry)
 	}
 
+	scontext.SetFlags(cmd.Context(), cmd.Flags())
 	// set value for telemetry status in context so that we do not need to call IsTelemetryEnabled every time to check its status
 	scontext.SetTelemetryStatus(cmd.Context(), segment.IsTelemetryEnabled(cfg))
 

--- a/pkg/segment/context/context_test.go
+++ b/pkg/segment/context/context_test.go
@@ -2,7 +2,6 @@ package context
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -172,10 +171,24 @@ func TestSetFlags(t *testing.T) {
 			},
 			want: "flag2",
 		},
+		{
+			name: "two changed flags",
+			args: args{
+				ctx: NewContext(context.Background()),
+				flags: func() *pflag.FlagSet {
+					f := &pflag.FlagSet{}
+					f.String("flag1", "", "")
+					f.String("flag2", "", "")
+					f.Set("flag1", "value1")
+					f.Set("flag2", "value1")
+					return f
+				}(),
+			},
+			want: "flag1 flag2",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fmt.Println(tt.args.flags)
 			SetFlags(tt.args.ctx, tt.args.flags)
 			got := GetContextProperties(tt.args.ctx)[Flags]
 			if got != tt.want {

--- a/pkg/segment/context/context_test.go
+++ b/pkg/segment/context/context_test.go
@@ -151,6 +151,7 @@ func TestSetFlags(t *testing.T) {
 				flags: func() *pflag.FlagSet {
 					f := &pflag.FlagSet{}
 					f.String("flag1", "", "")
+					//nolint:errcheck
 					f.Set("flag1", "value1")
 					return f
 				}(),
@@ -165,6 +166,7 @@ func TestSetFlags(t *testing.T) {
 					f := &pflag.FlagSet{}
 					f.String("flag1", "", "")
 					f.String("flag2", "", "")
+					//nolint:errcheck
 					f.Set("flag2", "value1")
 					return f
 				}(),
@@ -179,7 +181,9 @@ func TestSetFlags(t *testing.T) {
 					f := &pflag.FlagSet{}
 					f.String("flag1", "", "")
 					f.String("flag2", "", "")
+					//nolint:errcheck
 					f.Set("flag1", "value1")
+					//nolint:errcheck
 					f.Set("flag2", "value1")
 					return f
 				}(),

--- a/pkg/segment/context/context_test.go
+++ b/pkg/segment/context/context_test.go
@@ -2,8 +2,11 @@ package context
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestGetContextProperties(t *testing.T) {
@@ -123,3 +126,61 @@ func TestSetTelemetryStatus(t *testing.T) {
 //	}
 //	fakeClient.SetDiscoveryInterface(fd)
 //}
+
+func TestSetFlags(t *testing.T) {
+	type args struct {
+		ctx   context.Context
+		flags *pflag.FlagSet
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no flags",
+			args: args{
+				ctx:   NewContext(context.Background()),
+				flags: &pflag.FlagSet{},
+			},
+			want: "",
+		},
+		{
+			name: "one changed flag",
+			args: args{
+				ctx: NewContext(context.Background()),
+				flags: func() *pflag.FlagSet {
+					f := &pflag.FlagSet{}
+					f.String("flag1", "", "")
+					f.Set("flag1", "value1")
+					return f
+				}(),
+			},
+			want: "flag1",
+		},
+		{
+			name: "one changed flag, one unchanged flag",
+			args: args{
+				ctx: NewContext(context.Background()),
+				flags: func() *pflag.FlagSet {
+					f := &pflag.FlagSet{}
+					f.String("flag1", "", "")
+					f.String("flag2", "", "")
+					f.Set("flag2", "value1")
+					return f
+				}(),
+			},
+			want: "flag2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fmt.Println(tt.args.flags)
+			SetFlags(tt.args.ctx, tt.args.flags)
+			got := GetContextProperties(tt.args.ctx)[Flags]
+			if got != tt.want {
+				t.Errorf("SetFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -207,6 +207,8 @@ ComponentSettings:
 			Expect(td.Properties.CmdProperties[segment.ComponentType]).To(ContainSubstring("nodejs"))
 			Expect(td.Properties.CmdProperties[segment.Language]).To(ContainSubstring("javascript"))
 			Expect(td.Properties.CmdProperties[segment.ProjectType]).To(ContainSubstring("nodejs"))
+			Expect(td.Properties.CmdProperties[segment.Flags]).To(BeEmpty())
+
 		})
 	})
 

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -362,6 +362,8 @@ var _ = Describe("odo devfile init command tests", func() {
 			Expect(td.Properties.CmdProperties[segment.ComponentType]).To(ContainSubstring("Go"))
 			Expect(td.Properties.CmdProperties[segment.Language]).To(ContainSubstring("Go"))
 			Expect(td.Properties.CmdProperties[segment.ProjectType]).To(ContainSubstring("Go"))
+			Expect(td.Properties.CmdProperties[segment.Flags]).To(ContainSubstring("devfile name"))
+
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this:**

/kind feature


**What does this PR do / why we need it:**
Record what flags are used when the odo command is executed.

This will be helpful to get more insights what features are being used.
For example, currently, we can't see how many users user debug mode `odo dev --debug` or `--no-watch` feature. With this, we will be able to get more insights if those features are being used. 

It would be nice to include this in the v3 GA build, so we can start tracking this from the beginning. 



**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
