### PR TITLE
Isolate no cluster tests

### DIFF
--- a/.ibm/pipelines/kubernetes-tests.sh
+++ b/.ibm/pipelines/kubernetes-tests.sh
@@ -15,7 +15,7 @@ export SKIP_USER_LOGIN_TESTS=true
     export DEVFILE_PROXY="$(kubectl get svc -n devfile-proxy nginx -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' || true)"
     echo Using Devfile proxy: ${DEVFILE_PROXY}
     make install
-    make test-integration
+    make test-integration-cluster
     make test-e2e
 ) |& tee "/tmp/${LOGFILE}"
 

--- a/.ibm/pipelines/nocluster-tests.sh
+++ b/.ibm/pipelines/nocluster-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+LOGFILE="pr-${GIT_PR_NUMBER}-nocluster-tests-${BUILD_NUMBER}"
+
+source .ibm/pipelines/functions.sh
+
+ibmcloud login --apikey "${API_KEY_QE}"
+ibmcloud target -r "${IBM_REGION}"
+
+(
+    set -e
+    make install
+    make test-integration-no-cluster
+) |& tee "/tmp/${LOGFILE}"
+
+RESULT=${PIPESTATUS[0]}
+
+save_logs "${LOGFILE}" "NoCluster Tests" ${RESULT}
+
+exit ${RESULT}

--- a/.ibm/pipelines/openshift-tests.sh
+++ b/.ibm/pipelines/openshift-tests.sh
@@ -16,7 +16,7 @@ cleanup_namespaces
     export DEVFILE_PROXY="$(kubectl get svc -n devfile-proxy nginx -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' || true)"
     echo Using Devfile proxy: ${DEVFILE_PROXY}
     make install
-    make test-integration
+    make test-integration-cluster
     make test-e2e
 ) |& tee "/tmp/${LOGFILE}"
 

--- a/.ibm/pipelines/windows-test-script.ps1
+++ b/.ibm/pipelines/windows-test-script.ps1
@@ -80,7 +80,7 @@ function Run-Test {
     Shout "Create Binary"
     make install 
     Shout "Running test"
-    make test-integration           | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
+    make test-integration-cluster           | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
     Check-ExitCode $LASTEXITCODE
     make test-e2e           | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
     Check-ExitCode $LASTEXITCODE

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ export ARTIFACT_DIR ?= .
 
 GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --slow-spec-threshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT) --no-color
 
-# Flags for tests that must not be run in parallel.
-GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1
+# Flags to run one test per core.
+GINKGO_FLAGS_AUTO = $(GINKGO_FLAGS_ALL) -p
 # Flags for tests that may be run in parallel
 GINKGO_FLAGS=$(GINKGO_FLAGS_ALL) -nodes=$(TEST_EXEC_NODES)
 # GolangCi version for unit-validate test
@@ -184,9 +184,16 @@ vendor-update: ## Update vendoring
 openshiftci-presubmit-unittests:
 	./scripts/openshiftci-presubmit-unittests.sh
 
+.PHONY: test-integration-cluster
+test-integration-cluster:
+	$(RUN_GINKGO) $(GINKGO_FLAGS) --label-filter="!nocluster" tests/integration
+
+.PHONY: test-integration-no-cluster
+test-integration-no-cluster:
+	$(RUN_GINKGO) $(GINKGO_FLAGS_AUTO) --label-filter=nocluster tests/integration
+
 .PHONY: test-integration
-test-integration:
-	$(RUN_GINKGO) $(GINKGO_FLAGS) tests/integration
+test-integration: test-integration-no-cluster test-integration-cluster
 
 .PHONY: test-e2e
 test-e2e:

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -193,10 +193,10 @@ func CommonBeforeEach(setupCluster bool) CommonVar {
 	commonVar := CommonVar{}
 	commonVar.Context = CreateNewContext()
 	commonVar.ConfigDir = CreateNewContext()
-	commonVar.OriginalKubeconfig = os.Getenv("KUBECONFIG")
 	commonVar.CliRunner = GetCliRunner()
-	LocalKubeconfigSet(commonVar.ConfigDir)
+	commonVar.OriginalKubeconfig = os.Getenv("KUBECONFIG")
 	if setupCluster {
+		LocalKubeconfigSet(commonVar.ConfigDir)
 		commonVar.Project = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 	}
 	commonVar.OriginalWorkingDirectory = Getwd()

--- a/tests/helper/labels.go
+++ b/tests/helper/labels.go
@@ -1,0 +1,5 @@
+package helper
+
+const (
+	LabelNoCluster = "nocluster"
+)

--- a/tests/integration/cmd_analyze_test.go
+++ b/tests/integration/cmd_analyze_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo analyze command tests", func() {
+var _ = Describe("odo analyze command tests", Label(helper.LabelNoCluster), func() {
 	var commonVar helper.CommonVar
 
 	// This is run before every Spec (It)

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo devfile init command tests", func() {
+var _ = Describe("odo devfile init command tests", Label(helper.LabelNoCluster), func() {
 
 	var commonVar helper.CommonVar
 

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo devfile registry command tests", func() {
+var _ = Describe("odo devfile registry command tests", Label(helper.LabelNoCluster), func() {
 	const registryName string = "RegistryName"
 
 	// Use staging OCI-based registry for tests to avoid overload

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -13,7 +13,7 @@ import (
 
 const promptMessageSubString = "Help odo improve by allowing it to collect usage data."
 
-var _ = Describe("odo preference and config command tests", func() {
+var _ = Describe("odo preference and config command tests", Label(helper.LabelNoCluster), func() {
 	// TODO: A neater way to provide odo path. Currently we assume odo and oc in $PATH already.
 	var commonVar helper.CommonVar
 

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo init interactive command tests", func() {
+var _ = Describe("odo init interactive command tests", Label(helper.LabelNoCluster), func() {
 
 	var commonVar helper.CommonVar
 


### PR DESCRIPTION
**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**

This PR moves integration tests for commands not needing a cluster to a specific directory
so they can be executed separately, in an environment without any cluster.

**Which issue(s) this PR fixes:**

Fixes partly #6237 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
