### PR TITLE
Support `dev.odo.push.path:*` attributes on Podman

### DIFF
--- a/docs/website/docs/user-guides/advanced/pushing-specific-files.md
+++ b/docs/website/docs/user-guides/advanced/pushing-specific-files.md
@@ -2,16 +2,18 @@
 title: Only Push Specific Files
 sidebar_position: 2
 ---
-`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component.
+`odo` uses the `dev.odo.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component.
 
-The format of the attribute is `"odo.dev.push.path:<local_relative_path>": "<remote_relative_path>"`. We can mention multiple such attributes in the run command's `attributes` section.
+The format of the attribute is `"dev.odo.push.path:<local_relative_path>": "<remote_relative_path>"`. We can mention multiple such attributes in the run command's `attributes` section.
 
 ```yaml
 commands:
   - id: dev-run
+    # highlight-start
     attributes:
       "dev.odo.push.path:target/quarkus-app": "remote-target/quarkus-app"
       "dev.odo.push.path:README.txt": "docs/README.txt"
+    # highlight-end
     exec:
       component: tools
       commandLine: "java -jar remote-target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
@@ -21,6 +23,11 @@ commands:
         isDefault: true
       workingDir: $PROJECTS_ROOT
   - id: dev-debug
+    # highlight-start
+    attributes:
+      "dev.odo.push.path:target/quarkus-app": "remote-target/quarkus-app"
+      "dev.odo.push.path:README.txt": "docs/README.txt"
+    # highlight-end
     exec:
       component: tools
       commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar remote-target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
@@ -31,4 +38,5 @@ commands:
       workingDir: $PROJECTS_ROOT
 ```
 
-In the above example the contents of the `quarkus-app` folder, which is inside the `target` folder, will be pushed to the remote location of `remote-target/quarkus-app` and the file `README.txt` will be pushed to `doc/README.txt`. The local path is relative to the component's local folder. The remote location is relative to the folder containing the component's source code inside the container. 
+In the above example the contents of the `quarkus-app` folder, which is inside the `target` folder, will be pushed to the remote location of `remote-target/quarkus-app` and the file `README.txt` will be pushed to `doc/README.txt`.
+The local path is relative to the component's local folder. The remote location is relative to the folder containing the component's source code inside the container. 

--- a/docs/website/versioned_docs/version-2.5.0/tutorials/using-devfile-odo.dev.push.path-attribute.md
+++ b/docs/website/versioned_docs/version-2.5.0/tutorials/using-devfile-odo.dev.push.path-attribute.md
@@ -1,17 +1,19 @@
 ---
-title: Using the odo.dev.push.path related attribute
+title: Using the dev.odo.push.path related attribute
 sidebar_position: 4
 ---
-`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component.
+`odo` uses the `dev.odo.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component.
 
-The format of the attribute is `"odo.dev.push.path:<local_relative_path>": "<remote_relative_path>"`. We can mention multiple such attributes in the run command's `attributes` section.
+The format of the attribute is `"dev.odo.push.path:<local_relative_path>": "<remote_relative_path>"`. We can mention multiple such attributes in the run command's `attributes` section.
 
 ```yaml
 commands:
   - id: dev-run
+    # highlight-start
     attributes:
       "dev.odo.push.path:target/quarkus-app": "remote-target/quarkus-app"
       "dev.odo.push.path:README.txt": "docs/README.txt"
+    # highlight-end
     exec:
       component: tools
       commandLine: "java -jar remote-target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"

--- a/pkg/devfile/adapters/attributes.go
+++ b/pkg/devfile/adapters/attributes.go
@@ -1,0 +1,23 @@
+package adapters
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+)
+
+const _devPushPathAttributePrefix = "dev.odo.push.path:"
+
+// GetSyncFilesFromAttributes gets the target files and folders along with their respective remote destination from the devfile.
+// It uses the "dev.odo.push.path:" attribute prefix, if any, in the specified command.
+func GetSyncFilesFromAttributes(command v1alpha2.Command) map[string]string {
+	syncMap := make(map[string]string)
+	for key, value := range command.Attributes.Strings(nil) {
+		if strings.HasPrefix(key, _devPushPathAttributePrefix) {
+			localValue := strings.ReplaceAll(key, _devPushPathAttributePrefix, "")
+			syncMap[filepath.Clean(localValue)] = filepath.ToSlash(filepath.Clean(value))
+		}
+	}
+	return syncMap
+}

--- a/pkg/devfile/adapters/attributes_test.go
+++ b/pkg/devfile/adapters/attributes_test.go
@@ -1,0 +1,91 @@
+package adapters
+
+import (
+	"testing"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetSyncFilesFromAttributes(t *testing.T) {
+	type args struct {
+		command v1alpha2.Command
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "no attributes",
+			args: args{
+				command: v1alpha2.Command{},
+			},
+			want: make(map[string]string),
+		},
+		{
+			name: "no matching attributes",
+			args: args{
+				command: v1alpha2.Command{
+					Attributes: attributes.Attributes{}.FromStringMap(map[string]string{
+						"some-custom-attribute-key":    "some-value",
+						"another-custom-attribute-key": "some-value",
+					}),
+				},
+			},
+			want: make(map[string]string),
+		},
+		{
+			name: "dev.odo.push.path attribute key",
+			args: args{
+				command: v1alpha2.Command{
+					Attributes: attributes.Attributes{}.FromStringMap(map[string]string{
+						"dev.odo.push.path": "some-value",
+					}),
+				},
+			},
+			want: make(map[string]string),
+		},
+		{
+			name: "attribute with only matching prefix as key",
+			args: args{
+				command: v1alpha2.Command{
+					Attributes: attributes.Attributes{}.FromStringMap(map[string]string{
+						_devPushPathAttributePrefix: "server/",
+					}),
+				},
+			},
+			want: map[string]string{
+				".": "server",
+			},
+		},
+		{
+			name: "multiple matching attributes",
+			args: args{
+				command: v1alpha2.Command{
+					Attributes: attributes.Attributes{}.FromStringMap(map[string]string{
+						"some-custom-attribute-key":                      "some-value",
+						_devPushPathAttributePrefix + "server.js":        "server/server.js",
+						"some-other-custom-attribute-key":                "some-value",
+						_devPushPathAttributePrefix + "some-path/README": "another/nested/path/README.md",
+						_devPushPathAttributePrefix + "random-file.txt":  "/tmp/rand-file.txt",
+					}),
+				},
+			},
+			want: map[string]string{
+				"server.js":        "server/server.js",
+				"some-path/README": "another/nested/path/README.md",
+				"random-file.txt":  "/tmp/rand-file.txt",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetSyncFilesFromAttributes(tt.args.command)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("GetSyncFilesFromAttributes() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -243,7 +243,7 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 
 		CompInfo:  compInfo,
 		ForcePush: !deploymentExists || podChanged,
-		Files:     getSyncFilesFromAttributes(pushDevfileCommands),
+		Files:     getSyncFilesFromAttributes(parameters.Debug, pushDevfileCommands),
 	}
 
 	execRequired, err := a.syncClient.SyncFiles(syncParams)
@@ -761,9 +761,13 @@ type PushCommandsMap map[devfilev1.CommandGroupKind]devfilev1.Command
 
 // getSyncFilesFromAttributes gets the target files and folders along with their respective remote destination from the devfile
 // it uses the "dev.odo.push.path" attribute in the run command
-func getSyncFilesFromAttributes(commandsMap PushCommandsMap) map[string]string {
+func getSyncFilesFromAttributes(debug bool, commandsMap PushCommandsMap) map[string]string {
 	syncMap := make(map[string]string)
-	if value, ok := commandsMap[devfilev1.RunCommandGroupKind]; ok {
+	cmdKind := devfilev1.RunCommandGroupKind
+	if debug {
+		cmdKind = devfilev1.DebugCommandGroupKind
+	}
+	if value, ok := commandsMap[cmdKind]; ok {
 		for key, value := range value.Attributes.Strings(nil) {
 			if strings.HasPrefix(key, "dev.odo.push.path:") {
 				localValue := strings.ReplaceAll(key, "dev.odo.push.path:", "")

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -234,10 +234,11 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 	}
 
 	cmdKind := devfilev1.RunCommandGroupKind
+	cmdName := parameters.DevfileRunCmd
 	if parameters.Debug {
 		cmdKind = devfilev1.DebugCommandGroupKind
+		cmdName = parameters.DevfileDebugCmd
 	}
-	devfileCmd := pushDevfileCommands[cmdKind]
 
 	syncParams := sync.SyncParameters{
 		Path:                     parameters.Path,
@@ -248,7 +249,7 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 
 		CompInfo:  compInfo,
 		ForcePush: !deploymentExists || podChanged,
-		Files:     adapters.GetSyncFilesFromAttributes(devfileCmd),
+		Files:     adapters.GetSyncFilesFromAttributes(pushDevfileCommands[cmdKind]),
 	}
 
 	execRequired, err := a.syncClient.SyncFiles(syncParams)
@@ -268,11 +269,6 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 		}
 	}
 	componentStatus.PostStartEventsDone = true
-
-	cmdName := parameters.DevfileRunCmd
-	if parameters.Debug {
-		cmdName = parameters.DevfileDebugCmd
-	}
 
 	cmd, err := libdevfile.ValidateAndGetCommand(a.Devfile, cmdName, cmdKind)
 	if err != nil {

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"reflect"
 	"strings"
 	sync2 "sync"
@@ -234,6 +233,12 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 		SyncFolder:    syncFolder,
 	}
 
+	cmdKind := devfilev1.RunCommandGroupKind
+	if parameters.Debug {
+		cmdKind = devfilev1.DebugCommandGroupKind
+	}
+	devfileCmd := pushDevfileCommands[cmdKind]
+
 	syncParams := sync.SyncParameters{
 		Path:                     parameters.Path,
 		WatchFiles:               parameters.WatchFiles,
@@ -243,7 +248,7 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 
 		CompInfo:  compInfo,
 		ForcePush: !deploymentExists || podChanged,
-		Files:     getSyncFilesFromAttributes(parameters.Debug, pushDevfileCommands),
+		Files:     adapters.GetSyncFilesFromAttributes(devfileCmd),
 	}
 
 	execRequired, err := a.syncClient.SyncFiles(syncParams)
@@ -264,10 +269,8 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 	}
 	componentStatus.PostStartEventsDone = true
 
-	cmdKind := devfilev1.RunCommandGroupKind
 	cmdName := parameters.DevfileRunCmd
 	if parameters.Debug {
-		cmdKind = devfilev1.DebugCommandGroupKind
 		cmdName = parameters.DevfileDebugCmd
 	}
 
@@ -758,22 +761,3 @@ func (a Adapter) deleteServiceBindingSecrets(serviceBindingSecretsToRemove []uns
 
 // PushCommandsMap stores the commands to be executed as per their types.
 type PushCommandsMap map[devfilev1.CommandGroupKind]devfilev1.Command
-
-// getSyncFilesFromAttributes gets the target files and folders along with their respective remote destination from the devfile
-// it uses the "dev.odo.push.path" attribute in the run command
-func getSyncFilesFromAttributes(debug bool, commandsMap PushCommandsMap) map[string]string {
-	syncMap := make(map[string]string)
-	cmdKind := devfilev1.RunCommandGroupKind
-	if debug {
-		cmdKind = devfilev1.DebugCommandGroupKind
-	}
-	if value, ok := commandsMap[cmdKind]; ok {
-		for key, value := range value.Attributes.Strings(nil) {
-			if strings.HasPrefix(key, "dev.odo.push.path:") {
-				localValue := strings.ReplaceAll(key, "dev.odo.push.path:", "")
-				syncMap[filepath.Clean(localValue)] = filepath.ToSlash(filepath.Clean(value))
-			}
-		}
-	}
-	return syncMap
-}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-remote-attributes.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-remote-attributes.yaml
@@ -14,6 +14,8 @@ components:
       endpoints:
         - name: "3000-tcp"
           targetPort: 3000
+        - name: debug
+          targetPort: 5858
       mountSources: true
 commands:
   - id: devbuild
@@ -50,3 +52,18 @@ commands:
       workingDir: ${PROJECTS_ROOT}
       group:
         kind: run
+  - id: devdebug
+    attributes:
+      "dev.odo.push.path:server.js": "server-debug/server.js"
+      "dev.odo.push.path:test": "server-debug/test"
+      "dev.odo.push.path:package.json": "package.json"
+    exec:
+      component: runtime
+      commandLine: npm run debug
+      workingDir: ${PROJECTS_ROOT}
+      env:
+        - name: DEBUG_PORT_PROJECT
+          value: "5858"
+      group:
+        kind: debug
+        isDefault: true

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -85,13 +85,9 @@ var _ = Describe("odo dev debug command tests", func() {
 	for _, podman := range []bool{false, true} {
 		podman := podman
 		When("creating nodejs component, doing odo dev and run command has dev.odo.push.path attribute", helper.LabelPodmanIf(podman, func() {
-			// TODO Not implemented yet on Podman
 			var session helper.DevSession
 			var devStarted bool
 			BeforeEach(func() {
-				if podman {
-					Skip("not implemented yet on Podman - see #6492")
-				}
 				helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path",
 					helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-remote-attributes.yaml")).ShouldPass()
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -2604,13 +2604,9 @@ CMD ["npm", "start"]
 	for _, podman := range []bool{false, true} {
 		podman := podman
 		When("creating nodejs component, doing odo dev and run command has dev.odo.push.path attribute", helper.LabelPodmanIf(podman, func() {
-			// TODO Not implemented yet on Podman
 			var session helper.DevSession
 			var devStarted bool
 			BeforeEach(func() {
-				if podman {
-					Skip("not implemented yet on Podman - see #6492")
-				}
 				helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path",
 					helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-with-remote-attributes.yaml")).ShouldPass()
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)


### PR DESCRIPTION
Co-authored-by: @valaparthvi 

**What type of PR is this:**
/kind feature
/area odo-on-podman

**What does this PR do / why we need it:**
This adds support for command-level attributes prefixed with `dev.odo.push.path:` on Podman. See #6492 and [the doc](https://deploy-preview-6576--odo-docusaurus-preview.netlify.app/docs/user-guides/advanced/pushing-specific-files) for more context.

While working on this issue, we also found out that `odo` was always picking the attributes of the `run` command, regardless of whether users were running in Debug or not. This PR also fixes that behavior, by making sure we pick the right command attributes.

**Which issue(s) this PR fixes:**
Fixes #6492 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-6576--odo-docusaurus-preview.netlify.app/docs/user-guides/advanced/pushing-specific-files) 

**How to test changes / Special notes to the reviewer:**
See https://deploy-preview-6576--odo-docusaurus-preview.netlify.app/docs/user-guides/advanced/pushing-specific-files. This should now work on Podman.