### PR TITLE
updating bindable kind instance

### DIFF
--- a/scripts/ansible/kubernetes-cluster/operators-kubernetes.yml
+++ b/scripts/ansible/kubernetes-cluster/operators-kubernetes.yml
@@ -29,7 +29,7 @@
           name: my-cloud-native-postgresql
           namespace: operators
         spec:
-          channel: stable
+          channel: stable-v1.18
           name: cloud-native-postgresql
           source: operatorhubio-catalog
           sourceNamespace: olm

--- a/scripts/ansible/kubernetes-cluster/operators-openshift.yml
+++ b/scripts/ansible/kubernetes-cluster/operators-openshift.yml
@@ -29,7 +29,7 @@
           name: my-cloud-native-postgresql
           namespace: openshift-operators
         spec:
-          channel: stable
+          channel: stable-v1.18
           name: cloud-native-postgresql
           source: certified-operators
           sourceNamespace: openshift-marketplace

--- a/scripts/configure-cluster/common/setup-operators.sh
+++ b/scripts/configure-cluster/common/setup-operators.sh
@@ -27,7 +27,7 @@ install_postgres_operator(){
     name: my-cloud-native-postgresql
     namespace: $2
   spec:
-    channel: stable
+    channel: stable-v1.18
     name: cloud-native-postgresql
     source: $3
     sourceNamespace: $4

--- a/tests/examples/manifests/bindablekind-instance.yaml
+++ b/tests/examples/manifests/bindablekind-instance.yaml
@@ -3,8 +3,27 @@ kind: Cluster
 metadata:
   name: cluster-sample
 spec:
-  instances: 1
   logLevel: info
-  primaryUpdateStrategy: unsupervised
-  storage:
+  startDelay: 30
+  stopDelay: 30
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  enableSuperuserAccess: true
+  monitoring:
+    disableDefaultQueries: false
+    enablePodMonitor: false
+  minSyncReplicas: 0
+  postgresGID: 26
+  primaryUpdateMethod: switchover
+  postgresUID: 26
+  walStorage:
+    resizeInUseVolumes: true
     size: 1Gi
+  maxSyncReplicas: 0
+  switchoverDelay: 40000000
+  storage:
+    resizeInUseVolumes: true
+    size: 1Gi
+  primaryUpdateStrategy: unsupervised
+  instances: 1

--- a/tests/examples/source/devfiles/go/cluster.yaml
+++ b/tests/examples/source/devfiles/go/cluster.yaml
@@ -3,7 +3,6 @@ kind: Cluster
 metadata:
   name: cluster-example-initdb
 spec:
-  instances: 1
   bootstrap:
     initdb:
       database: appdb
@@ -12,8 +11,30 @@ spec:
         name: appuser-secret
       postInitApplicationSQL:
         - create table users (userid SERIAL PRIMARY KEY,  name TEXT,  age INT,  location TEXT)
-  storage:
+  logLevel: info
+  startDelay: 30
+  stopDelay: 30
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  enableSuperuserAccess: true
+  monitoring:
+    disableDefaultQueries: false
+    enablePodMonitor: false
+  minSyncReplicas: 0
+  postgresGID: 26
+  primaryUpdateMethod: switchover
+  postgresUID: 26
+  walStorage:
+    resizeInUseVolumes: true
     size: 1Gi
+  maxSyncReplicas: 0
+  switchoverDelay: 40000000
+  storage:
+    resizeInUseVolumes: true
+    size: 1Gi
+  primaryUpdateStrategy: unsupervised
+  instances: 1
 ---
 apiVersion: v1
 stringData:


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**
This PR updates the bindable kind instance to work with OCP 4.12, it also updates the version channel to use stable-v1.18 for postgres.

**Which issue(s) this PR fixes:**

Fixes #6334 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
