### PR TITLE
Exclude the 'dist' folder in 'check-gofmt.sh' script

### DIFF
--- a/scripts/check-gofmt.sh
+++ b/scripts/check-gofmt.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Why we are wrapping gofmt?
-# - ignore files in vendor directory
+# - ignore files in certain directories, like 'vendor' or 'dist' (created when building RPM Packages of odo)
 # - gofmt doesn't exit with error code when there are errors
 
-GO_FILES=$(find . -path ./vendor -prune -o -name '*.go' -print)
+GO_FILES=$(find . \( -path ./vendor -o -path ./dist \) -prune -o -name '*.go' -print)
 
 for file in $GO_FILES; do
 	gofmtOutput=$(gofmt -l "$file")
@@ -17,7 +17,7 @@ done
 if [ ${#errors[@]} -eq 0 ]; then
 	echo "gofmt OK"
 else
-	echo "gofmt ERROR - These files are not formated by gofmt:"
+	echo "gofmt ERROR - These files are not formatted by gofmt:"
 	for err in "${errors[@]}"; do
 		echo "$err"
 	done


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
`make validate` does not pass if run right after generating a local RPM Package using the `rpm-prepare.sh` and `rpm-local-build.sh` scripts.

The problem is that `check-gofmt.sh` picks Go files from the `dist/rpmbuild/BUILD/**/vendor` folder, e.g.:

```
$ ./scripts/rpm-prepare.sh
$ ./scripts/rpm-local-build.sh
$ make validate 
./scripts/check-gofmt.sh
gofmt ERROR - These files are not formated by gofmt:
./dist/rpmbuild/BUILD/openshift-odo-3.1.0-1/vendor/github.com/AlecAivazis/survey/v2/terminal/display_posix.go
./dist/rpmbuild/BUILD/openshift-odo-3.1.0-1/vendor/github.com/AlecAivazis/survey/v2/terminal/output.go
./dist/rpmbuild/BUILD/openshift-odo-3.1.0-1/vendor/github.com/AlecAivazis/survey/v2/terminal/runereader_bsd.go
--- Truncated ---
```

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```shell
# Generate a local RPM package
./scripts/rpm-prepare.sh && ./scripts/rpm-local-build.sh

# `make validate` should pass with this PR. It won't pass without the changes here.
make validate
```