### PR TITLE
resolve inconsistent order of registries in preference view

### DIFF
--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -64,18 +64,9 @@ func (o *ViewOptions) RunForJsonOutput(ctx context.Context) (result interface{},
 	preferenceList := o.clientset.PreferenceClient.NewPreferenceList()
 	registryList := o.clientset.PreferenceClient.RegistryList()
 
-	var regList, newRegistryList []preference.Registry
-	if registryList != nil {
-		regList = *registryList
-	}
-	// Loop backwards here to ensure the registry display order is correct (display latest newly added registry firstly)
-	for i := len(regList) - 1; i >= 0; i-- {
-		newRegistryList = append(newRegistryList, regList[i])
-	}
-
 	return api.PreferenceView{
 		Preferences: preferenceList.Items,
-		Registries:  newRegistryList,
+		Registries:  *registryList,
 	}, nil
 }
 
@@ -98,7 +89,7 @@ func HumanReadableOutput(preferenceList preference.PreferenceList, registryList 
 		regList = *registryList
 	}
 	// Loop backwards here to ensure the registry display order is correct (display latest newly added registry firstly)
-	for i := len(regList) - 1; i >= 0; i-- {
+	for i := range regList {
 		registry := regList[i]
 		secure := "No"
 		if registry.Secure {

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -63,9 +63,19 @@ func (o *ViewOptions) Run(ctx context.Context) (err error) {
 func (o *ViewOptions) RunForJsonOutput(ctx context.Context) (result interface{}, err error) {
 	preferenceList := o.clientset.PreferenceClient.NewPreferenceList()
 	registryList := o.clientset.PreferenceClient.RegistryList()
+
+	var regList, newRegistryList []preference.Registry
+	if registryList != nil {
+		regList = *registryList
+	}
+	// Loop backwards here to ensure the registry display order is correct (display latest newly added registry firstly)
+	for i := len(regList) - 1; i >= 0; i-- {
+		newRegistryList = append(newRegistryList, regList[i])
+	}
+
 	return api.PreferenceView{
 		Preferences: preferenceList.Items,
-		Registries:  *registryList,
+		Registries:  newRegistryList,
 	}, nil
 }
 

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -84,13 +84,9 @@ func HumanReadableOutput(preferenceList preference.PreferenceList, registryList 
 	registryT := ui.NewTable()
 	registryT.AppendHeader(table.Row{"NAME", "URL", "SECURE"})
 
-	var regList []preference.Registry
-	if registryList != nil {
-		regList = *registryList
-	}
 	// Loop backwards here to ensure the registry display order is correct (display latest newly added registry firstly)
-	for i := range regList {
-		registry := regList[i]
+	for i := range *registryList {
+		registry := (*registryList)[i]
 		secure := "No"
 		if registry.Secure {
 			secure = "Yes"

--- a/pkg/preference/implem.go
+++ b/pkg/preference/implem.go
@@ -133,6 +133,19 @@ func newPreferenceInfo() (*preferenceInfo, error) {
 		return nil, err
 	}
 
+	regList := []Registry{}
+	if c.OdoSettings.RegistryList != nil {
+		regList = *c.OdoSettings.RegistryList
+	}
+
+	i := 0
+	j := len(regList) - 1
+	for i < j {
+		regList[i], regList[j] = regList[j], regList[i]
+		i++
+		j--
+	}
+
 	// TODO: This code block about logging warnings should be removed once users completely shift to odo v3.
 	// The warning will be printed more than once, and it can be annoying, but it should ensure that the user will change these values.
 	var requiresChange []string

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -48,13 +48,13 @@ OdoSettings:
 			registryName: "",
 			want: []api.Registry{
 				{
-					Name:   "CheDevfileRegistry",
-					URL:    "https://che-devfile-registry.openshift.io/",
+					Name:   "DefaultDevfileRegistry",
+					URL:    "https://registry.devfile.io",
 					Secure: false,
 				},
 				{
-					Name:   "DefaultDevfileRegistry",
-					URL:    "https://registry.devfile.io",
+					Name:   "CheDevfileRegistry",
+					URL:    "https://che-devfile-registry.openshift.io/",
 					Secure: false,
 				},
 			},

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -133,7 +133,7 @@ var _ = Describe("odo devfile registry command tests", Label(helper.LabelNoClust
 				helper.JsonPathContentIs(output, "registries.0.name", registryName)
 				helper.JsonPathContentIs(output, "registries.0.url", addRegistryURL)
 				helper.JsonPathContentIs(output, "registries.1.name", "DefaultDevfileRegistry")
-				helper.JsonPathContentIs(output, "registries.1.url", "https://registry.stage.devfile.io")
+				helper.JsonPathContentIs(output, "registries.1.url", addRegistryURL) // as we are using its updated in case of Proxy
 			})
 
 		})

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -125,10 +125,23 @@ var _ = Describe("odo devfile registry command tests", Label(helper.LabelNoClust
 			helper.Cmd("odo", "preference", "remove", "registry", registryName, "-f").ShouldPass()
 			helper.Cmd("odo", "init", "--name", "aname", "--devfile", "java-maven", "--devfile-registry", registryName).ShouldFail()
 		})
+
+		It("should list registry with recently added registry on top", func() {
+			By("for json output", func() {
+				output := helper.Cmd("odo", "preference", "view", "-o", "json").ShouldPass().Out()
+				Expect(helper.IsJSON(output)).To(BeTrue())
+				helper.JsonPathContentIs(output, "registries.0.name", registryName)
+				helper.JsonPathContentIs(output, "registries.0.url", addRegistryURL)
+				helper.JsonPathContentIs(output, "registries.1.name", "DefaultDevfileRegistry")
+				helper.JsonPathContentIs(output, "registries.1.url", "https://registry.stage.devfile.io")
+			})
+
+		})
 	})
 
 	It("should fail when adding a git based registry", func() {
 		err := helper.Cmd("odo", "preference", "add", "registry", "RegistryFromGitHub", "https://github.com/devfile/registry").ShouldFail().Err()
 		helper.MatchAllInOutput(err, []string{"github", "no", "supported", "https://github.com/devfile/registry-support"})
 	})
+
 })


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**
This PR resolves the inconsistency in output of registry list in command `odo preference view` and `odo preference view -o json`
**Which issue(s) this PR fixes:**

Fixes #6205 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```
odo preference add registry CheRegistry https://che-devfile-registry.openshift.io

odo preference view 
odo preference view -o json
```
Order of registry list should be same in `odo preference view` `odo preference view -o json` with latest added registry on the top.