### PR TITLE
Downloading wrong starter project when using `odo init`

### DIFF
--- a/pkg/init/asker/asker.go
+++ b/pkg/init/asker/asker.go
@@ -53,7 +53,6 @@ func (o *Survey) AskType(types registry.TypesWithDetails) (back bool, _ api.Devf
 }
 
 func (o *Survey) AskStarterProject(projects []string) (bool, int, error) {
-	sort.Strings(projects)
 	projects = append(projects, "** NO STARTER PROJECT **")
 	question := &survey.Select{
 		Message: "Which starter project do you want to use?",

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -95,6 +95,11 @@ func (o *InteractiveBackend) SelectStarterProject(devfile parser.DevfileObj, fla
 	if err != nil {
 		return nil, err
 	}
+
+	sort.Slice(starterProjects, func(i, j int) bool {
+		return starterProjects[i].Name < starterProjects[j].Name
+	})
+
 	names := make([]string, 0, len(starterProjects))
 	for _, starterProject := range starterProjects {
 		names = append(names, starterProject.Name)

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -153,6 +153,35 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 		Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 	})
 
+	It("should download correct devfile-starter", func() {
+
+		command := []string{"odo", "init"}
+		output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
+
+			By("showing the interactive mode notice message", func() {
+				helper.ExpectString(ctx, messages.InteractiveModeEnabled)
+			})
+
+			helper.ExpectString(ctx, "Select language")
+			helper.SendLine(ctx, "java")
+
+			helper.ExpectString(ctx, "Select project type")
+			helper.SendLine(ctx, "Vert.x Java")
+
+			helper.ExpectString(ctx, "Which starter project do you want to use")
+			helper.SendLine(ctx, "vertx-cache-example-redhat")
+
+			helper.ExpectString(ctx, "Enter component name")
+			helper.SendLine(ctx, "my-app")
+
+			helper.ExpectString(ctx, "Your new component 'my-app' is ready in the current directory")
+
+		})
+
+		Expect(err).To(BeNil())
+		Expect(output).To(ContainSubstring("Downloading starter project \"vertx-cache-example-redhat\""))
+	})
+
 	Describe("displaying welcoming messages", func() {
 
 		// testFunc is a function that returns a `Tester` function (intended to be used via `helper.RunInteractive`),


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**
This PR fixes downloading of the wrong devfile-starter when using `odo init` in interactive mode

**Which issue(s) this PR fixes:**
Fixes #6195 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
