### PR TITLE
Trigger the IBM Cloud Image Workflow on PRs as well

### DIFF
--- a/.github/workflows/build-push-ibm-image.yaml
+++ b/.github/workflows/build-push-ibm-image.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Image
+name: Build and Push IBM Cloud Image
 on:
   push:
     branches:
@@ -6,10 +6,17 @@ on:
     paths:
       - '.ibm/images/Dockerfile'
       - '.github/workflows/build-push-ibm-image.yaml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.ibm/images/Dockerfile'
+      - '.github/workflows/build-push-ibm-image.yaml'
+
 jobs:
   build:
-    name: Build and push image
-    runs-on: ubuntu-20.04
+    name: Build and push IBM Cloud image
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -28,6 +35,7 @@ jobs:
     # in which case 'username' and 'password' can be omitted.
     - name: Push To quay.io
       id: push-to-quay
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
@@ -37,4 +45,5 @@ jobs:
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
     - name: Print image url
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
**What type of PR is this:**
/area testing

**What does this PR do / why we need it:**

For some context, while working on #6586, I wanted to make sure that updating the Go version in the Dockerfile will not break the image (this happened already in the past - see https://github.com/redhat-developer/odo/pull/6166#discussion_r1016623089).
I checked manually but thought it would be nice to have our Workflow check that instead.
So this PR allows us to test that the image can be built successfully on PRs as well.

Pushing the image to the registry is run only upon a push on the `main` branch.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
An example of workflow run on this PR: https://github.com/redhat-developer/odo/actions/runs/4135154988/jobs/7147225272