### PR TITLE
Make exec package agnostic of platform

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -3,7 +3,6 @@ package component
 import (
 	"errors"
 	"fmt"
-	"io"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -212,7 +211,6 @@ func (a Adapter) Push(parameters adapters.PushParameters, componentStatus *watch
 		WatchDeletedFiles:        parameters.WatchDeletedFiles,
 		IgnoredFiles:             parameters.IgnoredFiles,
 		DevfileScanIndexForWatch: parameters.DevfileScanIndexForWatch,
-		SyncExtracter:            a.ExtractProjectToComponent,
 
 		CompInfo:  compInfo,
 		ForcePush: !deploymentExists || podChanged,
@@ -586,11 +584,6 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, s
 	}
 
 	return "", "", fmt.Errorf("in order to sync files, odo requires at least one component in a devfile to set 'mountSources: true'")
-}
-
-// ExtractProjectToComponent extracts the project archive(tar) to the target path from the reader stdin
-func (a Adapter) ExtractProjectToComponent(componentInfo sync.ComponentInfo, targetPath string, stdin io.Reader) error {
-	return a.kubeClient.ExtractProjectToComponent(componentInfo.ContainerName, componentInfo.PodName, targetPath, stdin)
 }
 
 // PushCommandsMap stores the commands to be executed as per their types.

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -9,17 +9,17 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/platform"
 )
 
 type ExecClient struct {
-	kubeClient kclient.ClientInterface
+	platformClient platform.Client
 }
 
-func NewExecClient(kubeClient kclient.ClientInterface) *ExecClient {
+func NewExecClient(platformClient platform.Client) *ExecClient {
 	return &ExecClient{
-		kubeClient: kubeClient,
+		platformClient: platformClient,
 	}
 }
 
@@ -42,7 +42,7 @@ func (o ExecClient) ExecuteCommand(
 	stdoutCompleteChannel := startReaderGoroutine(soutReader, show, &stdout, stdoutWriter)
 	stderrCompleteChannel := startReaderGoroutine(serrReader, show, &stderr, stderrWriter)
 
-	err = o.kubeClient.ExecCMDInContainer(containerName, podName, command, soutWriter, serrWriter, nil, false)
+	err = o.platformClient.ExecCMDInContainer(containerName, podName, command, soutWriter, serrWriter, nil, false)
 
 	// Block until we have received all the container output from each stream
 	_ = soutWriter.Close()

--- a/pkg/kclient/interface.go
+++ b/pkg/kclient/interface.go
@@ -109,7 +109,6 @@ type ClientInterface interface {
 
 	// pods.go
 	ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error
-	ExtractProjectToComponent(containerName, podName string, targetPath string, stdin io.Reader) error
 	GetPodUsingComponentName(componentName string) (*corev1.Pod, error)
 	GetRunningPodFromSelector(selector string) (*corev1.Pod, error)
 	GetPodLogs(podName, containerName string, followLog bool) (io.ReadCloser, error)

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/blang/semver"
+	"github.com/redhat-developer/odo/pkg/platform"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,6 +76,7 @@ type Client struct {
 }
 
 var _ ClientInterface = (*Client)(nil)
+var _ platform.Client = (*Client)(nil)
 
 // New creates a new client
 func New() (*Client, error) {

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -1,15 +1,9 @@
 package kclient
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"strings"
-
-	"k8s.io/klog"
-
-	"github.com/redhat-developer/odo/pkg/log"
 
 	// api resource types
 
@@ -64,24 +58,6 @@ func (c *Client) ExecCMDInContainer(containerName, podName string, cmd []string,
 		return fmt.Errorf("error while streaming command: %w", err)
 	}
 
-	return nil
-}
-
-// ExtractProjectToComponent extracts the project archive(tar) to the target path from the reader stdin
-func (c *Client) ExtractProjectToComponent(containerName, podName string, targetPath string, stdin io.Reader) error {
-	// cmdArr will run inside container
-	cmdArr := []string{"tar", "xf", "-", "-C", targetPath, "--no-same-owner"}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	klog.V(3).Infof("Executing command %s", strings.Join(cmdArr, " "))
-	err := c.ExecCMDInContainer(containerName, podName, cmdArr, &stdout, &stderr, stdin, false)
-	if err != nil {
-		log.Errorf("Command '%s' in container failed.\n", strings.Join(cmdArr, " "))
-		log.Errorf("stdout: %s\n", stdout.String())
-		log.Errorf("stderr: %s\n", stderr.String())
-		log.Errorf("err: %s\n", err.Error())
-		return err
-	}
 	return nil
 }
 

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/exec"
 	"github.com/redhat-developer/odo/pkg/logs"
+	"github.com/redhat-developer/odo/pkg/odo/commonflags"
 	"github.com/redhat-developer/odo/pkg/portForward"
 	"github.com/redhat-developer/odo/pkg/sync"
 
@@ -135,7 +136,7 @@ func isDefined(command *cobra.Command, dependency string) bool {
 	return ok
 }
 
-func Fetch(command *cobra.Command) (*Clientset, error) {
+func Fetch(command *cobra.Command, platform string) (*Clientset, error) {
 	dep := Clientset{}
 	var err error
 
@@ -164,7 +165,9 @@ func Fetch(command *cobra.Command) (*Clientset, error) {
 		dep.AlizerClient = alizer.NewAlizerClient(dep.RegistryClient)
 	}
 	if isDefined(command, EXEC) {
-		dep.ExecClient = exec.NewExecClient(dep.KubernetesClient)
+		if platform == commonflags.RunOnCluster {
+			dep.ExecClient = exec.NewExecClient(dep.KubernetesClient)
+		}
 	}
 	if isDefined(command, DELETE_COMPONENT) {
 		dep.DeleteClient = _delete.NewDeleteComponentClient(dep.KubernetesClient, dep.ExecClient)

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -134,17 +134,17 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	util.LogErrorAndExit(commonflags.CheckRunOnCommand(cmd), "")
 	util.LogErrorAndExit(commonflags.CheckVariablesCommand(cmd), "")
 
-	deps, err := clientset.Fetch(cmd)
+	cmdLineObj := cmdline.NewCobra(cmd)
+	platform := commonflags.GetRunOnValue(cmdLineObj)
+	deps, err := clientset.Fetch(cmd, platform)
 	if err != nil {
 		util.LogErrorAndExit(err, "")
 	}
 	o.SetClientset(deps)
 
-	cmdLineObj := cmdline.NewCobra(cmd)
-
 	ctx := cmdLineObj.Context()
 	ctx = fcontext.WithJsonOutput(ctx, commonflags.GetJsonOutputValue(cmdLineObj))
-	ctx = fcontext.WithRunOn(ctx, commonflags.GetRunOnValue(cmdLineObj))
+	ctx = fcontext.WithRunOn(ctx, platform)
 	ctx = odocontext.WithApplication(ctx, defaultAppName)
 
 	if deps.KubernetesClient != nil {

--- a/pkg/platform/interface.go
+++ b/pkg/platform/interface.go
@@ -1,0 +1,7 @@
+package platform
+
+import "io"
+
+type Client interface {
+	ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error
+}

--- a/pkg/sync/copy.go
+++ b/pkg/sync/copy.go
@@ -66,9 +66,8 @@ func (a SyncClient) ExtractProjectToComponent(containerName, podName string, tar
 		log.Errorf("stdout: %s\n", stdout.String())
 		log.Errorf("stderr: %s\n", stderr.String())
 		log.Errorf("err: %s\n", err.Error())
-		return err
 	}
-	return nil
+	return err
 }
 
 // checkFileExist check if given file exists or not

--- a/pkg/sync/interface.go
+++ b/pkg/sync/interface.go
@@ -20,7 +20,6 @@ type SyncParameters struct {
 	IgnoredFiles             []string // IgnoredFiles is the list of files to not push up to a component
 	DevfileScanIndexForWatch bool     // DevfileScanIndexForWatch is true if watch's push should regenerate the index file during SyncFiles, false otherwise. See 'pkg/sync/adapter.go' for details
 	ForcePush                bool
-	SyncExtracter            SyncExtracter
 	CompInfo                 ComponentInfo
 	Files                    map[string]string
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog"
 )
 
-// SyncClient is a Kubernetes implementationn for sync
+// SyncClient is a platform-agnostic implementation for sync
 type SyncClient struct {
 	platformClient platform.Client
 	execClient     exec.Client

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -103,10 +103,6 @@ func TestSyncFiles(t *testing.T) {
 	// Assert that Bar() is invoked.
 	defer ctrl.Finish()
 
-	syncClient := func(ComponentInfo, string, io.Reader) error {
-		return nil
-	}
-
 	tests := []struct {
 		name               string
 		syncParameters     SyncParameters
@@ -123,8 +119,7 @@ func TestSyncFiles(t *testing.T) {
 				CompInfo: ComponentInfo{
 					ContainerName: "abcd",
 				},
-				ForcePush:     true,
-				SyncExtracter: syncClient,
+				ForcePush: true,
 			},
 			wantErr:            false,
 			wantIsPushRequired: true,
@@ -139,8 +134,7 @@ func TestSyncFiles(t *testing.T) {
 				CompInfo: ComponentInfo{
 					ContainerName: "abcd",
 				},
-				ForcePush:     false,
-				SyncExtracter: syncClient,
+				ForcePush: false,
 			},
 			wantErr:            false,
 			wantIsPushRequired: false, // always false after case 1
@@ -155,8 +149,7 @@ func TestSyncFiles(t *testing.T) {
 				CompInfo: ComponentInfo{
 					ContainerName: "abcd",
 				},
-				ForcePush:     false,
-				SyncExtracter: syncClient,
+				ForcePush: false,
 			},
 			wantErr:            true,
 			wantIsPushRequired: false,
@@ -172,8 +165,7 @@ func TestSyncFiles(t *testing.T) {
 					ComponentName: testComponentName,
 					ContainerName: "abcd",
 				},
-				ForcePush:     false,
-				SyncExtracter: syncClient,
+				ForcePush: false,
 			},
 			wantErr:            false,
 			wantIsPushRequired: true,
@@ -323,7 +315,7 @@ func TestPushLocal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			execClient := exec.NewExecClient(kc)
 			syncAdapter := NewSyncClient(kc, execClient)
-			err := syncAdapter.pushLocal(tt.path, tt.files, tt.delFiles, tt.isForcePush, []string{}, tt.compInfo, syncClient, util.IndexerRet{})
+			err := syncAdapter.pushLocal(tt.path, tt.files, tt.delFiles, tt.isForcePush, []string{}, tt.compInfo, util.IndexerRet{})
 			if !tt.wantErr && err != nil {
 				t.Errorf("TestPushLocal error: error pushing files: %v", err)
 			}


### PR DESCRIPTION
**What type of PR is this:**

/kind code-refactoring

**What does this PR do / why we need it:**

This package makes the exec package, and thus the sync package using it, agnostic of the platform. 
 The platform is injected by the dependency injection system, depending on the `--run-on` flag.

**Which issue(s) this PR fixes:**

Fixes #6160 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
