### PR TITLE
Show Devfile Stack versions in "odo registry" output

### DIFF
--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -314,69 +314,106 @@ odo registry -o json
 ```
 ```json
 [
-	{
-		"name": "python-django",
-		"displayName": "Django",
-		"description": "Python3.7 with Django",
-		"registry": {
-			"name": "DefaultDevfileRegistry",
-			"url": "https://registry.devfile.io",
-			"secure": false
-		},
-		"language": "python",
-		"tags": [
-			"Python",
-			"pip",
-			"Django"
-		],
-		"projectType": "django",
-		"version": "1.0.0",
-		"starterProjects": [
-			"django-example"
-		]
-	}, [...]
+  {
+    "name": "python",
+    "displayName": "Python",
+    "description": "Python is an interpreted, object-oriented, high-level programming language with dynamic semantics. Its high-level built in data structures, combined with dynamic typing and dynamic binding, make it very attractive for Rapid Application Development, as well as for use as a scripting or glue language to connect existing components together.",
+    "registry": {
+      "name": "DefaultDevfileRegistry",
+      "url": "https://registry.devfile.io",
+      "secure": false
+    },
+    "language": "Python",
+    "tags": [
+      "Python",
+      "Pip",
+      "Flask"
+    ],
+    "projectType": "Python",
+    "version": "2.1.0",
+    "versions": [
+      {
+        "version": "2.1.0",
+        "isDefault": true,
+        "schemaVersion": "2.1.0",
+        "starterProjects": [
+          "flask-example"
+        ]
+      },
+      {
+        "version": "3.0.0",
+        "isDefault": false,
+        "schemaVersion": "2.2.0",
+        "starterProjects": [
+          "flask-example"
+        ]
+      }
+    ],
+    "starterProjects": [
+      "flask-example"
+    ]
+  },
+  [...]
 ]
 ```
 
 Using the `--details` flag, you will also get information about the Devfile:
 
 ```shell
-odo registry --details -o json
+odo registry --devfile java-springboot --details -o json
 ```
 ```json
 [
-	{
-		"name": "python-django",
-		"displayName": "Django",
-		"description": "Python3.7 with Django",
-		"registry": {
-			"name": "DefaultDevfileRegistry",
-			"url": "https://registry.devfile.io",
-			"secure": false
-		},
-		"language": "python",
-		"tags": [
-			"Python",
-			"pip",
-			"Django"
-		],
-		"projectType": "django",
-		"version": "1.0.0",
-		"starterProjects": [
-			"django-example"
-		],
-		"devfileData": {
-			"devfile": {
-				"schemaVersion": "2.0.0",
-				[ devfile.yaml file content ]
-			},
-			"supportedOdoFeatures": {
-				"dev": true,
-				"deploy": false,
-				"debug": true
-			}
-		},
-	}, [...]
+  {
+    "name": "java-springboot",
+    "displayName": "Spring Boot",
+    "description": "Spring Boot using Java",
+    "registry": {
+      "name": "DefaultDevfileRegistry",
+      "url": "https://registry.devfile.io",
+      "secure": false
+    },
+    "language": "Java",
+    "tags": [
+      "Java",
+      "Spring Boot"
+    ],
+    "projectType": "springboot",
+    "version": "1.2.0",
+    "versions": [
+      {
+        "version": "1.2.0",
+        "isDefault": true,
+        "schemaVersion": "2.1.0",
+        "starterProjects": [
+          "springbootproject"
+        ]
+      },
+      {
+        "version": "2.0.0",
+        "isDefault": false,
+        "schemaVersion": "2.2.0",
+        "starterProjects": [
+          "springbootproject"
+        ]
+      }
+    ],
+    "starterProjects": [
+      "springbootproject"
+    ],
+    "devfileData": {
+      "devfile": {
+        "schemaVersion": "2.0.0",
+        [ devfile.yaml file content ]
+      },
+      "supportedOdoFeatures": {
+        "dev": true,
+        "deploy": false,
+        "debug": true
+      }
+    }
+  },
+  [...]
 ]
 ```
 

--- a/docs/website/docs/command-reference/registry.md
+++ b/docs/website/docs/command-reference/registry.md
@@ -18,10 +18,9 @@ These flags let you filter the listed Devfile stacks:
 when adding the registry to the preferences with `odo preference add registry <name> <url>`)
 * `--filter <term>` to list the Devfile for which the term is found in the devfile name or description
 
-By default, the name, registry and description 
-of the Devfile stacks are displayed on a table.
+By default, the name, registry, description and versions of the Devfile stacks are displayed on a table.
 
-This flag lets you change the content of the output:
+The flags below let you change the content of the output:
 
 * `--details` to display details about the Devfile stacks
 * `-o json` to output the information in a JSON format
@@ -50,18 +49,18 @@ odo registry
 
 ```console
 $ odo registry
- NAME                          REGISTRY                DESCRIPTION                                 
- dotnet50                      Staging                 Stack with .NET 5.0                         
- dotnet50                      DefaultDevfileRegistry  Stack with .NET 5.0                         
- dotnet60                      Staging                 Stack with .NET 6.0                         
- dotnet60                      DefaultDevfileRegistry  Stack with .NET 6.0                         
- dotnetcore31                  Staging                 Stack with .NET Core 3.1                    
- dotnetcore31                  DefaultDevfileRegistry  Stack with .NET Core 3.1                    
- go                            Staging                 Stack with the latest Go version            
- go                            DefaultDevfileRegistry  Stack with the latest Go version            
- java-maven                    Staging                 Upstream Maven and OpenJDK 11               
- java-maven                    DefaultDevfileRegistry  Upstream Maven and OpenJDK 11               
-[...]
+ NAME                          REGISTRY                DESCRIPTION                                  VERSIONS
+ dotnet50                      Staging                 Stack with .NET 5.0                          1.0.3
+ dotnet50                      DefaultDevfileRegistry  Stack with .NET 5.0                          1.0.3
+ dotnet60                      Staging                 Stack with .NET 6.0                          1.0.2
+ dotnet60                      DefaultDevfileRegistry  Stack with .NET 6.0                          1.0.2
+ dotnetcore31                  Staging                 Stack with .NET Core 3.1                     1.0.3
+ dotnetcore31                  DefaultDevfileRegistry  Stack with .NET Core 3.1                     1.0.3
+ go                            Staging                 Go is an open source programming languag...  1.0.2, 2.0.0
+ go                            DefaultDevfileRegistry  Go is an open source programming languag...  1.0.2, 2.0.0
+ java-maven                    Staging                 Upstream Maven and OpenJDK 11                1.2.0
+ java-maven                    DefaultDevfileRegistry  Upstream Maven and OpenJDK 11                1.2.0
+ [...]
 ```
 </details>
 
@@ -77,13 +76,13 @@ odo registry --devfile-registry <registry>
 
 ```console
 $ odo registry --devfile-registry Staging
- NAME                          REGISTRY                DESCRIPTION                                 
- dotnet50                      Staging                 Stack with .NET 5.0                         
- dotnet60                      Staging                 Stack with .NET 6.0                         
- dotnetcore31                  Staging                 Stack with .NET Core 3.1                    
- go                            Staging                 Stack with the latest Go version            
- java-maven                    Staging                 Upstream Maven and OpenJDK 11               
-[...]
+ NAME                          REGISTRY  DESCRIPTION                                  VERSIONS
+ dotnet50                      Staging   Stack with .NET 5.0                          1.0.3
+ dotnet60                      Staging   Stack with .NET 6.0                          1.0.2
+ dotnetcore31                  Staging   Stack with .NET Core 3.1                     1.0.3
+ go                            Staging   Go is an open source programming languag...  1.0.2, 2.0.0
+ java-maven                    Staging   Upstream Maven and OpenJDK 11                1.2.0
+ [...]
 ```
 </details>
 
@@ -98,15 +97,15 @@ odo registry --filter <keyword>
 
 ```console
 $ odo registry --filter Maven
- NAME                       REGISTRY                DESCRIPTION                                 
- java-maven                 Staging                 Upstream Maven and OpenJDK 11               
- java-maven                 DefaultDevfileRegistry  Upstream Maven and OpenJDK 11               
- java-openliberty           Staging                 Java application Maven-built stack using... 
- java-openliberty           DefaultDevfileRegistry  Java application Maven-built stack using... 
- java-websphereliberty      Staging                 Java application Maven-built stack using... 
- java-websphereliberty      DefaultDevfileRegistry  Java application Maven-built stack using... 
- java-wildfly-bootable-jar  Staging                 Java stack with WildFly in bootable Jar ... 
- java-wildfly-bootable-jar  DefaultDevfileRegistry  Java stack with WildFly in bootable Jar ... 
+ NAME                       REGISTRY                DESCRIPTION                                  VERSIONS
+ java-maven                 Staging                 Upstream Maven and OpenJDK 11                1.2.0
+ java-maven                 DefaultDevfileRegistry  Upstream Maven and OpenJDK 11                1.2.0
+ java-openliberty           Staging                 Java application Maven-built stack using...  0.9.0
+ java-openliberty           DefaultDevfileRegistry  Java application Maven-built stack using...  0.9.0
+ java-websphereliberty      Staging                 Java application Maven-built stack using...  0.9.0
+ java-websphereliberty      DefaultDevfileRegistry  Java application Maven-built stack using...  0.9.0
+ java-wildfly-bootable-jar  Staging                 Java stack with WildFly in bootable Jar ...  1.1.0
+ java-wildfly-bootable-jar  DefaultDevfileRegistry  Java stack with WildFly in bootable Jar ...  1.1.0
 ```
 </details>
 
@@ -125,17 +124,20 @@ Name: java-maven
 Display Name: Maven Java
 Registry: Staging
 Registry URL: https://registry.stage.devfile.io
-Version: 1.1.0
+Version: 1.2.0
 Description: Upstream Maven and OpenJDK 11 
 Tags: Java, Maven
-Project Type: maven
-Language: java
+Project Type: Maven
+Language: Java
 Starter Projects:
   - springbootproject
 Supported odo Features:
   - Dev: Y
   - Deploy: N
   - Debug: Y
+Versions:
+  - 1.2.0
+
 ```
 </details>
 

--- a/docs/website/docs/user-guides/quickstart/quickstart.md
+++ b/docs/website/docs/user-guides/quickstart/quickstart.md
@@ -18,30 +18,31 @@ A full list of example applications can be viewed with the `odo registry` comman
 
 ```shell
 $ odo registry
- NAME                          REGISTRY                DESCRIPTION                                 
- dotnet50                      DefaultDevfileRegistry  Stack with .NET 5.0                         
- dotnet60                      DefaultDevfileRegistry  Stack with .NET 6.0                         
- dotnetcore31                  DefaultDevfileRegistry  Stack with .NET Core 3.1                    
- go                            DefaultDevfileRegistry  Go is an open source programming languag... 
- java-maven                    DefaultDevfileRegistry  Upstream Maven and OpenJDK 11               
- java-openliberty              DefaultDevfileRegistry  Java application Maven-built stack using... 
- java-openliberty-gradle       DefaultDevfileRegistry  Java application Gradle-built stack usin... 
- java-quarkus                  DefaultDevfileRegistry  Quarkus with Java                           
- java-springboot               DefaultDevfileRegistry  Spring Boot® using Java                     
- java-vertx                    DefaultDevfileRegistry  Upstream Vert.x using Java                  
- java-websphereliberty         DefaultDevfileRegistry  Java application Maven-built stack using... 
- java-websphereliberty-gradle  DefaultDevfileRegistry  Java application Gradle-built stack usin... 
- java-wildfly                  DefaultDevfileRegistry  Upstream WildFly                            
- java-wildfly-bootable-jar     DefaultDevfileRegistry  Java stack with WildFly in bootable Jar ... 
- nodejs                        DefaultDevfileRegistry  Stack with Node.js 16                       
- nodejs-angular                DefaultDevfileRegistry  Angular is a development platform, built... 
- nodejs-nextjs                 DefaultDevfileRegistry  Next.js gives you the best developer exp... 
- nodejs-nuxtjs                 DefaultDevfileRegistry  Nuxt is the backbone of your Vue.js proj... 
- nodejs-react                  DefaultDevfileRegistry  React is a free and open-source front-en... 
- nodejs-svelte                 DefaultDevfileRegistry  Svelte is a radical new approach to buil... 
- nodejs-vue                    DefaultDevfileRegistry  Vue is a JavaScript framework for buildi... 
- php-laravel                   DefaultDevfileRegistry  Laravel is an open-source PHP framework,... 
- python                        DefaultDevfileRegistry  Python is an interpreted, object-oriente... 
- python-django                 DefaultDevfileRegistry  Django is a high-level Python web framew...
+ NAME                          REGISTRY                DESCRIPTION                                  VERSIONS
+ dotnet50                      DefaultDevfileRegistry  Stack with .NET 5.0                          1.0.3
+ dotnet60                      DefaultDevfileRegistry  Stack with .NET 6.0                          1.0.2
+ dotnetcore31                  DefaultDevfileRegistry  Stack with .NET Core 3.1                     1.0.3
+ go                            DefaultDevfileRegistry  Go is an open source programming languag...  1.0.2, 2.0.0
+ java-maven                    DefaultDevfileRegistry  Upstream Maven and OpenJDK 11                1.2.0
+ java-openliberty              DefaultDevfileRegistry  Java application Maven-built stack using...  0.9.0
+ java-openliberty-gradle       DefaultDevfileRegistry  Java application Gradle-built stack usin...  0.4.0
+ java-quarkus                  DefaultDevfileRegistry  Quarkus with Java                            1.3.0
+ java-springboot               DefaultDevfileRegistry  Spring Boot using Java                       1.2.0, 2.0.0
+ java-vertx                    DefaultDevfileRegistry  Upstream Vert.x using Java                   1.2.0
+ java-websphereliberty         DefaultDevfileRegistry  Java application Maven-built stack using...  0.9.0
+ java-websphereliberty-gradle  DefaultDevfileRegistry  Java application Gradle-built stack usin...  0.4.0
+ java-wildfly                  DefaultDevfileRegistry  Upstream WildFly                             1.1.0
+ java-wildfly-bootable-jar     DefaultDevfileRegistry  Java stack with WildFly in bootable Jar ...  1.1.0
+ nodejs                        DefaultDevfileRegistry  Stack with Node.js 16                        2.1.1
+ nodejs-angular                DefaultDevfileRegistry  Angular is a development platform, built...  2.0.2
+ nodejs-nextjs                 DefaultDevfileRegistry  Next.js gives you the best developer exp...  1.0.3
+ nodejs-nuxtjs                 DefaultDevfileRegistry  Nuxt is the backbone of your Vue.js proj...  1.0.3
+ nodejs-react                  DefaultDevfileRegistry  React is a free and open-source front-en...  2.0.2
+ nodejs-svelte                 DefaultDevfileRegistry  Svelte is a radical new approach to buil...  1.0.3
+ nodejs-vue                    DefaultDevfileRegistry  Vue is a JavaScript framework for buildi...  1.0.2
+ php-laravel                   DefaultDevfileRegistry  Laravel is an open-source PHP framework,...  1.0.1
+ python                        DefaultDevfileRegistry  Python is an interpreted, object-oriente...  2.1.0, 3.0.0
+ python-django                 DefaultDevfileRegistry  Django is a high-level Python web framew...  2.1.0
+
 ```
 </details>

--- a/pkg/api/registry.go
+++ b/pkg/api/registry.go
@@ -11,14 +11,24 @@ type Registry struct {
 
 // DevfileStack is the main struct for devfile stack
 type DevfileStack struct {
-	Name            string       `json:"name"`
-	DisplayName     string       `json:"displayName"`
-	Description     string       `json:"description"`
-	Registry        Registry     `json:"registry"`
-	Language        string       `json:"language"`
-	Tags            []string     `json:"tags"`
-	ProjectType     string       `json:"projectType"`
-	Version         string       `json:"version"`
-	StarterProjects []string     `json:"starterProjects"`
-	DevfileData     *DevfileData `json:"devfileData,omitempty"`
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Description string   `json:"description"`
+	Registry    Registry `json:"registry"`
+	Language    string   `json:"language"`
+	Tags        []string `json:"tags"`
+	ProjectType string   `json:"projectType"`
+
+	// DefaultVersion is the default version. Marshalled as "version" for backward compatibility.
+	// Deprecated. Use Versions instead.
+	DefaultVersion  string                `json:"version"`
+	Versions        []DevfileStackVersion `json:"versions,omitempty"`
+	StarterProjects []string              `json:"starterProjects"`
+	DevfileData     *DevfileData          `json:"devfileData,omitempty"`
+}
+
+type DevfileStackVersion struct {
+	Version       string `json:"version,omitempty"`
+	IsDefault     bool   `json:"isDefault"`
+	SchemaVersion string `json:"schemaVersion,omitempty"`
 }

--- a/pkg/api/registry.go
+++ b/pkg/api/registry.go
@@ -21,14 +21,19 @@ type DevfileStack struct {
 
 	// DefaultVersion is the default version. Marshalled as "version" for backward compatibility.
 	// Deprecated. Use Versions instead.
-	DefaultVersion  string                `json:"version"`
-	Versions        []DevfileStackVersion `json:"versions,omitempty"`
-	StarterProjects []string              `json:"starterProjects"`
-	DevfileData     *DevfileData          `json:"devfileData,omitempty"`
+	DefaultVersion string                `json:"version"`
+	Versions       []DevfileStackVersion `json:"versions,omitempty"`
+
+	// DefaultStarterProjects is the list of starter projects for the default stack.
+	// Marshalled as "starterProjects" for backward compatibility.
+	// Deprecated. Use Versions.StarterProjects instead.
+	DefaultStarterProjects []string     `json:"starterProjects"`
+	DevfileData            *DevfileData `json:"devfileData,omitempty"`
 }
 
 type DevfileStackVersion struct {
-	Version       string `json:"version,omitempty"`
-	IsDefault     bool   `json:"isDefault"`
-	SchemaVersion string `json:"schemaVersion,omitempty"`
+	Version         string   `json:"version,omitempty"`
+	IsDefault       bool     `json:"isDefault"`
+	SchemaVersion   string   `json:"schemaVersion,omitempty"`
+	StarterProjects []string `json:"starterProjects"`
 }

--- a/pkg/odo/cli/registry/registry.go
+++ b/pkg/odo/cli/registry/registry.go
@@ -217,7 +217,7 @@ func (o *ListOptions) printDevfileList(DevfileList []api.DevfileStack) {
 				log.Sbold("Tags"), strings.Join(devfileComponent.Tags[:], ", "),
 				log.Sbold("Project Type"), devfileComponent.ProjectType,
 				log.Sbold("Language"), devfileComponent.Language,
-				log.Sbold("Starter Projects"), strings.Join(devfileComponent.StarterProjects, "\n  - "),
+				log.Sbold("Starter Projects"), strings.Join(devfileComponent.DefaultStarterProjects, "\n  - "),
 				log.Sbold("Supported odo Features"),
 				boolToYesNo(devfileComponent.DevfileData.SupportedOdoFeatures.Dev),
 				boolToYesNo(devfileComponent.DevfileData.SupportedOdoFeatures.Deploy),

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -218,26 +218,27 @@ func createRegistryDevfiles(registry api.Registry, devfileIndex []indexSchema.Sc
 	registryDevfiles := make([]api.DevfileStack, 0, len(devfileIndex))
 	for _, devfileIndexEntry := range devfileIndex {
 		stackDevfile := api.DevfileStack{
-			Name:            devfileIndexEntry.Name,
-			DisplayName:     devfileIndexEntry.DisplayName,
-			Description:     devfileIndexEntry.Description,
-			Registry:        registry,
-			Language:        devfileIndexEntry.Language,
-			Tags:            devfileIndexEntry.Tags,
-			ProjectType:     devfileIndexEntry.ProjectType,
-			StarterProjects: devfileIndexEntry.StarterProjects,
-			DefaultVersion:  devfileIndexEntry.Version,
+			Name:                   devfileIndexEntry.Name,
+			DisplayName:            devfileIndexEntry.DisplayName,
+			Description:            devfileIndexEntry.Description,
+			Registry:               registry,
+			Language:               devfileIndexEntry.Language,
+			Tags:                   devfileIndexEntry.Tags,
+			ProjectType:            devfileIndexEntry.ProjectType,
+			DefaultStarterProjects: devfileIndexEntry.StarterProjects,
+			DefaultVersion:         devfileIndexEntry.Version,
 		}
-		hasDefaultVersion := devfileIndexEntry.Version != ""
 		for _, v := range devfileIndexEntry.Versions {
-			if !hasDefaultVersion && v.Default {
+			if v.Default {
+				// There should be only 1 default version. But if there is more than one, the last one will be used.
 				stackDevfile.DefaultVersion = v.Version
-				hasDefaultVersion = true
+				stackDevfile.DefaultStarterProjects = v.StarterProjects
 			}
 			stackDevfile.Versions = append(stackDevfile.Versions, api.DevfileStackVersion{
-				IsDefault:     v.Default,
-				Version:       v.Version,
-				SchemaVersion: v.SchemaVersion,
+				IsDefault:       v.Default,
+				Version:         v.Version,
+				SchemaVersion:   v.SchemaVersion,
+				StarterProjects: v.StarterProjects,
 			})
 		}
 		sort.Slice(stackDevfile.Versions, func(i, j int) bool {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/blang/semver"
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	dfutil "github.com/devfile/library/pkg/util"
 	indexSchema "github.com/devfile/registry-support/index/generator/schema"
@@ -239,6 +240,17 @@ func createRegistryDevfiles(registry api.Registry, devfileIndex []indexSchema.Sc
 				SchemaVersion: v.SchemaVersion,
 			})
 		}
+		sort.Slice(stackDevfile.Versions, func(i, j int) bool {
+			vi, err := semver.Make(stackDevfile.Versions[i].Version)
+			if err != nil {
+				return false
+			}
+			vj, err := semver.Make(stackDevfile.Versions[j].Version)
+			if err != nil {
+				return false
+			}
+			return vi.LT(vj)
+		})
 
 		registryDevfiles = append(registryDevfiles, stackDevfile)
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -216,8 +216,21 @@ func createRegistryDevfiles(registry api.Registry, devfileIndex []indexSchema.Sc
 			Tags:            devfileIndexEntry.Tags,
 			ProjectType:     devfileIndexEntry.ProjectType,
 			StarterProjects: devfileIndexEntry.StarterProjects,
-			Version:         devfileIndexEntry.Version,
+			DefaultVersion:  devfileIndexEntry.Version,
 		}
+		hasDefaultVersion := devfileIndexEntry.Version != ""
+		for _, v := range devfileIndexEntry.Versions {
+			if !hasDefaultVersion && v.Default {
+				stackDevfile.DefaultVersion = v.Version
+				hasDefaultVersion = true
+			}
+			stackDevfile.Versions = append(stackDevfile.Versions, api.DevfileStackVersion{
+				IsDefault:     v.Default,
+				Version:       v.Version,
+				SchemaVersion: v.SchemaVersion,
+			})
+		}
+
 		registryDevfiles = append(registryDevfiles, stackDevfile)
 	}
 


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area registry

**What does this PR do / why we need it:**
This PR fetches and displays the Devfile Stack versions in the "odo registry" output (both human-readable and JSON).
As discussed in the linked issue, it does so by first querying (using the Devfile library) the `/v2index` registry endpoint (which should expose a list of stack versions), and falls back to the `/index` endpoint if the `/v2index` is not available.
See https://github.com/redhat-developer/odo/issues/6314 for more context.

For backward compatibility, the `Version` and `Starter Projects` fields have not been removed. Just like before, they are representing the version and starter projects of the default Stack version.

**Which issue(s) this PR fixes:**
Fixes #6314

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] Documentation
  - [Quickstart](https://deploy-preview-6397--odo-docusaurus-preview.netlify.app/docs/user-guides/quickstart/)
  - [`odo registry` command reference](https://deploy-preview-6397--odo-docusaurus-preview.netlify.app/docs/command-reference/registry)
  - [`odo registry -o json`](https://deploy-preview-6397--odo-docusaurus-preview.netlify.app/docs/command-reference/json-output#odo-registry--o-json)

**How to test changes / Special notes to the reviewer:**

- A new "VERSIONS" column is added to the human-readable output of `odo registry`:
```
$ odo registry --devfile-registry Staging                       
 NAME                          REGISTRY  DESCRIPTION                                  VERSIONS     
 dotnet50                      Staging   Stack with .NET 5.0                          1.0.3        
 dotnet60                      Staging   Stack with .NET 6.0                          1.0.2        
 dotnetcore31                  Staging   Stack with .NET Core 3.1                     1.0.3        
 go                            Staging   Go is an open source programming languag...  1.0.2, 2.0.0 
 java-maven                    Staging   Upstream Maven and OpenJDK 11                1.2.0        
 java-openliberty              Staging   Java application Maven-built stack using...  0.9.0        
 java-openliberty-gradle       Staging   Java application Gradle-built stack usin...  0.4.0        
 java-quarkus                  Staging   Quarkus with Java                            1.3.0        
 java-springboot               Staging   Spring Boot using Java                       1.2.0, 2.0.0 
 java-vertx                    Staging   Upstream Vert.x using Java                   1.2.0        
 java-websphereliberty         Staging   Java application Maven-built stack using...  0.9.0        
 java-websphereliberty-gradle  Staging   Java application Gradle-built stack usin...  0.4.0        
 java-wildfly                  Staging   Upstream WildFly                             1.1.0        
 java-wildfly-bootable-jar     Staging   Java stack with WildFly in bootable Jar ...  1.1.0        
 nodejs                        Staging   Stack with Node.js 16                        2.1.1        
 nodejs-angular                Staging   Angular is a development platform, built...  2.0.2        
 nodejs-nextjs                 Staging   Next.js gives you the best developer exp...  1.0.3        
 nodejs-nuxtjs                 Staging   Nuxt is the backbone of your Vue.js proj...  1.0.3        
 nodejs-react                  Staging   React is a free and open-source front-en...  2.0.2        
 nodejs-svelte                 Staging   Svelte is a radical new approach to buil...  1.0.3        
 nodejs-vue                    Staging   Vue is a JavaScript framework for buildi...  1.0.2        
 php-laravel                   Staging   Laravel is an open-source PHP framework,...  1.0.1        
 python                        Staging   Python is an interpreted, object-oriente...  2.1.0, 3.0.0 
 python-django                 Staging   Django is a high-level Python web framew...  2.1.0        
```

- A new "versions" field is added to the JSON output of `odo registry`

```
$ odo registry --devfile-registry Staging --devfile go -o json            
[
        {
                "name": "go",
                "displayName": "Go Runtime",
                "description": "Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.",
                "registry": {
                        "name": "Staging",
                        "url": "https://registry.stage.devfile.io",
                        "secure": false
                },
                "language": "Go",
                "tags": [
                        "Go"
                ],
                "projectType": "Go",
                "version": "1.0.2",
                "versions": [
                        {
                                "version": "1.0.2",
                                "isDefault": true,
                                "schemaVersion": "2.1.0",
                                "starterProjects": [
                                        "go-starter"
                                ]
                        },
                        {
                                "version": "2.0.0",
                                "isDefault": false,
                                "schemaVersion": "2.2.0",
                                "starterProjects": [
                                        "go-starter"
                                ]
                        }
                ],
                "starterProjects": [
                        "go-starter"
                ]
        }
]
```

- A new "Versions:" section is added to the human-readable output of `odo registry --details`
```
$ odo registry --devfile-registry Staging --devfile go --details
Name: go
Display Name: Go Runtime
Registry: Staging
Registry URL: https://registry.stage.devfile.io
Version: 1.0.2
Description: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software. 
Tags: Go
Project Type: Go
Language: Go
Starter Projects:
  - go-starter
Supported odo Features:
  - Dev: Y
  - Deploy: N
  - Debug: N
Versions:
  - 1.0.2
  - 2.0.0
```