### PR TITLE
Fallback to interactive mode if there is no match from Alizer when initializing a component

### DIFF
--- a/tests/integration/interactive_deploy_test.go
+++ b/tests/integration/interactive_deploy_test.go
@@ -27,125 +27,158 @@ var _ = Describe("odo deploy interactive command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("directory is not empty", func() {
+	Context("directory is not empty", func() {
 
-		BeforeEach(func() {
-			helper.CopyExample(filepath.Join("source", "python"), commonVar.Context)
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(
-				SatisfyAll(
-					HaveLen(2),
-					ContainElements("requirements.txt", "wsgi.py")))
+		When("there is a match from Alizer", func() {
+			BeforeEach(func() {
+				helper.CopyExample(filepath.Join("source", "python"), commonVar.Context)
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(
+					SatisfyAll(
+						HaveLen(2),
+						ContainElements("requirements.txt", "wsgi.py")))
+			})
+			It("should run alizer to download devfile successfully even with -v flag", func() {
+
+				language := "Python"
+				projectType := "Python"
+				devfileName := "python"
+				output, err := helper.RunInteractive([]string{"odo", "deploy", "-v", "4"},
+					nil,
+					func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+						helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+						helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+
+						helper.ExpectString(ctx,
+							fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
+
+						helper.ExpectString(ctx, "Is this correct")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-app")
+
+						helper.ExpectString(ctx, "no default deploy command found in devfile")
+					})
+
+				Expect(err).To(Not(BeNil()))
+				Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+			})
+
+			It("should run alizer to download devfile", func() {
+
+				language := "Python"
+				projectType := "Python"
+				devfileName := "python"
+				output, err := helper.RunInteractive([]string{"odo", "deploy"},
+					nil,
+					func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+						helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+						helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+
+						helper.ExpectString(ctx,
+							fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
+
+						helper.ExpectString(ctx, "Is this correct")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-app")
+
+						helper.ExpectString(ctx, "no default deploy command found in devfile")
+					})
+
+				Expect(err).To(Not(BeNil()))
+				Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+			})
+
+			It("should display welcoming messages first", func() {
+
+				if os.Getenv("SKIP_WELCOMING_MESSAGES") == "true" {
+					Skip("This is a Unix specific scenario, skipping")
+				}
+
+				language := "Python"
+				projectType := "Python"
+				devfileName := "python"
+				output, err := helper.RunInteractive([]string{"odo", "deploy"},
+					// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
+					// message displayed to the end user. So we do not want any potential debug lines to be printed first.
+					// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513
+					[]string{"ODO_LOG_LEVEL=0"},
+					func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+						helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+						helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+
+						helper.ExpectString(ctx,
+							fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
+
+						helper.ExpectString(ctx, "Is this correct")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-app")
+
+						helper.ExpectString(ctx, "no default deploy command found in devfile")
+					})
+
+				Expect(err).To(Not(BeNil()))
+				// Make sure it also displays welcoming messages first
+				lines, err := helper.ExtractLines(output)
+				Expect(err).To(BeNil())
+				Expect(lines).To(Not(BeEmpty()))
+				Expect(lines[1]).To(ContainSubstring("Deploy mode ran, but no Devfile was found. Initializing a component in the current directory"))
+			})
 		})
-		It("should run alizer to download devfile successfully even with -v flag", func() {
 
-			language := "Python"
-			projectType := "Python"
-			devfileName := "python"
-			output, err := helper.RunInteractive([]string{"odo", "deploy", "-v", "4"},
-				nil,
-				func(ctx helper.InteractiveContext) {
-					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+		When("Alizer cannot determine a Devfile based on the current source code", func() {
+			BeforeEach(func() {
+				helper.CreateSimpleFile(commonVar.Context, "some-file-", ".ext")
+			})
 
-					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+			It("should not fail but fallback to the interactive mode", func() {
+				output, err := helper.RunInteractive([]string{"odo", "deploy"}, nil, func(ctx helper.InteractiveContext) {
+					helper.ExpectString(ctx, "Could not determine a Devfile based on the files in the current directory")
 
-					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+					helper.ExpectString(ctx, "Select language")
+					helper.SendLine(ctx, "PHP")
 
-					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
-
-					helper.ExpectString(ctx, "Is this correct")
+					helper.ExpectString(ctx, "Select project type")
 					helper.SendLine(ctx, "")
 
-					helper.ExpectString(ctx, "Select container for which you want to change configuration")
+					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
 					helper.SendLine(ctx, "")
 
 					helper.ExpectString(ctx, "Enter component name")
-					helper.SendLine(ctx, "my-app")
+					helper.SendLine(ctx, "my-php-app")
 
 					helper.ExpectString(ctx, "no default deploy command found in devfile")
 				})
 
-			Expect(err).To(Not(BeNil()))
-			Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
-		})
-
-		It("should run alizer to download devfile", func() {
-
-			language := "Python"
-			projectType := "Python"
-			devfileName := "python"
-			output, err := helper.RunInteractive([]string{"odo", "deploy"},
-				nil,
-				func(ctx helper.InteractiveContext) {
-					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
-
-					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
-
-					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
-
-					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
-
-					helper.ExpectString(ctx, "Is this correct")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Select container for which you want to change configuration")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Enter component name")
-					helper.SendLine(ctx, "my-app")
-
-					helper.ExpectString(ctx, "no default deploy command found in devfile")
-				})
-
-			Expect(err).To(Not(BeNil()))
-			Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
-		})
-
-		It("should display welcoming messages first", func() {
-
-			if os.Getenv("SKIP_WELCOMING_MESSAGES") == "true" {
-				Skip("This is a Unix specific scenario, skipping")
-			}
-
-			language := "Python"
-			projectType := "Python"
-			devfileName := "python"
-			output, err := helper.RunInteractive([]string{"odo", "deploy"},
-				// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
-				// message displayed to the end user. So we do not want any potential debug lines to be printed first.
-				// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513
-				[]string{"ODO_LOG_LEVEL=0"},
-				func(ctx helper.InteractiveContext) {
-					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
-
-					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
-
-					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
-
-					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile \"%s\" from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
-
-					helper.ExpectString(ctx, "Is this correct")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Select container for which you want to change configuration")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Enter component name")
-					helper.SendLine(ctx, "my-app")
-
-					helper.ExpectString(ctx, "no default deploy command found in devfile")
-				})
-
-			Expect(err).To(Not(BeNil()))
-			// Make sure it also displays welcoming messages first
-			lines, err := helper.ExtractLines(output)
-			Expect(err).To(BeNil())
-			Expect(lines).To(Not(BeEmpty()))
-			Expect(lines[1]).To(ContainSubstring("Deploy mode ran, but no Devfile was found. Initializing a component in the current directory"))
+				Expect(err).To(Not(BeNil()))
+				Expect(output).ShouldNot(ContainSubstring("Which starter project do you want to use"))
+				Expect(output).To(ContainSubstring("no default deploy command found in devfile"))
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElement("devfile.yaml"))
+			})
 		})
 	})
 })

--- a/tests/integration/interactive_dev_test.go
+++ b/tests/integration/interactive_dev_test.go
@@ -27,122 +27,154 @@ var _ = Describe("odo dev interactive command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("directory is not empty", func() {
+	Context("directory is not empty", func() {
 
-		BeforeEach(func() {
-			helper.CopyExample(filepath.Join("source", "python"), commonVar.Context)
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(
-				SatisfyAll(
-					HaveLen(2),
-					ContainElements("requirements.txt", "wsgi.py")))
+		When("there is a match from Alizer", func() {
+			BeforeEach(func() {
+				helper.CopyExample(filepath.Join("source", "python"), commonVar.Context)
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(
+					SatisfyAll(
+						HaveLen(2),
+						ContainElements("requirements.txt", "wsgi.py")))
+			})
+			It("should run alizer to download devfile successfully even with -v flag", func() {
+
+				language := "Python"
+				projectType := "Python"
+				devfileName := "python"
+				_, _ = helper.RunInteractive([]string{"odo", "dev", "--random-ports", "-v", "4"},
+					nil,
+					func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+						helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+						helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+
+						helper.ExpectString(ctx,
+							fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
+
+						helper.ExpectString(ctx, "Is this correct")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-app")
+
+						helper.ExpectString(ctx, "[Ctrl+c] - Exit")
+						ctx.StopCommand()
+					})
+
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+			})
+
+			It("should run alizer to download devfile", func() {
+
+				language := "Python"
+				projectType := "Python"
+				devfileName := "python"
+				_, _ = helper.RunInteractive([]string{"odo", "dev", "--random-ports"},
+					nil,
+					func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+						helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+						helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+
+						helper.ExpectString(ctx,
+							fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
+
+						helper.ExpectString(ctx, "Is this correct")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-app")
+
+						helper.ExpectString(ctx, "[Ctrl+c] - Exit")
+						ctx.StopCommand()
+					})
+
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+			})
+
+			It("should display welcoming messages first", func() {
+
+				if os.Getenv("SKIP_WELCOMING_MESSAGES") == "true" {
+					Skip("This is a Unix specific scenario, skipping")
+				}
+
+				language := "Python"
+				projectType := "Python"
+				devfileName := "python"
+				output, _ := helper.RunInteractive([]string{"odo", "dev", "--random-ports"},
+					// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
+					// message displayed to the end user. So we do not want any potential debug lines to be printed first.
+					// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513
+					[]string{"ODO_LOG_LEVEL=0"},
+					func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+
+						helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+
+						helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+
+						helper.ExpectString(ctx,
+							fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
+
+						helper.ExpectString(ctx, "Is this correct")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-app")
+
+						helper.ExpectString(ctx, "[Ctrl+c] - Exit")
+						ctx.StopCommand()
+					})
+
+				lines, err := helper.ExtractLines(output)
+				Expect(err).To(BeNil())
+				Expect(lines).To(Not(BeEmpty()))
+				Expect(lines[1]).To(ContainSubstring("Dev mode ran, but no Devfile was found. Initializing a component in the current directory"))
+			})
 		})
-		It("should run alizer to download devfile successfully even with -v flag", func() {
 
-			language := "Python"
-			projectType := "Python"
-			devfileName := "python"
-			_, _ = helper.RunInteractive([]string{"odo", "dev", "--random-ports", "-v", "4"},
-				nil,
-				func(ctx helper.InteractiveContext) {
-					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
+		When("Alizer cannot determine a Devfile based on the current source code", func() {
+			BeforeEach(func() {
+				helper.CreateSimpleFile(commonVar.Context, "some-file-", ".ext")
+			})
 
-					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
+			It("should not fail but fallback to the interactive mode", func() {
+				output, _ := helper.RunInteractive([]string{"odo", "dev", "--random-ports"}, nil, func(ctx helper.InteractiveContext) {
+					helper.ExpectString(ctx, "Could not determine a Devfile based on the files in the current directory")
 
-					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
+					helper.ExpectString(ctx, "Select language")
+					helper.SendLine(ctx, "Python")
 
-					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
-
-					helper.ExpectString(ctx, "Is this correct")
+					helper.ExpectString(ctx, "Select project type")
 					helper.SendLine(ctx, "")
 
-					helper.ExpectString(ctx, "Select container for which you want to change configuration")
+					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
 					helper.SendLine(ctx, "")
 
 					helper.ExpectString(ctx, "Enter component name")
 					helper.SendLine(ctx, "my-app")
 
-					helper.ExpectString(ctx, "[Ctrl+c] - Exit")
+					helper.ExpectString(ctx, "Building your application in container on cluster")
 					ctx.StopCommand()
 				})
 
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
-		})
-
-		It("should run alizer to download devfile", func() {
-
-			language := "Python"
-			projectType := "Python"
-			devfileName := "python"
-			_, _ = helper.RunInteractive([]string{"odo", "dev", "--random-ports"},
-				nil,
-				func(ctx helper.InteractiveContext) {
-					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
-
-					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
-
-					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
-
-					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
-
-					helper.ExpectString(ctx, "Is this correct")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Select container for which you want to change configuration")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Enter component name")
-					helper.SendLine(ctx, "my-app")
-
-					helper.ExpectString(ctx, "[Ctrl+c] - Exit")
-					ctx.StopCommand()
-				})
-
-			Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
-		})
-
-		It("should display welcoming messages first", func() {
-
-			if os.Getenv("SKIP_WELCOMING_MESSAGES") == "true" {
-				Skip("This is a Unix specific scenario, skipping")
-			}
-
-			language := "Python"
-			projectType := "Python"
-			devfileName := "python"
-			output, _ := helper.RunInteractive([]string{"odo", "dev", "--random-ports"},
-				// Setting verbosity level to 0, because we would be asserting the welcoming message is the first
-				// message displayed to the end user. So we do not want any potential debug lines to be printed first.
-				// Using envvars here (and not via the -v flag), because of https://github.com/redhat-developer/odo/issues/5513
-				[]string{"ODO_LOG_LEVEL=0"},
-				func(ctx helper.InteractiveContext) {
-					helper.ExpectString(ctx, "Based on the files in the current directory odo detected")
-
-					helper.ExpectString(ctx, fmt.Sprintf("Language: %s", language))
-
-					helper.ExpectString(ctx, fmt.Sprintf("Project type: %s", projectType))
-
-					helper.ExpectString(ctx,
-						fmt.Sprintf("The devfile %q from the registry \"DefaultDevfileRegistry\" will be downloaded.", devfileName))
-
-					helper.ExpectString(ctx, "Is this correct")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Select container for which you want to change configuration")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Enter component name")
-					helper.SendLine(ctx, "my-app")
-
-					helper.ExpectString(ctx, "[Ctrl+c] - Exit")
-					ctx.StopCommand()
-				})
-
-			lines, err := helper.ExtractLines(output)
-			Expect(err).To(BeNil())
-			Expect(lines).To(Not(BeEmpty()))
-			Expect(lines[1]).To(ContainSubstring("Dev mode ran, but no Devfile was found. Initializing a component in the current directory"))
+				Expect(output).ShouldNot(ContainSubstring("Which starter project do you want to use"))
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElement("devfile.yaml"))
+			})
 		})
 	})
 

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -521,6 +521,36 @@ var _ = Describe("odo init interactive command tests", func() {
 					})
 				})
 			})
+
+			When("Alizer cannot determine a Devfile based on the current source code", func() {
+				BeforeEach(func() {
+					helper.CreateSimpleFile(commonVar.Context, "some-file-", ".ext")
+				})
+
+				It("should not fail but fallback to the interactive mode", func() {
+					output, err := helper.RunInteractive([]string{"odo", "init"}, nil, func(ctx helper.InteractiveContext) {
+						helper.ExpectString(ctx, "Could not determine a Devfile based on the files in the current directory")
+
+						helper.ExpectString(ctx, "Select language")
+						helper.SendLine(ctx, "PHP")
+
+						helper.ExpectString(ctx, "Select project type")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Enter component name")
+						helper.SendLine(ctx, "my-php-app")
+
+						helper.ExpectString(ctx, "Your new component 'my-php-app' is ready in the current directory")
+					})
+
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(output).ShouldNot(ContainSubstring("Which starter project do you want to use"))
+					Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElement("devfile.yaml"))
+				})
+			})
 		})
 	}
 })


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area init

**What does this PR do / why we need it:**
If there is no match from Alizer, odo should ask users to select a Devfile manually, similarly to how it is done when `odo init` is executed in the empty directory.
So instead of exiting right away in such cases, this PR makes `odo` use the interactive backend of `odo init` as a fallback. This is applicable to all places where Devfile selection happens:
- `odo init` from a directory with source code and no Devfile
- `odo dev` from a directory with source code and no Devfile
- `odo deploy` from a directory with source code and no Devfile

**Which issue(s) this PR fixes:**
Fixes #6364

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
See https://github.com/redhat-developer/odo/issues/6364 for the reproduction steps.

```
$ mkdir asdf        
mkdir: created directory 'asdf'

$ cd asdf

$ touch asdf

$ odo init
  __
 /  \__     Initializing a new component
 \__/  \    Files: Source code detected, a Devfile will be determined based upon source code autodetection
 /  \__/    odo version: v3.4.0
 \__/

Interactive mode enabled, please answer the following questions:
 ⚠  Could not determine a Devfile based on the files in the current directory. Error is: No valid devfile found for project in /tmp/mynewproject/asdf
? Select language: .NET
? Select project type: .NET 5.0 (dotnet50, registry: DefaultDevfileRegistry)
 ✓  Downloading devfile "dotnet50" from registry "DefaultDevfileRegistry" [1s]

↪ Container Configuration "dotnet":
  OPEN PORTS:
    - 8080
  ENVIRONMENT VARIABLES:
    - CONFIGURATION = Debug
    - STARTUP_PROJECT = app.csproj
    - ASPNETCORE_ENVIRONMENT = Development
    - ASPNETCORE_URLS = http://*:8080

? Select container for which you want to change configuration? NONE - configuration is correct
? Enter component name: asdf

You can automate this command by executing:
   odo init --name asdf --devfile dotnet50 --devfile-registry DefaultDevfileRegistry

Your new component 'asdf' is ready in the current directory.
To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.

```