### PR TITLE
Skip DevfileRegistriesList-related tests on non Kubernetes clusters

### DIFF
--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -579,6 +579,9 @@ var _ = Describe("odo devfile init command tests", func() {
 
 	When("DevfileRegistriesList CRD is installed on cluster", func() {
 		BeforeEach(func() {
+			if !helper.IsKubernetesCluster() {
+				Skip("skipped on non Kubernetes clusters")
+			}
 			devfileRegistriesLists := commonVar.CliRunner.Run("apply", "-f", helper.GetExamplePath("manifests", "devfileregistrieslists.yaml"))
 			Expect(devfileRegistriesLists.ExitCode()).To(BeEquivalentTo(0))
 		})

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -206,6 +206,9 @@ var _ = Describe("odo devfile registry command tests", func() {
 
 	When("DevfileRegistriesList CRD is installed on cluster", func() {
 		BeforeEach(func() {
+			if !helper.IsKubernetesCluster() {
+				Skip("skipped on non Kubernetes clusters")
+			}
 			// install CRDs for devfile registry
 			devfileRegistriesLists := commonVar.CliRunner.Run("apply", "-f", helper.GetExamplePath("manifests", "devfileregistrieslists.yaml"))
 			Expect(devfileRegistriesLists.ExitCode()).To(BeEquivalentTo(0))

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -204,6 +204,9 @@ OdoSettings:
 	}
 	When("DevfileRegistriesList CRD is installed on cluster", func() {
 		BeforeEach(func() {
+			if !helper.IsKubernetesCluster() {
+				Skip("skipped on non Kubernetes clusters")
+			}
 			// install CRDs for devfile registry
 			//TODO: install clusterRegestryList from scripts
 			// clusterRegistryList := commonVar.CliRunner.Run("apply", "-f", helper.GetExamplePath("manifests", "clusterdevfileregistrieslists.yaml"))

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -569,6 +569,9 @@ var _ = Describe("odo init interactive command tests", func() {
 
 	When("DevfileRegistriesList CRD is installed on cluster", func() {
 		BeforeEach(func() {
+			if !helper.IsKubernetesCluster() {
+				Skip("skipped on non Kubernetes clusters")
+			}
 			devfileRegistriesLists := commonVar.CliRunner.Run("apply", "-f", helper.GetExamplePath("manifests", "devfileregistrieslists.yaml"))
 			Expect(devfileRegistriesLists.ExitCode()).To(BeEquivalentTo(0))
 		})


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area testing

**What does this PR do / why we need it:**
On Prow, users do not seem to have permission to install the `DevfileRegistriesList` Custom Resource Definition.

**Which issue(s) this PR fixes:**
Fixes #6637 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
On an OpenShift cluster (with the `oc` client available in the `PATH`), this should pass:
```
unset KUBERNETES && make test-integration-cluster
```