### PR TITLE
copy aritifacts only if ARTIFACT_DIR var is exposed

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -37,7 +37,7 @@ if [ "${ARCH}" == "s390x" ]; then
     make test-integration
     # E2e tests
     make test-e2e
-elif  [ "${ARCH}" == "ppc64le" ]; then
+elif [ "${ARCH}" == "ppc64le" ]; then
     # Integration tests
     make test-integration
     # E2e tests
@@ -55,7 +55,9 @@ else
     fi
 fi
 
-#copy artifact to shared volume
-cp -r test-*.xml $ARTIFACT_DIR
-
+if [ ! -z "$ARTIFACT_DIR" ]
+then
+    #copy artifact to $ARTIFACT_DIR if ARTIFACT_DIR var is exposed
+    cp -r test-*.xml $ARTIFACT_DIR
+fi
 oc logout


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

/kind test

**What does this PR do / why we need it:**
InterOP tests uses  `scripts/openshiftci-presubmit-all-tests.sh` script to run tests, which is failing due to copy of artifact as it's handled differently on their side.
This PR adds a check if ARTIFACT_DIR var is not provided, it will not copy tests result files

**Which issue(s) this PR fixes:**

Fixes #NA

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
