### PR TITLE
[WIP] Display Pod is Running before syncing files

### DIFF
--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -218,6 +218,10 @@ func (o *WatchClient) eventWatcher(
 	<-retryTimer.C
 
 	podReady := false
+	if !parameters.WatchCluster {
+		// If we don't watch cluster (on podman), we consider pod is ready
+		podReady = true
+	}
 	podsPhases := NewPodPhases()
 
 	for {

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -290,6 +290,7 @@ func (o *WatchClient) eventWatcher(
 			}
 
 		case <-deployTimer.C:
+			// If the pod is not displayed as ready, wait a little longer
 			if !podReady {
 				deployTimer.Reset(300 * time.Millisecond)
 				continue

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -237,6 +237,7 @@ func (o *WatchClient) eventWatcher(
 			// If the pod is not displayed as ready, wait a little longer
 			if !podReady {
 				sourcesTimer.Reset(100 * time.Millisecond)
+				continue
 			}
 
 			var changedFiles, deletedPaths []string
@@ -289,6 +290,10 @@ func (o *WatchClient) eventWatcher(
 			}
 
 		case <-deployTimer.C:
+			if !podReady {
+				deployTimer.Reset(300 * time.Millisecond)
+				continue
+			}
 			retry, err := processEventsHandler(ctx, nil, nil, parameters, out, &componentStatus, expBackoff)
 			if err != nil {
 				return err
@@ -304,6 +309,12 @@ func (o *WatchClient) eventWatcher(
 			devfileTimer.Reset(100 * time.Millisecond)
 
 		case <-devfileTimer.C:
+			// If the pod is not displayed as ready, wait a little longer
+			if !podReady {
+				devfileTimer.Reset(100 * time.Millisecond)
+				continue
+			}
+
 			fmt.Fprintf(out, "Updating Component...\n\n")
 			retry, err := processEventsHandler(ctx, nil, nil, parameters, out, &componentStatus, expBackoff)
 			if err != nil {


### PR DESCRIPTION
**What type of PR is this:**

/kind tests

**What does this PR do / why we need it:**

During tests, `Pod is Running` is regularly displayed after syncing files:
```
  Expected
      <string>:   (
        	"""
        	... // 9 identical lines
        	•  Waiting for Kubernetes resources  ...
        	⚠  Pod is Pending
      - 	✓  Pod is Running
        	✓  Syncing files into the container [1s]
        	✓  Building your application in container (command: install) [1s]
        	... // 9 identical lines
        	[Ctrl+c] - Exit and delete resources from the cluster
        	[p] - Manually apply local changes to the application on the cluster
      + 	✓  Pod is Running
        	```
        	"""
        )
      
  to be empty
```

**Which issue(s) this PR fixes:**

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
