### PR TITLE
Tell readers of the QuickStart Guide to select "Maven" on Spring Initializr

### DIFF
--- a/docs/website/docs/user-guides/quickstart/java.md
+++ b/docs/website/docs/user-guides/quickstart/java.md
@@ -12,14 +12,15 @@ import InitialSourceCodeInfo from './docs-mdx/initial_source_code_description.md
 For Java, we will use the [Spring Initializr](https://start.spring.io/) to generate the example source code:
 
 1. Navigate to [start.spring.io](https://start.spring.io/) 
-2. Under **Spring Boot** select **2.7.\*** version.
+2. Select **Maven** under **Project**
+3. Under **Spring Boot** select **2.7.\*** version.
 :::caution
 For now, don't use SpringBoot 3. Currently there is no Devfile in [registry.devfile.io](https://registry.devfile.io/) with Java 17.
 :::
-3. Select **11** under **Java**
-4. Click on "Add" under "Dependencies"
-5. Select "Spring Web"
-6. Click "Generate" to generate and download the source code
+4. Select **11** under **Java**
+5. Click on "Add" under "Dependencies"
+6. Select "Spring Web"
+7. Click "Generate" to generate and download the source code
 
 :::caution
 For now, don't use SpringBoot 3. Currently there is no Devfile in [registry.devfile.io](https://registry.devfile.io/) with Java 17.


### PR DESCRIPTION
**What type of PR is this:**
/area documentation

**What does this PR do / why we need it:**
It looks like the default "Project" on [1] is now "Gradle - Groovy" (it used to be Maven),
but there is no Devfile usable with a SpringBoot Gradle project.

Without this, "odo init" prompts to select the "java-openliberty-gradle" Devfile,
which won't work because it executes tasks specific to OpenLiberty.

And even if we manually select the "java-springboot" Devfile,
it won't work out of the box because it requires Maven and there is
no "pom.xml" in the project generated by the Spring Initializr.

[1] https://start.spring.io/

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] [Documentation](https://deploy-preview-6469--odo-docusaurus-preview.netlify.app/docs/user-guides/quickstart/java) 

**How to test changes / Special notes to the reviewer:**
