### PR TITLE
Fix: Panic when running odo list namespaces without an active Kubernetes context

### DIFF
--- a/pkg/odo/cli/remove/binding/binding.go
+++ b/pkg/odo/cli/remove/binding/binding.go
@@ -86,7 +86,7 @@ func NewCmdBinding(name, fullName string) *cobra.Command {
 		},
 	}
 	bindingCmd.Flags().String(backend.FLAG_NAME, "", "Name of the Binding to create")
-	clientset.Add(bindingCmd, clientset.REMOVE_BINDING, clientset.FILESYSTEM)
+	clientset.Add(bindingCmd, clientset.BINDING, clientset.FILESYSTEM)
 
 	return bindingCmd
 }

--- a/pkg/odo/cli/remove/binding/binding.go
+++ b/pkg/odo/cli/remove/binding/binding.go
@@ -86,7 +86,7 @@ func NewCmdBinding(name, fullName string) *cobra.Command {
 		},
 	}
 	bindingCmd.Flags().String(backend.FLAG_NAME, "", "Name of the Binding to create")
-	clientset.Add(bindingCmd, clientset.BINDING, clientset.FILESYSTEM)
+	clientset.Add(bindingCmd, clientset.REMOVE_BINDING, clientset.FILESYSTEM)
 
 	return bindingCmd
 }

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -94,7 +94,7 @@ var subdeps map[string][]string = map[string][]string{
 	INIT:             {ALIZER, FILESYSTEM, PREFERENCE, REGISTRY},
 	LOGS:             {KUBERNETES_NULLABLE, PODMAN},
 	PORT_FORWARD:     {KUBERNETES_NULLABLE, STATE},
-	PROJECT:          {KUBERNETES_NULLABLE},
+	PROJECT:          {KUBERNETES},
 	REGISTRY:         {FILESYSTEM, PREFERENCE},
 	STATE:            {FILESYSTEM},
 	SYNC:             {EXEC},

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -46,6 +46,9 @@ const (
 	ALIZER = "DEP_ALIZER"
 	// BINDING instantiates client for pkg/binding
 	BINDING = "DEP_BINDING"
+	// REMOVE_BINDING instantiates client for pkg/binding for removing a binding;
+	// this is required so that the command can be run even when the cluster is inaccessible
+	REMOVE_BINDING = "DEP_REMOVE_BINDING"
 	// DELETE_COMPONENT instantiates client for pkg/component/delete
 	DELETE_COMPONENT = "DEP_DELETE_COMPONENT"
 	// DEPLOY instantiates client for pkg/deploy
@@ -100,6 +103,7 @@ var subdeps map[string][]string = map[string][]string{
 	SYNC:             {EXEC},
 	WATCH:            {KUBERNETES_NULLABLE},
 	BINDING:          {PROJECT, KUBERNETES_NULLABLE},
+	REMOVE_BINDING:   {KUBERNETES_NULLABLE},
 	/* Add sub-dependencies here, if any */
 }
 
@@ -227,7 +231,7 @@ func Fetch(command *cobra.Command, platform string) (*Clientset, error) {
 	if isDefined(command, WATCH) {
 		dep.WatchClient = watch.NewWatchClient(dep.KubernetesClient)
 	}
-	if isDefined(command, BINDING) {
+	if isDefined(command, BINDING) || isDefined(command, REMOVE_BINDING) {
 		dep.BindingClient = binding.NewBindingClient(dep.ProjectClient, dep.KubernetesClient)
 	}
 	if isDefined(command, PORT_FORWARD) {

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -178,6 +178,11 @@ ComponentSettings:
 		})
 
 		Describe("list "+commandName, func() {
+			It("should fail, without cluster", Label(helper.LabelNoCluster), func() {
+				out := helper.Cmd("odo", "list", commandName).ShouldFail().Err()
+				Expect(out).To(ContainSubstring("Please ensure you have an active kubernetes context to your cluster."))
+			})
+
 			It(fmt.Sprintf("should successfully list all the %ss", commandName), func() {
 				Eventually(func() string {
 					out := helper.Cmd("odo", "list", commandName).ShouldPass().Out()


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #6316 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
`odo list namespace` no longer panics, instead throws an appropriate error.
```sh
KUBECONFIG=/dev/null odo list namespace
```
```sh
$ KUBECONFIG=/dev/null odo list namespace
 ✗  
Please ensure you have an active kubernetes context to your cluster. 
Consult your Kubernetes distribution's documentation for more details.
Error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable


```

`odo remove binding` still works when the cluster is inaccessible. The [test](https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-tests-openshift-logs/pr-6367-nocluster-tests-433.txt) for this was failing when a new REMOVE_BINDING dep was not added. Commit f542b220835b96f577975b693710cd8957914c7d fixes that.

```sh
KUBECONFIG=/dev/null odo remove binding --name something
```
```sh
$ KUBECONFIG=/dev/null odo remove binding --name something
 ✗  Service Binding "something" not found in the devfile. Available Service Bind
ings:

```