### PR TITLE
Debug validate errors on IBM Cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ clean:
 
 .PHONY: goget-tools
 goget-tools:
-	(curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v$(GOLANGCI_LINT_VERSION)) || go install -mod=readonly github.com/golangci/golangci-lint/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
+	(cd / && go install -mod=mod github.com/golangci/golangci-lint/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION))
 
 .PHONY: goget-ginkgo
 goget-ginkgo:


### PR DESCRIPTION
Modify installation of golangci-lint

- No use of binaries because of errors(1)
- Using -mod=mod for go install because of: https://github.com/golang/go/issues/54908


(1)
```
golangci-lint run ./... --timeout 15m
level=warning msg="[runner] Can't run linter goanalysis_metalinter: S1019: failed prerequisites: [(inspect@github.com/redhat-developer/odo/pkg/log/fidget, isgenerated@github.com/redhat-developer/odo/pkg/log/fidget): analysis skipped: errors in package: [/go/odo_1/pkg/log/fidget/spinner.go:26:2: could not import fmt (/usr/local/go/src/fmt/errors.go:7:8: could not import errors (/usr/local/go/src/errors/wrap.go:8:2: could not import internal/reflectlite (/usr/local/go/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool)))) /go/odo_1/pkg/log/fidget/spinner.go:27:2: could not import io (/usr/local/go/src/io/io.go:16:2: could not import errors (/usr/local/go/src/errors/wrap.go:8:2: could not import internal/reflectlite (/usr/local/go/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool)))) /go/odo_1/pkg/log/fidget/spinner.go:28:2: could not import runtime (/usr/local/go/src/runtime/alg.go:8:2: could not import internal/cpu (-: could not load export data: cannot import \"internal/cpu\" (unknown iexport format version 2), export data is newer version - update tool)) /go/odo_1/pkg/log/fidget/spinner.go:29:2: could not import sync (/usr/local/go/src/sync/cond.go:8:2: could not import sync/atomic (/usr/local/go/src/sync/atomic/value.go:17:4: undeclared name: any)) /go/odo_1/pkg/log/fidget/spinner.go:30:2: could not import time (/usr/local/go/src/time/format.go:7:8: could not import errors (/usr/local/go/src/errors/wrap.go:8:2: could not import internal/reflectlite (/usr/local/go/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool))))]]"
make: *** [Makefile:100: golint] Killed
```