### PR TITLE
Flake odo add binding in interactive doest show namespace recently created

### DIFF
--- a/tests/integration/interactive_add_binding_test.go
+++ b/tests/integration/interactive_add_binding_test.go
@@ -223,11 +223,11 @@ var _ = Describe("odo add binding interactive command tests", func() {
 
 			BeforeEach(func() {
 				otherNS = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+				nsWithNoService = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 				addBindableKindInOtherNs := commonVar.CliRunner.Run("-n", otherNS, "apply", "-f",
 					helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
 				Expect(addBindableKindInOtherNs.ExitCode()).To(BeEquivalentTo(0))
 				commonVar.CliRunner.EnsurePodIsUp(otherNS, "cluster-sample-1")
-				nsWithNoService = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 				commonVar.CliRunner.ListNamespaceProject(nsWithNoService)
 				commonVar.CliRunner.ListNamespaceProject(otherNS)
 
@@ -556,11 +556,11 @@ var _ = Describe("odo add binding interactive command tests", func() {
 
 			BeforeEach(func() {
 				otherNS = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
+				nsWithNoService = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 				addBindableKindInOtherNs := commonVar.CliRunner.Run("-n", otherNS, "apply", "-f",
 					helper.GetExamplePath("manifests", "bindablekind-instance.yaml"))
 				Expect(addBindableKindInOtherNs.ExitCode()).To(BeEquivalentTo(0))
 				commonVar.CliRunner.EnsurePodIsUp(otherNS, "cluster-sample-1")
-				nsWithNoService = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 				commonVar.CliRunner.ListNamespaceProject(nsWithNoService)
 				commonVar.CliRunner.ListNamespaceProject(otherNS)
 


### PR DESCRIPTION
**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**
This PR fixes test Flake of odo interactive mode
- [It] should error out if service is not found in the namespace selected

**Which issue(s) this PR fixes:**

Fixes #6390

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
