### PR TITLE
Make sure to use random component names when copying sample Devfiles in integration tests

### DIFF
--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -18,8 +18,10 @@ import (
 
 var _ = Describe("E2E Test", func() {
 	var commonVar helper.CommonVar
+	var componentName string
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
+		componentName = helper.RandString(6)
 	})
 	var _ = AfterEach(func() {
 		helper.CommonAfterEach(commonVar)
@@ -40,7 +42,6 @@ var _ = Describe("E2E Test", func() {
 	}
 
 	Context("starting with empty Directory", func() {
-		componentName := helper.RandString(6)
 		var _ = BeforeEach(func() {
 			helper.Chdir(commonVar.Context)
 			Expect(helper.ListFilesInDir(commonVar.Context)).To(BeEmpty())
@@ -113,8 +114,10 @@ var _ = Describe("E2E Test", func() {
 			Expect(pods).To(BeEmpty())
 
 			// "run odo deploy"
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
-			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "nodejs-prj1-api-abhz", componentName)
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
+				path.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(componentName))
 
 			stdout = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 			Expect(stdout).To(ContainSubstring("Your Devfile has been successfully deployed"))
@@ -159,7 +162,6 @@ var _ = Describe("E2E Test", func() {
 	})
 
 	Context("starting with non-empty Directory", func() {
-		componentName := helper.RandString(6)
 		var _ = BeforeEach(func() {
 			helper.Chdir(commonVar.Context)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
@@ -234,7 +236,10 @@ var _ = Describe("E2E Test", func() {
 			Expect(pods).To(BeEmpty())
 
 			// "run odo deploy"
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
+				path.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(componentName))
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "nodejs-prj1-api-abhz", componentName)
 			stdout = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 			Expect(stdout).To(ContainSubstring("Your Devfile has been successfully deployed"))
@@ -277,8 +282,6 @@ var _ = Describe("E2E Test", func() {
 	})
 
 	Context("starting with non-empty Directory add Binding", func() {
-		componentName := helper.RandString(6)
-
 		sendDataEntry := func(url string) map[string]interface{} {
 			values := map[string]interface{}{"name": "joe",
 				"location": "tokyo",

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -90,7 +90,8 @@ var _ = Describe("odo delete command tests", func() {
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
-					path.Join(commonVar.Context, "devfile.yaml"))
+					path.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName))
 				if withDotOdoDir {
 					helper.MakeDir(filepath.Join(commonVar.Context, util.DotOdoDirectory))
 				}

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -565,11 +565,13 @@ var _ = Describe("odo describe component command tests", func() {
 		} {
 			ctx := ctx
 			When("running odo deploy to create ingress/routes", func() {
-				const (
-					componentName = "nodejs-prj1-api-abhz" // hard-coded from the Devfiles
-				)
+				var componentName string
 				BeforeEach(func() {
-					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", ctx.devfile), path.Join(commonVar.Context, "devfile.yaml"))
+					componentName = helper.RandString(6)
+					helper.CopyExampleDevFile(
+						filepath.Join("source", "devfiles", "nodejs", ctx.devfile),
+						path.Join(commonVar.Context, "devfile.yaml"),
+						helper.DevfileMetadataNameSetter(componentName))
 					helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
 				})
 				It(fmt.Sprintf("should show the %s in odo describe component output", ctx.title), func() {

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -66,21 +66,17 @@ var _ = Describe("odo dev debug command tests", func() {
 	})
 
 	for _, devfileHandlerCtx := range []struct {
-		name           string
-		cmpName        string
-		devfileHandler func(path string)
+		name          string
+		sourceHandler func(path string, originalCmpName string)
 	}{
 		{
 			name: "with metadata.name",
-			// cmpName from Devfile
-			cmpName: "nodejs",
 		},
 		{
 			name: "without metadata.name",
-			// cmpName is returned by alizer.DetectName
-			cmpName: "nodejs-starter",
-			devfileHandler: func(path string) {
-				helper.UpdateDevfileContent(path, []helper.DevfileUpdater{helper.DevfileMetadataNameRemover})
+			sourceHandler: func(path string, originalCmpName string) {
+				helper.UpdateDevfileContent(filepath.Join(path, "devfile.yaml"), []helper.DevfileUpdater{helper.DevfileMetadataNameRemover})
+				helper.ReplaceString(filepath.Join(path, "package.json"), "nodejs-starter", originalCmpName)
 			},
 		},
 	} {
@@ -92,11 +88,14 @@ var _ = Describe("odo dev debug command tests", func() {
 			var stderr []byte
 			var ports map[string]string
 			BeforeEach(func() {
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRunAndDebug.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				devfileCmpName = helper.RandString(6)
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRunAndDebug.yaml"),
+					filepath.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(devfileCmpName))
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-				devfileCmpName = devfileHandlerCtx.cmpName
-				if devfileHandlerCtx.devfileHandler != nil {
-					devfileHandlerCtx.devfileHandler(filepath.Join(commonVar.Context, "devfile.yaml"))
+				if devfileHandlerCtx.sourceHandler != nil {
+					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
 				var err error
 				session, stdout, stderr, ports, err = helper.StartDevMode(helper.DevSessionOpts{
@@ -171,7 +170,10 @@ var _ = Describe("odo dev debug command tests", func() {
 
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-commands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-commands.yaml"),
+				filepath.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(cmpName))
 			session, sessionOut, _, ports, err = helper.StartDevMode(helper.DevSessionOpts{
 				EnvVars:     []string{"PODMAN_CMD=echo"},
 				CmdlineArgs: []string{"--debug"},
@@ -226,21 +228,17 @@ var _ = Describe("odo dev debug command tests", func() {
 	})
 
 	for _, devfileHandlerCtx := range []struct {
-		name           string
-		cmpName        string
-		devfileHandler func(path string)
+		name          string
+		sourceHandler func(path string, originalCmpName string)
 	}{
 		{
 			name: "with metadata.name",
-			// cmpName from Devfile
-			cmpName: "nodejs",
 		},
 		{
 			name: "without metadata.name",
-			// cmpName is returned by alizer.DetectName
-			cmpName: "nodejs-starter",
-			devfileHandler: func(path string) {
-				helper.UpdateDevfileContent(path, []helper.DevfileUpdater{helper.DevfileMetadataNameRemover})
+			sourceHandler: func(path string, originalCmpName string) {
+				helper.UpdateDevfileContent(filepath.Join(path, "devfile.yaml"), []helper.DevfileUpdater{helper.DevfileMetadataNameRemover})
+				helper.ReplaceString(filepath.Join(path, "package.json"), "nodejs-starter", originalCmpName)
 			},
 		},
 	} {
@@ -252,13 +250,14 @@ var _ = Describe("odo dev debug command tests", func() {
 			var stderr []byte
 			var ports map[string]string
 			BeforeEach(func() {
+				devfileCmpName = helper.RandString(6)
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfileCompositeBuildRunDebugInMultiContainersAndSharedVolume.yaml"),
-					filepath.Join(commonVar.Context, "devfile.yaml"))
+					filepath.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(devfileCmpName))
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-				devfileCmpName = devfileHandlerCtx.cmpName
-				if devfileHandlerCtx.devfileHandler != nil {
-					devfileHandlerCtx.devfileHandler(filepath.Join(commonVar.Context, "devfile.yaml"))
+				if devfileHandlerCtx.sourceHandler != nil {
+					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
 				var err error
 				session, stdout, stderr, ports, err = helper.StartDevMode(helper.DevSessionOpts{

--- a/tests/integration/cmd_devfile_build_images_test.go
+++ b/tests/integration/cmd_devfile_build_images_test.go
@@ -22,8 +22,10 @@ var _ = Describe("odo devfile build-images command tests", func() {
 		var _ = Context("label "+label, Label(label), func() {
 
 			var commonVar helper.CommonVar
+			var cmpName string
 
 			var _ = BeforeEach(func() {
+				cmpName = helper.RandString(6)
 				commonVar = helper.CommonBeforeEach()
 				helper.Chdir(commonVar.Context)
 			})
@@ -133,9 +135,9 @@ var _ = Describe("odo devfile build-images command tests", func() {
 				BeforeEach(func() {
 					helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 					helper.CopyExampleDevFile(
-						filepath.Join("source", "devfiles", "nodejs",
-							"issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
-						filepath.Join(commonVar.Context, "devfile.yaml"))
+						filepath.Join("source", "devfiles", "nodejs", "issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
+						filepath.Join(commonVar.Context, "devfile.yaml"),
+						helper.DevfileMetadataNameSetter(cmpName))
 					helper.CreateLocalEnv(commonVar.Context, "aname", commonVar.Project)
 				})
 
@@ -184,8 +186,10 @@ var _ = Describe("odo devfile build-images command tests", func() {
 
 					BeforeEach(func() {
 						helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-outerloop.yaml"),
-							path.Join(commonVar.Context, "devfile.yaml"))
+						helper.CopyExampleDevFile(
+							filepath.Join("source", "devfiles", "nodejs", "devfile-outerloop.yaml"),
+							path.Join(commonVar.Context, "devfile.yaml"),
+							helper.DevfileMetadataNameSetter(cmpName))
 					})
 
 					When("remote server returns an error", func() {

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -19,8 +19,10 @@ import (
 var _ = Describe("odo devfile deploy command tests", func() {
 
 	var commonVar helper.CommonVar
+	var cmpName string
 
 	var _ = BeforeEach(func() {
+		cmpName = helper.RandString(6)
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})
@@ -71,8 +73,10 @@ var _ = Describe("odo devfile deploy command tests", func() {
 			deploymentName := "my-component"
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", ctx.devfileName),
-					path.Join(commonVar.Context, "devfile.yaml"))
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", ctx.devfileName),
+					path.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName))
 				if ctx.setupFunc != nil {
 					ctx.setupFunc()
 				}
@@ -173,7 +177,10 @@ ComponentSettings:
 	When("using a devfile.yaml containing two deploy commands", func() {
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-two-deploy-commands.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-with-two-deploy-commands.yaml"),
+				path.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(cmpName))
 		})
 		It("should run odo deploy", func() {
 			stdout := helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
@@ -191,7 +198,10 @@ ComponentSettings:
 	When("recording telemetry data", func() {
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
+				path.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(cmpName))
 			helper.EnableTelemetryDebug()
 			helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
 		})
@@ -264,7 +274,10 @@ ComponentSettings:
 		var resources []string
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-multiple-k8s-resources-in-single-component.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-multiple-k8s-resources-in-single-component.yaml"),
+				filepath.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(cmpName))
 			out = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 			resources = []string{"Deployment/my-component", "Service/my-component-svc"}
 		})
@@ -295,7 +308,10 @@ ComponentSettings:
 		When("odo deploy is run", func() {
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-with-SB.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-with-SB.yaml"),
+					filepath.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName))
 				helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
 			})
 			It("should successfully deploy the ServiceBinding resource", func() {
@@ -312,9 +328,9 @@ ComponentSettings:
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 			helper.CopyExampleDevFile(
-				filepath.Join("source", "devfiles", "nodejs",
-					"issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
-				filepath.Join(commonVar.Context, "devfile.yaml"))
+				filepath.Join("source", "devfiles", "nodejs", "issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
+				filepath.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(cmpName))
 		})
 
 		for _, scope := range []struct {
@@ -366,8 +382,10 @@ ComponentSettings:
 
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
-					path.Join(commonVar.Context, "devfile.yaml"))
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
+					path.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName))
 			})
 
 			When("remote server returns an error", func() {

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -75,14 +75,18 @@ var _ = Describe("odo devfile init command tests", func() {
 					helper.Cmd("odo", "init", "--name", "aname", "--devfile", "invalid").ShouldFail()
 				})
 				By("running odo init in a directory containing a devfile.yaml", func() {
-					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+					helper.CopyExampleDevFile(
+						filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"),
+						filepath.Join(commonVar.Context, "devfile.yaml"))
 					defer os.Remove(filepath.Join(commonVar.Context, "devfile.yaml"))
 					err := helper.Cmd("odo", "init").ShouldFail().Err()
 					Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))
 				})
 
 				By("running odo init in a directory containing a .devfile.yaml", func() {
-					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), filepath.Join(commonVar.Context, ".devfile.yaml"))
+					helper.CopyExampleDevFile(
+						filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"),
+						filepath.Join(commonVar.Context, ".devfile.yaml"))
 					defer helper.DeleteFile(filepath.Join(commonVar.Context, ".devfile.yaml"))
 					err := helper.Cmd("odo", "init").ShouldFail().Err()
 					Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))

--- a/tests/integration/cmd_devfile_list_test.go
+++ b/tests/integration/cmd_devfile_list_test.go
@@ -96,11 +96,15 @@ var _ = Describe("odo list with devfile", func() {
 	When("a component created in 'app' application", func() {
 
 		var devSession helper.DevSession
-		var componentName = "nodejs-prj1-api-abhz" // from devfile-deploy.yaml
+		var componentName string
 
 		BeforeEach(func() {
+			componentName = helper.RandString(6)
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), path.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(
+				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
+				path.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(componentName))
 			helper.Chdir(commonVar.Context)
 		})
 

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -143,10 +143,13 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 			When("running inside a component directory", func() {
 				activeNs := "my-current-ns"
 
+				var cmpName string
 				BeforeEach(func() {
+					cmpName = helper.RandString(6)
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
-						filepath.Join(commonVar.Context, "devfile.yaml"))
+						filepath.Join(commonVar.Context, "devfile.yaml"),
+						helper.DevfileMetadataNameSetter(cmpName))
 					helper.Chdir(commonVar.Context)
 
 					// Bootstrap the component with a .odo/env/env.yaml file


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**
This updates the `helper.CopyExampleDevfile` method to accept a parameter that allows to perform operations on the destination Devfile (like setting its `metadata.name`). This way, callers are able to pass a unique random component name.
Using a random name helps prevent conflicts when isolation is not possible (for example on Podman). This will allow fixing the Podman tests in #6499.

For consistency, the next step could be not to use `odo init --devfile-path /path/to/example/devfile` (so as not to depend on the `odo init` command), but instead rely on the updated `helper.CopyExampleDevfile` function everywhere. But this can be done in a subsequent PR.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
