### PR TITLE
Bump odo version from 3.0.0-rc2 to 3.0.0

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -16,7 +16,7 @@ LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts-container \
     summary="This image contains the Linux, Mac and Windows version of odo"
 
 # Change version as needed. Note no "-" is allowed
-LABEL version=3.0.0-rc2
+LABEL version=3.0.0
 
 COPY --from=builder /go/src/github.com/redhat-developer/odo/dist/bin/darwin-amd64/odo /usr/share/redhat-developer/odo/mac/odo
 COPY --from=builder /go/src/github.com/redhat-developer/odo/dist/bin/windows-amd64/odo.exe /usr/share/redhat-developer/odo/windows/odo.exe

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ Changing these values will change the versioning information when releasing odo.
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v3.0.0-rc2"
+	VERSION = "v3.0.0"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/redhat-developer/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/rpm-prepare.sh
+++ b/scripts/rpm-prepare.sh
@@ -5,7 +5,7 @@ set +ex
 echo "Reading ODO_VERSION, ODO_RELEASE and GIT_COMMIT env, if they are set"
 # Change version as needed. In most cases ODO_RELEASE would not be touched unless
 # we want to do a re-lease of same version as we are not backport
-export ODO_VERSION=${ODO_VERSION:=3.0.0-rc2}
+export ODO_VERSION=${ODO_VERSION:=3.0.0}
 export ODO_RELEASE=${ODO_RELEASE:=1}
 
 export GIT_COMMIT=${GIT_COMMIT:=$(git rev-parse --short HEAD 2>/dev/null)}


### PR DESCRIPTION
**What type of PR is this:**
Bumps odo version from `3.0.0-rc2` to `3.0.0` (on the `release/v3.0.0` branch).

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
ref #6011

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```sh
$ odo version --client
odo v3.0.0 (dafce5dc8)

```