### PR TITLE
Set the date for the v3 GA blog post

### DIFF
--- a/docs/website/blog/3.0.0-GA-blog.md
+++ b/docs/website/blog/3.0.0-GA-blog.md
@@ -5,6 +5,7 @@ author_url: https://github.com/valaparthvi
 author_image_url: https://github.com/valaparthvi.png
 tags: ["release"]
 slug: odo-v3-release
+date: 2022-10-19
 ---
 
 `odo` v3 is now GA! 🎉


### PR DESCRIPTION
**What type of PR is this:**
/area documentation

**What does this PR do / why we need it:**

This sets an explicit date for the v3 GA blog post, which does not follow the `YYYY-MM-DD-$myBlogTitle.md` file naming pattern. See https://docusaurus.io/docs/blog#blog-post-date.
Otherwise, in some circumstances, Docusaurus would list this post as the first one on the list.
It happened to me while working on #6564 and #6562.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
