### PR TITLE
Fix potential unit tests failures caused by envconfig relying on the system environment

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,8 +20,12 @@ type Configuration struct {
 }
 
 func GetConfiguration() (*Configuration, error) {
+	return GetConfigurationWith(envconfig.OsLookuper())
+}
+
+func GetConfigurationWith(lookuper envconfig.Lookuper) (*Configuration, error) {
 	var s Configuration
-	err := envconfig.Process(context.Background(), &s)
+	err := envconfig.ProcessWith(context.Background(), &s, lookuper)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,10 +19,15 @@ type Configuration struct {
 	OdoExperimentalMode   bool    `env:"ODO_EXPERIMENTAL_MODE,default=false"`
 }
 
+// GetConfiguration initializes a Configuration for odo by using the system environment.
+// See GetConfigurationWith for a more configurable version.
 func GetConfiguration() (*Configuration, error) {
 	return GetConfigurationWith(envconfig.OsLookuper())
 }
 
+// GetConfigurationWith initializes a Configuration for odo by using the specified envconfig.Lookuper to resolve values.
+// It is recommended to use this function (instead of GetConfiguration) if you don't need to depend on the current system environment,
+// typically in unit tests.
 func GetConfigurationWith(lookuper envconfig.Lookuper) (*Configuration, error) {
 	var s Configuration
 	err := envconfig.ProcessWith(context.Background(), &s, lookuper)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"testing"
+
+	"github.com/sethvargo/go-envconfig"
 )
 
 func TestDefaultValues(t *testing.T) {
-	cfg, err := GetConfiguration()
+	cfg, err := GetConfigurationWith(envconfig.MapLookuper(nil))
 	if err != nil {
 		t.Errorf("Error is not expected: %v", err)
 	}

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/sethvargo/go-envconfig"
 
 	"github.com/redhat-developer/odo/pkg/config"
 	"github.com/redhat-developer/odo/pkg/kclient"
@@ -290,14 +291,11 @@ func TestIsTelemetryEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range tt.env {
-				t.Setenv(k, v)
-			}
 			ctrl := gomock.NewController(t)
 			cfg := preference.NewMockClient(ctrl)
 			cfg.EXPECT().GetConsentTelemetry().Return(tt.consentTelemetryPref).AnyTimes()
 
-			envConfig, err := config.GetConfiguration()
+			envConfig, err := config.GetConfigurationWith(envconfig.MapLookuper(tt.env))
 			if err != nil {
 				t.Errorf("Get configuration fails: %v", err)
 			}


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area testing

**What does this PR do / why we need it:**
I just ran into the issue below, where our unit tests might fail depending on the system environment variables:

```
$ GLOBALODOCONFIG=/dev/null PODMAN_CMD=docker go test -race github.com/redhat-developer/odo/pkg/config/
--- FAIL: TestDefaultValues (0.00s)
    config_test.go:30: default value for "PodmanCmd" should be "podman" but is "docker"
    config_test.go:44: value for non specified env var "Globalodoconfig" should be nil but is "/dev/null"
    config_test.go:44: value for non specified env var "Globalodoconfig" should be nil but is "/dev/null"
FAIL
FAIL    github.com/redhat-developer/odo/pkg/config      0.008s
FAIL
```

I think unit tests should not depend on the system environment, as this can cause troubles.
`envconfig` supports this use case by providing a `Lookuper`: https://github.com/sethvargo/go-envconfig#testing

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
