### PR TITLE
Display error message when odo dev fails on podman and clean resources

### DIFF
--- a/pkg/dev/podmandev/cleanup.go
+++ b/pkg/dev/podmandev/cleanup.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"fmt"
 	"io"
+
+	corev1 "k8s.io/api/core/v1"
+
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
+	"github.com/redhat-developer/odo/pkg/util"
 )
 
 func (o *DevClient) CleanupResources(ctx context.Context, out io.Writer) error {
 	fmt.Printf("Cleaning up resources\n")
 	if o.deployedPod == nil {
-		return nil
+		compName := odocontext.GetComponentName(ctx)
+		appName := odocontext.GetApplication(ctx)
+		name, err := util.NamespaceKubernetesObject(compName, appName)
+		if err != nil {
+			return nil
+		}
+		o.deployedPod = &corev1.Pod{}
+		o.deployedPod.SetName(name)
 	}
 	return o.podmanClient.CleanupPodResources(o.deployedPod)
 }

--- a/pkg/dev/podmandev/cleanup.go
+++ b/pkg/dev/podmandev/cleanup.go
@@ -4,24 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	corev1 "k8s.io/api/core/v1"
-
-	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
-	"github.com/redhat-developer/odo/pkg/util"
 )
 
 func (o *DevClient) CleanupResources(ctx context.Context, out io.Writer) error {
 	fmt.Printf("Cleaning up resources\n")
 	if o.deployedPod == nil {
-		compName := odocontext.GetComponentName(ctx)
-		appName := odocontext.GetApplication(ctx)
-		name, err := util.NamespaceKubernetesObject(compName, appName)
-		if err != nil {
-			return nil
-		}
-		o.deployedPod = &corev1.Pod{}
-		o.deployedPod.SetName(name)
+		return nil
 	}
 	return o.podmanClient.CleanupPodResources(o.deployedPod)
 }

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -181,6 +181,11 @@ func (o *DevClient) deployPod(ctx context.Context, options dev.StartOptions) (*c
 
 	err = o.podmanClient.PlayKube(pod)
 	if err != nil {
+		// there are cases when pod is created even if there is an error with the pod def; for e.g. incorrect image
+		if podMap, _ := o.podmanClient.PodLs(); podMap[pod.Name] {
+			o.deployedPod = &corev1.Pod{}
+			o.deployedPod.SetName(pod.Name)
+		}
 		return nil, nil, err
 	}
 

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -88,10 +88,7 @@ func (o *PodmanCli) PlayKube(pod *corev1.Pod) error {
 	}()
 	if err = cmd.Wait(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			out := strings.Split(podmanOut, "\n")
-			// the last line is an empty new line; so we revert to the second last line for error
-			errLine := out[len(out)-2]
-			err = fmt.Errorf("%s: %s\n%s", err, string(exiterr.Stderr), errLine)
+			err = fmt.Errorf("%s: %s\nComplete Podman output:\n%s", err, string(exiterr.Stderr), podmanOut)
 		}
 		return err
 	}

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -2567,7 +2567,7 @@ CMD ["npm", "start"]
 	for _, podman := range []bool{false, true} {
 		podman := podman
 		When("creating nodejs component, doing odo dev and run command has dev.odo.push.path attribute", helper.LabelPodmanIf(podman, func() {
-			//TODO Not implemented yet on Podman
+			// TODO Not implemented yet on Podman
 			var session helper.DevSession
 			var devStarted bool
 			BeforeEach(func() {
@@ -3263,4 +3263,22 @@ CMD ["npm", "start"]
 		}))
 
 	}
+
+	Context("odo dev on podman with a devfile bound to fail", Label(helper.LabelPodman), func() {
+		// var devSession helper.DevSession
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
+				filepath.Join(commonVar.Context, "devfile.yaml"),
+				helper.DevfileMetadataNameSetter(cmpName))
+			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "registry.access.redhat.com/ubi8/nodejs", "registry.access.redhat.com/ubi8/nose")
+			// devSession, out, errOut, _, err := helper.()
+		})
+		It("should fail with an error and cleanup resources", func() {
+			errContents := helper.Cmd("odo", "dev", "--platform=podman").AddEnv("ODO_EXPERIMENTAL_MODE=true").ShouldFail().Err()
+			helper.MatchAllInOutput(errContents, []string{"registry.access.redhat.com/ubi8/nose", "Repo not found"})
+			component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
+			component.ExpectIsNotDeployed()
+		})
+	})
 })

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -3265,18 +3265,16 @@ CMD ["npm", "start"]
 	}
 
 	Context("odo dev on podman with a devfile bound to fail", Label(helper.LabelPodman), func() {
-		// var devSession helper.DevSession
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
 				helper.DevfileMetadataNameSetter(cmpName))
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "registry.access.redhat.com/ubi8/nodejs", "registry.access.redhat.com/ubi8/nose")
-			// devSession, out, errOut, _, err := helper.()
 		})
 		It("should fail with an error and cleanup resources", func() {
 			errContents := helper.Cmd("odo", "dev", "--platform=podman").AddEnv("ODO_EXPERIMENTAL_MODE=true").ShouldFail().Err()
-			helper.MatchAllInOutput(errContents, []string{"registry.access.redhat.com/ubi8/nose", "Repo not found"})
+			helper.MatchAllInOutput(errContents, []string{"Complete Podman output", "registry.access.redhat.com/ubi8/nose", "Repo not found"})
 			component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 			component.ExpectIsNotDeployed()
 		})


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR ensures `odo dev` on podman exits with actual failure from podman and also cleans up pod if it was created.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #6487 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `odo init --devfile nodejs --starter nodejs-starter --name my-nodejs-app`
2. `sed -i "s/registry.access.redhat.com\/ubi8\/nodejs-16:latest/adsffdfe/" devfile.yaml`
3. `ODO_EXPERIMENTAL_MODE=true odo dev --platform=podman`

For 6501
1. `export PODMAN_CMD=echo`
2. `ODO_EXPERIMENTAL_MODE=true odo dev --platform=podman`