### PR TITLE
fix: add exit code check for no-cluster tests

### DIFF
--- a/.ibm/pipelines/windows-test-script.ps1
+++ b/.ibm/pipelines/windows-test-script.ps1
@@ -81,6 +81,7 @@ function Run-Test {
     make install 
     Shout "Running test"
     make test-integration-no-cluster | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
+    Check-ExitCode $LASTEXITCODE
     make test-integration-cluster    | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE
     Check-ExitCode $LASTEXITCODE
     make test-e2e                    | tee -a  C:\Users\Administrator.ANSIBLE-TEST-VS\AppData\Local\Temp\$LOGFILE


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**
/kind bug
/kind tests

**What does this PR do / why we need it:**
This PR adds the check for exit code in windows tests for no-cluster tests

**Which issue(s) this PR fixes:**

Fixes #6342

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
