### PR TITLE
Add missing example to init command reference doc

### DIFF
--- a/docs/website/docs/command-reference/init.md
+++ b/docs/website/docs/command-reference/init.md
@@ -134,6 +134,25 @@ Devfile registries:
  NAME                       URL                                   SECURE
  Staging                    https://registry.stage.devfile.io     No
  DefaultDevfileRegistry     https://registry.devfile.io           No
+
+$  odo registry --devfile nodejs-react
+ NAME          REGISTRY                DESCRIPTION                                  VERSIONS 
+ nodejs-react  StagingRegistry         React is a free and open-source front-en...  2.0.2    
+ nodejs-react  DefaultDevfileRegistry  React is a free and open-source front-en...  2.0.2   
+
+$ odo init --devfile nodejs-react --name my-nr-app 
+  __
+ /  \__     Initializing a new component
+ \__/  \    
+ /  \__/    odo version: v3.4.0
+ \__/
+
+ ✓  Downloading devfile "nodejs-react" [3s]
+
+Your new component 'my-nr-app' is ready in the current directory.
+To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
+Changes will be directly reflected on the cluster.
+
 ```
 </details>
 
@@ -152,9 +171,7 @@ Devfile registries:
  NAME                       URL                                   SECURE
  Staging                    https://registry.stage.devfile.io     No
  DefaultDevfileRegistry     https://registry.devfile.io           No
-```
 
-```shell
 $ odo init --name my-spring-app --devfile java-springboot --devfile-registry DefaultDevfileRegistry --starter springbootproject
  ✓  Downloading devfile "java-springboot" from registry "DefaultDevfileRegistry" [980ms]
  ✓  Downloading starter project "springbootproject" [399ms]


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
/area documentation
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR adds a missing example to the init command reference doc.
https://odo.dev/docs/command-reference/init#fetch-devfile-from-any-registry-of-the-list is missing the example.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
