### PR TITLE
Run Devfile personalization in interactive mode from empty directory

### DIFF
--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -240,14 +240,9 @@ func (o *InitClient) PersonalizeName(devfile parser.DevfileObj, flags map[string
 
 func (o InitClient) PersonalizeDevfileConfig(devfileobj parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (parser.DevfileObj, error) {
 	var backend backend.InitBackend
-	onlyDevfile, err := location.DirContainsOnlyDevfile(fs, dir)
-	if err != nil {
-		return parser.DevfileObj{}, err
-	}
 
 	// Interactive mode since no flags are provided
-	if len(flags) == 0 && !onlyDevfile {
-		// Other files present in the directory; hence alizer is run
+	if len(flags) == 0 {
 		backend = o.interactiveBackend
 	} else {
 		backend = o.flagsBackend

--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -61,6 +61,9 @@ var _ = Describe("E2E Test", func() {
 				helper.ExpectString(ctx, "Select project type")
 				helper.SendLine(ctx, "Node.js")
 
+				helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+				helper.SendLine(ctx, "")
+
 				helper.ExpectString(ctx, "Which starter project do you want to use")
 				helper.SendLine(ctx, "nodejs-starter")
 

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -52,6 +52,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 			helper.ExpectString(ctx, "Select project type")
 			helper.SendLine(ctx, "")
 
+			helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+			helper.SendLine(ctx, "")
+
 			helper.ExpectString(ctx, "Which starter project do you want to use")
 			helper.SendLine(ctx, "")
 
@@ -74,6 +77,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 			helper.SendLine(ctx, "Go")
 
 			helper.ExpectString(ctx, "Select project type")
+			helper.SendLine(ctx, "")
+
+			helper.ExpectString(ctx, "Select container for which you want to change configuration?")
 			helper.SendLine(ctx, "")
 
 			helper.ExpectString(ctx, "Which starter project do you want to use")
@@ -113,6 +119,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 			helper.ExpectString(ctx, "Select project type")
 			helper.SendLine(ctx, "")
 
+			helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+			helper.SendLine(ctx, "")
+
 			helper.ExpectString(ctx, "Which starter project do you want to use")
 			helper.SendLine(ctx, starter)
 
@@ -144,6 +153,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 			helper.ExpectString(ctx, "Select project type")
 			helper.SendLine(ctx, "")
 
+			helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+			helper.SendLine(ctx, "")
+
 			helper.ExpectString(ctx, "Which starter project do you want to use")
 			helper.SendLine(ctx, "")
 
@@ -173,6 +185,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 
 			helper.ExpectString(ctx, "Select project type")
 			helper.SendLine(ctx, "Vert.x Java")
+
+			helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+			helper.SendLine(ctx, "")
 
 			helper.ExpectString(ctx, "Which starter project do you want to use")
 			helper.SendLine(ctx, "vertx-cache-example-redhat")
@@ -263,6 +278,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 					helper.SendLine(ctx, language)
 
 					helper.ExpectString(ctx, "Select project type")
+					helper.SendLine(ctx, "")
+
+					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
 					helper.SendLine(ctx, "")
 
 					helper.ExpectString(ctx, "Which starter project do you want to use")
@@ -412,6 +430,9 @@ var _ = Describe("odo init interactive command tests", Label(helper.LabelNoClust
 			helper.SendLine(ctx, ".NET")
 
 			helper.ExpectString(ctx, "Select project type")
+			helper.SendLine(ctx, "")
+
+			helper.ExpectString(ctx, "Select container for which you want to change configuration?")
 			helper.SendLine(ctx, "")
 
 			helper.ExpectString(ctx, "Which starter project do you want to use")


### PR DESCRIPTION

Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**

/kind bug
**What does this PR do / why we need it:**

This PR adds the ability to personalization devfile when running  `odo init` in interactive mode from an empty directory

**Which issue(s) this PR fixes:**

Fixes #6313 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```
mkdir /tmp/testodo; cd /tmp/testodo
 odo init
  __
 /  \__     Initializing a new component
 \__/  \    Files: No source code detected, a starter project will be created in the current directory
 /  \__/    odo version: v3.3.0
 \__/

Interactive mode enabled, please answer the following questions:
? Select language: Go
? Select project type: Go Runtime
 ✓  Downloading devfile "go" from registry "DefaultDevfileRegistry" [2s]

↪ Container Configuration "runtime":
  OPEN PORTS:
    - 8080
  ENVIRONMENT VARIABLES:

? Select container for which you want to change configuration? NONE - configuration is correct
? Which starter project do you want to use? go-starter
? Enter component name: test
 ✓  Downloading starter project "go-starter" [733ms]

Port configuration using flag is currently not supported  

You can automate this command by executing:
   odo init --name test --devfile go --devfile-registry DefaultDevfileRegistry --starter go-starter


Your new component 'test' is ready in the current directory.
To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.

```