### PR TITLE
Fix preference not taken into account for `odo version`

### DIFF
--- a/cmd/odo/help_test.go
+++ b/cmd/odo/help_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redhat-developer/odo/pkg/config"
+	envcontext "github.com/redhat-developer/odo/pkg/config/context"
+	"github.com/redhat-developer/odo/pkg/odo/cli"
+	"k8s.io/klog"
+)
+
+var (
+	intro = `Usage:
+  odo [flags]
+  odo [command]
+
+Examples:
+  Initializing your component by taking your pick from multiple languages or frameworks:
+  odo init
+  
+  After creating your initial component, start development with:
+  odo dev
+  
+  Want to deploy after development? See it live with:
+  odo deploy`
+
+	mainCommands = `Main Commands:
+  build-images Build images
+  deploy       Deploy components
+  dev          Deploy component to development cluster
+  init         Init bootstraps a new project
+  logs         Show logs of all containers of the component
+  registry     List all components from the Devfile registry
+
+`
+
+	managementCommands = `Management Commands:
+  add          Add resources to devfile (binding)
+  create       Perform create operation (namespace)
+  delete       Delete resources (component, namespace)
+  describe     Describe resource (binding, component)
+  list         List all components in the current namespace (binding, component, namespace, services)
+  remove       Remove resources from devfile (binding)
+  set          Perform set operation (namespace)
+
+`
+
+	openshiftCommands = `OpenShift Commands:
+  login        Login to cluster 
+  logout       Logout of the cluster`
+
+	utilityCommands = `Utility Commands:
+  analyze      Detect devfile to use based on files present in current directory
+  completion   Add odo completion support to your development environment
+  preference   Modifies preference settings (add, remove, set, unset, view)
+  version      Print the client version information
+
+`
+)
+
+func TestOdoHelp(t *testing.T) {
+	ctx := context.Background()
+	envConfig, err := config.GetConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx = envcontext.WithEnvConfig(ctx, *envConfig)
+	klog.InitFlags(nil)
+
+	root := cli.NewCmdOdo(ctx, cli.OdoRecommendedName, cli.OdoRecommendedName)
+
+	var stdoutB, stderrB bytes.Buffer
+	root.SetOut(&stdoutB)
+	root.SetErr(&stderrB)
+
+	root.SetArgs([]string{"help"})
+
+	err = root.ExecuteContext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := stdoutB.String()
+	stderr := stderrB.String()
+
+	if stderr != "" {
+		t.Fatal("stderr should be empty")
+	}
+
+	if !strings.Contains(stdout, intro) {
+		t.Fatalf("stdout should contain \n%s\nbut is\n%s\n", intro, stdout)
+	}
+	if !strings.Contains(stdout, mainCommands) {
+		t.Fatalf("stdout should contain \n%s\nbut is\n%s\n", mainCommands, stdout)
+	}
+	if !strings.Contains(stdout, managementCommands) {
+		t.Fatalf("stdout should contain \n%s\nbut is\n%s\n", managementCommands, stdout)
+	}
+	if !strings.Contains(stdout, openshiftCommands) {
+		t.Fatalf("stdout should contain \n%s\nbut is\n%s\n", openshiftCommands, stdout)
+	}
+	if !strings.Contains(stdout, utilityCommands) {
+		t.Fatalf("stdout should contain \n%s\nbut is\n%s\n", utilityCommands, stdout)
+	}
+}

--- a/pkg/odo/cli/add/add.go
+++ b/pkg/odo/cli/add/add.go
@@ -19,7 +19,7 @@ func NewCmdAdd(name, fullName string) *cobra.Command {
 
 	bindingCmd := binding.NewCmdBinding(binding.BindingRecommendedCommandName, util.GetFullName(fullName, binding.BindingRecommendedCommandName))
 	createCmd.AddCommand(bindingCmd)
-	createCmd.Annotations = map[string]string{"command": "management"}
+	util.SetCommandGroup(createCmd, util.ManagementGroup)
 	createCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return createCmd

--- a/pkg/odo/cli/alizer/alizer.go
+++ b/pkg/odo/cli/alizer/alizer.go
@@ -11,6 +11,7 @@ import (
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/spf13/cobra"
@@ -74,8 +75,8 @@ func NewCmdAlizer(name, fullName string) *cobra.Command {
 		},
 	}
 	clientset.Add(alizerCmd, clientset.ALIZER, clientset.FILESYSTEM)
+	util.SetCommandGroup(alizerCmd, util.UtilityGroup)
 	commonflags.UseOutputFlag(alizerCmd)
 	alizerCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
-	alizerCmd.Annotations["command"] = "utility"
 	return alizerCmd
 }

--- a/pkg/odo/cli/build_images/build_images.go
+++ b/pkg/odo/cli/build_images/build_images.go
@@ -12,6 +12,7 @@ import (
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 )
 
@@ -79,8 +80,7 @@ func NewCmdBuildImages(name, fullName string) *cobra.Command {
 		},
 	}
 
-	// Add a defined annotation in order to appear in the help menu
-	buildImagesCmd.Annotations = map[string]string{"command": "main"}
+	util.SetCommandGroup(buildImagesCmd, util.MainGroup)
 	buildImagesCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	buildImagesCmd.Flags().BoolVar(&o.pushFlag, "push", false, "If true, build and push the images")
 	clientset.Add(buildImagesCmd, clientset.FILESYSTEM)

--- a/pkg/odo/cli/completion/completion.go
+++ b/pkg/odo/cli/completion/completion.go
@@ -90,6 +90,6 @@ func NewCmdCompletion(name, fullName string) *cobra.Command {
 	}
 
 	completionCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	completionCmd.Annotations = map[string]string{"command": "utility"}
+	util.SetCommandGroup(completionCmd, util.UtilityGroup)
 	return completionCmd
 }

--- a/pkg/odo/cli/create/create.go
+++ b/pkg/odo/cli/create/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/odo/pkg/odo/cli/create/namespace"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 )
 
@@ -23,12 +24,12 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf("%s\n",
 			namespaceCreateCmd.Example,
 		),
-		Annotations: map[string]string{"command": "management"},
 	}
 
 	createCmd.AddCommand(namespaceCreateCmd)
 
 	// Add a defined annotation in order to appear in the help menu
+	util.SetCommandGroup(createCmd, util.ManagementGroup)
 	createCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return createCmd

--- a/pkg/odo/cli/create/namespace/namespace.go
+++ b/pkg/odo/cli/create/namespace/namespace.go
@@ -16,6 +16,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 )
 
@@ -128,13 +129,13 @@ func NewCmdNamespaceCreate(name, fullName string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return genericclioptions.GenericRun(o, cmd, args)
 		},
-		Annotations: map[string]string{"command": "main"},
-		Aliases:     []string{"project"},
+		Aliases: []string{"project"},
 	}
 
 	namespaceCreateCmd.Flags().BoolVarP(&o.waitFlag, "wait", "w", false, "Wait until the namespace is ready")
 
 	clientset.Add(namespaceCreateCmd, clientset.KUBERNETES, clientset.PROJECT)
+	util.SetCommandGroup(namespaceCreateCmd, util.MainGroup)
 
 	return namespaceCreateCmd
 }

--- a/pkg/odo/cli/delete/delete.go
+++ b/pkg/odo/cli/delete/delete.go
@@ -13,9 +13,8 @@ const RecommendedCommandName = "delete"
 // NewCmdDelete implements the delete odo command
 func NewCmdDelete(name, fullName string) *cobra.Command {
 	var deleteCmd = &cobra.Command{
-		Use:         name,
-		Short:       "Delete resources",
-		Annotations: map[string]string{"command": "management"},
+		Use:   name,
+		Short: "Delete resources",
 	}
 
 	componentCmd := component.NewCmdComponent(component.ComponentRecommendedCommandName,
@@ -26,6 +25,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 		util.GetFullName(fullName, namespace.RecommendedCommandName))
 	deleteCmd.AddCommand(namespaceDeleteCmd)
 
+	util.SetCommandGroup(deleteCmd, util.ManagementGroup)
 	deleteCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return deleteCmd

--- a/pkg/odo/cli/delete/namespace/namespace.go
+++ b/pkg/odo/cli/delete/namespace/namespace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 )
 
@@ -123,8 +124,7 @@ func NewCmdNamespaceDelete(name, fullName string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return genericclioptions.GenericRun(do, cmd, args)
 		},
-		Annotations: map[string]string{"command": "main"},
-		Aliases:     []string{"project"},
+		Aliases: []string{"project"},
 	}
 
 	namespaceDeleteCmd.Flags().BoolVarP(&do.forceFlag, "force", "f", false, "Delete namespace without prompting")
@@ -134,5 +134,6 @@ func NewCmdNamespaceDelete(name, fullName string) *cobra.Command {
 		"Wait until the namespace no longer exists")
 
 	clientset.Add(namespaceDeleteCmd, clientset.KUBERNETES, clientset.PROJECT)
+	util.SetCommandGroup(namespaceDeleteCmd, util.MainGroup)
 	return namespaceDeleteCmd
 }

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -12,6 +12,7 @@ import (
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/version"
@@ -106,7 +107,7 @@ func NewCmdDeploy(name, fullName string) *cobra.Command {
 	clientset.Add(deployCmd, clientset.INIT, clientset.DEPLOY, clientset.FILESYSTEM)
 
 	// Add a defined annotation in order to appear in the help menu
-	deployCmd.Annotations["command"] = "main"
+	util.SetCommandGroup(deployCmd, util.MainGroup)
 	deployCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	commonflags.UseVariablesFlags(deployCmd)
 	return deployCmd

--- a/pkg/odo/cli/describe/describe.go
+++ b/pkg/odo/cli/describe/describe.go
@@ -18,7 +18,7 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 	componentCmd := NewCmdComponent(ComponentRecommendedCommandName, util.GetFullName(fullName, ComponentRecommendedCommandName))
 	bindingCmd := NewCmdBinding(BindingRecommendedCommandName, util.GetFullName(fullName, BindingRecommendedCommandName))
 	describeCmd.AddCommand(componentCmd, bindingCmd)
-	describeCmd.Annotations = map[string]string{"command": "management"}
+	util.SetCommandGroup(describeCmd, util.ManagementGroup)
 	describeCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return describeCmd

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -238,7 +238,7 @@ It forwards endpoints with any exposure values ('public', 'internal' or 'none') 
 		clientset.WATCH,
 	)
 	// Add a defined annotation in order to appear in the help menu
-	devCmd.Annotations["command"] = "main"
+	odoutil.SetCommandGroup(devCmd, odoutil.MainGroup)
 	devCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	commonflags.UseVariablesFlags(devCmd)
 	commonflags.UseRunOnFlag(devCmd)

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -27,6 +27,7 @@ import (
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/version"
@@ -271,7 +272,7 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 
 	commonflags.UseOutputFlag(initCmd)
 	// Add a defined annotation in order to appear in the help menu
-	initCmd.Annotations["command"] = "main"
+	util.SetCommandGroup(initCmd, util.MainGroup)
 	initCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	return initCmd
 }

--- a/pkg/odo/cli/list/component/list.go
+++ b/pkg/odo/cli/list/component/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cli/feature"
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/commonflags"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/redhat-developer/odo/pkg/component"
 
@@ -141,12 +142,11 @@ func NewCmdComponentList(ctx context.Context, name, fullName string) *cobra.Comm
 	o := NewListOptions()
 
 	var listCmd = &cobra.Command{
-		Use:         name,
-		Short:       "List all components in the current namespace",
-		Long:        "List all components in the current namespace.",
-		Example:     fmt.Sprintf(listExample, fullName),
-		Args:        genericclioptions.NoArgsAndSilenceJSON,
-		Annotations: map[string]string{"command": "management"},
+		Use:     name,
+		Short:   "List all components in the current namespace",
+		Long:    "List all components in the current namespace.",
+		Example: fmt.Sprintf(listExample, fullName),
+		Args:    genericclioptions.NoArgsAndSilenceJSON,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return genericclioptions.GenericRun(o, cmd, args)
 		},
@@ -158,6 +158,7 @@ func NewCmdComponentList(ctx context.Context, name, fullName string) *cobra.Comm
 	}
 	listCmd.Flags().StringVar(&o.namespaceFlag, "namespace", "", "Namespace for odo to scan for components")
 
+	util.SetCommandGroup(listCmd, util.ManagementGroup)
 	commonflags.UseOutputFlag(listCmd)
 	commonflags.UseRunOnFlag(listCmd)
 

--- a/pkg/odo/cli/list/list.go
+++ b/pkg/odo/cli/list/list.go
@@ -21,6 +21,7 @@ import (
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 
 	dfutil "github.com/devfile/library/pkg/util"
@@ -161,12 +162,11 @@ func NewCmdList(ctx context.Context, name, fullName string) *cobra.Command {
 	o := NewListOptions()
 
 	var listCmd = &cobra.Command{
-		Use:         name,
-		Short:       "List all components in the current namespace",
-		Long:        "List all components in the current namespace.",
-		Example:     fmt.Sprintf(listExample, fullName),
-		Args:        genericclioptions.NoArgsAndSilenceJSON,
-		Annotations: map[string]string{"command": "management"},
+		Use:     name,
+		Short:   "List all components in the current namespace",
+		Long:    "List all components in the current namespace.",
+		Example: fmt.Sprintf(listExample, fullName),
+		Args:    genericclioptions.NoArgsAndSilenceJSON,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return genericclioptions.GenericRun(o, cmd, args)
 		},
@@ -182,6 +182,7 @@ func NewCmdList(ctx context.Context, name, fullName string) *cobra.Command {
 	servicesCmd := services.NewCmdServicesList(services.RecommendedCommandName, odoutil.GetFullName(fullName, services.RecommendedCommandName))
 	listCmd.AddCommand(namespaceCmd, bindingCmd, componentCmd, servicesCmd)
 
+	util.SetCommandGroup(listCmd, util.ManagementGroup)
 	listCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	listCmd.Flags().StringVar(&o.namespaceFlag, "namespace", "", "Namespace for odo to scan for components")
 

--- a/pkg/odo/cli/login/login.go
+++ b/pkg/odo/cli/login/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -105,8 +106,7 @@ func NewCmdLogin(name, fullName string) *cobra.Command {
 		},
 	}
 
-	// Add a defined annotation in order to appear in the help menu
-	loginCmd.Annotations = map[string]string{"command": "openshift"}
+	util.SetCommandGroup(loginCmd, util.OpenshiftGroup)
 	loginCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	loginCmd.Flags().StringVarP(&o.userNameFlag, "username", "u", "", "username, will prompt if not provided")
 	loginCmd.Flags().StringVarP(&o.passwordFlag, "password", "p", "", "password, will prompt if not provided")

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -8,6 +8,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -67,7 +68,7 @@ func NewCmdLogout(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	logoutCmd.Annotations = map[string]string{"command": "openshift"}
+	util.SetCommandGroup(logoutCmd, util.OpenshiftGroup)
 	logoutCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	clientset.Add(logoutCmd, clientset.KUBERNETES)

--- a/pkg/odo/cli/logs/logs.go
+++ b/pkg/odo/cli/logs/logs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/log"
 
 	"github.com/redhat-developer/odo/pkg/devfile/location"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 
 	"github.com/spf13/cobra"
@@ -243,7 +244,7 @@ By default it shows logs of all containers running in both Dev and Deploy mode. 
 	logsCmd.Flags().BoolVar(&o.follow, "follow", false, "Follow/tail the logs of the pods")
 
 	clientset.Add(logsCmd, clientset.LOGS, clientset.FILESYSTEM)
-	logsCmd.Annotations["command"] = "main"
+	util.SetCommandGroup(logsCmd, util.MainGroup)
 	logsCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	return logsCmd
 }

--- a/pkg/odo/cli/preference/add/add.go
+++ b/pkg/odo/cli/preference/add/add.go
@@ -31,7 +31,7 @@ func NewCmdAdd(name, fullName string) *cobra.Command {
 
 	addCmd.AddCommand(registryCmd)
 	addCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	addCmd.Annotations = map[string]string{"command": "main"}
+	util.SetCommandGroup(addCmd, util.MainGroup)
 
 	return addCmd
 }

--- a/pkg/odo/cli/preference/preference.go
+++ b/pkg/odo/cli/preference/preference.go
@@ -49,7 +49,7 @@ func NewCmdPreference(ctx context.Context, name, fullName string) *cobra.Command
 	// Add the commands, help, usage and annotations
 	preferenceCmd.AddCommand(preferenceViewCmd, preferenceSetCmd, preferenceUnsetCmd, preferenceAddCmd, preferenceRemoveCmd)
 	preferenceCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	preferenceCmd.Annotations = map[string]string{"command": "utility"}
+	util.SetCommandGroup(preferenceCmd, util.UtilityGroup)
 
 	return preferenceCmd
 }

--- a/pkg/odo/cli/preference/remove/remove.go
+++ b/pkg/odo/cli/preference/remove/remove.go
@@ -31,7 +31,7 @@ func NewCmdRemove(name, fullName string) *cobra.Command {
 
 	removeCmd.AddCommand(registryCmd)
 	removeCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	removeCmd.Annotations = map[string]string{"command": "main"}
+	util.SetCommandGroup(removeCmd, util.MainGroup)
 
 	return removeCmd
 }

--- a/pkg/odo/cli/registry/registry.go
+++ b/pkg/odo/cli/registry/registry.go
@@ -122,7 +122,7 @@ func NewCmdRegistry(name, fullName string) *cobra.Command {
 	listCmd.Flags().BoolVar(&o.detailsFlag, "details", false, "Show details of each component")
 
 	// Add a defined annotation in order to appear in the help menu
-	listCmd.Annotations["command"] = "main"
+	odoutil.SetCommandGroup(listCmd, odoutil.MainGroup)
 	listCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	commonflags.UseOutputFlag(listCmd)

--- a/pkg/odo/cli/remove/remove.go
+++ b/pkg/odo/cli/remove/remove.go
@@ -19,7 +19,7 @@ func NewCmdRemove(name, fullName string) *cobra.Command {
 
 	bindingCmd := binding.NewCmdBinding(binding.BindingRecommendedCommandName, util.GetFullName(fullName, binding.BindingRecommendedCommandName))
 	removeCmd.AddCommand(bindingCmd)
-	removeCmd.Annotations = map[string]string{"command": "management"}
+	util.SetCommandGroup(removeCmd, util.ManagementGroup)
 	removeCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return removeCmd

--- a/pkg/odo/cli/set/namespace/namespace.go
+++ b/pkg/odo/cli/set/namespace/namespace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	"github.com/redhat-developer/odo/pkg/odo/util"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -99,11 +100,11 @@ func NewCmdNamespaceSet(name, fullName string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return genericclioptions.GenericRun(o, cmd, args)
 		},
-		Annotations: map[string]string{"command": "main"},
-		Aliases:     []string{"project"},
+		Aliases: []string{"project"},
 	}
 
 	clientset.Add(namespaceSetCmd, clientset.KUBERNETES, clientset.FILESYSTEM, clientset.PROJECT)
+	util.SetCommandGroup(namespaceSetCmd, util.MainGroup)
 
 	return namespaceSetCmd
 }

--- a/pkg/odo/cli/set/set.go
+++ b/pkg/odo/cli/set/set.go
@@ -24,12 +24,11 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf("%s\n",
 			namespaceSetCmd.Example,
 		),
-		Annotations: map[string]string{"command": "management"},
 	}
 
 	setCmd.AddCommand(namespaceSetCmd)
 
-	// Add a defined annotation in order to appear in the help menu
+	util.SetCommandGroup(setCmd, util.ManagementGroup)
 	setCmd.SetUsageTemplate(util.CmdUsageTemplate)
 
 	return setCmd

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
-	"github.com/redhat-developer/odo/pkg/preference"
 	odoversion "github.com/redhat-developer/odo/pkg/version"
 
 	"github.com/spf13/cobra"
@@ -63,16 +61,7 @@ func (o *VersionOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline, 
 		client, err := kclient.New()
 
 		if err == nil {
-			// checking the value of timeout in preference
-			var timeout time.Duration
-			if o.clientset.PreferenceClient != nil {
-				timeout = o.clientset.PreferenceClient.GetTimeout()
-			} else {
-				// the default timeout will be used
-				// when the value is not readable from preference
-				timeout = preference.DefaultTimeout
-			}
-			o.serverInfo, err = client.GetServerVersion(timeout)
+			o.serverInfo, err = client.GetServerVersion(o.clientset.PreferenceClient.GetTimeout())
 			if err != nil {
 				klog.V(4).Info("unable to fetch the server version: ", err)
 			}

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -130,9 +130,8 @@ func NewCmdVersion(name, fullName string) *cobra.Command {
 		},
 	}
 	clientset.Add(versionCmd, clientset.PREFERENCE)
+	util.SetCommandGroup(versionCmd, util.UtilityGroup)
 
-	// Add a defined annotation in order to appear in the help menu
-	versionCmd.Annotations["command"] = "utility"
 	versionCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	versionCmd.Flags().BoolVar(&o.clientFlag, "client", false, "Client version only (no server required).")
 

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -132,7 +132,7 @@ func NewCmdVersion(name, fullName string) *cobra.Command {
 	clientset.Add(versionCmd, clientset.PREFERENCE)
 
 	// Add a defined annotation in order to appear in the help menu
-	versionCmd.Annotations = map[string]string{"command": "utility"}
+	versionCmd.Annotations["command"] = "utility"
 	versionCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	versionCmd.Flags().BoolVar(&o.clientFlag, "client", false, "Client version only (no server required).")
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -7,8 +7,16 @@ import (
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/machineoutput"
+	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+)
+
+var (
+	MainGroup       = "main"
+	ManagementGroup = "management"
+	OpenshiftGroup  = "openshift"
+	UtilityGroup    = "utility"
 )
 
 func LogError(err error, context string) {
@@ -78,3 +86,10 @@ Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
+
+func SetCommandGroup(cmd *cobra.Command, groupName string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["command"] = groupName
+}


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

This PR adds the PREFERNECE dependency to `odo version`, and creates a CommandGroup abstraction to avoid this error occurs again.

**Which issue(s) this PR fixes:**

`odo version` can use the Timeout value defined in the odo preferences, but this value were never taken into account, because the PREFERENCE dependency were overwritten when setting the command group.

Fixes #6417

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
