### PR TITLE
Make `bump-version.sh` also update the version in documentation sample outputs

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -34,6 +34,15 @@ echo "* Bumping version in Dockerfile.rhel"
 sed -i "s/\(version=\).*/\1${NEW_VERSION}/g" Dockerfile.rhel
 check_version Dockerfile.rhel
 
+echo "* Bumping version in documentation sample outputs"
+# globstar: allows the '**' to recursively try to find file and directories
+# nullglob: filename patterns that don't match any filenames are expanded to nothing rather than remaining unexpanded.
+shopt -s globstar nullglob
+for file in ./docs/website/docs/**/docs-mdx/**/*.mdx; do
+  sed -i 's/\(odo version: v\).*/\1'"${NEW_VERSION}"'/g' "$file"
+done
+
+echo
 echo "****************************************************************************************"
 echo "* Don't forget to update homebrew package at https://github.com/kadel/homebrew-odo ! *"
 echo "****************************************************************************************"


### PR DESCRIPTION
**What type of PR is this:**

**What does this PR do / why we need it:**
`bump-version.sh` is used whenever we are ready to tag a new version. But now that documentation tests are integrated into the CI jobs (https://github.com/redhat-developer/odo/pull/6521), checks for the new version would not pass straight away, and we would need to manually figure out which files would need to be updated.
This happened in the PR for `v3.7.0`: https://github.com/redhat-developer/odo/pull/6596#issuecomment-1431213837

So this PR is about ensuring the odo version is also updated accordingly in the documentation sample outputs potentially referenced by the Docs tests.

**Which issue(s) this PR fixes:**
Related to  #6192

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Run the script and make sure it updated the relevant `*.mdx` files under `docs/website/docs/**/docs-mdx/**/`.