### PR TITLE
odo delete component deletes components running on podman

### DIFF
--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -97,11 +97,7 @@ func references(list []unstructured.Unstructured, ownerRef metav1.OwnerReference
 
 // ListResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on the cluster and can be deleted
 // Returns a Warning if an error happens communicating with the cluster
-func (do DeleteComponentClient) ListResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string, mode string) (isInnerLoopDeployed bool, resources []unstructured.Unstructured, err error) {
-	if do.kubeClient == nil {
-		return
-	}
-
+func (do DeleteComponentClient) ListClusterResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string, mode string) (isInnerLoopDeployed bool, resources []unstructured.Unstructured, err error) {
 	var deployment *v1.Deployment
 	if mode == odolabels.ComponentDevMode || mode == odolabels.ComponentAnyMode {
 		// Inner Loop

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/kclient"
 	odolabels "github.com/redhat-developer/odo/pkg/labels"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
+	"github.com/redhat-developer/odo/pkg/podman"
 	odoTestingUtil "github.com/redhat-developer/odo/pkg/testingutil"
 	"github.com/redhat-developer/odo/pkg/util"
 )
@@ -116,7 +117,8 @@ func TestDeleteComponentClient_ListClusterResourcesToDelete(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			kubeClient := tt.fields.kubeClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
-			do := NewDeleteComponentClient(kubeClient, execClient)
+			podmanClient := podman.NewMockClient(ctrl)
+			do := NewDeleteComponentClient(kubeClient, podmanClient, execClient)
 			ctx := odocontext.WithApplication(context.TODO(), "app")
 			got, err := do.ListClusterResourcesToDelete(ctx, tt.args.componentName, tt.args.namespace)
 			if (err != nil) != tt.wantErr {
@@ -232,8 +234,9 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			kubeClient := tt.fields.kubeClient(ctrl)
+			podmanClient := podman.NewMockClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
-			do := NewDeleteComponentClient(kubeClient, execClient)
+			do := NewDeleteComponentClient(kubeClient, podmanClient, execClient)
 			got := do.DeleteResources(tt.args.resources, false)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("DeleteComponentClient.DeleteResources() mismatch (-want +got):\n%s", diff)
@@ -705,8 +708,9 @@ func TestDeleteComponentClient_ExecutePreStopEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			kubeClient := tt.fields.kubeClient(ctrl)
+			podmanClient := podman.NewMockClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
-			do := NewDeleteComponentClient(kubeClient, execClient)
+			do := NewDeleteComponentClient(kubeClient, podmanClient, execClient)
 			if err := do.ExecutePreStopEvents(tt.args.devfileObj, tt.args.appName, tt.args.devfileObj.GetMetadataName()); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteComponent() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/kclient"
 	odolabels "github.com/redhat-developer/odo/pkg/labels"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
-	"github.com/redhat-developer/odo/pkg/podman"
 	odoTestingUtil "github.com/redhat-developer/odo/pkg/testingutil"
 	"github.com/redhat-developer/odo/pkg/util"
 )
@@ -117,8 +116,7 @@ func TestDeleteComponentClient_ListClusterResourcesToDelete(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			kubeClient := tt.fields.kubeClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
-			podmanClient := podman.NewMockClient(ctrl)
-			do := NewDeleteComponentClient(kubeClient, podmanClient, execClient)
+			do := NewDeleteComponentClient(kubeClient, nil, execClient)
 			ctx := odocontext.WithApplication(context.TODO(), "app")
 			got, err := do.ListClusterResourcesToDelete(ctx, tt.args.componentName, tt.args.namespace)
 			if (err != nil) != tt.wantErr {
@@ -234,9 +232,8 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			kubeClient := tt.fields.kubeClient(ctrl)
-			podmanClient := podman.NewMockClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
-			do := NewDeleteComponentClient(kubeClient, podmanClient, execClient)
+			do := NewDeleteComponentClient(kubeClient, nil, execClient)
 			got := do.DeleteResources(tt.args.resources, false)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("DeleteComponentClient.DeleteResources() mismatch (-want +got):\n%s", diff)
@@ -708,9 +705,8 @@ func TestDeleteComponentClient_ExecutePreStopEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			kubeClient := tt.fields.kubeClient(ctrl)
-			podmanClient := podman.NewMockClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
-			do := NewDeleteComponentClient(kubeClient, podmanClient, execClient)
+			do := NewDeleteComponentClient(kubeClient, nil, execClient)
 			if err := do.ExecutePreStopEvents(tt.args.devfileObj, tt.args.appName, tt.args.devfileObj.GetMetadataName()); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteComponent() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -242,7 +242,7 @@ func TestDeleteComponentClient_DeleteResources(t *testing.T) {
 	}
 }
 
-func TestDeleteComponentClient_ListResourcesToDeleteFromDevfile(t *testing.T) {
+func TestDeleteComponentClient_ListClusterResourcesToDeleteFromDevfile(t *testing.T) {
 	const compName = "nodejs-prj1-api-abhz"
 	innerLoopCoreDeploymentName, _ := util.NamespaceKubernetesObject(compName, appName)
 
@@ -550,7 +550,7 @@ func TestDeleteComponentClient_ListResourcesToDeleteFromDevfile(t *testing.T) {
 			do := DeleteComponentClient{
 				kubeClient: tt.fields.kubeClient(ctrl),
 			}
-			gotIsInnerLoopDeployed, gotResources, err := do.ListResourcesToDeleteFromDevfile(tt.args.devfileObj, tt.args.appName, tt.args.devfileObj.GetMetadataName(), tt.args.mode)
+			gotIsInnerLoopDeployed, gotResources, err := do.ListClusterResourcesToDeleteFromDevfile(tt.args.devfileObj, tt.args.appName, tt.args.devfileObj.GetMetadataName(), tt.args.mode)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ListResourcesToDeleteFromDevfile() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/devfile/library/pkg/devfile/parser"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -19,4 +20,7 @@ type Client interface {
 	// and a bool that indicates if the devfile component has been pushed to the innerloop
 	// the mode indicates which component to list, either Dev, Deploy or Any (using constant labels.Component*Mode)
 	ListClusterResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string, mode string) (bool, []unstructured.Unstructured, error)
+	// ListPodmanResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on podman in Dev mode that can be deleted,
+	// and a bool that indicates if the devfile component has been pushed to the innerloop
+	ListPodmanResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string) (isInnerLoopDeployed bool, pods []*v1.Pod, err error)
 }

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/devfile/library/pkg/devfile/parser"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -22,5 +22,5 @@ type Client interface {
 	ListClusterResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string, mode string) (bool, []unstructured.Unstructured, error)
 	// ListPodmanResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on podman in Dev mode that can be deleted,
 	// and a bool that indicates if the devfile component has been pushed to the innerloop
-	ListPodmanResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string) (isInnerLoopDeployed bool, pods []*v1.Pod, err error)
+	ListPodmanResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string) (isInnerLoopDeployed bool, pods []*corev1.Pod, err error)
 }

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -15,8 +15,8 @@ type Client interface {
 	DeleteResources(resources []unstructured.Unstructured, wait bool) []unstructured.Unstructured
 	// ExecutePreStopEvents executes preStop events if any, as a precondition to deleting a devfile component deployment
 	ExecutePreStopEvents(devfileObj parser.DevfileObj, appName string, componentName string) error
-	// ListResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on the cluster that can be deleted,
+	// ListClusterResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on the cluster that can be deleted,
 	// and a bool that indicates if the devfile component has been pushed to the innerloop
 	// the mode indicates which component to list, either Dev, Deploy or Any (using constant labels.Component*Mode)
-	ListResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string, mode string) (bool, []unstructured.Unstructured, error)
+	ListClusterResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName string, componentName string, mode string) (bool, []unstructured.Unstructured, error)
 }

--- a/pkg/component/delete/mock.go
+++ b/pkg/component/delete/mock.go
@@ -79,18 +79,18 @@ func (mr *MockClientMockRecorder) ListClusterResourcesToDelete(ctx, componentNam
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterResourcesToDelete", reflect.TypeOf((*MockClient)(nil).ListClusterResourcesToDelete), ctx, componentName, namespace)
 }
 
-// ListResourcesToDeleteFromDevfile mocks base method.
-func (m *MockClient) ListResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName, componentName, mode string) (bool, []unstructured.Unstructured, error) {
+// ListClusterResourcesToDeleteFromDevfile mocks base method.
+func (m *MockClient) ListClusterResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName, componentName, mode string) (bool, []unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResourcesToDeleteFromDevfile", devfileObj, appName, componentName, mode)
+	ret := m.ctrl.Call(m, "ListClusterResourcesToDeleteFromDevfile", devfileObj, appName, componentName, mode)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].([]unstructured.Unstructured)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// ListResourcesToDeleteFromDevfile indicates an expected call of ListResourcesToDeleteFromDevfile.
-func (mr *MockClientMockRecorder) ListResourcesToDeleteFromDevfile(devfileObj, appName, componentName, mode interface{}) *gomock.Call {
+// ListClusterResourcesToDeleteFromDevfile indicates an expected call of ListClusterResourcesToDeleteFromDevfile.
+func (mr *MockClientMockRecorder) ListClusterResourcesToDeleteFromDevfile(devfileObj, appName, componentName, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourcesToDeleteFromDevfile", reflect.TypeOf((*MockClient)(nil).ListResourcesToDeleteFromDevfile), devfileObj, appName, componentName, mode)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterResourcesToDeleteFromDevfile", reflect.TypeOf((*MockClient)(nil).ListClusterResourcesToDeleteFromDevfile), devfileObj, appName, componentName, mode)
 }

--- a/pkg/component/delete/mock.go
+++ b/pkg/component/delete/mock.go
@@ -10,6 +10,7 @@ import (
 
 	parser "github.com/devfile/library/pkg/devfile/parser"
 	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -93,4 +94,20 @@ func (m *MockClient) ListClusterResourcesToDeleteFromDevfile(devfileObj parser.D
 func (mr *MockClientMockRecorder) ListClusterResourcesToDeleteFromDevfile(devfileObj, appName, componentName, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterResourcesToDeleteFromDevfile", reflect.TypeOf((*MockClient)(nil).ListClusterResourcesToDeleteFromDevfile), devfileObj, appName, componentName, mode)
+}
+
+// ListPodmanResourcesToDeleteFromDevfile mocks base method.
+func (m *MockClient) ListPodmanResourcesToDeleteFromDevfile(devfileObj parser.DevfileObj, appName, componentName string) (bool, []*v1.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPodmanResourcesToDeleteFromDevfile", devfileObj, appName, componentName)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].([]*v1.Pod)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListPodmanResourcesToDeleteFromDevfile indicates an expected call of ListPodmanResourcesToDeleteFromDevfile.
+func (mr *MockClientMockRecorder) ListPodmanResourcesToDeleteFromDevfile(devfileObj, appName, componentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodmanResourcesToDeleteFromDevfile", reflect.TypeOf((*MockClient)(nil).ListPodmanResourcesToDeleteFromDevfile), devfileObj, appName, componentName)
 }

--- a/pkg/dev/kubedev/cleanup.go
+++ b/pkg/dev/kubedev/cleanup.go
@@ -17,7 +17,7 @@ func (o *DevClient) CleanupResources(ctx context.Context, out io.Writer) error {
 	)
 	fmt.Fprintln(out, "Cleaning resources, please wait")
 	appname := odocontext.GetApplication(ctx)
-	isInnerLoopDeployed, resources, err := o.deleteClient.ListResourcesToDeleteFromDevfile(*devfileObj, appname, componentName, labels.ComponentDevMode)
+	isInnerLoopDeployed, resources, err := o.deleteClient.ListClusterResourcesToDeleteFromDevfile(*devfileObj, appname, componentName, labels.ComponentDevMode)
 	if err != nil {
 		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
 			fmt.Fprintf(out, "Error connecting to the cluster, the resources were not cleaned up.\nPlease log in again and cleanup the resource with `odo delete component`\n\n")

--- a/pkg/dev/podmandev/cleanup.go
+++ b/pkg/dev/podmandev/cleanup.go
@@ -4,36 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"k8s.io/klog"
 )
 
 func (o *DevClient) CleanupResources(ctx context.Context, out io.Writer) error {
 	fmt.Printf("Cleaning up resources\n")
-
 	if o.deployedPod == nil {
 		return nil
 	}
-
-	err := o.podmanClient.PodStop(o.deployedPod.GetName())
-	if err != nil {
-		return err
-	}
-	err = o.podmanClient.PodRm(o.deployedPod.GetName())
-	if err != nil {
-		return err
-	}
-
-	for _, volume := range o.deployedPod.Spec.Volumes {
-		if volume.PersistentVolumeClaim == nil {
-			continue
-		}
-		volumeName := volume.PersistentVolumeClaim.ClaimName
-		klog.V(3).Infof("deleting podman volume %q", volumeName)
-		err = o.podmanClient.VolumeRm(volumeName)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return o.podmanClient.CleanupPodResources(o.deployedPod)
 }

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -696,7 +696,7 @@ func (mr *MockClientInterfaceMockRecorder) GetOneDeploymentFromSelector(selector
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOneDeploymentFromSelector", reflect.TypeOf((*MockClientInterface)(nil).GetOneDeploymentFromSelector), selector)
 }
 
-// GetOneService mocks base method
+// GetOneService mocks base method.
 func (m *MockClientInterface) GetOneService(componentName, appName string, isPartOfComponent bool) (*v11.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOneService", componentName, appName, isPartOfComponent)
@@ -705,7 +705,7 @@ func (m *MockClientInterface) GetOneService(componentName, appName string, isPar
 	return ret0, ret1
 }
 
-// GetOneService indicates an expected call of GetOneService
+// GetOneService indicates an expected call of GetOneService.
 func (mr *MockClientInterfaceMockRecorder) GetOneService(componentName, appName, isPartOfComponent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOneService", reflect.TypeOf((*MockClientInterface)(nil).GetOneService), componentName, appName, isPartOfComponent)

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -184,7 +184,7 @@ func odoRootCmd(ctx context.Context, name, fullName string) *cobra.Command {
 		build_images.NewCmdBuildImages(build_images.RecommendedCommandName, util.GetFullName(fullName, build_images.RecommendedCommandName)),
 		deploy.NewCmdDeploy(deploy.RecommendedCommandName, util.GetFullName(fullName, deploy.RecommendedCommandName)),
 		_init.NewCmdInit(_init.RecommendedCommandName, util.GetFullName(fullName, _init.RecommendedCommandName)),
-		_delete.NewCmdDelete(_delete.RecommendedCommandName, util.GetFullName(fullName, _delete.RecommendedCommandName)),
+		_delete.NewCmdDelete(ctx, _delete.RecommendedCommandName, util.GetFullName(fullName, _delete.RecommendedCommandName)),
 		add.NewCmdAdd(add.RecommendedCommandName, util.GetFullName(fullName, add.RecommendedCommandName)),
 		remove.NewCmdRemove(remove.RecommendedCommandName, util.GetFullName(fullName, remove.RecommendedCommandName)),
 		dev.NewCmdDev(dev.RecommendedCommandName, util.GetFullName(fullName, dev.RecommendedCommandName)),

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/labels"
 	"github.com/redhat-developer/odo/pkg/log"
+	clierrors "github.com/redhat-developer/odo/pkg/odo/cli/errors"
 	"github.com/redhat-developer/odo/pkg/odo/cli/files"
 	"github.com/redhat-developer/odo/pkg/odo/cli/ui"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
@@ -140,7 +141,11 @@ func (o *ComponentOptions) deleteDevfileComponent(ctx context.Context) error {
 	log.Info("Searching resources to delete, please wait...")
 	isInnerLoopDeployed, devfileResources, err := o.clientset.DeleteClient.ListResourcesToDeleteFromDevfile(*devfileObj, appName, componentName, labels.ComponentAnyMode)
 	if err != nil {
-		return err
+		if clierrors.AsWarning(err) {
+			log.Warning(err.Error())
+		} else {
+			return err
+		}
 	}
 
 	var hasClusterResources bool

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -133,8 +133,8 @@ func (o *ComponentOptions) deleteDevfileComponent(ctx context.Context) error {
 	var (
 		devfileObj    = odocontext.GetDevfileObj(ctx)
 		componentName = odocontext.GetComponentName(ctx)
-		namespace     = odocontext.GetNamespace(ctx)
 		appName       = odocontext.GetApplication(ctx)
+		namespace     string
 	)
 
 	log.Info("Searching resources to delete, please wait...")
@@ -142,14 +142,19 @@ func (o *ComponentOptions) deleteDevfileComponent(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	hasClusterResources := len(devfileResources) != 0
-	if hasClusterResources {
-		// Print all the resources that odo will attempt to delete
-		printDevfileComponents(componentName, namespace, devfileResources)
-	} else {
-		log.Infof("No resource found for component %q in namespace %q\n", componentName, namespace)
-		if !o.withFilesFlag {
-			return nil
+
+	var hasClusterResources bool
+	if o.clientset.KubernetesClient != nil {
+		namespace = odocontext.GetNamespace(ctx)
+		hasClusterResources = len(devfileResources) != 0
+		if hasClusterResources {
+			// Print all the resources that odo will attempt to delete
+			printDevfileComponents(componentName, namespace, devfileResources)
+		} else {
+			log.Infof("No resource found for component %q in namespace %q\n", componentName, namespace)
+			if !o.withFilesFlag {
+				return nil
+			}
 		}
 	}
 

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -101,6 +101,9 @@ func (o *ComponentOptions) Validate(ctx context.Context) error {
 }
 
 func (o *ComponentOptions) Run(ctx context.Context) error {
+	if !feature.IsEnabled(ctx, feature.GenericRunOnFlag) {
+		o.clientset.PodmanClient = nil
+	}
 	switch fcontext.GetRunOn(ctx, "") {
 	case commonflags.RunOnCluster:
 		o.clientset.PodmanClient = nil
@@ -209,7 +212,7 @@ func (o *ComponentOptions) deleteDevfileComponent(ctx context.Context) error {
 		}
 		hasPodmanResources = len(podmanPods) != 0
 		if hasPodmanResources {
-			log.Printf("The following pods and associated volumes will be deleted:")
+			log.Printf("The following pods and associated volumes will be deleted from podman:")
 			for _, pod := range podmanPods {
 				fmt.Printf("\t- %s\n", pod.GetName())
 			}

--- a/pkg/odo/cli/delete/component/component_test.go
+++ b/pkg/odo/cli/delete/component/component_test.go
@@ -131,7 +131,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 			name: "deleting a component with access to devfile",
 			deleteClient: func(ctrl *gomock.Controller) _delete.Client {
 				deleteClient := _delete.NewMockClient(ctrl)
-				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
+				deleteClient.EXPECT().ListClusterResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(gomock.Any(), compName, projectName).Return(resources, nil)
 				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				deleteClient.EXPECT().DeleteResources(resources, false).Return([]unstructured.Unstructured{})
@@ -146,7 +146,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 			name: "deleting a component should not fail even if ExecutePreStopEvents fails",
 			deleteClient: func(ctrl *gomock.Controller) _delete.Client {
 				deleteClient := _delete.NewMockClient(ctrl)
-				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
+				deleteClient.EXPECT().ListClusterResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(gomock.Any(), compName, projectName).Return(resources, nil)
 				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), appName, gomock.Any()).Return(errors.New("some error"))
 				deleteClient.EXPECT().DeleteResources(resources, false).Return(nil)
@@ -161,7 +161,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 			name: "deleting a component should fail if ListResourcesToDeleteFromDevfile fails",
 			deleteClient: func(ctrl *gomock.Controller) _delete.Client {
 				deleteClient := _delete.NewMockClient(ctrl)
-				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(false, nil, errors.New("some error"))
+				deleteClient.EXPECT().ListClusterResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(false, nil, errors.New("some error"))
 				return deleteClient
 			},
 			fields: fields{
@@ -173,7 +173,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 			name: "deleting a component should be aborted if forceFlag is not passed",
 			deleteClient: func(ctrl *gomock.Controller) _delete.Client {
 				deleteClient := _delete.NewMockClient(ctrl)
-				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
+				deleteClient.EXPECT().ListClusterResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
 				return deleteClient
 			},
 			fields: fields{
@@ -185,7 +185,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 			name: "nothing to delete",
 			deleteClient: func(ctrl *gomock.Controller) _delete.Client {
 				deleteClient := _delete.NewMockClient(ctrl)
-				deleteClient.EXPECT().ListResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(false, nil, nil)
+				deleteClient.EXPECT().ListClusterResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(false, nil, nil)
 				return deleteClient
 			},
 			fields: fields{

--- a/pkg/odo/cli/delete/delete.go
+++ b/pkg/odo/cli/delete/delete.go
@@ -1,6 +1,8 @@
 package delete
 
 import (
+	"context"
+
 	"github.com/redhat-developer/odo/pkg/odo/cli/delete/component"
 	"github.com/redhat-developer/odo/pkg/odo/cli/delete/namespace"
 	"github.com/redhat-developer/odo/pkg/odo/util"
@@ -11,13 +13,13 @@ import (
 const RecommendedCommandName = "delete"
 
 // NewCmdDelete implements the delete odo command
-func NewCmdDelete(name, fullName string) *cobra.Command {
+func NewCmdDelete(ctx context.Context, name, fullName string) *cobra.Command {
 	var deleteCmd = &cobra.Command{
 		Use:   name,
 		Short: "Delete resources",
 	}
 
-	componentCmd := component.NewCmdComponent(component.ComponentRecommendedCommandName,
+	componentCmd := component.NewCmdComponent(ctx, component.ComponentRecommendedCommandName,
 		util.GetFullName(fullName, component.ComponentRecommendedCommandName))
 	deleteCmd.AddCommand(componentCmd)
 

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -87,7 +87,7 @@ const (
 // Clients will be created only once and be reused for sub-dependencies
 var subdeps map[string][]string = map[string][]string{
 	ALIZER:           {REGISTRY},
-	DELETE_COMPONENT: {KUBERNETES_NULLABLE, EXEC},
+	DELETE_COMPONENT: {KUBERNETES_NULLABLE, PODMAN_NULLABLE, EXEC},
 	DEPLOY:           {KUBERNETES, FILESYSTEM},
 	DEV:              {BINDING, DELETE_COMPONENT, EXEC, FILESYSTEM, KUBERNETES_NULLABLE, PODMAN_NULLABLE, PORT_FORWARD, PREFERENCE, STATE, SYNC, WATCH},
 	EXEC:             {KUBERNETES_NULLABLE},
@@ -198,7 +198,7 @@ func Fetch(command *cobra.Command, platform string) (*Clientset, error) {
 		}
 	}
 	if isDefined(command, DELETE_COMPONENT) {
-		dep.DeleteClient = _delete.NewDeleteComponentClient(dep.KubernetesClient, dep.ExecClient)
+		dep.DeleteClient = _delete.NewDeleteComponentClient(dep.KubernetesClient, dep.PodmanClient, dep.ExecClient)
 	}
 	if isDefined(command, DEPLOY) {
 		dep.DeployClient = deploy.NewDeployClient(dep.KubernetesClient, dep.FS)

--- a/pkg/podman/interface.go
+++ b/pkg/podman/interface.go
@@ -24,6 +24,9 @@ type Client interface {
 	// VolumeRm deletes the volume with given volumeName
 	VolumeRm(volumeName string) error
 
+	// CleanupResources stops and removes a pod and its associated resources (volumes)
+	CleanupPodResources(pod *corev1.Pod) error
+
 	ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error
 
 	// GetPodLogs returns the logs of the specified pod container.

--- a/pkg/podman/interface.go
+++ b/pkg/podman/interface.go
@@ -12,11 +12,17 @@ type Client interface {
 	// PlayKube creates the Pod with Podman
 	PlayKube(pod *corev1.Pod) error
 
+	// KubeGenerate returns a Kubernetes Pod definition of an existing Pod
+	KubeGenerate(name string) (*corev1.Pod, error)
+
 	// PodStop stops the pod with given podname
 	PodStop(podname string) error
 
 	// PodRm deletes the pod with given podname
 	PodRm(podname string) error
+
+	// PodLs lists the names of existing pods
+	PodLs() (map[string]bool, error)
 
 	// VolumeLs lists the names of existing volumes
 	VolumeLs() (map[string]bool, error)

--- a/pkg/podman/mock.go
+++ b/pkg/podman/mock.go
@@ -37,6 +37,20 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CleanupPodResources mocks base method.
+func (m *MockClient) CleanupPodResources(pod *v1.Pod) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupPodResources", pod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupPodResources indicates an expected call of CleanupPodResources.
+func (mr *MockClientMockRecorder) CleanupPodResources(pod interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupPodResources", reflect.TypeOf((*MockClient)(nil).CleanupPodResources), pod)
+}
+
 // ExecCMDInContainer mocks base method.
 func (m *MockClient) ExecCMDInContainer(containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
 	m.ctrl.T.Helper()
@@ -126,6 +140,21 @@ func (mr *MockClientMockRecorder) GetRunningPodFromSelector(selector interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningPodFromSelector", reflect.TypeOf((*MockClient)(nil).GetRunningPodFromSelector), selector)
 }
 
+// KubeGenerate mocks base method.
+func (m *MockClient) KubeGenerate(name string) (*v1.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KubeGenerate", name)
+	ret0, _ := ret[0].(*v1.Pod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// KubeGenerate indicates an expected call of KubeGenerate.
+func (mr *MockClientMockRecorder) KubeGenerate(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeGenerate", reflect.TypeOf((*MockClient)(nil).KubeGenerate), name)
+}
+
 // ListAllComponents mocks base method.
 func (m *MockClient) ListAllComponents() ([]api.ComponentAbstract, error) {
 	m.ctrl.T.Helper()
@@ -153,6 +182,21 @@ func (m *MockClient) PlayKube(pod *v1.Pod) error {
 func (mr *MockClientMockRecorder) PlayKube(pod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlayKube", reflect.TypeOf((*MockClient)(nil).PlayKube), pod)
+}
+
+// PodLs mocks base method.
+func (m *MockClient) PodLs() (map[string]bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PodLs")
+	ret0, _ := ret[0].(map[string]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PodLs indicates an expected call of PodLs.
+func (mr *MockClientMockRecorder) PodLs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PodLs", reflect.TypeOf((*MockClient)(nil).PodLs))
 }
 
 // PodRm mocks base method.

--- a/pkg/podman/mock.go
+++ b/pkg/podman/mock.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	api "github.com/redhat-developer/odo/pkg/api"
 	v1 "k8s.io/api/core/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -123,6 +124,21 @@ func (m *MockClient) GetRunningPodFromSelector(selector string) (*v1.Pod, error)
 func (mr *MockClientMockRecorder) GetRunningPodFromSelector(selector interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningPodFromSelector", reflect.TypeOf((*MockClient)(nil).GetRunningPodFromSelector), selector)
+}
+
+// ListAllComponents mocks base method.
+func (m *MockClient) ListAllComponents() ([]api.ComponentAbstract, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllComponents")
+	ret0, _ := ret[0].([]api.ComponentAbstract)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllComponents indicates an expected call of ListAllComponents.
+func (mr *MockClientMockRecorder) ListAllComponents() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllComponents", reflect.TypeOf((*MockClient)(nil).ListAllComponents))
 }
 
 // PlayKube mocks base method.

--- a/tests/helper/component_cluster.go
+++ b/tests/helper/component_cluster.go
@@ -23,6 +23,12 @@ func NewClusterComponent(name string, app string, namespace string, cli CliRunne
 	}
 }
 
+func (o *ClusterComponent) ExpectIsDeployed() {
+	deploymentName := fmt.Sprintf("%s-%s", o.name, o.app)
+	stdout := o.cli.Run("get", "deployment", "-n", o.namespace).Out.Contents()
+	Expect(string(stdout)).To(ContainSubstring(deploymentName))
+}
+
 func (o *ClusterComponent) ExpectIsNotDeployed() {
 	deploymentName := fmt.Sprintf("%s-%s", o.name, o.app)
 	stdout := o.cli.Run("get", "deployment", "-n", o.namespace).Out.Contents()

--- a/tests/helper/component_interface.go
+++ b/tests/helper/component_interface.go
@@ -6,6 +6,8 @@ import (
 
 // Component is an abstraction for a Devfile Component deployed on a specific platform
 type Component interface {
+	// ExpectIsDeployed checks that the component is deployed
+	ExpectIsDeployed()
 	// ExpectIsNotDeployed checks that the component is not deployed
 	ExpectIsNotDeployed()
 	// Exec executes the command in specific container of the component

--- a/tests/helper/component_podman.go
+++ b/tests/helper/component_podman.go
@@ -23,6 +23,14 @@ func NewPodmanComponent(name string, app string) *PodmanComponent {
 	}
 }
 
+func (o *PodmanComponent) ExpectIsDeployed() {
+	podName := fmt.Sprintf("%s-%s", o.name, o.app)
+	cmd := exec.Command("podman", "pod", "list", "--format", "{{.Name}}", "--noheading")
+	stdout, err := cmd.Output()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(string(stdout)).To(ContainSubstring(podName))
+}
+
 func (o *PodmanComponent) ExpectIsNotDeployed() {
 	podName := fmt.Sprintf("%s-%s", o.name, o.app)
 	cmd := exec.Command("podman", "pod", "list", "--format", "{{.Name}}", "--noheading")
@@ -39,7 +47,6 @@ func (o *PodmanComponent) Exec(container string, args ...string) string {
 	cmdargs = append(cmdargs, args...)
 
 	command := exec.Command("podman", cmdargs...)
-	fmt.Printf("exec %v\n", cmdargs)
 	out, err := command.Output()
 	Expect(err).ToNot(HaveOccurred())
 	return string(out)

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -154,6 +154,10 @@ var _ = Describe("odo delete command tests", func() {
 					Expect(stdOut).To(ContainSubstring("No resource found for component %q in namespace %q", cmpName, commonVar.Project))
 				})
 
+				It("should work if cluster is not accessible", Label(helper.LabelNoCluster), func() {
+					helper.Cmd("odo", "delete", "component").ShouldPass()
+				})
+
 				It("should delete the respective files with --files", func() {
 					stdOut := helper.Cmd("odo", "delete", "component", "--files", "-f").ShouldPass().Out()
 					By("not finding resources in namepace", func() {

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -154,9 +154,14 @@ var _ = Describe("odo delete command tests", func() {
 					Expect(stdOut).To(ContainSubstring("No resource found for component %q in namespace %q", cmpName, commonVar.Project))
 				})
 
-				It("should work if cluster is not accessible", Label(helper.LabelNoCluster), func() {
-					helper.Cmd("odo", "delete", "component").ShouldPass()
-				})
+				for _, label := range []string{
+					helper.LabelNoCluster, helper.LabelUnauth,
+				} {
+					label := label
+					It("should work without cluster", Label(label), func() {
+						helper.Cmd("odo", "delete", "component").ShouldPass()
+					})
+				}
 
 				It("should delete the respective files with --files", func() {
 					stdOut := helper.Cmd("odo", "delete", "component", "--files", "-f").ShouldPass().Out()

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -427,7 +427,7 @@ ComponentSettings:
 				})
 
 				AfterEach(func() {
-					devSession.Kill()
+					devSession.Stop()
 					devSession.WaitEnd()
 				})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

`odo delete component` support for podman when devfile is present

(support for `--name` will be done in a separate PR)

**Which issue(s) this PR fixes:**

Fixes partially #6296

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
