### PR TITLE
Fix UX inconsistency when handling commands bound to events

### DIFF
--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -216,7 +216,8 @@ func (do *DeleteComponentClient) ExecutePreStopEvents(devfileObj parser.DevfileO
 
 	klog.V(4).Infof("Executing %q event commands for component %q", libdevfile.PreStop, componentName)
 	// ignore the failures if any; delete should not fail because preStop events failed to execute
-	err = libdevfile.ExecPreStopEvents(devfileObj, component.NewExecHandler(do.kubeClient, do.execClient, appName, componentName, pod.Name, "", false))
+	err = libdevfile.ExecPreStopEvents(devfileObj,
+		component.NewExecHandler(do.kubeClient, do.execClient, appName, componentName, pod.Name, "Executing pre-stop command in container", false))
 	if err != nil {
 		klog.V(4).Infof("Failed to execute %q event commands for component %q, cause: %v", libdevfile.PreStop, componentName, err.Error())
 	}

--- a/pkg/component/exec_handler.go
+++ b/pkg/component/exec_handler.go
@@ -55,7 +55,7 @@ func (o *execHandler) ApplyOpenShift(openshift v1alpha2.Component) error {
 func (o *execHandler) Execute(command v1alpha2.Command) error {
 	msg := o.msg
 	if msg == "" {
-		msg = fmt.Sprintf("Executing %s command %q on container %q", command.Id, command.Exec.CommandLine, command.Exec.Component)
+		msg = fmt.Sprintf("Executing %s command on container %q", command.Id, command.Exec.Component)
 	} else {
 		msg += " (command: " + command.Id + ")"
 	}

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -62,7 +62,7 @@ func (o *DevClient) reconcile(
 			appName,
 			componentName,
 			pod.Name,
-			"",
+			"Executing post-start command in container",
 			false, /* TODO */
 		)
 		err = libdevfile.ExecPostStartEvents(*devfileObj, execHandler)

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -257,7 +257,7 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 	// didn't previously exist
 	if !componentStatus.PostStartEventsDone && libdevfile.HasPostStartEvents(a.Devfile) {
 		err = libdevfile.ExecPostStartEvents(a.Devfile,
-			component.NewExecHandler(a.kubeClient, a.execClient, a.AppName, a.ComponentName, pod.Name, "", parameters.Show))
+			component.NewExecHandler(a.kubeClient, a.execClient, a.AppName, a.ComponentName, pod.Name, "Executing post-start command in container", parameters.Show))
 		if err != nil {
 			return err
 		}

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -713,7 +713,7 @@ var _ = Describe("odo delete command tests", func() {
 			It("should delete the component", func() {
 				By("listing preStop events", func() {
 					for _, cmdName := range []string{"myprestop", "secondprestop", "thirdprestop"} {
-						Expect(out).To(ContainSubstring(fmt.Sprintf("Executing pre-stop command in container (command: %s)", cmdName)))
+						Expect(out).To(ContainSubstring("Executing pre-stop command in container (command: %s)", cmdName))
 					}
 				})
 				files := helper.ListFilesInDir(commonVar.Context)

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -712,11 +712,9 @@ var _ = Describe("odo delete command tests", func() {
 			})
 			It("should delete the component", func() {
 				By("listing preStop events", func() {
-					helper.MatchAllInOutput(out, []string{
-						"Executing myprestop command",
-						"Executing secondprestop command",
-						"Executing thirdprestop command",
-					})
+					for _, cmdName := range []string{"myprestop", "secondprestop", "thirdprestop"} {
+						Expect(out).To(ContainSubstring(fmt.Sprintf("Executing pre-stop command in container (command: %s)", cmdName)))
+					}
 				})
 				files := helper.ListFilesInDir(commonVar.Context)
 				if withFiles {


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area UX
/area dev

**What does this PR do / why we need it:**
See https://github.com/redhat-developer/odo/issues/6573.

For the example provided in the issue description, this PR changes the `odo dev` output from:
```
 ✓  Executing copy-galleon command "cp -Rf /opt/jboss/container/wildfly/s2i/galleon/galleon-m2-repository /tmp/. && cp -Rf /opt/wildfly /tmp/." on container "wildfly" [960ms]
 ✓  Executing provision-server command "/usr/local/s2i/assemble && cp -Rf $JBOSS_HOME ." on container "wildfly" [8s]
 ✓  Executing store-config command "mkdir $STANDALONE_RESTORE && cp -f $JBOSS_HOME/standalone/configuration/standalone.xml $STANDALONE_RESTORE/standalone.xml" on container "wildfly" [47ms]
```

to

```
 ✓  Executing post-start command in container (command: copy-galleon) [835ms]
 ✓  Executing post-start command in container (command: provision-server) [8s]
 ✓  Executing post-start command in container (command: store-config) [52ms]
```

**Which issue(s) this PR fixes:**
Fixes #6573 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```
$ odo init --name my-java-wildfly --devfile java-wildfly --starter microprofile-openapi
$ odo dev
```