### PR TITLE
Isolate Podman tests in namespaces

### DIFF
--- a/.github/workflows/podman-test.yaml
+++ b/.github/workflows/podman-test.yaml
@@ -4,6 +4,7 @@ on:
     branches:    
       - main
 
+
 jobs:
   ODO-PODMAN-TEST:
     runs-on: ubuntu-latest
@@ -21,5 +22,6 @@ jobs:
       run: make install
 
     - name: Run Integration tests
-      run: |
-        make test-integration-podman
+      env:
+        PODMAN_EXEC_NODES: ${{ vars.PODMAN_TEST_EXEC_NODES }}
+      run: make test-integration-podman

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-integration-no-cluster:
 
 .PHONY: test-integration-podman
 test-integration-podman:
-	$(RUN_GINKGO) $(GINKGO_FLAGS_AUTO)  --junit-report="test-integration-podman.xml" --label-filter=podman tests/integration
+	$(RUN_GINKGO) $(GINKGO_FLAGS_ONE)  --junit-report="test-integration-podman.xml" --label-filter=podman tests/integration
 
 .PHONY: test-integration
 test-integration: test-integration-no-cluster test-integration-cluster

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-integration-no-cluster:
 
 .PHONY: test-integration-podman
 test-integration-podman:
-	$(RUN_GINKGO) $(GINKGO_FLAGS_ONE)  --junit-report="test-integration-podman.xml" --label-filter=podman tests/integration
+	$(RUN_GINKGO) $(GINKGO_FLAGS_AUTO)  --junit-report="test-integration-podman.xml" --label-filter=podman tests/integration
 
 .PHONY: test-integration
 test-integration: test-integration-no-cluster test-integration-cluster

--- a/pkg/dev/podmandev/pod.go
+++ b/pkg/dev/podmandev/pod.go
@@ -2,7 +2,7 @@ package podmandev
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand" //#nosec
 	"time"
 
 	"github.com/devfile/library/pkg/devfile/generator"
@@ -135,9 +135,9 @@ func addHostPorts(containers []corev1.Container, debug bool, randomPorts bool, u
 					freePort = usedPortsCopy[0]
 					usedPortsCopy = usedPortsCopy[1:]
 				} else {
-					rand.Seed(time.Now().UnixNano())
+					rand.Seed(time.Now().UnixNano()) //#nosec
 					for {
-						freePort = rand.Intn(endPort-startPort+1) + startPort
+						freePort = rand.Intn(endPort-startPort+1) + startPort //#nosec
 						if util.IsPortFree(freePort) {
 							break
 						}

--- a/pkg/dev/podmandev/pod.go
+++ b/pkg/dev/podmandev/pod.go
@@ -2,6 +2,8 @@ package podmandev
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/devfile/library/pkg/devfile/generator"
 	"github.com/devfile/library/pkg/devfile/parser"
@@ -28,6 +30,7 @@ func createPodFromComponent(
 	buildCommand string,
 	runCommand string,
 	debugCommand string,
+	randomPorts bool,
 	usedPorts []int,
 ) (*corev1.Pod, []api.ForwardedPort, error) {
 	containers, err := generator.GetContainers(devfileObj, common.DevfileOptions{})
@@ -45,7 +48,7 @@ func createPodFromComponent(
 	utils.AddOdoProjectVolume(&containers)
 	utils.AddOdoMandatoryVolume(&containers)
 
-	fwPorts := addHostPorts(containers, debug, usedPorts)
+	fwPorts := addHostPorts(containers, debug, randomPorts, usedPorts)
 
 	volumes := []corev1.Volume{
 		{
@@ -111,10 +114,12 @@ func getVolumeName(volume string, componentName string, appName string) string {
 	return volume + "-" + componentName + "-" + appName
 }
 
-func addHostPorts(containers []corev1.Container, debug bool, usedPorts []int) []api.ForwardedPort {
+func addHostPorts(containers []corev1.Container, debug bool, randomPorts bool, usedPorts []int) []api.ForwardedPort {
 	var result []api.ForwardedPort
 	startPort := 40001
 	endPort := startPort + 10000
+	usedPortsCopy := make([]int, len(usedPorts))
+	copy(usedPortsCopy, usedPorts)
 	for i := range containers {
 		var ports []corev1.ContainerPort
 		for _, port := range containers[i].Ports {
@@ -124,10 +129,29 @@ func addHostPorts(containers []corev1.Container, debug bool, usedPorts []int) []
 					containers[i].Name, portName, port.ContainerPort)
 				continue
 			}
-			freePort, err := util.NextFreePort(startPort, endPort, usedPorts)
-			if err != nil {
-				klog.Infof("%s", err)
-				continue
+			var freePort int
+			if randomPorts {
+				if len(usedPortsCopy) != 0 {
+					freePort = usedPortsCopy[0]
+					usedPortsCopy = usedPortsCopy[1:]
+				} else {
+					rand.Seed(time.Now().UnixNano())
+					for {
+						freePort = rand.Intn(endPort-startPort+1) + startPort
+						if util.IsPortFree(freePort) {
+							break
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+				}
+			} else {
+				var err error
+				freePort, err = util.NextFreePort(startPort, endPort, usedPorts)
+				if err != nil {
+					klog.Infof("%s", err)
+					continue
+				}
+				startPort = freePort + 1
 			}
 			result = append(result, api.ForwardedPort{
 				Platform:      commonflags.PlatformPodman,
@@ -138,7 +162,6 @@ func addHostPorts(containers []corev1.Container, debug bool, usedPorts []int) []
 			})
 			port.HostPort = int32(freePort)
 			ports = append(ports, port)
-			startPort = freePort + 1
 		}
 		containers[i].Ports = ports
 	}

--- a/pkg/dev/podmandev/pod_test.go
+++ b/pkg/dev/podmandev/pod_test.go
@@ -388,6 +388,7 @@ func Test_createPodFromComponent(t *testing.T) {
 				tt.args.buildCommand,
 				tt.args.runCommand,
 				tt.args.debugCommand,
+				false,
 				[]int{40001, 40002},
 			)
 			if (err != nil) != tt.wantErr {

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -160,6 +160,7 @@ func (o *DevClient) deployPod(ctx context.Context, options dev.StartOptions) (*c
 		options.BuildCommand,
 		options.RunCommand,
 		"",
+		options.RandomPorts,
 		o.usedPorts,
 	)
 	if err != nil {

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -63,6 +63,12 @@ func (o *PodmanCli) PlayKube(pod *corev1.Pod) error {
 		return err
 	}
 
+	if klog.V(4) {
+		var sb strings.Builder
+		_ = serializer.Encode(pod, &sb)
+		klog.Infof("Pod spec to play: \n---\n%s\n---\n", sb.String())
+	}
+
 	err = serializer.Encode(pod, stdin)
 	if err != nil {
 		return err

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -319,8 +319,8 @@ func JsonPathContentIsValidUserPort(json string, path string) {
 	))
 }
 
-// SetProjectName sets projectNames based on the name of the test file name (without path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
-func SetProjectName() string {
+// GetProjectName sets projectNames based on the name of the test file name (without path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
+func GetProjectName() string {
 	//Get current test filename and remove file path, file extension and replace undescores with hyphens
 	currGinkgoTestFileName := strings.Replace(strings.Split(strings.Split(CurrentSpecReport().
 		ContainerHierarchyLocations[0].FileName, "/")[len(strings.Split(CurrentSpecReport().ContainerHierarchyLocations[0].FileName, "/"))-1], ".")[0], "_", "-", -1)

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -195,9 +195,10 @@ func CommonBeforeEach() CommonVar {
 	commonVar.ConfigDir = CreateNewContext()
 	commonVar.CliRunner = GetCliRunner()
 	commonVar.OriginalKubeconfig = os.Getenv("KUBECONFIG")
-	if NeedsCluster(CurrentSpecReport().Labels()) {
+	specLabels := CurrentSpecReport().Labels()
+	if NeedsCluster(specLabels) {
 		LocalKubeconfigSet(commonVar.ConfigDir)
-		if IsAuth(CurrentSpecReport().Labels()) {
+		if IsAuth(specLabels) {
 			commonVar.Project = commonVar.CliRunner.CreateAndSetRandNamespaceProject()
 		} else {
 			commonVar.CliRunner.AssertNonAuthenticated()
@@ -211,6 +212,11 @@ func CommonBeforeEach() CommonVar {
 		err = kubeconfig.Close()
 		Expect(err).To(BeNil())
 		os.Setenv("KUBECONFIG", kubeconfig.Name())
+
+		if NeedsPodman(specLabels) {
+			// Generate a dedicated containers.conf with a specific namespace
+			GenerateAndSetContainersConf(commonVar.ConfigDir)
+		}
 	}
 	commonVar.OriginalWorkingDirectory = Getwd()
 

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -151,7 +151,7 @@ func (kubectl KubectlRunner) GetServices(namespace string) string {
 
 // CreateAndSetRandNamespaceProject create and set new project
 func (kubectl KubectlRunner) CreateAndSetRandNamespaceProject() string {
-	projectName := SetProjectName()
+	projectName := GetProjectName()
 	kubectl.createAndSetRandNamespaceProject(projectName)
 	return projectName
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -312,7 +312,7 @@ func (oc OcRunner) VerifyResourceToBeDeleted(ri ResourceInfo) {
 
 // CreateAndSetRandNamespaceProject create and set new project
 func (oc OcRunner) CreateAndSetRandNamespaceProject() string {
-	projectName := SetProjectName()
+	projectName := GetProjectName()
 	oc.createAndSetRandNamespaceProject(projectName)
 	return projectName
 }

--- a/tests/helper/helper_podman.go
+++ b/tests/helper/helper_podman.go
@@ -1,0 +1,20 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+)
+
+func GenerateAndSetContainersConf(dir string) {
+	ns := GetProjectName()
+	containersConfPath := filepath.Join(dir, "containers.conf")
+	err := CreateFileWithContent(containersConfPath, fmt.Sprintf(`
+[engine]
+namespace=%q
+`, ns))
+	Expect(err).ShouldNot(HaveOccurred())
+	os.Setenv("CONTAINERS_CONF", containersConfPath)
+}

--- a/tests/helper/labels.go
+++ b/tests/helper/labels.go
@@ -22,6 +22,15 @@ func NeedsCluster(labels []string) bool {
 	return true
 }
 
+func NeedsPodman(labels []string) bool {
+	for _, label := range labels {
+		if label == LabelPodman {
+			return true
+		}
+	}
+	return false
+}
+
 func IsAuth(labels []string) bool {
 	for _, label := range labels {
 		if label == LabelUnauth {

--- a/tests/helper/odo_utils.go
+++ b/tests/helper/odo_utils.go
@@ -34,7 +34,7 @@ func GetPreferenceValue(key string) string {
 // CreateRandProject create new project with random name (10 letters)
 // without writing to the config file (without switching project)
 func CreateRandProject() string {
-	projectName := SetProjectName()
+	projectName := GetProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	session := Cmd("odo", "create", "project", projectName, "-w", "-v4").ShouldPass().Out()
 	Expect(session).To(ContainSubstring("New project created"))

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -2894,7 +2894,10 @@ CMD ["npm", "start"]
 		When("using devfile that contains K8s resource to run it on podman", Label(helper.LabelPodman), func() {
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-different-commandgk.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-different-commandgk.yaml"),
+					filepath.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName))
 			})
 			It(fmt.Sprintf("should show warning about being unable to create the resource when running odo dev %s on podman", ctx.title), func() {
 				err := helper.RunDevMode(helper.DevSessionOpts{RunOnPodman: true, CmdlineArgs: ctx.args}, func(session *gexec.Session, outContents, errContents []byte, ports map[string]string) {

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -2920,6 +2920,7 @@ CMD ["npm", "start"]
 			var executeRunCommand = "Executing the application (command: dev-run)"
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "java-quarkus"), commonVar.Context)
+				helper.UpdateDevfileContent(filepath.Join(commonVar.Context, "devfile.yaml"), []helper.DevfileUpdater{helper.DevfileMetadataNameSetter(cmpName)})
 				var err error
 				devSession, stdout, _, _, err = helper.StartDevMode(helper.DevSessionOpts{
 					RunOnPodman: podman,


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
Unblocks #6485 by isolating each Podman test under a dedicated namespace. See https://github.com/redhat-developer/odo/pull/6485#issuecomment-1384068344

Note that even with isolated namespaces, two Podman containers cannot have the same name (I guess they share the same underlying `storage.conf`). So #6504 made sure to use random component names in our tests.

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
With proper isolation, we can run those Podman tests in parallel. This is the tentative done in [`66ed98f` (#6499)](https://github.com/redhat-developer/odo/pull/6499/commits/66ed98fe0ee0e1ec5b42d35650c54615bc40ae96), which works well on GitHub Actions (up to a certain number of parallel nodes), but used to fail locally.