### PR TITLE
Display a generic Experimental mode warning message when this mode is enabled

### DIFF
--- a/docs/website/docs/user-guides/advanced/experimental-mode.md
+++ b/docs/website/docs/user-guides/advanced/experimental-mode.md
@@ -25,8 +25,11 @@ Example:
 ```shell
 $ ODO_EXPERIMENTAL_MODE=true odo dev --run-on=some-platform
 
-Experimental mode enabled for flag: --run-on. Use at your own risk. More details on https://odo.dev/docs/user-guides/advanced/experimental-mode
-...
+============================================================================
+⚠ Experimental mode enabled. Use at your own risk.
+More details on https://odo.dev/docs/user-guides/advanced/experimental-mode
+============================================================================
+
 ...
 -  Forwarding from 127.0.0.1:40001 -> 8080
 ```

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -301,16 +301,16 @@ func Fsuccess(out io.Writer, a ...interface{}) {
 	}
 }
 
-// Experimental will output in an appropriate "progress" manner
-func Experimental(a ...interface{}) {
-	Experimentalf("%s", a)
-}
-
-// Experimentalf will output in an appropriate "progress" manner
-func Experimentalf(format string, a ...interface{}) {
+// DisplayExperimentalWarning displays the experimental mode warning message.
+func DisplayExperimentalWarning() {
 	if !IsJSON() {
 		yellow := color.New(color.FgYellow).SprintFunc()
-		fmt.Fprintf(GetStdout(), "%s\n", yellow(fmt.Sprintf(format, a...)))
+		h := "============================================================================"
+		fmt.Fprintln(GetStdout(), yellow(fmt.Sprintf(`%[1]s
+%s Experimental mode enabled. Use at your own risk.
+More details on https://odo.dev/docs/user-guides/advanced/experimental-mode
+%[1]s
+`, h, getWarningString())))
 	}
 }
 

--- a/pkg/odo/cli/feature/doc.go
+++ b/pkg/odo/cli/feature/doc.go
@@ -1,4 +1,2 @@
 // Package feature allows to determine whether a given feature is enabled or not at the CLI level.
-// Active features are accumulated in a global `enabledFeatures` variable, and warning
-// can be displayed with the DisplayWarnings function
 package feature

--- a/pkg/odo/cli/feature/experimental.go
+++ b/pkg/odo/cli/feature/experimental.go
@@ -6,11 +6,10 @@ import (
 	envcontext "github.com/redhat-developer/odo/pkg/config/context"
 )
 
-const (
-	OdoExperimentalModeEnvVar = "ODO_EXPERIMENTAL_MODE"
-	OdoExperimentalModeTrue   = "true"
-)
+const OdoExperimentalModeEnvVar = "ODO_EXPERIMENTAL_MODE"
 
-func isExperimentalModeEnabled(ctx context.Context) bool {
+// IsExperimentalModeEnabled returns whether the experimental mode is enabled or not,
+// which means by checking the value of the "ODO_EXPERIMENTAL_MODE" environment variable.
+func IsExperimentalModeEnabled(ctx context.Context) bool {
 	return envcontext.GetEnvConfig(ctx).OdoExperimentalMode
 }

--- a/pkg/odo/cli/feature/features.go
+++ b/pkg/odo/cli/feature/features.go
@@ -2,9 +2,6 @@ package feature
 
 import (
 	"context"
-	"sort"
-
-	"github.com/redhat-developer/odo/pkg/log"
 )
 
 // OdoFeature represents a uniquely identifiable feature of odo.
@@ -16,10 +13,6 @@ type OdoFeature struct {
 	// isExperimental indicates whether this feature should be considered in early or intermediate stages of development.
 	// Features that are not experimental by default will always be enabled, regardless of the experimental mode.
 	isExperimental bool
-
-	// description provides a human-readable overview of this feature.
-	// Note that this will be visible by the end users if this feature is experimental and the experimental mode is enabled.
-	description string
 }
 
 var (
@@ -27,15 +20,12 @@ var (
 	GenericRunOnFlag = OdoFeature{
 		id:             "generic-run-on",
 		isExperimental: true,
-		description:    "flag: --run-on",
 	}
-
-	enabledFeatures = map[OdoFeature]struct{}{}
 )
 
 // IsEnabled returns whether the specified feature should be enabled or not.
 // If the feature is not marked as experimental, it should always be enabled.
-// Otherwise, it is enabled only if the experimental mode is enabled (see the isExperimentalModeEnabled package-level function).
+// Otherwise, it is enabled only if the experimental mode is enabled (see the IsExperimentalModeEnabled package-level function).
 func IsEnabled(ctx context.Context, feat OdoFeature) bool {
 	// Features not marked as experimental are always enabled, regardless of the experimental mode
 	if !feat.isExperimental {
@@ -43,23 +33,5 @@ func IsEnabled(ctx context.Context, feat OdoFeature) bool {
 	}
 
 	// Features marked as experimental are enabled only if the experimental mode is set
-	experimentalModeEnabled := isExperimentalModeEnabled(ctx)
-	if experimentalModeEnabled {
-		enabledFeatures[feat] = struct{}{}
-	}
-	return experimentalModeEnabled
-}
-
-func DisplayWarnings() {
-	features := make([]OdoFeature, 0, len(enabledFeatures))
-	for k := range enabledFeatures {
-		features = append(features, k)
-	}
-	sort.Slice(features, func(i, j int) bool {
-		return features[i].id < features[j].id
-	})
-	for _, feat := range features {
-		log.Experimentalf("Experimental mode enabled for %s. Use at your own risk. More details on https://odo.dev/docs/user-guides/advanced/experimental-mode",
-			feat.description)
-	}
+	return IsExperimentalModeEnabled(ctx)
 }

--- a/pkg/odo/cli/feature/features.go
+++ b/pkg/odo/cli/feature/features.go
@@ -7,9 +7,6 @@ import (
 // OdoFeature represents a uniquely identifiable feature of odo.
 // It can either be a CLI command or flag.
 type OdoFeature struct {
-	// id is a free-form but unique identifier of this feature.
-	id string
-
 	// isExperimental indicates whether this feature should be considered in early or intermediate stages of development.
 	// Features that are not experimental by default will always be enabled, regardless of the experimental mode.
 	isExperimental bool
@@ -18,7 +15,6 @@ type OdoFeature struct {
 var (
 	// GenericRunOnFlag is the feature supporting the `--run-on` generic CLI flag.
 	GenericRunOnFlag = OdoFeature{
-		id:             "generic-run-on",
 		isExperimental: true,
 	}
 )

--- a/pkg/odo/cli/feature/features_test.go
+++ b/pkg/odo/cli/feature/features_test.go
@@ -22,13 +22,8 @@ func TestIsEnabled(t *testing.T) {
 		want bool
 	}
 
-	nonExperimentalFeature := OdoFeature{
-		id: "my-awesome-feature",
-	}
-	experimentalFeature := OdoFeature{
-		id:             "my-wip-flag",
-		isExperimental: true,
-	}
+	nonExperimentalFeature := OdoFeature{}
+	experimentalFeature := OdoFeature{isExperimental: true}
 
 	for _, tt := range []testCase{
 		{

--- a/pkg/odo/cli/feature/features_test.go
+++ b/pkg/odo/cli/feature/features_test.go
@@ -23,13 +23,11 @@ func TestIsEnabled(t *testing.T) {
 	}
 
 	nonExperimentalFeature := OdoFeature{
-		id:          "my-awesome-feature",
-		description: "command: my awesome feature",
+		id: "my-awesome-feature",
 	}
 	experimentalFeature := OdoFeature{
 		id:             "my-wip-flag",
 		isExperimental: true,
-		description:    "flag: --my-awesome-flag",
 	}
 
 	for _, tt := range []testCase{

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -203,7 +203,9 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) error {
 	}
 	o.SetClientset(deps)
 
-	feature.DisplayWarnings()
+	if feature.IsExperimentalModeEnabled(ctx) {
+		log.DisplayExperimentalWarning()
+	}
 
 	ctx = fcontext.WithJsonOutput(ctx, commonflags.GetJsonOutputValue(cmdLineObj))
 	if platform != "" {

--- a/tests/helper/helper_experimental.go
+++ b/tests/helper/helper_experimental.go
@@ -11,7 +11,7 @@ import (
 
 // EnableExperimentalMode enables the experimental mode, so that experimental features of odo can be used.
 func EnableExperimentalMode() {
-	err := os.Setenv(feature.OdoExperimentalModeEnvVar, feature.OdoExperimentalModeTrue)
+	err := os.Setenv(feature.OdoExperimentalModeEnvVar, "true")
 	Expect(err).ShouldNot(HaveOccurred())
 }
 

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -137,7 +137,7 @@ var _ = Describe("odo generic", func() {
 		})
 	})
 
-	Describe("Experimental Mode", func() {
+	Describe("Experimental Mode", Label(helper.LabelNoCluster), func() {
 		experimentalFlag := "--run-on"
 
 		AfterEach(func() {
@@ -166,6 +166,11 @@ var _ = Describe("odo generic", func() {
 
 			AfterEach(func() {
 				helper.ResetExperimentalMode()
+			})
+
+			It("should display warning message", func() {
+				out := helper.Cmd("odo", "version", "--client").ShouldPass().Out()
+				Expect(out).Should(ContainSubstring("Experimental mode enabled. Use at your own risk."))
 			})
 
 			It("experimental flags should be usable", func() {


### PR DESCRIPTION
**What type of PR is this:**
/kind code-refactoring

**What does this PR do / why we need it:**
This fixes the issue of having this warning message displayed for a specific feature that might not be actually used by the user.
Instead, we are now displaying a more generic and feature-agnostic warning message once we detect that the experimental mode is enabled.

**Which issue(s) this PR fixes:**
Fixes #6381 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
The experimental mode warning message should now be more visible, and not dependent on the experimental feature:

Before:
```
$ ODO_EXPERIMENTAL_MODE=t odo version --client
Experimental mode enabled for flag: --run-on. Use at your own risk. More details on https://odo.dev/docs/user-guides/advanced/experimental-mode
odo v3.4.0 (b8662ef74)
```

With this PR:
```
$ ODO_EXPERIMENTAL_MODE=t odo version --client
============================================================================
⚠ Experimental mode enabled. Use at your own risk.
More details on https://odo.dev/docs/user-guides/advanced/experimental-mode
============================================================================

odo v3.4.0 (4bb04d493)
```