### PR TITLE
add make release-bin target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 COMMON_GOFLAGS := -mod=vendor
 COMMON_LDFLAGS := -X $(PROJECT)/pkg/version.GITCOMMIT=$(GITCOMMIT)
 BUILD_FLAGS := $(COMMON_GOFLAGS) -ldflags="$(COMMON_LDFLAGS)"
-CROSS_BUILD_FLAGS := $(COMMON_GOFLAGS) -ldflags="-s -w -X $(PROJECT)/pkg/segment.writeKey=R1Z79HadJIrphLoeONZy5uqOjusljSwN $(COMMON_LDFLAGS)"
+RELEASE_BUILD_FLAGS := $(COMMON_GOFLAGS) -ldflags="-s -w -X $(PROJECT)/pkg/segment.writeKey=R1Z79HadJIrphLoeONZy5uqOjusljSwN $(COMMON_LDFLAGS)"
 PKGS := $(shell go list $(COMMON_GOFLAGS)  ./... | grep -v $(PROJECT)/vendor | grep -v $(PROJECT)/tests)
 FILES := odo dist
 TIMEOUT ?= 14400s
@@ -67,6 +67,10 @@ help: ## Show this help.
 .PHONY: bin
 bin: ## build the odo binary
 	go build ${BUILD_FLAGS} cmd/odo/odo.go
+
+.PHONY: release-bin
+release-bin: ## build the odo binary
+	go build ${RELEASE_BUILD_FLAGS} cmd/odo/odo.go
 
 .PHONY: install
 install:
@@ -127,7 +131,7 @@ test-coverage: ## Run unit tests and collect coverage
 
 .PHONY: cross
 cross: ## compile for multiple platforms
-	./scripts/cross-compile.sh $(CROSS_BUILD_FLAGS)
+	./scripts/cross-compile.sh $(RELEASE_BUILD_FLAGS)
 
 .PHONY: generate-cli-structure
 generate-cli-structure:


### PR DESCRIPTION

**What type of PR is this:**

Adds new `release-bin` make target.

This is for the homebrew package, and it could be also used by another packaging system.

The problem is that currently, [odo-dev formulae ](https://github.com/Homebrew/homebrew-core/blob/master/Formula/odo-dev.rb) uses `make bin`, this is a problem because this build odo with dev Segment key. This means that MacOS users installing odo via homebrew don't show up in our production telemetry. 

new `make release-bin` uses prod Segment key and it should be used only in packaging systems.








<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind cleanup
/kind tests
/kind documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->



**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
