### PR TITLE
Use oc v4.11 instead v4.7 to fix version comparison

### DIFF
--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
     mv kubectl /usr/local/bin/ && \
     curl -sLO https://raw.githubusercontent.com/cptmorgan-rh/install-oc-tools/master/install-oc-tools.sh > /dev/null && \
     chmod +x install-oc-tools.sh && \
-    ./install-oc-tools.sh --latest 4.7 && \
+    ./install-oc-tools.sh --latest 4.11 && \
     apt-get update -y && \
     apt-get install -y sshpass jq colorized-logs && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**What type of PR is this:**

/kind tests


**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**

`oc` versions v4.7 and v4.11 use different information from the cluster to retrieve the OpenShift cluster version.

In odo, we send platform information to telemetry, and get information from the cluster the same way oc v4.11 is getting it.

In the tests, we currently compare the output of `oc version` v4.7 with what odo get, to check that we are sending the good version.

Unfortunalety, in some circumstances, oc v4.7 and v4.11 return different version.

This makes our tests fail in these circumstances.

Updating oc to version v4.11 for the tests should fix the problem.


Failing test: https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-tests-openshift-logs/pr-6545-openshift-tests-3993.html

This happens when cluster is updating:

```
$ kubectl get clusterversions.config.openshift.io version -o yaml
[...]
status:
  availableUpdates: null
  conditions:
  - lastTransitionTime: "2022-10-20T13:59:32Z"
    message: The update channel has not been configured.
    reason: NoChannel
    status: "False"
    type: RetrievedUpdates
  - lastTransitionTime: "2022-10-20T14:53:17Z"
    message: Done applying 4.9.52
    status: "True"
    type: Available
  - lastTransitionTime: "2022-11-16T12:24:52Z"
    status: "False"
    type: Failing
  - lastTransitionTime: "2023-02-01T12:53:09Z"
    message: 'Working towards 4.9.54: 447 of 561 done (79% complete), waiting on image-registry'
    reason: ClusterOperatorUpdating
    status: "True"
    type: Progressing
  desired:
    image: registry.eu-de.bluemix.net/armada-master/ocp-release:4.9.54-x86_64
    url: https://access.redhat.com/errata/RHSA-2022:9111
    version: 4.9.54
  history:
  - completionTime: null
    image: registry.eu-de.bluemix.net/armada-master/ocp-release:4.9.54-x86_64
    startedTime: "2023-02-01T12:53:09Z"
    state: Partial
    verified: false
    version: 4.9.54
  - completionTime: "2022-12-16T01:31:28Z"
    image: registry.eu-de.bluemix.net/armada-master/ocp-release:4.9.52-x86_64
    startedTime: "2022-12-16T01:19:43Z"
    state: Completed
    verified: false
    version: 4.9.52
```


**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
