### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -85,10 +85,7 @@ func TestSyncFiles(t *testing.T) {
 	testComponentName := "test"
 
 	// create a temp dir for the file indexer
-	directory, e := ioutil.TempDir("", "")
-	if e != nil {
-		t.Errorf("TestSyncFiles error: error creating temporary directory for the indexer: %v", e)
-	}
+	directory := t.TempDir()
 
 	jsFile, e := os.Create(filepath.Join(directory, "red.js"))
 	if e != nil {
@@ -188,11 +185,6 @@ func TestSyncFiles(t *testing.T) {
 	if err != nil {
 		t.Errorf("TestSyncFiles error: error deleting the temp dir %s, err: %v", directory, err)
 	}
-	// Remove the temp dir created for the file indexer
-	err = os.RemoveAll(directory)
-	if err != nil {
-		t.Errorf("TestSyncFiles error: error deleting the temp dir %s, err: %v", directory, err)
-	}
 }
 
 func TestPushLocal(t *testing.T) {
@@ -200,10 +192,7 @@ func TestPushLocal(t *testing.T) {
 	testComponentName := "test"
 
 	// create a temp dir for the file indexer
-	directory, e := ioutil.TempDir("", "")
-	if e != nil {
-		t.Errorf("TestPushLocal error: error creating temporary directory for the indexer: %v", e)
-	}
+	directory := t.TempDir()
 
 	newFilePath := filepath.Join(directory, "foobar.txt")
 	if err := helper.CreateFileWithContent(newFilePath, "hello world"); err != nil {
@@ -322,12 +311,6 @@ func TestPushLocal(t *testing.T) {
 
 		})
 	}
-
-	// Remove the temp dir created for the file indexer
-	err := os.RemoveAll(directory)
-	if err != nil {
-		t.Errorf("TestPushLocal error: error deleting the temp dir %s", directory)
-	}
 }
 
 func TestUpdateIndexWithWatchChanges(t *testing.T) {
@@ -360,10 +343,7 @@ func TestUpdateIndexWithWatchChanges(t *testing.T) {
 	for _, tt := range tests {
 
 		// create a temp dir for the fake component
-		directory, err := ioutil.TempDir("", "")
-		if err != nil {
-			t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: error creating temporary directory for the indexer: %v", err)
-		}
+		directory := t.TempDir()
 
 		fileIndexPath, err := util.ResolveIndexFilePath(directory)
 		if err != nil {

--- a/pkg/util/file_indexer_test.go
+++ b/pkg/util/file_indexer_test.go
@@ -140,10 +140,7 @@ func mockDirectoryInfo(create bool, contextDir string, fs filesystem.Filesystem)
 func TestCalculateFileDataKeyFromPath(t *testing.T) {
 
 	// create a temp dir for the fake component
-	directory, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: error creating temporary directory for the indexer: %v", err)
-	}
+	directory := t.TempDir()
 
 	tests := []struct {
 		absolutePath   string
@@ -186,10 +183,7 @@ func TestCalculateFileDataKeyFromPath(t *testing.T) {
 func TestGenerateNewFileDataEntry(t *testing.T) {
 
 	// create a temp dir for the fake component
-	directory, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: error creating temporary directory for the indexer: %v", err)
-	}
+	directory := t.TempDir()
 
 	tests := []struct {
 		testName      string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -518,11 +518,7 @@ func RemoveContentsFromDir(dir string) error {
 }
 
 func TestGetIgnoreRulesFromDirectory(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "odo-tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 	tests := []struct {
 		name             string
 		directoryName    string
@@ -1326,14 +1322,10 @@ func TestUnzip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "unzip")
-			if err != nil {
-				t.Errorf("Error creating temp dir: %s", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 			t.Logf(dir)
 
-			_, err = Unzip(filepath.FromSlash(tt.src), dir, tt.pathToUnzip)
+			_, err := Unzip(filepath.FromSlash(tt.src), dir, tt.pathToUnzip)
 			if err != nil {
 				tt.expectedError = strings.ReplaceAll(tt.expectedError, "/", string(filepath.Separator))
 				if !strings.HasPrefix(err.Error(), tt.expectedError) {
@@ -1397,11 +1389,7 @@ func TestIsValidProjectDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "valid-project")
-			if err != nil {
-				t.Errorf("Error creating temp dir: %s", err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			for _, f := range tt.filesToCreate {
 				file := filepath.Join(tmpDir, f)
@@ -1417,7 +1405,7 @@ func TestIsValidProjectDir(t *testing.T) {
 				}
 			}
 
-			err = IsValidProjectDir(tmpDir, tt.devfilePath)
+			err := IsValidProjectDir(tmpDir, tt.devfilePath)
 			expectedError := tt.expectedError
 			if expectedError != "" {
 				expectedError = fmt.Sprintf(expectedError, tmpDir)
@@ -1573,10 +1561,7 @@ func TestValidateURL(t *testing.T) {
 
 func TestValidateFile(t *testing.T) {
 	// Create temp dir and temp file
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Errorf("Failed to create temp dir: %s, error: %v", tempDir, err)
-	}
+	tempDir := t.TempDir()
 	tempFile, err := ioutil.TempFile(tempDir, "")
 	if err != nil {
 		t.Errorf("Failed to create temp file: %s, error: %v", tempFile.Name(), err)
@@ -1616,10 +1601,7 @@ func TestValidateFile(t *testing.T) {
 
 func TestCopyFile(t *testing.T) {
 	// Create temp dir
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Errorf("Failed to create temp dir: %s, error: %v", tempDir, err)
-	}
+	tempDir := t.TempDir()
 
 	// Create temp file under temp dir as source file
 	tempFile, err := ioutil.TempFile(tempDir, "")
@@ -2410,12 +2392,7 @@ func TestGetCommandStringFromEnvs(t *testing.T) {
 }
 
 func TestGetGitOriginPath(t *testing.T) {
-	tempGitDirWithOrigin, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(tempGitDirWithOrigin)
+	tempGitDirWithOrigin := t.TempDir()
 
 	repoWithOrigin, err := git.PlainInit(tempGitDirWithOrigin, true)
 	if err != nil {
@@ -2430,12 +2407,7 @@ func TestGetGitOriginPath(t *testing.T) {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	tempGitDirWithoutOrigin, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(tempGitDirWithoutOrigin)
+	tempGitDirWithoutOrigin := t.TempDir()
 
 	repoWithoutOrigin, err := git.PlainInit(tempGitDirWithoutOrigin, true)
 	if err != nil {


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

/kind tests
/kind code-refactoring

**What does this PR do / why we need it:**

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if e != nil {
		t.Fatal(e)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
