### PR TITLE
`odo dev` deletes remote resources not present in the Devfile

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -701,17 +701,12 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 		return nil
 	}
 
-	// stopCh := make(chan struct{})
-	// errCh := make(chan error)
-	// var goroutineCount int64
 	g := new(errgroup.Group)
 	// Delete the resources present on the cluster but not in the Devfile
 	for _, objectToRemove := range objectsToRemove {
-		spinner := log.Spinnerf("Deleting Kubernetes resource: %s/%s", objectToRemove.GetKind(), objectToRemove.GetName())
-		defer spinner.End(false)
-		// wg.Add(1)
-		// atomic.AddInt64(&goroutineCount, 1)
 		g.Go(func() error {
+			spinner := log.Spinnerf("Deleting Kubernetes resource: %s/%s", objectToRemove.GetKind(), objectToRemove.GetName())
+			defer spinner.End(false)
 			gvr, err := a.kubeClient.GetGVRFromGVK(objectToRemove.GroupVersionKind())
 			if err != nil {
 				err = fmt.Errorf("unable to get information about Kubernetes resource: %s/%s: %s", objectToRemove.GetKind(), objectToRemove.GetName(), err.Error())
@@ -728,8 +723,6 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 				klog.V(4).Infof("Failed to delete Kubernetes resource: %s/%s; resource not found", objectToRemove.GetKind(), objectToRemove.GetName())
 			}
 			spinner.End(true)
-			// atomic.AddInt64(&goroutineCount, -1)
-			// stopCh <- struct{}{}
 			return nil
 		})
 	}
@@ -738,16 +731,6 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 		return err
 	}
 	return nil
-	// for {
-	// 	select {
-	// 	case err := <-errCh:
-	// 		return err
-	// 	case <-stopCh:
-	// 		if goroutineCount == 0 {
-	// 			return nil
-	// 		}
-	// 	}
-	// }
 }
 
 // deleteServiceBindingSecrets takes a list of Service Binding secrets that should be deleted;

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -709,8 +709,10 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 	defer spinner.End(false)
 
 	g := new(errgroup.Group)
+
 	// Delete the resources present on the cluster but not in the Devfile
 	for _, objectToRemove := range objectsToRemove {
+		objectToRemove := objectToRemove
 		g.Go(func() error {
 			gvr, err := a.kubeClient.GetGVRFromGVK(objectToRemove.GroupVersionKind())
 			if err != nil {

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -1,18 +1,12 @@
 package component
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/devfile/library/pkg/devfile/generator"
 	"github.com/devfile/library/pkg/devfile/parser/data"
 	"github.com/golang/mock/gomock"
-	"github.com/redhat-developer/service-binding-operator/pkg/converter"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/devfile/library/pkg/devfile/generator"
 
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"github.com/redhat-developer/odo/pkg/preference"
@@ -351,152 +345,6 @@ func TestAdapter_generateDeploymentObjectMeta(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("generateDeploymentObjectMeta() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestAdapter_deleteRemoteResourcesNotPresentInDevfile(t *testing.T) {
-	const (
-		componentName      = "nodejs"
-		coreDeploymentName = "nodejs-app"
-		deploymentName     = "my-component"
-		namespace          = "namespace-1"
-	)
-	deployment := odoTestingUtil.CreateFakeDeployment(deploymentName, false)
-	deployment.SetNamespace(namespace)
-	deploymentGVR := schema.GroupVersionResource{
-		Group:    deployment.GroupVersionKind().Group,
-		Version:  deployment.GroupVersionKind().Version,
-		Resource: "deployments",
-	}
-	unstructuredDeployment, _ := converter.ToUnstructured(deployment)
-
-	coreDeployment := odoTestingUtil.CreateFakeDeployment(coreDeploymentName, true)
-	coreDeployment.SetNamespace(namespace)
-	unstructuredCoreDeployment, _ := converter.ToUnstructured(coreDeployment)
-
-	selector := odolabels.GetSelector(componentName, "app", odolabels.ComponentDevMode, false)
-
-	type fields struct {
-		kubeClient     func(ctrl *gomock.Controller) kclient.ClientInterface
-		AdapterContext AdapterContext
-	}
-	type args struct {
-		selector string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    []unstructured.Unstructured
-		wantErr bool
-	}{
-		{
-			name: "should delete remote resources from cluster that are not present in the devfile; this should not include core components",
-			fields: fields{
-				kubeClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
-					kubeClient := kclient.NewMockClientInterface(ctrl)
-					kubeClient.EXPECT().GetCurrentNamespace().Return(namespace)
-					kubeClient.EXPECT().GetAllResourcesFromSelector(selector, namespace).Return([]unstructured.Unstructured{*unstructuredDeployment, *unstructuredCoreDeployment}, nil)
-					kubeClient.EXPECT().GetGVRFromGVK(deployment.GroupVersionKind()).Return(deploymentGVR, nil)
-					kubeClient.EXPECT().DeleteDynamicResource(deployment.GetName(), gomock.Any(), gomock.Any()).Return(nil)
-					return kubeClient
-				},
-				AdapterContext: AdapterContext{
-					ComponentName: componentName,
-					AppName:       "app",
-					Devfile:       odoTestingUtil.GetTestDevfileObjFromFile("devfile.yaml"),
-				},
-			},
-			args: args{
-				selector: selector,
-			},
-			want:    []unstructured.Unstructured{*unstructuredDeployment},
-			wantErr: false,
-		},
-		{
-			name: "should not delete resources that are present in both devfile and cluster",
-			fields: fields{
-				kubeClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
-					kubeClient := kclient.NewMockClientInterface(ctrl)
-					kubeClient.EXPECT().GetCurrentNamespace().Return(namespace).Times(2)
-					kubeClient.EXPECT().GetAllResourcesFromSelector(selector, namespace).Return([]unstructured.Unstructured{*unstructuredDeployment, *unstructuredCoreDeployment}, nil)
-					return kubeClient
-				},
-				AdapterContext: AdapterContext{
-					ComponentName: componentName,
-					AppName:       "app",
-					Devfile:       odoTestingUtil.GetTestDevfileObjFromFile("devfile-with-k8s-resource.yaml"),
-				},
-			},
-			args: args{
-				selector: selector,
-			},
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			name: "should fail if there is an error",
-			fields: fields{
-				kubeClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
-					kubeClient := kclient.NewMockClientInterface(ctrl)
-					kubeClient.EXPECT().GetCurrentNamespace().Return(namespace)
-					kubeClient.EXPECT().GetAllResourcesFromSelector(selector, namespace).Return([]unstructured.Unstructured{*unstructuredDeployment, *unstructuredCoreDeployment}, nil)
-					kubeClient.EXPECT().GetGVRFromGVK(deployment.GroupVersionKind()).Return(deploymentGVR, nil)
-					kubeClient.EXPECT().DeleteDynamicResource(deployment.GetName(), gomock.Any(), gomock.Any()).Return(errors.New("failed to delete the resource"))
-					return kubeClient
-				},
-				AdapterContext: AdapterContext{
-					ComponentName: componentName,
-					AppName:       "app",
-					Devfile:       odoTestingUtil.GetTestDevfileObjFromFile("devfile.yaml"),
-				},
-			},
-			args: args{
-				selector: selector,
-			},
-			want:    []unstructured.Unstructured{*unstructuredDeployment},
-			wantErr: true,
-		},
-		{
-			name: "should not fail if DeleteDynamicResource returns a NotFound error",
-			fields: fields{
-				kubeClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
-					kubeClient := kclient.NewMockClientInterface(ctrl)
-					kubeClient.EXPECT().GetCurrentNamespace().Return(namespace)
-					kubeClient.EXPECT().GetAllResourcesFromSelector(selector, namespace).Return([]unstructured.Unstructured{*unstructuredDeployment, *unstructuredCoreDeployment}, nil)
-					kubeClient.EXPECT().GetGVRFromGVK(deployment.GroupVersionKind()).Return(deploymentGVR, nil)
-					kubeClient.EXPECT().DeleteDynamicResource(deployment.GetName(), gomock.Any(), gomock.Any()).Return(kerrors.NewNotFound(deploymentGVR.GroupResource(), deployment.GetName()))
-					return kubeClient
-				},
-				AdapterContext: AdapterContext{
-					ComponentName: componentName,
-					AppName:       "app",
-					Devfile:       odoTestingUtil.GetTestDevfileObjFromFile("devfile.yaml"),
-				},
-			},
-			args: args{
-				selector: selector,
-			},
-			want:    []unstructured.Unstructured{*unstructuredDeployment},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			a := Adapter{
-				kubeClient:     tt.fields.kubeClient(ctrl),
-				AdapterContext: tt.fields.AdapterContext,
-			}
-			got, err := a.deleteRemoteResources(tt.args.selector)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("deleteRemoteResourcesNotPresentInDevfile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("deleteRemoteResourcesNotPresentInDevfile() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/devfile/adapters/kubernetes/component/push.go
+++ b/pkg/devfile/adapters/kubernetes/component/push.go
@@ -43,7 +43,7 @@ func (a *Adapter) pushDevfileKubernetesComponents(
 ) ([]devfilev1.Component, error) {
 	// fetch the "kubernetes inlined components" to create them on cluster
 	// from odo standpoint, these components contain yaml manifest of ServiceBinding
-	k8sComponents, err := devfile.GetKubernetesComponentsToPush(a.Devfile)
+	k8sComponents, err := devfile.GetKubernetesComponentsToPush(a.Devfile, false)
 	if err != nil {
 		return nil, fmt.Errorf("error while trying to fetch service(s) from devfile: %w", err)
 	}

--- a/pkg/devfile/components.go
+++ b/pkg/devfile/components.go
@@ -9,6 +9,7 @@ import (
 // GetKubernetesComponentsToPush returns the list of Kubernetes components to push,
 // by getting the list of Kubernetes components and removing the ones
 // referenced from a command in the devfile
+// It takes an additional allowApply boolean, which set to true, will append the components from apply command to the list
 func GetKubernetesComponentsToPush(devfileObj parser.DevfileObj, allowApply bool) ([]devfilev1.Component, error) {
 	k8sComponents, err := devfileObj.Data.GetComponents(parsercommon.DevfileOptions{
 		ComponentOptions: parsercommon.ComponentOptions{ComponentType: devfilev1.KubernetesComponentType},

--- a/pkg/devfile/components.go
+++ b/pkg/devfile/components.go
@@ -9,7 +9,7 @@ import (
 // GetKubernetesComponentsToPush returns the list of Kubernetes components to push,
 // by getting the list of Kubernetes components and removing the ones
 // referenced from a command in the devfile
-func GetKubernetesComponentsToPush(devfileObj parser.DevfileObj) ([]devfilev1.Component, error) {
+func GetKubernetesComponentsToPush(devfileObj parser.DevfileObj, allowApply bool) ([]devfilev1.Component, error) {
 	k8sComponents, err := devfileObj.Data.GetComponents(parsercommon.DevfileOptions{
 		ComponentOptions: parsercommon.ComponentOptions{ComponentType: devfilev1.KubernetesComponentType},
 	})
@@ -31,7 +31,7 @@ func GetKubernetesComponentsToPush(devfileObj parser.DevfileObj) ([]devfilev1.Co
 		componentName := ""
 		if command.Exec != nil {
 			componentName = command.Exec.Component
-		} else if command.Apply != nil {
+		} else if !allowApply && command.Apply != nil {
 			componentName = command.Apply.Component
 		}
 		if componentName == "" {

--- a/pkg/devfile/components_test.go
+++ b/pkg/devfile/components_test.go
@@ -53,6 +53,7 @@ func TestGetKubernetesComponentsToPush(t *testing.T) {
 		name       string
 		devfileObj parser.DevfileObj
 		want       []devfilev1.Component
+		allowApply bool
 		wantErr    bool
 	}{
 		{
@@ -108,10 +109,31 @@ func TestGetKubernetesComponentsToPush(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// TODO: Fix this; it should fail
+			name:       "allow apply command when allowApply is true",
+			devfileObj: getDevfileWithApplyCommand("component1"),
+			allowApply: true,
+			want: []devfilev1.Component{
+				{
+					Name: "component1",
+					ComponentUnion: devfilev1.ComponentUnion{
+						Kubernetes: &devfilev1.KubernetesComponent{
+							K8sLikeComponent: devfilev1.K8sLikeComponent{
+								K8sLikeComponentLocation: devfilev1.K8sLikeComponentLocation{
+									Inlined: "Component 1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetKubernetesComponentsToPush(tt.devfileObj)
+			got, err := GetKubernetesComponentsToPush(tt.devfileObj, tt.allowApply)
 			gotErr := err != nil
 			if len(got) != len(tt.want) {
 				t.Errorf("Got %d components, expected %d\n", len(got), len(tt.want))

--- a/pkg/kclient/secrets.go
+++ b/pkg/kclient/secrets.go
@@ -23,6 +23,8 @@ import (
 // ComponentPortAnnotationName annotation is used on the secrets that are created for each exposed port of the component
 const ComponentPortAnnotationName = "component-port"
 
+var SecretGVK = corev1.SchemeGroupVersion.WithKind("Secret")
+
 // CreateTLSSecret creates a TLS Secret with the given certificate and private key
 // serviceName is the name of the service for the target reference
 // ingressDomain is the ingress domain to use for the ingress

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -202,6 +202,13 @@ func GetSelector(componentName string, applicationName string, mode string, isPa
 	return labels.String()
 }
 
+func IsCoreComponent(labels map[string]string) bool {
+	if _, ok := labels[componentLabel]; ok {
+		return true
+	}
+	return false
+}
+
 // getLabels return labels that should be applied to every object for given component in active application
 // additional labels are used only for creating object
 // if you are creating something use additional=true

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -178,6 +178,13 @@ func GetMode(labels map[string]string) string {
 	return labels[odoModeLabel]
 }
 
+// IsProjectTypeSetInAnnotations checks if the ProjectType annotation is set;
+// this function is helpful in identifying if a resource is created by odo
+func IsProjectTypeSetInAnnotations(annotations map[string]string) bool {
+	_, ok := annotations[odoProjectTypeAnnotation]
+	return ok
+}
+
 func GetProjectType(labels map[string]string, annotations map[string]string) (string, error) {
 	// For backwards compatibility with previously deployed components that could be non-odo, check the annotation first
 	// then check to see if there is a label with the project type
@@ -202,6 +209,8 @@ func GetSelector(componentName string, applicationName string, mode string, isPa
 	return labels.String()
 }
 
+// IsCoreComponent determines if a resource is core component (created in Dev mode and includes deployment, svc, pv, pvc, etc.)
+// by checking for 'component' label key.
 func IsCoreComponent(labels map[string]string) bool {
 	if _, ok := labels[componentLabel]; ok {
 		return true

--- a/pkg/service/link.go
+++ b/pkg/service/link.go
@@ -12,9 +12,8 @@ import (
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	odolabels "github.com/redhat-developer/odo/pkg/labels"
-
 	"github.com/redhat-developer/odo/pkg/kclient"
+	odolabels "github.com/redhat-developer/odo/pkg/labels"
 
 	sboApi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 	sboKubernetes "github.com/redhat-developer/service-binding-operator/pkg/client/kubernetes"
@@ -71,7 +70,7 @@ func pushLinksWithoutOperator(client kclient.ClientInterface, u unstructured.Uns
 	serviceBinding.Spec.Services[0].Namespace = &ns
 
 	var processingPipeline sboPipeline.Pipeline
-	processingPipeline, err = getPipeline(client)
+	processingPipeline, err = GetPipeline(client)
 	if err != nil {
 		return err
 	}
@@ -124,8 +123,8 @@ func pushLinksWithoutOperator(client kclient.ClientInterface, u unstructured.Uns
 	return nil
 }
 
-// getPipeline gets the pipeline to process service binding requests
-func getPipeline(client kclient.ClientInterface) (sboPipeline.Pipeline, error) {
+// GetPipeline gets the pipeline to process service binding requests
+func GetPipeline(client kclient.ClientInterface) (sboPipeline.Pipeline, error) {
 	mgr, err := ctrl.NewManager(client.GetClientConfig(), ctrl.Options{
 		Scheme: runtime.NewScheme(),
 		// disable the health probes to prevent binding to them

--- a/pkg/service/link.go
+++ b/pkg/service/link.go
@@ -124,8 +124,8 @@ func pushLinksWithoutOperator(client kclient.ClientInterface, u unstructured.Uns
 	return nil
 }
 
-// DeleteLinkWithoutOperator deletes the ServiceBinding secret when Service Binding Operator is not installed
-func DeleteLinkWithoutOperator(kubeClient kclient.ClientInterface, secretToRemove unstructured.Unstructured, deployment *appsv1.Deployment) error {
+// UnbindWithLibrary unbinds the component and service using the ServiceBinding library and deletes the secret
+func UnbindWithLibrary(kubeClient kclient.ClientInterface, secretToRemove unstructured.Unstructured, deployment *appsv1.Deployment) error {
 	currentNamespace := kubeClient.GetCurrentNamespace()
 	var processingPipeline sboPipeline.Pipeline
 	deploymentGVK, err := kubeClient.GetDeploymentAPIVersion()

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -35,6 +35,14 @@ const ServiceLabel = "app.kubernetes.io/service-name"
 // ServiceKind is the kind of the service in the service binding object
 const ServiceKind = "app.kubernetes.io/service-kind"
 
+// IsLinkSecret helps in identifying if a secret is related to Service Binding
+func IsLinkSecret(labels map[string]string) bool {
+	_, hasLinkLabel := labels[LinkLabel]
+	_, hasServiceLabel := labels[ServiceLabel]
+	_, hasServiceKindLabel := labels[ServiceKind]
+	return hasLinkLabel && hasServiceLabel && hasServiceKindLabel
+}
+
 // DeleteOperatorService deletes an Operator backed service
 // TODO: make it unlink the service from component as a part of
 // https://github.com/redhat-developer/odo/issues/3563
@@ -262,8 +270,7 @@ func PushKubernetesResource(client kclient.ClientInterface, u unstructured.Unstr
 	// If the component is of Kind: ServiceBinding, trying to run in Dev mode and SBO is not installed, run it without operator.
 	if isLinkResource(u.GetKind()) && mode == odolabels.ComponentDevMode && !sboSupported {
 		// it's a service binding related resource
-		err = pushLinksWithoutOperator(client, u, labels)
-		return err
+		return pushLinksWithoutOperator(client, u, labels)
 	}
 
 	// Add all passed in labels to the k8s resource regardless if it's an operator or not

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 
 	"github.com/redhat-developer/odo/pkg/libdevfile"
-
-	"github.com/redhat-developer/odo/pkg/kclient"
-	odolabels "github.com/redhat-developer/odo/pkg/labels"
 	"github.com/redhat-developer/odo/pkg/log"
 
 	devfile "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -20,6 +17,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog"
+
+	"github.com/redhat-developer/odo/pkg/kclient"
+	odolabels "github.com/redhat-developer/odo/pkg/labels"
 
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -341,7 +341,7 @@ func updateOperatorService(client kclient.ClientInterface, u unstructured.Unstru
 	}
 
 	if updated {
-		createSpinner := log.Spinnerf("Creating kind %s", u.GetKind())
+		createSpinner := log.Spinnerf("Creating resource %s/%s", u.GetKind(), u.GetName())
 		createSpinner.End(true)
 	}
 	return updated, err

--- a/tests/examples/source/devfiles/nodejs/devfile-with-k8s-resource.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-k8s-resource.yaml
@@ -43,14 +43,6 @@ components:
                       cpu: "500m"
 
 commands:
-  - id: devbuild
-    exec:
-      component: runtime
-      commandLine: npm install
-      workingDir: ${PROJECTS_ROOT}
-      group:
-        kind: build
-        isDefault: true
   - id: build
     exec:
       component: runtime
@@ -58,13 +50,6 @@ commands:
       workingDir: ${PROJECTS_ROOT}
       group:
         kind: build
-  - id: devrun
-    exec:
-      component: runtime
-      commandLine: npm start
-      workingDir: ${PROJECTS_ROOT}
-      group:
-        kind: run
         isDefault: true
   - id: run
     exec:
@@ -73,3 +58,4 @@ commands:
       workingDir: ${PROJECTS_ROOT}
       group:
         kind: run
+        isDefault: true

--- a/tests/examples/source/devfiles/nodejs/devfile-with-k8s-resource.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-k8s-resource.yaml
@@ -1,0 +1,75 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  projectType: nodejs
+  language: nodejs
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000-tcp"
+          targetPort: 3000
+      mountSources: true
+  - name: deploy-k8s-resource
+    kubernetes:
+      inlined: |
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: my-component
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: node-app
+          template:
+            metadata:
+              labels:
+                app: node-app
+            spec:
+              containers:
+                - name: main
+                  image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+                  resources:
+                    limits:
+                      memory: "128Mi"
+                      cpu: "500m"
+
+commands:
+  - id: devbuild
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: true
+  - id: build
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+  - id: devrun
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run

--- a/tests/integration/cmd_add_binding_test.go
+++ b/tests/integration/cmd_add_binding_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var _ = Describe("odo add binding command tests", func() {
+	// TODO: Add integration tests to check when SBO is not installed
 	var commonVar helper.CommonVar
 	var devSession helper.DevSession
 	var err error

--- a/tests/integration/cmd_add_binding_test.go
+++ b/tests/integration/cmd_add_binding_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 var _ = Describe("odo add binding command tests", func() {
-	// TODO: Add integration tests to check when SBO is not installed
+	// TODO: Add integration tests for the following cases when SBO is not installed
+	// * servicebinding with envvars does not send `odo dev` in an infinite loop
+	// * `odo dev` deletes service binding secrets for SB that is not present locally
+
 	var commonVar helper.CommonVar
 	var devSession helper.DevSession
 	var err error

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -230,7 +230,7 @@ var _ = Describe("odo dev debug command tests", func() {
 		},
 		{
 			name: "without metadata.name",
-			//cmpName is returned by alizer.DetectName
+			// cmpName is returned by alizer.DetectName
 			cmpName: "nodejs-starter",
 			devfileHandler: func(path string) {
 				helper.UpdateDevfileContent(path, []helper.DevfileUpdater{helper.DevfileMetadataNameRemover})

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -496,11 +496,12 @@ ComponentSettings:
 		})
 
 		When("a new k8s resource is added to the devfile", func() {
+			// instead of adding a new resource, we will simply change the resource name to make it act as a new one
 			const newDeploymentName = "changed-component"
 			BeforeEach(func() {
-				// instead of adding a new resource, we will simply change the resource name to make it act as a new one
 				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), deploymentName, newDeploymentName)
-				devSession.WaitSync()
+				_, _, _, err := devSession.WaitSync()
+				Expect(err).To(BeNil())
 			})
 			It("should have deleted the old resource and created the new resource", func() {
 				getDeployments := commonVar.CliRunner.Run(getDeployArgs...).Out.Contents()

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -474,7 +474,8 @@ ComponentSettings:
 			envvars     []string
 		}{
 			{title: "without apply command", devfileName: "devfile-with-k8s-resource.yaml", envvars: nil},
-			{title: "with apply command", devfileName: "devfile-composite-apply-commands.yaml", envvars: []string{"PODMAN_CMD=echo"}}} {
+			{title: "with apply command", devfileName: "devfile-composite-apply-commands.yaml", envvars: []string{"PODMAN_CMD=echo"}},
+		} {
 			devfile := devfile
 			When(fmt.Sprintf("odo dev is executed to run a devfile containing a k8s resource %s", devfile.title), func() {
 				var (

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -469,13 +469,14 @@ ComponentSettings:
 	})
 	Context("checking if odo dev matches local Devfile K8s resources and remote resources", func() {
 		for _, devfile := range []struct {
-			devfileName, title string
-			envvars            []string
+			title       string
+			devfileName string
+			envvars     []string
 		}{
-			{"devfile-with-k8s-resource.yaml", "", nil},
-			{"devfile-composite-apply-commands.yaml", " with apply command", []string{"PODMAN_CMD=echo"}}} {
+			{title: "without apply command", devfileName: "devfile-with-k8s-resource.yaml", envvars: nil},
+			{title: "with apply command", devfileName: "devfile-composite-apply-commands.yaml", envvars: []string{"PODMAN_CMD=echo"}}} {
 			devfile := devfile
-			When(fmt.Sprintf("odo dev is executed to run a devfile containing a k8s resource%s", devfile.title), func() {
+			When(fmt.Sprintf("odo dev is executed to run a devfile containing a k8s resource %s", devfile.title), func() {
 				var (
 					devSession    helper.DevSession
 					err           error
@@ -493,8 +494,11 @@ ComponentSettings:
 						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile.devfileName), filepath.Join(commonVar.Context, "devfile.yaml"))
 						devSession, _, _, _, err = helper.StartDevMode(devfile.envvars)
 						Expect(err).To(BeNil())
+
+						// ensure the deployment is created by `odo dev`
 						Expect(commonVar.CliRunner.Run(getDeployArgs...).Out.Contents()).To(ContainSubstring(deploymentName))
 
+						// we fake the new deployment creation by changing the old deployment's name
 						helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), deploymentName, newDeploymentName)
 
 						_, _, _, err := devSession.WaitSync()
@@ -513,7 +517,8 @@ ComponentSettings:
 			})
 		}
 	})
-	When("odo dev is executed to run a devfile containing a k8s resource", func() {
+
+	When("odo dev is executed to run a devfile containing a k8s resource ", func() {
 		var (
 			devSession    helper.DevSession
 			err           error


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
/area dev
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
With this PR, `odo dev` now handles K8s component related changes to the Devfile. It will remove resources from the cluster that are not present in the local Devfile.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5943
Fixes #6101


**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1.
```sh
odo init --devfile nodejs --name my-node-app --starter nodejs-starter
```
2. Replace the devfile.yaml with content below.
<details>
<summary>devfile.yaml</summary>

```yaml
commands:
- exec:
    commandLine: npm install
    component: runtime
    group:
      isDefault: true
      kind: build
    hotReloadCapable: false
    workingDir: ${PROJECT_SOURCE}
  id: install
- exec:
    commandLine: npm start
    component: runtime
    group:
      isDefault: true
      kind: run
    hotReloadCapable: false
    workingDir: ${PROJECT_SOURCE}
  id: run
- exec:
    commandLine: npm run debug
    component: runtime
    group:
      isDefault: true
      kind: debug
    hotReloadCapable: false
    workingDir: ${PROJECT_SOURCE}
  id: debug
- exec:
    commandLine: npm test
    component: runtime
    group:
      isDefault: true
      kind: test
    hotReloadCapable: false
    workingDir: ${PROJECT_SOURCE}
  id: test
components:
- container:
    args:
    - tail
    - -f
    - /dev/null
    dedicatedPod: false
    endpoints:
    - name: http-node
      secure: false
      targetPort: 3000
    image: registry.access.redhat.com/ubi8/nodejs-16:latest
    memoryLimit: 1024Mi
    mountSources: true
  name: runtime
- name: my-node-app-app-cluster-sample
  kubernetes:
    inlined: |
      apiVersion: servicebinding.io/v1beta1
      kind: ServiceBinding
      metadata:
        name: my-node-app-app-cluster-sample
      spec:
        workload:
          apiVersion: apps/v1
          kind: Deployment
          name: my-node-app-app
        service:
          apiVersion: postgresql.k8s.enterprisedb.io/v1
          kind: Cluster
          name: cluster-sample
- name: deploy-k8s-resource
  kubernetes:
    inlined: |
        kind: Deployment
        apiVersion: apps/v1
        metadata:
          name: my-component
        spec:
          replicas: 1
          selector:
            matchLabels:
              app: node-app
          template:
            metadata:
              labels:
                app: node-app
            spec:
              containers:
                - name: main
                  image: registry.access.redhat.com/ubi8/nodejs-12:1-36
                  resources:
                    limits:
                      memory: "128Mi"
                      cpu: "500m"
metadata:
  description: Stack with Node.js 16
  displayName: Node.js Runtime
  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
  language: javascript
  name: my-node-app
  projectType: nodejs
  tags:
  - NodeJS
  - Express
  - ubi8
  version: 2.0.0
schemaVersion: 2.1.0
starterProjects:
- git:
    remotes:
      origin: https://github.com/odo-devfiles/nodejs-ex.git
  name: nodejs-starter
```
</details>

3. After you run the command below, ensure that `odo dev` detects the change, and removes ServiceBinding.v1beta1.servicebinding.io from the cluster.
```shell
odo remove binding --name my-node-app-cluster-sample
```
4. Remove the deployment K8s component from devfile.yaml, and ensure that `odo dev` detects it and removes it from the cluster.