### PR TITLE
Replace group by apiVersion in odo list services output

### DIFF
--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -740,8 +740,8 @@ $ odo list services -o json
 			"name": "cluster-sample",
 			"namespace": "myproject",
 			"kind": "Cluster",
-			"group": "postgresql.k8s.enterprisedb.io",
-			"service": "cluster-sample/Cluster.postgresql.k8s.enterprisedb.io"
+			"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+			"service": "cluster-sample/Cluster.postgresql.k8s.enterprisedb.io/v1"
 		}
 	]
 }
@@ -758,8 +758,8 @@ $ odo list services -o json -n newproject
 			"name": "hello-world",
 			"namespace": "newproject",
 			"kind": "RabbitmqCluster",
-			"group": "rabbitmq.com",
-			"service": "hello-world/RabbitmqCluster.rabbitmq.com"
+			"apiVersion": "rabbitmq.com/v1",
+			"service": "hello-world/RabbitmqCluster.rabbitmq.com/v1"
 		}
 	]
 }
@@ -777,15 +777,15 @@ $ odo list services -o json -A
 			"name": "cluster-sample",
 			"namespace": "myproject",
 			"kind": "Cluster",
-			"group": "postgresql.k8s.enterprisedb.io",
-			"service": "cluster-sample/Cluster.postgresql.k8s.enterprisedb.io"
+			"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+			"service": "cluster-sample/Cluster.postgresql.k8s.enterprisedb.io/v1"
 		},
 		{
 			"name": "hello-world",
 			"namespace": "newproject",
 			"kind": "RabbitmqCluster",
-			"group": "rabbitmq.com",
-			"service": "hello-world/RabbitmqCluster.rabbitmq.com"
+			"apiVersion": "rabbitmq.com/v1",
+			"service": "hello-world/RabbitmqCluster.rabbitmq.com/v1"
 		}
 	]
 }

--- a/docs/website/docs/command-reference/list-services.md
+++ b/docs/website/docs/command-reference/list-services.md
@@ -16,8 +16,8 @@ odo list services
 $ odo list services
  ✓  Listing bindable services from namespace "myproject" [82ms]
 
- NAME                                               NAMESPACE 
- redis-standalone/Redis.redis.redis.opstreelabs.in  myproject 
+ NAME                                                  NAMESPACE 
+ redis-standalone/Redis.redis.redis.opstreelabs.in/v1  myproject 
 ```
 
 To list bindable services in all projects/namespaces accessible to the user:
@@ -28,9 +28,9 @@ odo list services -A
 odo list services -A
  ✓  Listing bindable services from all namespaces [182ms]
 
- NAME                                               NAMESPACE  
- redis-standalone/Redis.redis.redis.opstreelabs.in  myproject  
- hello-world/RabbitmqCluster.rabbitmq.com           newproject 
+ NAME                                                  NAMESPACE  
+ redis-standalone/Redis.redis.redis.opstreelabs.in/v1  myproject  
+ hello-world/RabbitmqCluster.rabbitmq.com/v1           newproject 
 ```
 
 To list bindable services in a particular project/namespace that is accessible to the user:
@@ -41,8 +41,8 @@ odo list services -n <project-name>
 $ odo list services -n newproject
  ✓  Listing bindable services from namespace "newproject" [45ms]
 
- NAME                                      NAMESPACE  
- hello-world/RabbitmqCluster.rabbitmq.com  newproject 
+ NAME                                         NAMESPACE  
+ hello-world/RabbitmqCluster.rabbitmq.com/v1  newproject 
 ```
 
 To get the JSON formatted output for any of the above commands, add `-o json` to the commands shown above. That 

--- a/pkg/api/bindable_service.go
+++ b/pkg/api/bindable_service.go
@@ -1,9 +1,9 @@
 package api
 
 type BindableService struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Kind      string `json:"kind,omitempty"`
-	Group     string `json:"group,omitempty"`
-	Service   string `json:"service,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Service    string `json:"service,omitempty"`
 }

--- a/pkg/odo/cli/list/services/services.go
+++ b/pkg/odo/cli/list/services/services.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/redhat-developer/odo/pkg/api"
@@ -119,12 +118,12 @@ func (o *ServiceListOptions) run() (api.ResourcesList, error) {
 	var servicesList []api.BindableService
 	for _, svc := range services {
 		s := api.BindableService{
-			Name:      svc.GetName(),
-			Namespace: svc.GetNamespace(),
-			Kind:      svc.GetKind(),
-			Group:     strings.Split(svc.GetAPIVersion(), "/")[0],
+			Name:       svc.GetName(),
+			Namespace:  svc.GetNamespace(),
+			Kind:       svc.GetKind(),
+			APIVersion: svc.GetAPIVersion(),
 		}
-		s.Service = fmt.Sprintf("%s/%s.%s", s.Name, s.Kind, s.Group)
+		s.Service = fmt.Sprintf("%s/%s.%s", s.Name, s.Kind, s.APIVersion)
 		servicesList = append(servicesList, s)
 
 	}

--- a/tests/integration/cmd_list_services_test.go
+++ b/tests/integration/cmd_list_services_test.go
@@ -57,12 +57,12 @@ var _ = Describe("odo list services tests", func() {
 		Expect(gjson.Get(out, "bindableServices.0.name").String()).To(ContainSubstring("cluster-sample"))
 		Expect(gjson.Get(out, "bindableServices.0.namespace").String()).To(Equal(commonVar.Project))
 		Expect(gjson.Get(out, "bindableServices.0.kind").String()).To(Equal("Cluster"))
-		Expect(gjson.Get(out, "bindableServices.0.group").String()).To(Equal("postgresql.k8s.enterprisedb.io"))
+		Expect(gjson.Get(out, "bindableServices.0.apiVersion").String()).To(Equal("postgresql.k8s.enterprisedb.io/v1"))
 
 		// from all namespaces
 		out = helper.Cmd("odo", "list", "services", "-A", "-o", "json").ShouldPass().Out()
 		Expect(helper.IsJSON(out)).To(BeTrue())
-		helper.MatchAllInOutput(out, []string{"cluster-sample", commonVar.Project, randomProject, "Cluster", "postgresql.k8s.enterprisedb.io"})
+		helper.MatchAllInOutput(out, []string{"cluster-sample", commonVar.Project, randomProject, "Cluster", "postgresql.k8s.enterprisedb.io/v1"})
 
 		// fail if -A and -n flags are used together
 		out = helper.Cmd("odo", "list", "services", "-o", "json", "-A", "-n", commonVar.Project).ShouldFail().Err()


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

Thos PR removes the `group` field containing the group of the resource, and replaces it with an `apiVersion` field, containing the `group/version` information.

```
$ odo list services -o json -A
{
	"bindableServices": [
		{
			"name": "cluster-sample",
			"namespace": "cmd-describe-list-binding-test549cmw",
			"kind": "Cluster",
			"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
			"service": "cluster-sample/Cluster.postgresql.k8s.enterprisedb.io/v1"
		}
	]
}
```

**Which issue(s) this PR fixes:**

Fixes #6347 

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
