### PR TITLE
Fix error handling when trying to delete remote resources not present in Devfile

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -715,11 +715,11 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 
 			err = a.kubeClient.DeleteDynamicResource(objectToRemove.GetName(), gvr, true)
 			if err != nil {
-				if !kerrors.IsNotFound(err) || !kerrors.IsMethodNotSupported(err) {
+				if !(kerrors.IsNotFound(err) || kerrors.IsMethodNotSupported(err)) {
 					err = fmt.Errorf("unable to delete resource: %s/%s: %s", objectToRemove.GetKind(), objectToRemove.GetName(), err.Error())
 					return
 				}
-				klog.V(1).Infof("Failed to delete resource: %s/%s; resource not found", objectToRemove.GetKind(), objectToRemove.GetName())
+				klog.V(4).Infof("Failed to delete resource: %s/%s; resource not found or method not supported", objectToRemove.GetKind(), objectToRemove.GetName())
 				err = nil
 			}
 		}()

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -692,9 +692,8 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 		resources = append(resources, fmt.Sprintf("%s/%s", u.GetKind(), u.GetName()))
 	}
 
-	spinner := log.Spinnerf("Deleting resources not present in the Devfile: %s", strings.Join(resources, ", "))
-	defer spinner.End(false)
-
+	// Delete the resources present on the cluster but not in the Devfile
+	klog.V(3).Infof("Deleting %d resource(s) not present in the Devfile: %s", len(resources), strings.Join(resources, ", "))
 	g := new(errgroup.Group)
 	for _, objectToRemove := range objectsToRemove {
 		// Avoid re-use of the same `objectToRemove` value in each goroutine closure.
@@ -722,7 +721,6 @@ func (a Adapter) deleteRemoteResources(objectsToRemove []unstructured.Unstructur
 		return err
 	}
 
-	spinner.End(true)
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**
Stumbled upon this issue recently, and found a mistake in the `if` condition used to skip non-deletable resources (like `PodMetrics`). 

We had this previously, which would actually never match:
```go
if !kerrors.IsNotFound(err) || !kerrors.IsMethodNotSupported(err) {
```

After adding some unit tests, I also noticed that the way any error is detected might lead to a race condition: multiple Goroutines are trying to assign a shared error variable, and we are using that to determine the return value.
This is solved by using [`errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup) instead, which looks more appropriate to simplify goroutine error handling.

**Which issue(s) this PR fixes:**
Fixes #6475 

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
