### PR TITLE
Automate release process (GitHub part)

### DIFF
--- a/.github/workflow-data/release-management/blog-post-footer.tpl.md
+++ b/.github/workflow-data/release-management/blog-post-footer.tpl.md
@@ -1,0 +1,19 @@
+## Contributing to odo
+
+If `odo` interests you, and you would like to contribute to it, we welcome you!
+
+You can contribute to `odo` in a lot of different ways!
+
+Take it for a spin 🚘 and report back bugs🐞 that you encountered, or features🌟 that you would like to see.
+
+Help us with the documentation📜, or tell us how you used `odo` 🖍.
+
+Review the PRs👀, or help us fix a failing test 🚩.
+
+Work on the TODOs📝, or help us cleanup the code🚮.
+
+Or, simply tune in📻 to our [contributor calls](https://github.com/redhat-developer/odo#meetings) and learn more about `odo`.
+
+`odo` is your playground!
+
+Read the developer reference guide on [contributing to odo](/docs/development/contribution) to know more.

--- a/.github/workflow-data/release-management/blog-post-header.tpl.md
+++ b/.github/workflow-data/release-management/blog-post-header.tpl.md
@@ -1,0 +1,26 @@
+---
+title: odo ${TAG_NAME} Released
+author: $GITHUB_ACTOR
+author_url: https://github.com/$GITHUB_ACTOR
+author_image_url: https://github.com/$GITHUB_ACTOR.png
+tags: ["release"]
+slug: odo-${TAG_NAME}
+---
+
+odo `${TAG_NAME}` is now out!
+
+<!--truncate-->
+
+To install `odo`, follow [the installation guide](../docs/overview/installation).
+
+## Notable Changes
+Check this Playlist for an overview of the most notable changes in this release: [TODO Add Link to Youtube Playlist]
+
+### Features
+
+[TODO - Complete with embedded demos!]
+
+## Detailed Changelog
+
+As with every release, you can find the full list of changes and bug fixes on the [GitHub release page](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}).
+

--- a/.github/workflow-data/release-management/pr.tpl.md
+++ b/.github/workflow-data/release-management/pr.tpl.md
@@ -1,0 +1,11 @@
+/area documentation
+/area release-eng
+/hold
+
+Draft PR for new release: [$TAG_NAME](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME})
+
+Fixes #
+
+Feel free to edit and push to this branch.
+
+NOTE: Remove the hold and consider merging this PR only when binaries for this release are publicly available on [developers.redhat.com](https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/${TAG_NAME}).

--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Label issue
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
     runs-on: ubuntu-latest
-    concurrency: issue_labels
+    concurrency: issue_labels-${{ github.event.issue.number }}
     permissions:
       issues: write
     steps:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: manage_issue_labels
-    concurrency: issue_management_in_project-${{ github.event.action }}
+    concurrency: issue_management_in_project-${{ github.event.issue.number }}-${{ github.event.action }}
     env:
       # Personal Access Token (PAT) to be created with 'repo' and 'project' scopes and be added as repository secret.
       GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}

--- a/.github/workflows/release-management.yaml
+++ b/.github/workflows/release-management.yaml
@@ -67,61 +67,13 @@ jobs:
         id: generate_draft_blog_post
         run: |
           export blogFileName=docs/website/blog/$(date -I)-odo-${TAG_NAME}.md
-          cat <<EOF > "$blogFileName"
-          ---
-          title: odo ${TAG_NAME} Released
-          author: $GITHUB_ACTOR
-          author_url: https://github.com/$GITHUB_ACTOR
-          author_image_url: https://github.com/$GITHUB_ACTOR.png
-          tags: ["release"]
-          slug: odo-${TAG_NAME}
-          ---
-          
-          odo \`${TAG_NAME}\` is now out!
-          
-          <!--truncate-->
-          
-          To install \`odo\`, follow [the installation guide](../docs/overview/installation).
-            
-          ## Notable Changes
-          Check this Playlist for an overview of the most notable changes in this release: [TODO Add Link to Youtube Playlist]
-          
-          ### Features
-          
-          [TODO - Complete with embedded demos!]
-          
-          ## Detailed Changelog
-          
-          As with every release, you can find the full list of changes and bug fixes on the [GitHub release page](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}).
-          
-          EOF
 
-          cat /tmp/release-notes/release-changelog.md >> "$blogFileName"
+          envsubst < .github/workflow-data/release-management/blog-post-header.tpl.md > $blogFileName
+          cat /tmp/release-notes/release-changelog.md >> $blogFileName
+          echo "" >> $blogFileName
+          envsubst < .github/workflow-data/release-management/blog-post-footer.tpl.md >> $blogFileName
 
-          cat <<EOF >> "$blogFileName"
-
-          ## Contributing to odo
-          If \`odo\` interests you, and you would like to contribute to it, we welcome you!
-          
-          You can contribute to \`odo\` in a lot of different ways!
-          
-          Take it for a spin 🚘 and report back bugs🐞 that you encountered, or features🌟 that you would like to see.
-          
-          Help us with the documentation📜, or tell us how you used \`odo\` 🖍.
-          
-          Review the PRs👀, or help us fix a failing test 🚩.
-          
-          Work on the TODOs📝, or help us cleanup the code🚮.
-          
-          Or, simply tune in📻 to our [contributor calls](https://github.com/redhat-developer/odo#meetings) and learn more about \`odo\`.
-          
-          \`odo\` is your playground!
-          
-          Read the developer reference guide on [contributing to odo](/docs/development/contribution) to know more.
-  
-          EOF
-
-          cat "$blogFileName"
+          cat $blogFileName
           echo "blogFileName=${blogFileName}" >> $GITHUB_OUTPUT
 
       - name: Upload Release Notes Artifact
@@ -174,23 +126,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat <<EOF | gh pr create --draft \
+          envsubst < .github/workflow-data/release-management/pr.tpl.md | gh pr create --draft \
             --title "[WIP] Release PR for ${TAG_NAME}" \
             --reviewer "$GITHUB_ACTOR" \
             --base main \
             --repo ${GITHUB_REPOSITORY} \
             --body-file -
-          
-          /area documentation
-          /area release-eng
-          /hold
-          
-          Draft Release PR for new release: $TAG_NAME
-
-          Fixes #
-
-          Feel free to edit and push to this branch.
-          
-          NOTE: Remove the hold and consider merging this PR only when binaries for this release are publicly available.
-
-          EOF

--- a/.github/workflows/release-management.yaml
+++ b/.github/workflows/release-management.yaml
@@ -68,11 +68,12 @@ jobs:
         run: |
           export blogFileName=docs/website/blog/$(date -I)-odo-${TAG_NAME}.md
 
-          envsubst < .github/workflow-data/release-management/blog-post-header.tpl.md > $blogFileName
-          cat /tmp/release-notes/release-changelog.md >> $blogFileName
-          echo "" >> $blogFileName
-          envsubst < .github/workflow-data/release-management/blog-post-footer.tpl.md >> $blogFileName
-
+          (
+              envsubst < .github/workflow-data/release-management/blog-post-header.tpl.md 
+              cat /tmp/release-notes/release-changelog.md
+              echo ""
+              envsubst < .github/workflow-data/release-management/blog-post-footer.tpl.md
+          ) > $blogFileName
           cat $blogFileName
           echo "blogFileName=${blogFileName}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-management.yaml
+++ b/.github/workflows/release-management.yaml
@@ -45,6 +45,8 @@ jobs:
       pull-requests: write
       contents: write
 
+    concurrency: release-pr-${{ github.event.release.tag_name }}
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-management.yaml
+++ b/.github/workflows/release-management.yaml
@@ -1,0 +1,194 @@
+name: Release Management
+
+on:
+  release:
+    types:
+      - created
+
+env:
+  TAG_NAME: ${{ github.event.release.tag_name }}
+
+jobs:
+
+  generate_release_notes:
+    name: Generate Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: get_previous_tag
+        run: |
+          prevTag=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
+          echo "prev_tag=${prevTag}" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+        run: |
+          ./scripts/changelog-script.sh ${{ steps.get_previous_tag.outputs.prev_tag }} ${TAG_NAME}
+
+      - name: Upload Release Notes Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-changelog
+          path: release-changelog.md
+          retention-days: 30
+
+  create_draft_release_pr:
+    name: Create Draft Release PR
+    runs-on: ubuntu-latest
+    needs: generate_release_notes
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - run: mkdir -p /tmp/release-notes
+      - uses: actions/download-artifact@v3
+        with:
+          name: release-changelog
+          path: /tmp/release-notes
+      - run: find /tmp/release-notes -name release-changelog.md
+
+      - name: Update VERSION file
+        run: echo ${TAG_NAME} > build/VERSION
+
+      - name: Create draft release blog article with release notes
+        id: generate_draft_blog_post
+        run: |
+          export blogFileName=docs/website/blog/$(date -I)-odo-${TAG_NAME}.md
+          cat <<EOF > "$blogFileName"
+          ---
+          title: odo ${TAG_NAME} Released
+          author: $GITHUB_ACTOR
+          author_url: https://github.com/$GITHUB_ACTOR
+          author_image_url: https://github.com/$GITHUB_ACTOR.png
+          tags: ["release"]
+          slug: odo-${TAG_NAME}
+          ---
+          
+          odo \`${TAG_NAME}\` is now out!
+          
+          <!--truncate-->
+          
+          To install \`odo\`, follow [the installation guide](../docs/overview/installation).
+            
+          ## Notable Changes
+          Check this Playlist for an overview of the most notable changes in this release: [TODO Add Link to Youtube Playlist]
+          
+          ### Features
+          
+          [TODO - Complete with embedded demos!]
+          
+          ## Detailed Changelog
+          
+          As with every release, you can find the full list of changes and bug fixes on the [GitHub release page](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}).
+          
+          EOF
+
+          cat /tmp/release-notes/release-changelog.md >> "$blogFileName"
+
+          cat <<EOF >> "$blogFileName"
+
+          ## Contributing to odo
+          If \`odo\` interests you, and you would like to contribute to it, we welcome you!
+          
+          You can contribute to \`odo\` in a lot of different ways!
+          
+          Take it for a spin 🚘 and report back bugs🐞 that you encountered, or features🌟 that you would like to see.
+          
+          Help us with the documentation📜, or tell us how you used \`odo\` 🖍.
+          
+          Review the PRs👀, or help us fix a failing test 🚩.
+          
+          Work on the TODOs📝, or help us cleanup the code🚮.
+          
+          Or, simply tune in📻 to our [contributor calls](https://github.com/redhat-developer/odo#meetings) and learn more about \`odo\`.
+          
+          \`odo\` is your playground!
+          
+          Read the developer reference guide on [contributing to odo](/docs/development/contribution) to know more.
+  
+          EOF
+
+          cat "$blogFileName"
+          echo "blogFileName=${blogFileName}" >> $GITHUB_OUTPUT
+
+      - name: Upload Release Notes Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-blog-post-draft
+          path: ${{ steps.generate_draft_blog_post.outputs.blogFileName }}
+          retention-days: 30
+
+      - name: Update version in installation docs
+        run: |
+          prevTag=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
+          prevTagWithoutPrefix=${prevTag#v}
+          newTagWithoutPrefix=${TAG_NAME#v}
+          sed -i 's/'${prevTagWithoutPrefix}'/'${newTagWithoutPrefix}'/g' docs/website/docs/overview/installation.md
+
+      - name: Set Git identity
+        run: |
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global user.name "$GITHUB_ACTOR"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+
+      - name: Create and push branch
+        id: push_branch
+        run: |
+          git switch -c blog_post_${TAG_NAME}
+          git push -u origin blog_post_${TAG_NAME} 
+          if git status --porcelain | grep build/VERSION; then
+            git add build/VERSION
+            git commit -m "Set version in build/VERSION file"
+          fi
+          if git status --porcelain | grep docs/website/docs/; then
+            git add docs/website/docs/
+            git commit -m "Bump version in installation docs"
+          fi
+          if git status --porcelain | grep docs/website/blog/; then
+            git add docs/website/blog/
+            git commit -m "Add release blog post"
+          fi
+          unpushed=$(git cherry -v)
+          if [ -n "$unpushed" ]; then
+            git push
+            echo "pushed=true" >> $GITHUB_OUTPUT
+          else
+            echo "pushed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create draft PR
+        if: ${{ steps.push_branch.outputs.pushed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat <<EOF | gh pr create --draft \
+            --title "[WIP] Release PR for ${TAG_NAME}" \
+            --reviewer "$GITHUB_ACTOR" \
+            --base main \
+            --repo ${GITHUB_REPOSITORY} \
+            --body-file -
+          
+          /area documentation
+          /area release-eng
+          /hold
+          
+          Draft Release PR for new release: $TAG_NAME
+
+          Fixes #
+
+          Feel free to edit and push to this branch.
+          
+          NOTE: Remove the hold and consider merging this PR only when binaries for this release are publicly available.
+
+          EOF


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area release-eng

**What does this PR do / why we need it:**
In preparation for the upcoming release, I'm adding a new Workflow to automate as much as possible what we can automate.
When a new Release is created on GitHub (it can be a pre-release), this Workflow will take care of creating a draft PR with the following changes:
- Generates the release notes and adds them to a new blog post file
- Updates the `build/VERSION` file
- Updates the installation page with the new version

We still need to review this new PR (and potentially update at least the blog post), but that should be a good starting point.

**Which issue(s) this PR fixes:**
Fixes #6386 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Example of PR generated: https://github.com/rm3l/odo/pull/45