### PR TITLE
Fix issue with conflicting ports when starting multiple Dev sessions on Podman

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -782,12 +782,11 @@ func SafeGetBool(b *bool) bool {
 
 // IsPortFree checks if the port on localhost is free to use
 func IsPortFree(port int) bool {
-	address := fmt.Sprintf("localhost:%d", port)
+	address := fmt.Sprintf("0.0.0.0:%d", port)
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return false
 	}
-	_ = listener.Addr().(*net.TCPAddr).Port
 	err = listener.Close()
 	return err == nil
 }


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area odo-on-podman

**What does this PR do / why we need it:**
Due to regression on 6.1+ kernels [1], binding on 127.0.0.1:$port after some process listens on 0.0.0.0:$port does pass, which is not expected. Until this issue is fixed [2], a possible workaround is to try to bind on 0.0.0.0:$port. This works correctly on Podman, and also on Kubernetes (because we do port-forwarding on Kubernetes on 127.0.0.1:$port).

The unit test added should allow us to detect similar issues faster in the future, should it happen again.

[1] https://lore.kernel.org/stable/e21bf153-80b0-9ec0-15ba-e04a4ad42c34@redhat.com/T/
[2] https://lore.kernel.org/netdev/20230312031904.4674-3-kuniyu@amazon.com/T/

**Which issue(s) this PR fixes:**
Fixes #6612 

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
See the repro steps provided in #6612 
