### PR TITLE
Fix the port value (20001) in the quickstart guides

### DIFF
--- a/docs/website/docs/user-guides/quickstart/docs-mdx/odo_dev_description.mdx
+++ b/docs/website/docs/user-guides/quickstart/docs-mdx/odo_dev_description.mdx
@@ -11,9 +11,12 @@ Once you run `odo dev`, you can freely edit code in your favourite IDE and watch
 odo dev
 ```
 
+Then wait a few seconds until `odo dev` displays `Forwarding from 127.0.0.1:...` in its output,
+meaning that `odo` has successfully set up the port forwarding to reach the application running in the container.
+
 <details>
     <summary>Sample Output</summary>
     {props.devout}
 </details>
 
-You can now access the application at [127.0.0.1:20001](http://127.0.0.1:20001) in your local browser and start your development loop. `odo` will watch for changes and push the code for real-time updates.
+You can now access the application via the local port displayed by `odo dev` ([127.0.0.1:20001](http://127.0.0.1:20001) in the sample output above) and start your development loop. `odo` will watch for changes and push the code for real-time updates.

--- a/docs/website/docs/user-guides/quickstart/docs-mdx/odo_dev_description.mdx
+++ b/docs/website/docs/user-guides/quickstart/docs-mdx/odo_dev_description.mdx
@@ -16,4 +16,4 @@ odo dev
     {props.devout}
 </details>
 
-You can now access the application at [127.0.0.1:40001](http://127.0.0.1:40001) in your local browser and start your development loop. `odo` will watch for changes and push the code for real-time updates.
+You can now access the application at [127.0.0.1:20001](http://127.0.0.1:20001) in your local browser and start your development loop. `odo` will watch for changes and push the code for real-time updates.


### PR DESCRIPTION
**What type of PR is this:**
/area documentation

**What does this PR do / why we need it:**
The sample output displayed at the end of the Quickstart Guides no longer matches the port number we are instructing users to reach in order to access the application.

![Screenshot from 2023-02-03 17-33-00](https://user-images.githubusercontent.com/593208/216658069-7a2b735a-3614-4d19-a479-4f9647bbe2c1.png)

This PR changes the value displayed and adds an additional clarification line.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
