### PR TITLE
Add preview video of odo on the website home page

### DIFF
--- a/docs/website/src/pages/index.module.css
+++ b/docs/website/src/pages/index.module.css
@@ -46,7 +46,7 @@
 
 /* CSS for features */
 .overview {
-  padding: 80px 0px;
+  padding: 10px 0px;
 }
 
 .overviewAlt {
@@ -75,7 +75,7 @@
   font-weight: 600;
   text-align: center;
   font-size: var(--ifm-h3-font-size);
-  padding: 30px;
+  padding: 20px;
   margin: 0px auto;
 }
 
@@ -91,7 +91,7 @@
 
 .banner {
   background-color: #2b3137;
-  padding: 48px;
+  padding: 38px;
 }
 
 .bannerInner {
@@ -113,7 +113,7 @@
 
 .logo {
   float: right;
-  max-width: 250px;
+  max-width: 200px;
 }
 
 
@@ -123,7 +123,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: 24px;
+  margin-top: 20px;
 }
 
 .indexCtas a {

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -47,7 +47,7 @@ export default function Home(): JSX.Element {
         </div>
         <div className={clsx(styles.title, styles.titleDark)}>
           <div className={styles.titleInner}>
-            Version 3 of odo has just landed 🚀<br></br> <Link to="/docs/overview/installation">Install</Link> and <Link to="/docs/user-guides/quickstart/">try out</Link> our new features ⭐️
+            <Link to="/docs/overview/installation">Install</Link> and <Link to="/docs/user-guides/quickstart/">try out</Link> our features ⭐️
           </div>
         </div>
         <div className={clsx(styles.overview, styles.overviewAlt)}>

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -51,6 +51,9 @@ export default function Home(): JSX.Element {
           </div>
         </div>
         <div className={clsx(styles.overview, styles.overviewAlt)}>
+          <div className="container text--center margin-top--md" style={{marginBottom:'50px'}}>
+            <video className={styles.loopVideo} autoPlay loop muted style={{width:'85%'}}><source src="/video/odo-preview.hd.webm" type="video/webm"/></video>
+          </div>
           <div className="container text--center margin-top--md">
             <div className="row">
               <div className="col col--5 col--offset-1">

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home(): JSX.Element {
   className={styles.logo}
   src={useBaseUrl('/img/logo.png')}
   />
-              <span className={styles.bannerTitleTextHtml}>Fast <b>iterative</b> application <b>development</b> deployed immediately to your <b>kubernetes</b> cluster</span>
+                <span className={styles.bannerTitleTextHtml}>Simplified <b>container</b>-based application <b>development</b></span>
             </h1>
             <div className={styles.indexCtas}>
               <Link className="button button--primary" to="/docs/introduction">


### PR DESCRIPTION
**What type of PR is this:**
/area documentation

**What does this PR do / why we need it:**
This displays a short demo of the main commands on the home page, showcasing a typical inner-loop development workflow.
I've tried to make it short and to the point, so let me know what you think.
To make room for the video, I've also reworded the title to make it shorter and highlight more appealing words like "container". So let me know what you think.

**Which issue(s) this PR fixes:**
Fixes #6524 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] [Documentation](https://deploy-preview-6605--odo-docusaurus-preview.netlify.app/) 

**How to test changes / Special notes to the reviewer:**
https://deploy-preview-6605--odo-docusaurus-preview.netlify.app/

Preview:
![image](https://user-images.githubusercontent.com/593208/219667609-e8eb9b45-1d65-4277-a070-4f860666fa68.png)
