### PR TITLE
Rename the generated branch for release PRs

### DIFF
--- a/.github/workflows/release-management.yaml
+++ b/.github/workflows/release-management.yaml
@@ -100,8 +100,8 @@ jobs:
       - name: Create and push branch
         id: push_branch
         run: |
-          git switch -c blog_post_${TAG_NAME}
-          git push -u origin blog_post_${TAG_NAME} 
+          git switch -c release_pr_${TAG_NAME}
+          git push -u origin release_pr_${TAG_NAME}
           if git status --porcelain | grep build/VERSION; then
             git add build/VERSION
             git commit -m "Set version in build/VERSION file"


### PR DESCRIPTION
**What type of PR is this:**

**What does this PR do / why we need it:**
This renames the branch backing the generated release PR, from `blog_post_$tagName` to `release_pr_$tagName`, because it contains more than a blog post. This way, it is easier to identify and check out if needed.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
