### PR TITLE
Do not output log to stdout

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -79,11 +79,13 @@ func startReaderGoroutine(reader io.Reader, show bool, cmdOutput *[]string, cons
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			if show || log.IsDebug() {
+			if show {
 				_, err := fmt.Fprintln(os.Stdout, line)
 				if err != nil {
 					log.Errorf("Unable to print to stdout: %s", err.Error())
 				}
+			} else {
+				klog.V(2).Infof(line)
 			}
 
 			if cmdOutput != nil {


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

When running `odo dev -v2`, output of commands are displayed on stdout, and makes some tests fail because of these unexpected data in output. 



**Which issue(s) this PR fixes:**

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
