### PR TITLE
Display a warning when connection to cluster fails

### DIFF
--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -103,6 +103,9 @@ func (o *ComponentOptions) Run(ctx context.Context) error {
 // Run contains the logic for the odo command
 func (o *ComponentOptions) RunForJsonOutput(ctx context.Context) (out interface{}, err error) {
 	result, _, err := o.run(ctx) // TODO(feloy) handle warning
+	if clierrors.AsWarning(err) {
+		err = nil
+	}
 	return result, err
 }
 

--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/log"
+	clierrors "github.com/redhat-developer/odo/pkg/odo/cli/errors"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/commonflags"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
@@ -90,14 +91,18 @@ func (o *ComponentOptions) Validate(ctx context.Context) (err error) {
 func (o *ComponentOptions) Run(ctx context.Context) error {
 	result, devfileObj, err := o.run(ctx)
 	if err != nil {
-		return err
+		if clierrors.AsWarning(err) {
+			log.Warning(err.Error())
+		} else {
+			return err
+		}
 	}
 	return printHumanReadableOutput(result, devfileObj)
 }
 
 // Run contains the logic for the odo command
 func (o *ComponentOptions) RunForJsonOutput(ctx context.Context) (out interface{}, err error) {
-	result, _, err := o.run(ctx)
+	result, _, err := o.run(ctx) // TODO(feloy) handle warning
 	return result, err
 }
 
@@ -162,7 +167,8 @@ func (o *ComponentOptions) describeDevfileComponent(ctx context.Context) (result
 	}
 	ingresses, routes, err := component.ListRoutesAndIngresses(o.clientset.KubernetesClient, componentName, odocontext.GetApplication(ctx))
 	if err != nil {
-		return api.Component{}, nil, fmt.Errorf("failed to get ingresses/routes: %w", err)
+		err = clierrors.NewWarning("failed to get ingresses/routes", err)
+		// Do not return the error yet, as it is only a warning
 	}
 
 	return api.Component{
@@ -173,7 +179,7 @@ func (o *ComponentOptions) describeDevfileComponent(ctx context.Context) (result
 		ManagedBy:         "odo",
 		Ingresses:         ingresses,
 		Routes:            routes,
-	}, devfileObj, nil
+	}, devfileObj, err
 }
 
 func printHumanReadableOutput(cmp api.Component, devfileObj *parser.DevfileObj) error {

--- a/pkg/odo/cli/errors/errors.go
+++ b/pkg/odo/cli/errors/errors.go
@@ -1,6 +1,9 @@
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type NoCommandInDevfileError struct {
 	command string
@@ -14,4 +17,29 @@ func NewNoCommandInDevfileError(command string) NoCommandInDevfileError {
 
 func (o NoCommandInDevfileError) Error() string {
 	return fmt.Sprintf("no command of kind %q found in the devfile", o.command)
+}
+
+type Warning struct {
+	msg string
+	err error
+}
+
+func NewWarning(msg string, err error) Warning {
+	return Warning{
+		msg: msg,
+		err: err,
+	}
+}
+
+func (o Warning) Error() string {
+	return fmt.Errorf("%s: %w", o.msg, o.err).Error()
+}
+
+func IsWarning(err error) bool {
+	_, ok := err.(Warning)
+	return ok
+}
+
+func AsWarning(err error) bool {
+	return errors.As(err, &Warning{})
 }

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -107,39 +107,18 @@ var _ = Describe("odo describe component command tests", func() {
 			}
 		}
 
-		It("should describe the component in the current directory", Label(helper.LabelNoCluster), func() {
-			By("running with json output", func() {
-				res := helper.Cmd("odo", "describe", "component", "-o", "json").ShouldPass()
-				stdout, stderr := res.Out(), res.Err()
-				Expect(helper.IsJSON(stdout)).To(BeTrue())
-				Expect(stderr).To(BeEmpty())
-				checkDevfileJSONDescription(stdout, "devfile.yaml")
-				helper.JsonPathContentIs(stdout, "runningIn", "")
-				helper.JsonPathContentIs(stdout, "devForwardedPorts", "")
-			})
+		for _, label := range []string{
+			helper.LabelNoCluster, helper.LabelUnauth,
+		} {
+			label := label
 
-			By("running with default output", func() {
-				res := helper.Cmd("odo", "describe", "component").ShouldPass()
-				stdout := res.Out()
-				checkDevfileDescription(stdout, false)
-				Expect(stdout).To(ContainSubstring("Running in: None"))
-				Expect(stdout).ToNot(ContainSubstring("Forwarded ports"))
-			})
-		})
-
-		When("renaming to hide devfile.yaml file", Label(helper.LabelNoCluster), func() {
-			BeforeEach(func() {
-				err := os.Rename("devfile.yaml", ".devfile.yaml")
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should describe the component in the current directory using the hidden devfile", func() {
+			It("should describe the component in the current directory", Label(label), func() {
 				By("running with json output", func() {
 					res := helper.Cmd("odo", "describe", "component", "-o", "json").ShouldPass()
 					stdout, stderr := res.Out(), res.Err()
 					Expect(helper.IsJSON(stdout)).To(BeTrue())
 					Expect(stderr).To(BeEmpty())
-					checkDevfileJSONDescription(stdout, ".devfile.yaml")
+					checkDevfileJSONDescription(stdout, "devfile.yaml")
 					helper.JsonPathContentIs(stdout, "runningIn", "")
 					helper.JsonPathContentIs(stdout, "devForwardedPorts", "")
 				})
@@ -152,7 +131,34 @@ var _ = Describe("odo describe component command tests", func() {
 					Expect(stdout).ToNot(ContainSubstring("Forwarded ports"))
 				})
 			})
-		})
+
+			When("renaming to hide devfile.yaml file", Label(label), func() {
+				BeforeEach(func() {
+					err := os.Rename("devfile.yaml", ".devfile.yaml")
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should describe the component in the current directory using the hidden devfile", func() {
+					By("running with json output", func() {
+						res := helper.Cmd("odo", "describe", "component", "-o", "json").ShouldPass()
+						stdout, stderr := res.Out(), res.Err()
+						Expect(helper.IsJSON(stdout)).To(BeTrue())
+						Expect(stderr).To(BeEmpty())
+						checkDevfileJSONDescription(stdout, ".devfile.yaml")
+						helper.JsonPathContentIs(stdout, "runningIn", "")
+						helper.JsonPathContentIs(stdout, "devForwardedPorts", "")
+					})
+
+					By("running with default output", func() {
+						res := helper.Cmd("odo", "describe", "component").ShouldPass()
+						stdout := res.Out()
+						checkDevfileDescription(stdout, false)
+						Expect(stdout).To(ContainSubstring("Running in: None"))
+						Expect(stdout).ToNot(ContainSubstring("Forwarded ports"))
+					})
+				})
+			})
+		}
 
 		It("should not describe the component from another directory", func() {
 			By("running with json output", func() {

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -127,27 +127,6 @@ var _ = Describe("odo describe component command tests", func() {
 			})
 		})
 
-		It("should not describe the component from another directory", func() {
-			By("running with json output", func() {
-				err := os.Chdir("/")
-				Expect(err).NotTo(HaveOccurred())
-				res := helper.Cmd("odo", "describe", "component", "--name", cmpName, "-o", "json").ShouldFail()
-				stdout, stderr := res.Out(), res.Err()
-				Expect(helper.IsJSON(stderr)).To(BeTrue())
-				Expect(stdout).To(BeEmpty())
-				helper.JsonPathContentContain(stderr, "message", "no component found with name \""+cmpName+"\" in the namespace \""+commonVar.Project+"\"")
-			})
-
-			By("running with default output", func() {
-				err := os.Chdir("/")
-				Expect(err).NotTo(HaveOccurred())
-				res := helper.Cmd("odo", "describe", "component", "--name", cmpName).ShouldFail()
-				stdout, stderr := res.Out(), res.Err()
-				Expect(stdout).To(BeEmpty())
-				Expect(stderr).To(ContainSubstring("no component found with name \"" + cmpName + "\" in the namespace \"" + commonVar.Project + "\""))
-			})
-		})
-
 		When("renaming to hide devfile.yaml file", Label(helper.LabelNoCluster), func() {
 			BeforeEach(func() {
 				err := os.Rename("devfile.yaml", ".devfile.yaml")
@@ -172,6 +151,27 @@ var _ = Describe("odo describe component command tests", func() {
 					Expect(stdout).To(ContainSubstring("Running in: None"))
 					Expect(stdout).ToNot(ContainSubstring("Forwarded ports"))
 				})
+			})
+		})
+
+		It("should not describe the component from another directory", func() {
+			By("running with json output", func() {
+				err := os.Chdir("/")
+				Expect(err).NotTo(HaveOccurred())
+				res := helper.Cmd("odo", "describe", "component", "--name", cmpName, "-o", "json").ShouldFail()
+				stdout, stderr := res.Out(), res.Err()
+				Expect(helper.IsJSON(stderr)).To(BeTrue())
+				Expect(stdout).To(BeEmpty())
+				helper.JsonPathContentContain(stderr, "message", "no component found with name \""+cmpName+"\" in the namespace \""+commonVar.Project+"\"")
+			})
+
+			By("running with default output", func() {
+				err := os.Chdir("/")
+				Expect(err).NotTo(HaveOccurred())
+				res := helper.Cmd("odo", "describe", "component", "--name", cmpName).ShouldFail()
+				stdout, stderr := res.Out(), res.Err()
+				Expect(stdout).To(BeEmpty())
+				Expect(stderr).To(ContainSubstring("no component found with name \"" + cmpName + "\" in the namespace \"" + commonVar.Project + "\""))
 			})
 		})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR makes `odo describe component` display a warning (in non-json output mode) when an error occurs when trying to get ingresses/routes, and not fail.

For the moment, is warning is not returned to json output, the error is just ignored.

**Which issue(s) this PR fixes:**

Fixes #6379 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

```
$ odo logout
$ odo describe component 
 ⚠  failed to get ingresses/routes: ingresses.networking.k8s.io is forbidden: User "system:anonymous" cannot list resource "ingresses" in API group "networking.k8s.io" in the namespace "prj3"
Name: empty
Display Name: Go Runtime
Project Type: Go
Language: Go
Version: 1.0.2
Description: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
Tags: Go

Running in: None

Supported odo features:
 •  Dev: true
 •  Deploy: false
 •  Debug: false

Container components:
 •  runtime
```
