### PR TITLE
Set Priority field in GitHub Project item based on the 'priority/*' label on the issue

### DIFF
--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -5,6 +5,7 @@ on:
     types:
     - opened
     - reopened
+    - labeled
 
 env:
   ORGANIZATION: redhat-developer
@@ -26,14 +27,110 @@ jobs:
         add-labels: "needs-triage"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  add_issue_to_project:
-    name: Add issue to Project
+  manage_issue_in_project:
+    name: Manage issue in Project
     runs-on: ubuntu-latest
+    env:
+      # Personal Access Token (PAT) to be created with 'repo' and 'project' scopes and be added as repository secret.
+      GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
     steps:
+
+    - name: Get project data
+      run: |
+        gh api graphql -f query='
+          query($org: String!, $number: Int!) {
+            organization(login: $org){
+              projectV2(number: $number) {
+                id
+                fields(first:20) {
+                  nodes {
+                    ... on ProjectV2Field {
+                      id
+                      name
+                    }
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      name
+                      options {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+        
+        cat project_data.json
+        
+        echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+        echo 'PRIORITY_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Priority") |.id' project_data.json) >> $GITHUB_ENV
+        echo 'PRIORITY_URGENT_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Priority") | .options[] | select(.name | startswith("Urgent")) |.id' project_data.json) >> $GITHUB_ENV
+        echo 'PRIORITY_HIGH_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Priority") | .options[] | select(.name | startswith("High")) |.id' project_data.json) >> $GITHUB_ENV
+        echo 'PRIORITY_MEDIUM_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Priority") | .options[] | select(.name | startswith("Medium")) |.id' project_data.json) >> $GITHUB_ENV
+        echo 'PRIORITY_LOW_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Priority") | .options[] | select(.name | startswith("Low")) |.id' project_data.json) >> $GITHUB_ENV
+
     - name: Add issue to Project
-      uses: actions/add-to-project@v0.3.0
-      with:
-        project-url: https://github.com/orgs/${{ env.ORGANIZATION }}/projects/${{ env.PROJECT_NUMBER }}
-        # This action needs a Personal Access Token (PAT) to be created with 'repo' and 'project' scopes and be added as repository secret.
-        # See https://github.com/actions/add-to-project#creating-a-pat-and-adding-it-to-your-repository and https://github.com/settings/tokens/new
-        github-token: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      env:
+        ISSUE_ID: ${{ github.event.issue.node_id }}
+      run: |
+        gh api graphql -f query='
+          mutation($project: ID!, $issue: ID!) {
+            addProjectV2ItemById(
+              input: {
+                projectId: $project
+                contentId: $issue
+              }
+            ) {
+              item {
+                id
+              }
+            }
+          }' -f project=${{ env.PROJECT_ID }} -f issue=$ISSUE_ID > project_mutation_result.json
+        
+        cat project_mutation_result.json
+        
+        echo 'ITEM_ID='$(jq '.data.addProjectV2ItemById.item.id' project_mutation_result.json) >> $GITHUB_ENV
+
+    - name: Set Priority field in Project based on label
+      if: startsWith(github.event.label.name, 'priority/')
+      env:
+        ISSUE_ID: ${{ github.event.issue.node_id }}
+        PRIORITY_LABEL: ${{ github.event.label.name }}
+      run: |
+        if [[ "$PRIORITY_LABEL" == "priority/critical-urgent" ]] || [[ "$PRIORITY_LABEL" == "priority/Critical" ]]; then
+          echo Setting Urgent priority value: ${{ env.PRIORITY_URGENT_OPTION_ID }}
+          export priority_field_value=${{ env.PRIORITY_URGENT_OPTION_ID }}
+        elif [[ "$PRIORITY_LABEL" == "priority/High" ]]; then
+          echo Setting High priority value: ${{ env.PRIORITY_HIGH_OPTION_ID }}
+          export priority_field_value=${{ env.PRIORITY_HIGH_OPTION_ID }}
+        elif [[ "$PRIORITY_LABEL" == "priority/Medium" ]]; then
+          echo Setting Medium priority value: ${{ env.PRIORITY_MEDIUM_OPTION_ID }}
+          export priority_field_value=${{ env.PRIORITY_MEDIUM_OPTION_ID }}
+        elif [[ "$PRIORITY_LABEL" == "priority/Low" ]]; then
+          echo Setting Low priority value: ${{ env.PRIORITY_LOW_OPTION_ID }}
+          export priority_field_value=${{ env.PRIORITY_LOW_OPTION_ID }}
+        else
+          echo "Ignoring unknown priority label value: $PRIORITY_LABEL"
+        fi
+        echo "priority_field_value: $priority_field_value"
+        if [ -n "$priority_field_value" ]; then
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $priority_field: ID!, $priority_value: String!) {
+              updateProjectV2ItemFieldValue(
+                input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $priority_field
+                  value: { 
+                    singleSelectOptionId: $priority_value
+                  }
+                }
+              ) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=${{ env.PROJECT_ID }} -f item=${{ env.ITEM_ID }} -f priority_field=${{ env.PRIORITY_FIELD_ID }} -f priority_value=$priority_field_value
+        fi

--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -6,6 +6,7 @@ on:
     - opened
     - reopened
     - labeled
+    - unlabeled
 
 env:
   ORGANIZATION: redhat-developer
@@ -93,8 +94,8 @@ jobs:
         
         echo 'ITEM_ID='$(jq '.data.addProjectV2ItemById.item.id' project_mutation_result.json) >> $GITHUB_ENV
 
-    - name: Set Priority field in Project based on label
-      if: startsWith(github.event.label.name, 'priority/')
+    - name: Set Priority field in Project based on label added
+      if: ${{ github.event.action == 'labeled' && startsWith(github.event.label.name, 'priority/') }}
       env:
         ISSUE_ID: ${{ github.event.issue.node_id }}
         PRIORITY_LABEL: ${{ github.event.label.name }}
@@ -133,4 +134,70 @@ jobs:
                 }
               }
             }' -f project=${{ env.PROJECT_ID }} -f item=${{ env.ITEM_ID }} -f priority_field=${{ env.PRIORITY_FIELD_ID }} -f priority_value=$priority_field_value
+        fi
+
+    - name: Set Priority field in Project based on label removed
+      if: ${{ github.event.action == 'unlabeled' && startsWith(github.event.label.name, 'priority/') }}
+      env:
+        ISSUE_ID: ${{ github.event.issue.node_id }}
+      run: |
+        # Find an already existing label for that issue, and set the field in the Project. Otherwise, clear the field.
+        priorityLabels=$(gh issue view ${{ github.event.issue.number }} -R ${GITHUB_REPOSITORY} --json labels --jq '.labels.[] | select(.name | startswith("priority/")) |.name')
+        if [ -n "$priorityLabels" ]; then
+          echo "Handling priority labels: $priorityLabels"
+          for priorityLabel in $priorityLabels; do
+            # The last value wins
+            if [[ "$priorityLabel" == "priority/critical-urgent" ]] || [[ "$priorityLabel" == "priority/Critical" ]]; then
+              echo Setting Urgent priority value: ${{ env.PRIORITY_URGENT_OPTION_ID }}
+              export priority_field_value=${{ env.PRIORITY_URGENT_OPTION_ID }}
+            elif [[ "$priorityLabel" == "priority/High" ]]; then
+              echo Setting High priority value: ${{ env.PRIORITY_HIGH_OPTION_ID }}
+              export priority_field_value=${{ env.PRIORITY_HIGH_OPTION_ID }}
+            elif [[ "$priorityLabel" == "priority/Medium" ]]; then
+              echo Setting Medium priority value: ${{ env.PRIORITY_MEDIUM_OPTION_ID }}
+              export priority_field_value=${{ env.PRIORITY_MEDIUM_OPTION_ID }}
+            elif [[ "$priorityLabel" == "priority/Low" ]]; then
+              echo Setting Low priority value: ${{ env.PRIORITY_LOW_OPTION_ID }}
+              export priority_field_value=${{ env.PRIORITY_LOW_OPTION_ID }}
+            else
+              echo "Ignoring unknown priority label value: $priorityLabel"
+            fi
+            echo "priority_field_value: $priority_field_value"
+            if [ -n "$priority_field_value" ]; then
+              gh api graphql -f query='
+                mutation($project: ID!, $item: ID!, $priority_field: ID!, $priority_value: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $project
+                      itemId: $item
+                      fieldId: $priority_field
+                      value: {
+                        singleSelectOptionId: $priority_value
+                      }
+                    }
+                  ) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }' -f project=${{ env.PROJECT_ID }} -f item=${{ env.ITEM_ID }} -f priority_field=${{ env.PRIORITY_FIELD_ID }} -f priority_value=$priority_field_value
+            fi
+          done
+        else
+          # Clear the field
+          echo "Found no priority labels => clearing the field in the Project"
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $priority_field: ID!) {
+              clearProjectV2ItemFieldValue(
+                input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $priority_field
+                }
+              ) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=${{ env.PROJECT_ID }} -f item=${{ env.ITEM_ID }} -f priority_field=${{ env.PRIORITY_FIELD_ID }}
         fi

--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -14,13 +14,15 @@ env:
   PROJECT_NUMBER: 16
 
 jobs:
-  label_issue:
+  manage_issue_labels:
     name: Label issue
+    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
     runs-on: ubuntu-latest
+    concurrency: issue_labels
     permissions:
       issues: write
     steps:
-    - name: Label issue
+    - name: Add needs-triage label
       # Action recommended in https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues
       # Recommended to pin unofficial Actions to a specific commit SHA
       uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
@@ -31,6 +33,9 @@ jobs:
   manage_issue_in_project:
     name: Manage issue in Project
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: manage_issue_labels
+    concurrency: issue_management_in_project-${{ github.event.action }}
     env:
       # Personal Access Token (PAT) to be created with 'repo' and 'project' scopes and be added as repository secret.
       GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This adds a job to the GH issue management Workflow, enabling a one-way sync from the issue priority label to the priority field in the Project.
This way, we can keep prioritizing our issues with the `priority/*` labels; and this workflow, once triggered, will take care of updating the Project field for that issue accordingly.
I initially wanted also to sync the other way, but I could not find a way yet to trigger a workflow based on a field update in the Project item.

NOTES:
- once a `priority/*` label is added to the issue, the corresponding Priority field is updated accordingly
- if the issue already had a `priority/*` label and a new `priority/*` label is added, that newly-added label is used to set the Priority field
- when a `priority/*` label is removed from the issue, the job iterates over all the existing `priority/*` labels for that issue.
  - If there are multiple, they are all used to set the Priority field, and the order in which this is done is not guaranteed.
  - If none exist, the Priority field for that issue in the Project is cleared.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
