### PR TITLE
Fix potential issues with E2E tests

### DIFF
--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -379,13 +379,11 @@ var _ = Describe("E2E Test", func() {
 			helper.Cmd("odo", "add", "binding", "--name", bindingName, "--service", "cluster-example-initdb", "--bind-as-files=false").ShouldPass()
 
 			// Get new random port after restart
-			Eventually(func() map[string]string {
-				_, _, ports, err = devSession.GetInfo()
-				Expect(err).ToNot(HaveOccurred())
-				return ports
-			}, 180, 10).ShouldNot(BeEmpty())
+			_, _, ports, err = devSession.WaitRestartPortforward()
+			Expect(err).ToNot(HaveOccurred())
 
 			// "send data"
+			waitRemoteApp("http://127.0.0.1:8080/ping", "pong")
 			data := sendDataEntry(ports["8080"])
 			Expect(data["message"]).To(Equal("User created successfully"))
 

--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -30,7 +30,7 @@ var _ = Describe("E2E Test", func() {
 	waitRemoteApp := func(urlInContainer, assertString string) {
 		cmp := helper.NewComponent(componentName, "app", "Dev", commonVar.Project, commonVar.CliRunner)
 		Eventually(func() string {
-			stdout, _ := cmp.Exec("runtime", nil, "curl", urlInContainer)
+			stdout, _ := cmp.Exec("runtime", []string{"curl", urlInContainer}, nil)
 			return stdout
 		}, 120*time.Second, 15*time.Second).Should(Equal(assertString))
 	}

--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -29,10 +29,7 @@ var _ = Describe("E2E Test", func() {
 
 	waitRemoteApp := func(urlInContainer, assertString string) {
 		cmp := helper.NewComponent(componentName, "app", "Dev", commonVar.Project, commonVar.CliRunner)
-		Eventually(func() string {
-			stdout, _ := cmp.Exec("runtime", []string{"curl", urlInContainer}, nil)
-			return stdout
-		}, 120*time.Second, 15*time.Second).Should(Equal(assertString))
+		helper.WaitAppReadyInContainer(cmp, "runtime", []string{"curl", urlInContainer}, 5*time.Second, 120*time.Second, ContainSubstring(assertString), nil)
 	}
 
 	checkIfDevEnvIsUp := func(url, assertString string) {

--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -27,6 +27,14 @@ var _ = Describe("E2E Test", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
+	waitRemoteApp := func(urlInContainer, assertString string) {
+		cmp := helper.NewComponent(componentName, "app", "Dev", commonVar.Project, commonVar.CliRunner)
+		Eventually(func() string {
+			stdout, _ := cmp.Exec("runtime", nil, "curl", urlInContainer)
+			return stdout
+		}, 120*time.Second, 15*time.Second).Should(Equal(assertString))
+	}
+
 	checkIfDevEnvIsUp := func(url, assertString string) {
 		Eventually(func() string {
 			resp, err := http.Get(fmt.Sprintf("http://%s", url))
@@ -83,11 +91,15 @@ var _ = Describe("E2E Test", func() {
 			var ports map[string]string
 
 			devSession, _, _, ports, err = helper.StartDevMode(helper.DevSessionOpts{})
-			helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "from Node.js", "from updated Node.js")
 			Expect(err).ToNot(HaveOccurred())
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from Node.js Starter Application!")
+			checkIfDevEnvIsUp(ports["3000"], "Hello from Node.js Starter Application!")
+
+			helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "from Node.js", "from updated Node.js")
 			_, _, _, err = devSession.WaitSync()
 			Expect(err).ToNot(HaveOccurred())
 			// "should update the changes"
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from updated Node.js Starter Application!")
 			checkIfDevEnvIsUp(ports["3000"], "Hello from updated Node.js Starter Application!")
 
 			// "changes are made to the applications"
@@ -95,6 +107,7 @@ var _ = Describe("E2E Test", func() {
 			_, _, _, err = devSession.WaitSync()
 			Expect(err).ToNot(HaveOccurred())
 			// "should deploy new changes"
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from Node.js app v2 Starter Application!")
 			checkIfDevEnvIsUp(ports["3000"], "Hello from Node.js app v2 Starter Application!")
 
 			// "running odo list"
@@ -135,6 +148,7 @@ var _ = Describe("E2E Test", func() {
 			_, _, _, err = devSession.WaitSync()
 			Expect(err).ToNot(HaveOccurred())
 			// "should update the changes"
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from Node.js app v3 Starter Application!")
 			checkIfDevEnvIsUp(ports["3000"], "Hello from Node.js app v3 Starter Application!")
 
 			// should list both dev,deploy
@@ -201,22 +215,23 @@ var _ = Describe("E2E Test", func() {
 			var ports map[string]string
 
 			devSession, _, _, ports, err = helper.StartDevMode(helper.DevSessionOpts{})
-			helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "from Node.js", "from updated Node.js")
 			Expect(err).ToNot(HaveOccurred())
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from Node.js Starter Application!")
+			checkIfDevEnvIsUp(ports["3000"], "Hello from Node.js Starter Application!")
 
+			helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "from Node.js", "from updated Node.js")
 			_, _, _, err = devSession.WaitSync()
 			Expect(err).ToNot(HaveOccurred())
-
 			// "should update the changes"
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from updated Node.js Starter Application!")
 			checkIfDevEnvIsUp(ports["3000"], "Hello from updated Node.js Starter Application!")
 
-			// "changes are made made to the applications"
-
+			// "changes are made to the applications"
 			helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "from updated Node.js", "from Node.js app v2")
 			_, _, _, err = devSession.WaitSync()
 			Expect(err).ToNot(HaveOccurred())
-
 			// "should deploy new changes"
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from Node.js app v2 Starter Application!")
 			checkIfDevEnvIsUp(ports["3000"], "Hello from Node.js app v2 Starter Application!")
 
 			// "running odo list"
@@ -256,6 +271,7 @@ var _ = Describe("E2E Test", func() {
 			helper.ReplaceString(filepath.Join(commonVar.Context, "server.js"), "from Node.js app v2", "from Node.js app v3")
 
 			// "should update the changes"
+			waitRemoteApp("http://127.0.0.1:3000", "Hello from Node.js app v3 Starter Application!")
 			checkIfDevEnvIsUp(ports["3000"], "Hello from Node.js app v3 Starter Application!")
 
 			// should list both dev,deploy

--- a/tests/examples/source/devfiles/go/router/router.go
+++ b/tests/examples/source/devfiles/go/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"net/http"
+
 	"go-postgres/middleware"
 
 	"github.com/gorilla/mux"
@@ -10,6 +12,11 @@ import (
 func Router() *mux.Router {
 
 	router := mux.NewRouter()
+
+	router.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("pong"))
+	})
 
 	router.HandleFunc("/api/user/{id}", middleware.GetUser).Methods("GET", "OPTIONS")
 	router.HandleFunc("/api/user", middleware.GetAllUser).Methods("GET", "OPTIONS")

--- a/tests/helper/component_cluster.go
+++ b/tests/helper/component_cluster.go
@@ -41,9 +41,9 @@ func (o *ClusterComponent) ExpectIsNotDeployed() {
 	Expect(string(stdout)).To(Not(ContainSubstring(deploymentName)))
 }
 
-func (o *ClusterComponent) Exec(container string, success *bool, args ...string) (string, string) {
+func (o *ClusterComponent) Exec(container string, args []string, expectedSuccess *bool) (string, string) {
 	podName := o.cli.GetRunningPodNameByComponent(o.name, o.namespace)
-	return o.cli.Exec(podName, o.namespace, success, append([]string{"-c", container, "--"}, args...)...)
+	return o.cli.Exec(podName, o.namespace, append([]string{"-c", container, "--"}, args...), expectedSuccess)
 }
 
 func (o *ClusterComponent) GetEnvVars(string) map[string]string {

--- a/tests/helper/component_cluster.go
+++ b/tests/helper/component_cluster.go
@@ -41,9 +41,9 @@ func (o *ClusterComponent) ExpectIsNotDeployed() {
 	Expect(string(stdout)).To(Not(ContainSubstring(deploymentName)))
 }
 
-func (o *ClusterComponent) Exec(container string, args ...string) string {
+func (o *ClusterComponent) Exec(container string, success *bool, args ...string) (string, string) {
 	podName := o.cli.GetRunningPodNameByComponent(o.name, o.namespace)
-	return o.cli.Exec(podName, o.namespace, append([]string{"-c", container, "--"}, args...)...)
+	return o.cli.Exec(podName, o.namespace, success, append([]string{"-c", container, "--"}, args...)...)
 }
 
 func (o *ClusterComponent) GetEnvVars(string) map[string]string {

--- a/tests/helper/component_interface.go
+++ b/tests/helper/component_interface.go
@@ -12,10 +12,10 @@ type Component interface {
 	// ExpectIsNotDeployed checks that the component is not deployed
 	ExpectIsNotDeployed()
 	// Exec executes the command in specific container of the component.
-	// If success is true, the command exit code is expected to be 0.
-	// If success is false, the command exit code is expected to be non-zero.
-	// If success is nil, the command is just supposed to run, with no assertion on its exit code.
-	Exec(container string, success *bool, args ...string) (string, string)
+	// If expectedSuccess is nil, the command is just supposed to run, with no assertion on its exit code.
+	// If *expectedSuccess is true, the command exit code is expected to be 0.
+	// If *expectedSuccess is false, the command exit code is expected to be non-zero.
+	Exec(container string, args []string, expectedSuccess *bool) (string, string)
 	// GetEnvVars returns the environment variables defined for the container
 	GetEnvVars(container string) map[string]string
 	// GetLabels returns the labels defined for the component

--- a/tests/helper/component_interface.go
+++ b/tests/helper/component_interface.go
@@ -11,8 +11,11 @@ type Component interface {
 	ExpectIsDeployed()
 	// ExpectIsNotDeployed checks that the component is not deployed
 	ExpectIsNotDeployed()
-	// Exec executes the command in specific container of the component
-	Exec(container string, args ...string) string
+	// Exec executes the command in specific container of the component.
+	// If success is true, the command exit code is expected to be 0.
+	// If success is false, the command exit code is expected to be non-zero.
+	// If success is nil, the command is just supposed to run, with no assertion on its exit code.
+	Exec(container string, success *bool, args ...string) (string, string)
 	// GetEnvVars returns the environment variables defined for the container
 	GetEnvVars(container string) map[string]string
 	// GetLabels returns the labels defined for the component

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -7,7 +7,7 @@ import "github.com/onsi/gomega/gexec"
 type CliRunner interface {
 	Run(args ...string) *gexec.Session
 	ExecListDir(podName string, projectName string, dir string) string
-	Exec(podName string, projectName string, args ...string) string
+	Exec(podName string, projectName string, success *bool, args ...string) (string, string)
 	CheckCmdOpInRemoteDevfilePod(podName string, containerName string, prjName string, cmd []string, checkOp func(cmdOp string, err error) bool) bool
 	GetRunningPodNameByComponent(compName string, namespace string) string
 	GetVolumeMountNamesandPathsFromContainer(deployName string, containerName, namespace string) string

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -7,7 +7,11 @@ import "github.com/onsi/gomega/gexec"
 type CliRunner interface {
 	Run(args ...string) *gexec.Session
 	ExecListDir(podName string, projectName string, dir string) string
-	Exec(podName string, projectName string, success *bool, args ...string) (string, string)
+	// Exec executes the command in the specified pod and project/namespace.
+	// If expectedSuccess is nil, the command is just supposed to run, with no assertion on its exit code.
+	// If *expectedSuccess is true, the command exit code is expected to be 0.
+	// If *expectedSuccess is false, the command exit code is expected to be non-zero.
+	Exec(podName string, projectName string, args []string, expectedSuccess *bool) (string, string)
 	CheckCmdOpInRemoteDevfilePod(podName string, containerName string, prjName string, cmd []string, checkOp func(cmdOp string, err error) bool) bool
 	GetRunningPodNameByComponent(compName string, namespace string) string
 	GetVolumeMountNamesandPathsFromContainer(deployName string, containerName, namespace string) string

--- a/tests/helper/helper_component.go
+++ b/tests/helper/helper_component.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// WaitAppReadyInContainer probes the remote container using the specified command (cmd).
+// It waits until the specified timeout is reached or until the provided matchers match the remote command output.
+// At least one of the matchers must be provided.
+func WaitAppReadyInContainer(
+	cmp Component,
+	container string,
+	cmd []string,
+	pollingInterval time.Duration,
+	timeout time.Duration,
+	stdoutMatcher types.GomegaMatcher,
+	stderrMatcher types.GomegaMatcher,
+) {
+	if stdoutMatcher == nil && stderrMatcher == nil {
+		Fail("Please specify either stdoutMatcher or stderrMatcher!")
+	}
+	Eventually(func(g Gomega) {
+		stdout, stderr := cmp.Exec(container, cmd, nil)
+		if stdoutMatcher != nil {
+			g.Expect(stdout).Should(stdoutMatcher)
+		}
+		if stderrMatcher != nil {
+			g.Expect(stderr).Should(stderrMatcher)
+		}
+	}).WithPolling(pollingInterval).WithTimeout(timeout).Should(Succeed())
+}

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -212,7 +212,7 @@ func (o DevSession) WaitSync() ([]byte, []byte, map[string]string, error) {
 }
 
 func (o DevSession) WaitRestartPortforward() ([]byte, []byte, map[string]string, error) {
-	WaitForOutputToContain("Forwarding from", 30, 5, o.session)
+	WaitForOutputToContain("Forwarding from", 240, 10, o.session)
 	return o.GetInfo()
 }
 

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -362,7 +362,3 @@ func SetDefaultDevfileRegistryAsStaging() {
 	Cmd("odo", "preference", "remove", "registry", registryName, "-f").ShouldPass()
 	Cmd("odo", "preference", "add", "registry", registryName, addRegistryURL).ShouldPass()
 }
-
-func ToBoolPtr(b bool) *bool {
-	return &b
-}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -362,3 +362,7 @@ func SetDefaultDevfileRegistryAsStaging() {
 	Cmd("odo", "preference", "remove", "registry", registryName, "-f").ShouldPass()
 	Cmd("odo", "preference", "add", "registry", registryName, addRegistryURL).ShouldPass()
 }
+
+func ToBoolPtr(b bool) *bool {
+	return &b
+}

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -41,16 +41,16 @@ func (kubectl KubectlRunner) Run(args ...string) *gexec.Session {
 }
 
 // Exec allows generic execution of commands, returning the contents of stdout
-func (kubectl KubectlRunner) Exec(podName string, projectName string, success *bool, args ...string) (string, string) {
+func (kubectl KubectlRunner) Exec(podName string, projectName string, args []string, expectedSuccess *bool) (string, string) {
 
 	cmd := []string{"exec", podName, "--namespace", projectName}
 
 	cmd = append(cmd, args...)
 
 	cmdWrapper := Cmd(kubectl.path, cmd...)
-	if success == nil {
+	if expectedSuccess == nil {
 		cmdWrapper = cmdWrapper.ShouldRun()
-	} else if *success {
+	} else if *expectedSuccess {
 		cmdWrapper = cmdWrapper.ShouldPass()
 	} else {
 		cmdWrapper = cmdWrapper.ShouldFail()

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -41,14 +41,21 @@ func (kubectl KubectlRunner) Run(args ...string) *gexec.Session {
 }
 
 // Exec allows generic execution of commands, returning the contents of stdout
-func (kubectl KubectlRunner) Exec(podName string, projectName string, args ...string) string {
+func (kubectl KubectlRunner) Exec(podName string, projectName string, success *bool, args ...string) (string, string) {
 
 	cmd := []string{"exec", podName, "--namespace", projectName}
 
 	cmd = append(cmd, args...)
 
-	stdOut := Cmd(kubectl.path, cmd...).ShouldPass().Out()
-	return stdOut
+	cmdWrapper := Cmd(kubectl.path, cmd...)
+	if success == nil {
+		cmdWrapper = cmdWrapper.ShouldRun()
+	} else if *success {
+		cmdWrapper = cmdWrapper.ShouldPass()
+	} else {
+		cmdWrapper = cmdWrapper.ShouldFail()
+	}
+	return cmdWrapper.OutAndErr()
 }
 
 // ExecListDir returns dir list in specified location of pod

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -98,14 +98,19 @@ func (oc OcRunner) ExecListDir(podName string, projectName string, dir string) s
 }
 
 // Exec allows generic execution of commands, returning the contents of stdout
-func (oc OcRunner) Exec(podName string, projectName string, args ...string) string {
-
+func (oc OcRunner) Exec(podName string, projectName string, success *bool, args ...string) (string, string) {
 	cmd := []string{"exec", podName, "--namespace", projectName}
-
 	cmd = append(cmd, args...)
 
-	stdOut := Cmd(oc.path, cmd...).ShouldPass().Out()
-	return stdOut
+	cmdWrapper := Cmd(oc.path, cmd...)
+	if success == nil {
+		cmdWrapper = cmdWrapper.ShouldRun()
+	} else if *success {
+		cmdWrapper = cmdWrapper.ShouldPass()
+	} else {
+		cmdWrapper = cmdWrapper.ShouldFail()
+	}
+	return cmdWrapper.OutAndErr()
 }
 
 // CheckCmdOpInRemoteCmpPod runs the provided command on remote component pod and returns the return value of command output handler function passed to it

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -98,14 +98,14 @@ func (oc OcRunner) ExecListDir(podName string, projectName string, dir string) s
 }
 
 // Exec allows generic execution of commands, returning the contents of stdout
-func (oc OcRunner) Exec(podName string, projectName string, success *bool, args ...string) (string, string) {
+func (oc OcRunner) Exec(podName string, projectName string, args []string, expectedSuccess *bool) (string, string) {
 	cmd := []string{"exec", podName, "--namespace", projectName}
 	cmd = append(cmd, args...)
 
 	cmdWrapper := Cmd(oc.path, cmd...)
-	if success == nil {
+	if expectedSuccess == nil {
 		cmdWrapper = cmdWrapper.ShouldRun()
-	} else if *success {
+	} else if *expectedSuccess {
 		cmdWrapper = cmdWrapper.ShouldPass()
 	} else {
 		cmdWrapper = cmdWrapper.ShouldFail()

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -72,7 +72,7 @@ var _ = Describe("odo dev debug command tests", func() {
 				// #6056
 				It("should not add a DEBUG_PORT variable to the container", func() {
 					cmp := helper.NewComponent(cmpName, "app", "runtime", commonVar.Project, commonVar.CliRunner)
-					stdout := cmp.Exec("runtime", "sh", "-c", "echo -n ${DEBUG_PORT}")
+					stdout, _ := cmp.Exec("runtime", helper.ToBoolPtr(true), "sh", "-c", "echo -n ${DEBUG_PORT}")
 					Expect(stdout).To(BeEmpty())
 				})
 			}))

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/redhat-developer/odo/tests/helper"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -72,7 +74,7 @@ var _ = Describe("odo dev debug command tests", func() {
 				// #6056
 				It("should not add a DEBUG_PORT variable to the container", func() {
 					cmp := helper.NewComponent(cmpName, "app", "runtime", commonVar.Project, commonVar.CliRunner)
-					stdout, _ := cmp.Exec("runtime", helper.ToBoolPtr(true), "sh", "-c", "echo -n ${DEBUG_PORT}")
+					stdout, _ := cmp.Exec("runtime", []string{"sh", "-c", "echo -n ${DEBUG_PORT}"}, pointer.Bool(true))
 					Expect(stdout).To(BeEmpty())
 				})
 			}))

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -99,7 +99,7 @@ var _ = Describe("odo dev command tests", func() {
 
 					// File should exist, and its content should match what we initially set it to
 					component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					execResult := component.Exec("runtime", "cat", "/projects/"+filepath.Base(fileAPath))
+					execResult, _ := component.Exec("runtime", helper.ToBoolPtr(true), "cat", "/projects/"+filepath.Base(fileAPath))
 					Expect(execResult).To(ContainSubstring(fileAText))
 				})
 				Expect(err).ToNot(HaveOccurred())
@@ -447,7 +447,7 @@ ComponentSettings:
 
 					It("should not trigger a push", func() {
 						component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						execResult := component.Exec("runtime", "cat", "/projects/server.js")
+						execResult, _ := component.Exec("runtime", helper.ToBoolPtr(true), "cat", "/projects/server.js")
 						Expect(execResult).To(ContainSubstring("App started"))
 						Expect(execResult).ToNot(ContainSubstring("App is super started"))
 
@@ -467,7 +467,7 @@ ComponentSettings:
 							_, _, _, err := devSession.WaitSync()
 							Expect(err).ToNot(HaveOccurred())
 							component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-							execResult := component.Exec("runtime", "cat", "/projects/server.js")
+							execResult, _ := component.Exec("runtime", helper.ToBoolPtr(true), "cat", "/projects/server.js")
 							Expect(execResult).To(ContainSubstring("App is super started"))
 						})
 					})
@@ -1020,7 +1020,7 @@ ComponentSettings:
 						RunOnPodman: podman,
 					}, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						output := component.Exec("runtime", "ls", "-lai", "/projects")
+						output, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
 						helper.MatchAllInOutput(output, []string{"test_env_variable", "test_build_env_variable"})
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1046,7 +1046,7 @@ ComponentSettings:
 						RunOnPodman: podman,
 					}, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						output := component.Exec("runtime", "ls", "-lai", "/projects")
+						output, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
 						helper.MatchAllInOutput(output, []string{"test_build_env_variable1", "test_build_env_variable2", "test_env_variable1", "test_env_variable2"})
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1072,7 +1072,7 @@ ComponentSettings:
 						RunOnPodman: podman,
 					}, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						output := component.Exec("runtime", "ls", "-lai", "/projects")
+						output, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
 						helper.MatchAllInOutput(output, []string{"build env variable with space", "env with space"})
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1804,7 +1804,7 @@ CMD ["npm", "start"]
 					// Verify the command executed successfully
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 					dir := "/projects/testfolder"
-					out := component.Exec("runtime", "stat", dir)
+					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
 					Expect(out).To(ContainSubstring(dir))
 				})
 			}))
@@ -1836,7 +1836,7 @@ CMD ["npm", "start"]
 					// Verify the command executed successfully
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 					dir := "/projects/testfolder"
-					out := component.Exec("runtime", "stat", dir)
+					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
 					Expect(out).To(ContainSubstring(dir))
 				})
 			}))
@@ -1869,7 +1869,7 @@ CMD ["npm", "start"]
 
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 					dir := "/projects/testfolder"
-					out := component.Exec("runtime", "stat", dir)
+					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
 					Expect(out).To(ContainSubstring(dir))
 				})
 			}))
@@ -1929,7 +1929,7 @@ CMD ["npm", "start"]
 					By("verifying that the command did run successfully", func() {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 						dir := "/projects/testfolder"
-						out := component.Exec("runtime", "stat", dir)
+						out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
 						Expect(out).To(ContainSubstring(dir))
 					})
 				})
@@ -1996,7 +1996,7 @@ CMD ["npm", "start"]
 					By("verifying that the command did run successfully", func() {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 						dir := "/projects/testfolder"
-						out := component.Exec("runtime", "stat", dir)
+						out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
 						Expect(out).To(ContainSubstring(dir))
 					})
 				})
@@ -2116,7 +2116,8 @@ CMD ["npm", "start"]
 			It("should execute default build and run commands correctly", func() {
 
 				cmp := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-				cmdOutput := cmp.Exec("runtime",
+				cmdOutput, _ := cmp.Exec("runtime",
+					helper.ToBoolPtr(true),
 					// [s] to not match the current command: https://unix.stackexchange.com/questions/74185/how-can-i-prevent-grep-from-showing-up-in-ps-results
 					"bash", "-c", "grep [s]pring-boot:run /proc/*/cmdline")
 				Expect(cmdOutput).To(MatchRegexp("Binary file .* matches"))
@@ -2223,7 +2224,7 @@ CMD ["npm", "start"]
 
 				remoteFileChecker := func(path string) {
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					out := component.Exec("runtime", "stat", path)
+					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", path)
 					Expect(out).To(ContainSubstring(path))
 				}
 
@@ -2448,7 +2449,7 @@ CMD ["npm", "start"]
 
 					BeforeEach(func() {
 						// commonVar.CliRunner.PodsShouldBeRunning(commonVar.Project, podName)
-						output := component.Exec("tools", "find", "/projects")
+						output, _ := component.Exec("tools", helper.ToBoolPtr(true), "find", "/projects")
 
 						outputArr := []string{}
 						sc := bufio.NewScanner(strings.NewReader(output))
@@ -2599,12 +2600,12 @@ CMD ["npm", "start"]
 
 			It("should sync only the mentioned files at the appropriate remote destination", func() {
 				component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-				stdOut := component.Exec("runtime", "ls", "-lai", "/projects")
+				stdOut, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
 
 				helper.MatchAllInOutput(stdOut, []string{"package.json", "server"})
 				helper.DontMatchAllInOutput(stdOut, []string{"test", "views", "devfile.yaml"})
 
-				stdOut = component.Exec("runtime", "ls", "-lai", "/projects/server")
+				stdOut, _ = component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects/server")
 				helper.MatchAllInOutput(stdOut, []string{"server.js", "test"})
 			})
 		}))
@@ -2756,7 +2757,7 @@ CMD ["npm", "start"]
 					Expect(string(stderrBytes)).ToNot(ContainSubstring(errorMessage))
 
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					component.Exec("runtime", remotecmd.ShellExecutable, "-c", fmt.Sprintf("kill -0 $(cat %s/.odo_cmd_run.pid) 2>/dev/null ; echo -n $?",
+					component.Exec("runtime", helper.ToBoolPtr(true), remotecmd.ShellExecutable, "-c", fmt.Sprintf("kill -0 $(cat %s/.odo_cmd_run.pid) 2>/dev/null ; echo -n $?",
 						strings.TrimSuffix(storage.SharedDataMountPath, "/")))
 				})
 			}))
@@ -2992,7 +2993,7 @@ CMD ["npm", "start"]
 					componentName := "x" + filepath.Base(commonVar.Context)
 
 					component := helper.NewComponent(componentName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					component.Exec("runtime", remotecmd.ShellExecutable, "-c",
+					component.Exec("runtime", helper.ToBoolPtr(true), remotecmd.ShellExecutable, "-c",
 						fmt.Sprintf("cat %s/.odo_cmd_devrun.pid", strings.TrimSuffix(storage.SharedDataMountPath, "/")))
 				})
 			})

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -99,7 +99,7 @@ var _ = Describe("odo dev command tests", func() {
 
 					// File should exist, and its content should match what we initially set it to
 					component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					execResult, _ := component.Exec("runtime", helper.ToBoolPtr(true), "cat", "/projects/"+filepath.Base(fileAPath))
+					execResult, _ := component.Exec("runtime", []string{"cat", "/projects/" + filepath.Base(fileAPath)}, pointer.Bool(true))
 					Expect(execResult).To(ContainSubstring(fileAText))
 				})
 				Expect(err).ToNot(HaveOccurred())
@@ -447,7 +447,7 @@ ComponentSettings:
 
 					It("should not trigger a push", func() {
 						component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						execResult, _ := component.Exec("runtime", helper.ToBoolPtr(true), "cat", "/projects/server.js")
+						execResult, _ := component.Exec("runtime", []string{"cat", "/projects/server.js"}, pointer.Bool(true))
 						Expect(execResult).To(ContainSubstring("App started"))
 						Expect(execResult).ToNot(ContainSubstring("App is super started"))
 
@@ -467,7 +467,7 @@ ComponentSettings:
 							_, _, _, err := devSession.WaitSync()
 							Expect(err).ToNot(HaveOccurred())
 							component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-							execResult, _ := component.Exec("runtime", helper.ToBoolPtr(true), "cat", "/projects/server.js")
+							execResult, _ := component.Exec("runtime", []string{"cat", "/projects/server.js"}, pointer.Bool(true))
 							Expect(execResult).To(ContainSubstring("App is super started"))
 						})
 					})
@@ -1020,7 +1020,7 @@ ComponentSettings:
 						RunOnPodman: podman,
 					}, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						output, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
+						output, _ := component.Exec("runtime", []string{"ls", "-lai", "/projects"}, pointer.Bool(true))
 						helper.MatchAllInOutput(output, []string{"test_env_variable", "test_build_env_variable"})
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1046,7 +1046,7 @@ ComponentSettings:
 						RunOnPodman: podman,
 					}, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						output, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
+						output, _ := component.Exec("runtime", []string{"ls", "-lai", "/projects"}, pointer.Bool(true))
 						helper.MatchAllInOutput(output, []string{"test_build_env_variable1", "test_build_env_variable2", "test_env_variable1", "test_env_variable2"})
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1072,7 +1072,7 @@ ComponentSettings:
 						RunOnPodman: podman,
 					}, func(session *gexec.Session, out, err []byte, ports map[string]string) {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						output, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
+						output, _ := component.Exec("runtime", []string{"ls", "-lai", "/projects"}, pointer.Bool(true))
 						helper.MatchAllInOutput(output, []string{"build env variable with space", "env with space"})
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1804,7 +1804,7 @@ CMD ["npm", "start"]
 					// Verify the command executed successfully
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 					dir := "/projects/testfolder"
-					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
+					out, _ := component.Exec("runtime", []string{"stat", dir}, pointer.Bool(true))
 					Expect(out).To(ContainSubstring(dir))
 				})
 			}))
@@ -1836,7 +1836,7 @@ CMD ["npm", "start"]
 					// Verify the command executed successfully
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 					dir := "/projects/testfolder"
-					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
+					out, _ := component.Exec("runtime", []string{"stat", dir}, pointer.Bool(true))
 					Expect(out).To(ContainSubstring(dir))
 				})
 			}))
@@ -1869,7 +1869,7 @@ CMD ["npm", "start"]
 
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 					dir := "/projects/testfolder"
-					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
+					out, _ := component.Exec("runtime", []string{"stat", dir}, pointer.Bool(true))
 					Expect(out).To(ContainSubstring(dir))
 				})
 			}))
@@ -1929,7 +1929,7 @@ CMD ["npm", "start"]
 					By("verifying that the command did run successfully", func() {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 						dir := "/projects/testfolder"
-						out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
+						out, _ := component.Exec("runtime", []string{"stat", dir}, pointer.Bool(true))
 						Expect(out).To(ContainSubstring(dir))
 					})
 				})
@@ -1996,7 +1996,7 @@ CMD ["npm", "start"]
 					By("verifying that the command did run successfully", func() {
 						component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 						dir := "/projects/testfolder"
-						out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", dir)
+						out, _ := component.Exec("runtime", []string{"stat", dir}, pointer.Bool(true))
 						Expect(out).To(ContainSubstring(dir))
 					})
 				})
@@ -2117,9 +2117,13 @@ CMD ["npm", "start"]
 
 				cmp := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 				cmdOutput, _ := cmp.Exec("runtime",
-					helper.ToBoolPtr(true),
-					// [s] to not match the current command: https://unix.stackexchange.com/questions/74185/how-can-i-prevent-grep-from-showing-up-in-ps-results
-					"bash", "-c", "grep [s]pring-boot:run /proc/*/cmdline")
+					[]string{
+						"bash", "-c",
+						// [s] to not match the current command: https://unix.stackexchange.com/questions/74185/how-can-i-prevent-grep-from-showing-up-in-ps-results
+						"grep [s]pring-boot:run /proc/*/cmdline",
+					},
+					pointer.Bool(true),
+				)
 				Expect(cmdOutput).To(MatchRegexp("Binary file .* matches"))
 			})
 		}))
@@ -2224,7 +2228,7 @@ CMD ["npm", "start"]
 
 				remoteFileChecker := func(path string) {
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					out, _ := component.Exec("runtime", helper.ToBoolPtr(true), "stat", path)
+					out, _ := component.Exec("runtime", []string{"stat", path}, pointer.Bool(true))
 					Expect(out).To(ContainSubstring(path))
 				}
 
@@ -2449,7 +2453,7 @@ CMD ["npm", "start"]
 
 					BeforeEach(func() {
 						// commonVar.CliRunner.PodsShouldBeRunning(commonVar.Project, podName)
-						output, _ := component.Exec("tools", helper.ToBoolPtr(true), "find", "/projects")
+						output, _ := component.Exec("tools", []string{"find", "/projects"}, pointer.Bool(true))
 
 						outputArr := []string{}
 						sc := bufio.NewScanner(strings.NewReader(output))
@@ -2600,12 +2604,12 @@ CMD ["npm", "start"]
 
 			It("should sync only the mentioned files at the appropriate remote destination", func() {
 				component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-				stdOut, _ := component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects")
+				stdOut, _ := component.Exec("runtime", []string{"ls", "-lai", "/projects"}, pointer.Bool(true))
 
 				helper.MatchAllInOutput(stdOut, []string{"package.json", "server"})
 				helper.DontMatchAllInOutput(stdOut, []string{"test", "views", "devfile.yaml"})
 
-				stdOut, _ = component.Exec("runtime", helper.ToBoolPtr(true), "ls", "-lai", "/projects/server")
+				stdOut, _ = component.Exec("runtime", []string{"ls", "-lai", "/projects/server"}, pointer.Bool(true))
 				helper.MatchAllInOutput(stdOut, []string{"server.js", "test"})
 			})
 		}))
@@ -2757,8 +2761,15 @@ CMD ["npm", "start"]
 					Expect(string(stderrBytes)).ToNot(ContainSubstring(errorMessage))
 
 					component := helper.NewComponent(devfileCmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					component.Exec("runtime", helper.ToBoolPtr(true), remotecmd.ShellExecutable, "-c", fmt.Sprintf("kill -0 $(cat %s/.odo_cmd_run.pid) 2>/dev/null ; echo -n $?",
-						strings.TrimSuffix(storage.SharedDataMountPath, "/")))
+					component.Exec("runtime",
+						[]string{
+							remotecmd.ShellExecutable,
+							"-c",
+							fmt.Sprintf("kill -0 $(cat %s/.odo_cmd_run.pid) 2>/dev/null ; echo -n $?",
+								strings.TrimSuffix(storage.SharedDataMountPath, "/")),
+						},
+						pointer.Bool(true),
+					)
 				})
 			}))
 		}
@@ -2993,8 +3004,14 @@ CMD ["npm", "start"]
 					componentName := "x" + filepath.Base(commonVar.Context)
 
 					component := helper.NewComponent(componentName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-					component.Exec("runtime", helper.ToBoolPtr(true), remotecmd.ShellExecutable, "-c",
-						fmt.Sprintf("cat %s/.odo_cmd_devrun.pid", strings.TrimSuffix(storage.SharedDataMountPath, "/")))
+					component.Exec("runtime",
+						[]string{
+							remotecmd.ShellExecutable,
+							"-c",
+							fmt.Sprintf("cat %s/.odo_cmd_devrun.pid", strings.TrimSuffix(storage.SharedDataMountPath, "/")),
+						},
+						pointer.Bool(true),
+					)
 				})
 			})
 		}))


### PR DESCRIPTION
**What type of PR is this:**
/kind tests
/area testing

**What does this PR do / why we need it:**
This is an attempt to fix the recurring issues we have been seeing with E2E tests.
In a nutshell, it waits for the application to be actually running in the container before sending a request to the local port created by odo.
Otherwise, sending a request to the local port too early sometimes causes the port forwarding to be automatically restarted (with new random ports because we are running `odo dev` with `--random-ports`) (#6013)

**Which issue(s) this PR fixes:**
Fixes #6463 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
