### PR TITLE
More tests without cluster

### DIFF
--- a/.ibm/pipelines/windows-test-script.ps1
+++ b/.ibm/pipelines/windows-test-script.ps1
@@ -80,9 +80,10 @@ function Run-Test {
     Shout "Create Binary"
     make install 
     Shout "Running test"
-    make test-integration-cluster           | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
+    make test-integration-no-cluster | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
+    make test-integration-cluster    | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
     Check-ExitCode $LASTEXITCODE
-    make test-e2e           | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
+    make test-e2e                    | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
     Check-ExitCode $LASTEXITCODE
 
     Pop-Location 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -254,9 +254,13 @@ func getResourcesForComponent(
 // GetRunningModes returns the list of modes on which a "name" component is deployed, by looking into namespace
 // the resources deployed with matching labels, based on the "odo.dev/mode" label
 func GetRunningModes(ctx context.Context, client kclient.ClientInterface, name string) (api.RunningModes, error) {
+	if client == nil {
+		return nil, nil
+	}
+
 	list, err := getResourcesForComponent(ctx, client, name, client.GetCurrentNamespace())
 	if err != nil {
-		return api.RunningModes{}, nil
+		return nil, nil
 	}
 
 	if len(list) == 0 {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -341,6 +341,10 @@ func GetDevfileInfoFromCluster(ctx context.Context, client kclient.ClientInterfa
 // it only returns the resources created with Deploy mode;
 // it fetches resources from the cluster that match label and return.
 func ListRoutesAndIngresses(client kclient.ClientInterface, componentName, appName string) (ings []api.ConnectionData, routes []api.ConnectionData, err error) {
+	if client == nil {
+		return nil, nil, nil
+	}
+
 	selector := odolabels.GetSelector(componentName, appName, odolabels.ComponentDeployMode, false)
 
 	k8sIngresses, err := client.ListIngresses(client.GetCurrentNamespace(), selector)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -205,9 +205,13 @@ func ListAllClusterComponents(client kclient.ClientInterface, namespace string) 
 }
 
 func ListAllComponents(client kclient.ClientInterface, namespace string, devObj *parser.DevfileObj, componentName string) ([]api.ComponentAbstract, string, error) {
-	devfileComponents, err := ListAllClusterComponents(client, namespace)
-	if err != nil {
-		return nil, "", err
+	var devfileComponents []api.ComponentAbstract
+	var err error
+	if client != nil {
+		devfileComponents, err = ListAllClusterComponents(client, namespace)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 
 	localComponent := api.ComponentAbstract{

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -349,7 +349,7 @@ func TestGetRunningModes(t *testing.T) {
 				},
 				name: "aname",
 			},
-			want: api.RunningModes{},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -81,6 +81,9 @@ func (o *ComponentOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline
 }
 
 func (o *ComponentOptions) Validate(ctx context.Context) (err error) {
+	if o.clientset.KubernetesClient == nil {
+		log.Warning("No connection to cluster defined")
+	}
 	return nil
 }
 

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -2,6 +2,7 @@ package dev
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -99,6 +100,14 @@ func (o *DevOptions) Validate(ctx context.Context) error {
 	}
 	if o.debugFlag && !libdevfile.HasDebugCommand(devfileObj.Data) {
 		return clierrors.NewNoCommandInDevfileError("debug")
+	}
+
+	platform := fcontext.GetRunOn(ctx)
+	switch platform {
+	case commonflags.RunOnCluster:
+		if o.clientset.KubernetesClient == nil {
+			return errors.New("no connection to cluster defined")
+		}
 	}
 	return nil
 }

--- a/pkg/odo/cli/list/component/list.go
+++ b/pkg/odo/cli/list/component/list.go
@@ -73,6 +73,9 @@ func (lo *ListOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline, ar
 
 // Validate ...
 func (lo *ListOptions) Validate(ctx context.Context) (err error) {
+	if lo.clientset.KubernetesClient == nil {
+		log.Warning("No connection to cluster defined")
+	}
 	return nil
 }
 

--- a/pkg/odo/cli/list/component/list.go
+++ b/pkg/odo/cli/list/component/list.go
@@ -13,8 +13,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/commonflags"
 
-	dfutil "github.com/devfile/library/pkg/util"
-
 	"github.com/redhat-developer/odo/pkg/component"
 
 	"github.com/redhat-developer/odo/pkg/log"
@@ -59,20 +57,14 @@ func (o *ListOptions) SetClientset(clientset *clientset.Clientset) {
 
 // Complete ...
 func (lo *ListOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline, args []string) (err error) {
-
-	// Check to see if KUBECONFIG exists, and if not, error the user that we would not be able to get cluster information
-	// Do this before anything else, or else we will just error out with the:
-	// invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
-	// instead
-	if !dfutil.CheckKubeConfigExist() {
-		return errors.New("KUBECONFIG not found. Unable to retrieve cluster information. Please set your Kubernetes configuration via KUBECONFIG env variable or ~/.kube/config")
-	}
-
 	// If the namespace flag has been passed, we will search there.
 	// if it hasn't, we will search from the default project / namespace.
 	if lo.namespaceFlag != "" {
+		if lo.clientset.KubernetesClient == nil {
+			return errors.New("cluster is non accessible")
+		}
 		lo.namespaceFilter = lo.namespaceFlag
-	} else {
+	} else if lo.clientset.KubernetesClient != nil {
 		lo.namespaceFilter = odocontext.GetNamespace(ctx)
 	}
 
@@ -137,7 +129,7 @@ func NewCmdComponentList(name, fullName string) *cobra.Command {
 		},
 		Aliases: []string{"components"},
 	}
-	clientset.Add(listCmd, clientset.KUBERNETES, clientset.FILESYSTEM)
+	clientset.Add(listCmd, clientset.KUBERNETES_NULLABLE, clientset.FILESYSTEM)
 
 	listCmd.Flags().StringVar(&o.namespaceFlag, "namespace", "", "Namespace for odo to scan for components")
 

--- a/tests/e2escenarios/e2e_devfile_test.go
+++ b/tests/e2escenarios/e2e_devfile_test.go
@@ -24,7 +24,7 @@ var _ = Describe("odo devfile supported tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		projectDirPath = commonVar.Context + projectDir

--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("E2E Test", func() {
 	var commonVar helper.CommonVar
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 	})
 	var _ = AfterEach(func() {
 		helper.CommonAfterEach(commonVar)

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -184,12 +184,9 @@ type CommonVar struct {
 	testDuration float64
 }
 
-const SetupClusterTrue = true
-const SetupClusterFalse = false
-
 // CommonBeforeEach is common function runs before every test Spec (It)
 // returns CommonVar values that are used within the test script
-func CommonBeforeEach(setupCluster bool) CommonVar {
+func CommonBeforeEach() CommonVar {
 	SetDefaultEventuallyTimeout(10 * time.Minute)
 	SetDefaultConsistentlyDuration(30 * time.Second)
 
@@ -198,7 +195,7 @@ func CommonBeforeEach(setupCluster bool) CommonVar {
 	commonVar.ConfigDir = CreateNewContext()
 	commonVar.CliRunner = GetCliRunner()
 	commonVar.OriginalKubeconfig = os.Getenv("KUBECONFIG")
-	if setupCluster {
+	if NeedsCluster(CurrentSpecReport().Labels()) {
 		LocalKubeconfigSet(commonVar.ConfigDir)
 		commonVar.Project = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 	}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -198,6 +198,9 @@ func CommonBeforeEach() CommonVar {
 	if NeedsCluster(CurrentSpecReport().Labels()) {
 		LocalKubeconfigSet(commonVar.ConfigDir)
 		commonVar.Project = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+	} else {
+		// Disable the use of in-cluster configuration (seen in IBM Cloud pipeline)
+		os.Unsetenv("KUBERNETES_SERVICE_HOST")
 	}
 	commonVar.OriginalWorkingDirectory = Getwd()
 

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -201,6 +201,12 @@ func CommonBeforeEach() CommonVar {
 	} else {
 		// Disable the use of in-cluster configuration (seen in IBM Cloud pipeline)
 		os.Unsetenv("KUBERNETES_SERVICE_HOST")
+		// Create an empty kubeconfig file in the config dir and point KUBECONFIG to this file
+		kubeconfig, err := os.CreateTemp(commonVar.ConfigDir, "kubeconfig")
+		Expect(err).To(BeNil())
+		err = kubeconfig.Close()
+		Expect(err).To(BeNil())
+		os.Setenv("KUBECONFIG", kubeconfig.Name())
 	}
 	commonVar.OriginalWorkingDirectory = Getwd()
 

--- a/tests/helper/labels.go
+++ b/tests/helper/labels.go
@@ -3,3 +3,12 @@ package helper
 const (
 	LabelNoCluster = "nocluster"
 )
+
+func NeedsCluster(labels []string) bool {
+	for _, label := range labels {
+		if label == LabelNoCluster {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/integration/cmd_add_binding_test.go
+++ b/tests/integration/cmd_add_binding_test.go
@@ -20,7 +20,7 @@ var _ = Describe("odo add binding command tests", func() {
 	var err error
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 		// Ensure that the operators are installed
 		commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")

--- a/tests/integration/cmd_analyze_test.go
+++ b/tests/integration/cmd_analyze_test.go
@@ -14,7 +14,7 @@ var _ = Describe("odo analyze command tests", Label(helper.LabelNoCluster), func
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo delete command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		getDeployArgs = []string{"get", "deployment", "-n", commonVar.Project}

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -18,7 +18,7 @@ var _ = Describe("odo describe component command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 		cmpName = helper.RandString(6)
 	})
@@ -28,7 +28,7 @@ var _ = Describe("odo describe component command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	It("should fail", func() {
+	It("should fail, without cluster", Label(helper.LabelNoCluster), func() {
 		By("running odo describe component -o json with namespace flag without name flag", func() {
 			res := helper.Cmd("odo", "describe", "component", "--namespace", "default", "-o", "json").ShouldFail()
 			stdout, stderr := res.Out(), res.Err()
@@ -45,14 +45,6 @@ var _ = Describe("odo describe component command tests", func() {
 			helper.JsonPathContentContain(stderr, "message", "The current directory does not represent an odo component")
 		})
 
-		By("running odo describe component -o json with an unknown name", func() {
-			res := helper.Cmd("odo", "describe", "component", "--name", "unknown-name", "-o", "json").ShouldFail()
-			stdout, stderr := res.Out(), res.Err()
-			Expect(helper.IsJSON(stderr)).To(BeTrue())
-			Expect(stdout).To(BeEmpty())
-			helper.JsonPathContentContain(stderr, "message", "no component found with name \"unknown-name\" in the namespace \""+commonVar.Project+"\"")
-		})
-
 		By("running odo describe component with namespace flag without name flag", func() {
 			res := helper.Cmd("odo", "describe", "component", "--namespace", "default").ShouldFail()
 			stdout, stderr := res.Out(), res.Err()
@@ -65,6 +57,17 @@ var _ = Describe("odo describe component command tests", func() {
 			stdout, stderr := res.Out(), res.Err()
 			Expect(stdout).To(BeEmpty())
 			Expect(stderr).To(ContainSubstring("The current directory does not represent an odo component"))
+		})
+
+	})
+
+	It("should fail, with cluster", func() {
+		By("running odo describe component -o json with an unknown name", func() {
+			res := helper.Cmd("odo", "describe", "component", "--name", "unknown-name", "-o", "json").ShouldFail()
+			stdout, stderr := res.Out(), res.Err()
+			Expect(helper.IsJSON(stderr)).To(BeTrue())
+			Expect(stdout).To(BeEmpty())
+			helper.JsonPathContentContain(stderr, "message", "no component found with name \"unknown-name\" in the namespace \""+commonVar.Project+"\"")
 		})
 
 		By("running odo describe component with an unknown name", func() {
@@ -99,7 +102,7 @@ var _ = Describe("odo describe component command tests", func() {
 			}
 		}
 
-		It("should describe the component in the current directory", func() {
+		It("should describe the component in the current directory", Label(helper.LabelNoCluster), func() {
 			By("running with json output", func() {
 				res := helper.Cmd("odo", "describe", "component", "-o", "json").ShouldPass()
 				stdout, stderr := res.Out(), res.Err()
@@ -140,7 +143,7 @@ var _ = Describe("odo describe component command tests", func() {
 			})
 		})
 
-		When("renaming to hide devfile.yaml file", func() {
+		When("renaming to hide devfile.yaml file", Label(helper.LabelNoCluster), func() {
 			BeforeEach(func() {
 				err := os.Rename("devfile.yaml", ".devfile.yaml")
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/integration/cmd_describe_list_binding_test.go
+++ b/tests/integration/cmd_describe_list_binding_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo describe/list binding command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo dev debug command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -34,7 +34,7 @@ var _ = Describe("odo dev command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())

--- a/tests/integration/cmd_devfile_build_images_test.go
+++ b/tests/integration/cmd_devfile_build_images_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo devfile build-images command tests", func() {
+var _ = Describe("odo devfile build-images command tests", Label(helper.LabelNoCluster), func() {
 
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_devfile_build_images_test.go
+++ b/tests/integration/cmd_devfile_build_images_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo devfile build-images command tests", Label(helper.LabelNoC
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -21,7 +21,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -26,7 +26,7 @@ var _ = Describe("odo devfile init command tests", Label(helper.LabelNoCluster),
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
 	})

--- a/tests/integration/cmd_devfile_list_test.go
+++ b/tests/integration/cmd_devfile_list_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo list with devfile", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_devfile_list_test.go
+++ b/tests/integration/cmd_devfile_list_test.go
@@ -207,7 +207,7 @@ var _ = Describe("odo list with devfile", func() {
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 
-			It("should show the language for 'Type' in odo list", func() {
+			It("should show the language for 'Type' in odo list", Label(helper.LabelNoCluster), func() {
 				checkList(metadata.Language)
 			})
 			When("the component is pushed in dev mode", func() {
@@ -234,7 +234,7 @@ var _ = Describe("odo list with devfile", func() {
 				helper.CreateLocalEnv(commonVar.Context, "aname", commonVar.Project)
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
-			It("should show 'Not available' for 'Type' in odo list", func() {
+			It("should show 'Not available' for 'Type' in odo list", Label(helper.LabelNoCluster), func() {
 				checkList("Not available")
 			})
 			When("the component is pushed", func() {

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -23,7 +23,7 @@ var _ = Describe("odo devfile registry command tests", Label(helper.LabelNoClust
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/cmd_list_services_test.go
+++ b/tests/integration/cmd_list_services_test.go
@@ -12,7 +12,7 @@ var _ = Describe("odo list services tests", func() {
 	var randomProject string
 
 	BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 
 		// Ensure that the operators are installed
 		commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")

--- a/tests/integration/cmd_logs_test.go
+++ b/tests/integration/cmd_logs_test.go
@@ -29,7 +29,7 @@ var _ = Describe("odo logs command tests", func() {
 	}
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
 		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -20,7 +20,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 	var commonVar helper.CommonVar
 
 	BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 	})
 
 	AfterEach(func() {

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo preference and config command tests", Label(helper.LabelNo
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 	})
 
 	// Clean up after the test

--- a/tests/integration/cmd_remove_binding_test.go
+++ b/tests/integration/cmd_remove_binding_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo remove binding command tests", func() {
+var _ = Describe("odo remove binding command tests", Label(helper.LabelNoCluster), func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
 		helper.Chdir(commonVar.Context)
 		// Note: We do not add any operators here because `odo remove binding` is simply about removing the ServiceBinding from devfile.
 	})

--- a/tests/integration/cmd_remove_binding_test.go
+++ b/tests/integration/cmd_remove_binding_test.go
@@ -13,7 +13,7 @@ var _ = Describe("odo remove binding command tests", Label(helper.LabelNoCluster
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 		// Note: We do not add any operators here because `odo remove binding` is simply about removing the ServiceBinding from devfile.
 	})

--- a/tests/integration/cmd_remove_binding_test.go
+++ b/tests/integration/cmd_remove_binding_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhat-developer/odo/tests/helper"
 )
 
-var _ = Describe("odo remove binding command tests", Label(helper.LabelNoCluster), func() {
+var _ = Describe("odo remove binding command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
@@ -29,7 +29,7 @@ var _ = Describe("odo remove binding command tests", Label(helper.LabelNoCluster
 			helper.Cmd("odo", "init", "--name", "mynode", "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-service-binding-files.yaml")).ShouldPass()
 		})
 
-		When("removing the binding", func() {
+		When("removing the binding", Label(helper.LabelNoCluster), func() {
 			BeforeEach(func() {
 				helper.Cmd("odo", "remove", "binding", "--name", bindingName).ShouldPass()
 			})
@@ -38,7 +38,7 @@ var _ = Describe("odo remove binding command tests", Label(helper.LabelNoCluster
 				Expect(components).To(BeNil())
 			})
 		})
-		It("should fail to remove binding that does not exist", func() {
+		It("should fail to remove binding that does not exist", Label(helper.LabelNoCluster), func() {
 			helper.Cmd("odo", "remove", "binding", "--name", "my-binding").ShouldFail()
 		})
 		When("odo dev is running", func() {

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -26,7 +26,7 @@ var _ = Describe("odo generic", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("running odo --help", func() {
+	When("running odo --help", Label(helper.LabelNoCluster), func() {
 		var output string
 		BeforeEach(func() {
 			output = helper.Cmd("odo", "--help").ShouldPass().Out()
@@ -37,7 +37,7 @@ var _ = Describe("odo generic", func() {
 
 	})
 
-	When("running odo without subcommand and flags", func() {
+	When("running odo without subcommand and flags", Label(helper.LabelNoCluster), func() {
 		var output string
 		BeforeEach(func() {
 			output = helper.Cmd("odo").ShouldPass().Out()
@@ -47,12 +47,12 @@ var _ = Describe("odo generic", func() {
 		})
 	})
 
-	It("returns error when using an invalid command", func() {
+	It("returns error when using an invalid command", Label(helper.LabelNoCluster), func() {
 		output := helper.Cmd("odo", "hello").ShouldFail().Err()
 		Expect(output).To(ContainSubstring("Invalid command - see available commands/subcommands above"))
 	})
 
-	It("returns JSON error", func() {
+	It("returns JSON error", Label(helper.LabelNoCluster), func() {
 		By("using an invalid command with JSON output", func() {
 			res := helper.Cmd("odo", "unknown-command", "-o", "json").ShouldFail()
 			stdout, stderr := res.Out(), res.Err()
@@ -82,7 +82,7 @@ var _ = Describe("odo generic", func() {
 		})
 	})
 
-	It("returns error when using an invalid command with --help", func() {
+	It("returns error when using an invalid command with --help", Label(helper.LabelNoCluster), func() {
 		output := helper.Cmd("odo", "hello", "--help").ShouldFail().Err()
 		Expect(output).To(ContainSubstring("unknown command 'hello', type --help for a list of all commands"))
 	})
@@ -118,6 +118,11 @@ var _ = Describe("odo generic", func() {
 			Expect(odoVersion).Should(SatisfyAll(MatchRegexp(reOdoVersion), MatchRegexp(rekubernetesVersion)))
 			serverURL := oc.GetCurrentServerURL()
 			Expect(odoVersion).Should(ContainSubstring("Server: " + serverURL))
+		})
+
+		It("should show the version of odo major components", Label(helper.LabelNoCluster), func() {
+			reOdoVersion := `^odo\s*v[0-9]+.[0-9]+.[0-9]+(?:-\w+)?\s*\(\w+\)`
+			Expect(odoVersion).Should(MatchRegexp(reOdoVersion))
 		})
 	})
 

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo generic", func() {
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
 		oc = helper.NewOcRunner("oc")
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 	})
 
 	// Clean up after the test

--- a/tests/integration/interactive_add_binding_test.go
+++ b/tests/integration/interactive_add_binding_test.go
@@ -20,7 +20,7 @@ var _ = Describe("odo add binding interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 
 		// We make EXPLICITLY sure that we are outputting with NO COLOR

--- a/tests/integration/interactive_deploy_test.go
+++ b/tests/integration/interactive_deploy_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo deploy interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/interactive_dev_test.go
+++ b/tests/integration/interactive_dev_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odo dev interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterTrue)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
 

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -23,7 +23,7 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
-		commonVar = helper.CommonBeforeEach(helper.SetupClusterFalse)
+		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 
 		// We make EXPLICITLY sure that we are outputting with NO COLOR


### PR DESCRIPTION
**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes partially #6237 

This PR adds more integration tests to the list of tests running without cluster.

- `odo build-images`: all tests
- `odo remove binding`: all tests
- `odo describe component`: tests without `--name` flag and without `odo dev/deploy`
  - make `odo describe component` without `--name` flag work without Kube connection
- `odo list component`: tests without `--namespace` flag and without `odo dev/deploy`
  - make `odo list component` without `--namespace` flag work without Kube connection
- `odo help`
- `odo unknown-command`
- `odo`
- `odo version`