### PR TITLE
Define PODMAN_TEST_EXEC_NODES as a repository secret

### DIFF
--- a/.github/workflows/podman-test.yaml
+++ b/.github/workflows/podman-test.yaml
@@ -23,5 +23,5 @@ jobs:
 
     - name: Run Integration tests
       env:
-        PODMAN_EXEC_NODES: ${{ vars.PODMAN_TEST_EXEC_NODES }}
+        PODMAN_EXEC_NODES: ${{ secrets.PODMAN_TEST_EXEC_NODES }}
       run: make test-integration-podman


### PR DESCRIPTION
**What type of PR is this:**

**What does this PR do / why we need it:**
Addendum to 511792a (to speed up the Podman tests on GitHub), because defining it as a repo variable does not seem to work at this time in this repo.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
