### PR TITLE
Test version upon oc/kubectl version

### DIFF
--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -61,4 +61,5 @@ type CliRunner interface {
 	AssertNoContainsLabel(kind, namespace, componentName, appName, mode, key string)
 	EnsurePodIsUp(namespace, podName string)
 	AssertNonAuthenticated()
+	GetVersion() string
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -441,4 +442,15 @@ func (kubectl KubectlRunner) AssertNoContainsLabel(kind, namespace, componentNam
 
 func (kubectl KubectlRunner) AssertNonAuthenticated() {
 	// Nothing to do
+}
+
+func (kubectl KubectlRunner) GetVersion() string {
+	res := Cmd(kubectl.path, "version", "--output=json").ShouldPass().Out()
+	var js map[string]interface{}
+	err := json.Unmarshal([]byte(res), &js)
+	Expect(err).ShouldNot(HaveOccurred())
+	sv := js["serverVersion"].(map[string]interface{})
+	minor := sv["minor"].(string)
+	major := sv["major"].(string)
+	return major + "." + minor
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -630,4 +631,12 @@ func (oc OcRunner) EnsurePodIsUp(namespace, podName string) {
 
 func (oc OcRunner) AssertNonAuthenticated() {
 	Cmd(oc.path, "whoami").ShouldFail()
+}
+
+func (oc OcRunner) GetVersion() string {
+	res := Cmd(oc.path, "version", "--output=json").ShouldPass().Out()
+	var js map[string]interface{}
+	err := json.Unmarshal([]byte(res), &js)
+	Expect(err).ShouldNot(HaveOccurred())
+	return js["openshiftVersion"].(string)
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -638,5 +638,9 @@ func (oc OcRunner) GetVersion() string {
 	var js map[string]interface{}
 	err := json.Unmarshal([]byte(res), &js)
 	Expect(err).ShouldNot(HaveOccurred())
-	return js["openshiftVersion"].(string)
+	val, ok := js["openshiftVersion"].(string)
+	if !ok {
+		return ""
+	}
+	return val
 }

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -251,7 +251,11 @@ var _ = Describe("odo dev command tests", func() {
 					} else {
 						Expect(td.Properties.CmdProperties[segment.Platform]).To(Equal("openshift"))
 						serverVersion := commonVar.CliRunner.GetVersion()
-						Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
+						if serverVersion == "" {
+							Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(BeNil())
+						} else {
+							Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
+						}
 					}
 				})
 			}))

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -243,12 +243,16 @@ var _ = Describe("odo dev command tests", func() {
 					Expect(td.Properties.CmdProperties[segment.ExperimentalMode]).To(Equal(experimentalValue))
 					if podman {
 						Expect(td.Properties.CmdProperties[segment.Platform]).To(Equal("podman"))
+						Expect(td.Properties.CmdProperties[segment.PlatformVersion]).ToNot(BeEmpty())
 					} else if os.Getenv("KUBERNETES") == "true" {
 						Expect(td.Properties.CmdProperties[segment.Platform]).To(Equal("kubernetes"))
+						serverVersion := commonVar.CliRunner.GetVersion()
+						Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
 					} else {
 						Expect(td.Properties.CmdProperties[segment.Platform]).To(Equal("openshift"))
+						serverVersion := commonVar.CliRunner.GetVersion()
+						Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
 					}
-					Expect(td.Properties.CmdProperties[segment.PlatformVersion]).ToNot(BeEmpty())
 				})
 			}))
 

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -228,7 +228,11 @@ ComponentSettings:
 				Expect(td.Properties.CmdProperties[segment.Platform]).To(Equal("openshift"))
 			}
 			serverVersion := commonVar.CliRunner.GetVersion()
-			Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
+			if serverVersion == "" {
+				Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(BeNil())
+			} else {
+				Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
+			}
 		})
 	})
 

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -227,7 +227,8 @@ ComponentSettings:
 			} else {
 				Expect(td.Properties.CmdProperties[segment.Platform]).To(Equal("openshift"))
 			}
-			Expect(td.Properties.CmdProperties[segment.PlatformVersion]).ToNot(BeEmpty())
+			serverVersion := commonVar.CliRunner.GetVersion()
+			Expect(td.Properties.CmdProperties[segment.PlatformVersion]).To(ContainSubstring(serverVersion))
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind tests
**What does this PR do / why we need it:**

On OpenShift platforms used by prow tests, oc version does not return the OCP version. 
The tests get the value from oc/kubectl version to compare this value with the one found by odo

**Which issue(s) this PR fixes:**

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
