### PR TITLE
Make sure to delete the component resources after each "delete component" test spec

### DIFF
--- a/.github/workflows/podman-test.yaml
+++ b/.github/workflows/podman-test.yaml
@@ -30,4 +30,4 @@ jobs:
       if: ${{ always() }}
       run: |
         podman pod ls --format '{{.Name}}' | xargs -I '{}' podman pod inspect '{}'
-        podman pod ls --format '{{.Name}}' | xargs podman pod stop
+        podman pod ls --format '{{.Name}}' | xargs podman pod stop || true

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -237,6 +237,13 @@ var _ = Describe("odo delete command tests", func() {
 					})
 
 					AfterEach(func() {
+						args := []string{"delete", "component", "--name", cmpName}
+						if !podman {
+							args = append(args, "--namespace", commonVar.Project)
+						}
+						args = append(args, "-f", "--wait")
+						helper.Cmd("odo", args...).ShouldPass()
+
 						if podman {
 							helper.ResetExperimentalMode()
 						}


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
Otherwise, "odo delete component --running-in $mode" might leave some resources running
(on Podman especially).
For example, the Podman test that runs "delete component --running-in deploy"
(after starting and killing a Dev Session abruptly) might leave those Dev resources running.
This has been alleviated in CI via 9ebf766 by ensuring Ginkgo does not hang indefinitely and
by deleting those leftover resources.
But the issue was still persisting locally.

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
