### PR TITLE
Integration tests: Declare devfile volumes as ephemeral

### DIFF
--- a/.ibm/pipelines/kubernetes-tests.sh
+++ b/.ibm/pipelines/kubernetes-tests.sh
@@ -16,7 +16,6 @@ export SKIP_USER_LOGIN_TESTS=true
     echo Using Devfile proxy: ${DEVFILE_PROXY}
     make install
     make test-integration-cluster
-    make test-e2e
 ) |& tee "/tmp/${LOGFILE}"
 
 RESULT=${PIPESTATUS[0]}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-volumes.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-volumes.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: nodejs
 starterProjects:
@@ -33,8 +33,11 @@ components:
   - name: myvol
     volume:
       size: 200Mi
+      ephemeral : true
   - name: myvol2
-    volume: {}
+    volume:
+      ephemeral : true
+
 commands:
   - id: devbuild
     exec:

--- a/tests/examples/source/devfiles/springboot/devfile-registry.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-registry.yaml
@@ -36,6 +36,7 @@ components:
 - name: m2
   volume:
     size: 3Gi
+    ephemeral: true
 metadata:
   description: Spring Boot® using Java
   displayName: Spring Boot®
@@ -48,7 +49,7 @@ metadata:
   - Java
   - Spring
   version: 1.1.0
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 starterProjects:
 - git:
     remotes:

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
@@ -1,5 +1,5 @@
 ---
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: myspringbootproject
 starterProjects:
@@ -30,7 +30,8 @@ components:
           path: /data/cache/.m2
       mountSources: false
   - name: springbootpvc
-    volume: {}
+    volume:
+      ephemeral: true
 commands:
   - id: defaultbuild
     exec:

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
@@ -1,5 +1,5 @@
 ---
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: myspringbootproject
   language: java
@@ -31,7 +31,8 @@ components:
           path: /data/cache/.m2
       mountSources: false
   - name: springbootpvc
-    volume: {}
+    volume:
+      ephemeral: true
 commands:
   - id: defaultbuild
     exec:

--- a/tests/examples/source/devfiles/springboot/devfile.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile.yaml
@@ -1,5 +1,5 @@
 ---
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: java-spring-boot
   language: java
@@ -34,6 +34,7 @@ components:
   - name: springbootpvc
     volume:
       size: 3Gi
+      ephemeral: true
 commands:
   - id: defaultbuild
     exec:

--- a/tests/examples/source/java-quarkus/devfile.yaml
+++ b/tests/examples/source/java-quarkus/devfile.yaml
@@ -42,6 +42,7 @@ components:
 - name: m2
   volume:
     size: 3Gi
+    ephemeral: true
 events:
   postStart:
   - init-compile
@@ -57,7 +58,7 @@ metadata:
   - Quarkus
   version: 1.1.0
   website: https://quarkus.io
-schemaVersion: 2.1.0
+schemaVersion: 2.2.0
 starterProjects:
 - name: community
   zip:

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -285,6 +285,9 @@ ComponentSettings:
 
 			var devSession helper.DevSession
 			BeforeEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
 				helper.Cmd("odo", "preference", "set", "-f", "Ephemeral", "false").ShouldPass()
 				var err error
 				devSession, _, _, _, err = helper.StartDevMode(helper.DevSessionOpts{})
@@ -341,6 +344,9 @@ ComponentSettings:
 
 			var devSession helper.DevSession
 			BeforeEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
 				helper.Cmd("odo", "preference", "set", "-f", "Ephemeral", "false").ShouldPass()
 				var err error
 				devSession, _, _, _, err = helper.StartDevMode(helper.DevSessionOpts{})
@@ -348,6 +354,9 @@ ComponentSettings:
 			})
 
 			AfterEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					return
+				}
 				// We stop the process so the process does not remain after the end of the tests
 				devSession.Kill()
 				devSession.WaitEnd()
@@ -1368,6 +1377,9 @@ ComponentSettings:
 			var devfileCmpName string
 			var session helper.DevSession
 			BeforeEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 				devfileCmpName = devfileHandlerCtx.cmpName
@@ -1379,6 +1391,9 @@ ComponentSettings:
 				Expect(err).ToNot(HaveOccurred())
 			})
 			AfterEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					return
+				}
 				session.Stop()
 				session.WaitEnd()
 			})


### PR DESCRIPTION
**What type of PR is this:**

/kind tests


**What does this PR do / why we need it:**

Using persistent volumes during integration tests fail because of missing permissions.

This PR:
- modifies the PR to make the devfile volumes ephemeral.
- tests the non-ephemeral volumes on OpenShift only
- disables the e2e tests on Kubernetes (the e2e tests are using the Devfiles from the registry, defining persistent volumes)