### PR TITLE
Fix UX issue when exec command fails to run as part of a deploy command

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -192,6 +192,9 @@ func (o *deployHandler) Execute(command v1alpha2.Command) error {
 	// Wait for the command to complete execution
 	_, err = o.kubeClient.WaitForJobToComplete(createdJob)
 	done <- struct{}{}
+
+	spinner.End(err == nil)
+
 	if err != nil {
 		err = fmt.Errorf("failed to execute (command: %s)", command.Id)
 		// Print the job logs if the job failed
@@ -202,8 +205,6 @@ func (o *deployHandler) Execute(command v1alpha2.Command) error {
 		fmt.Println("Execution output:")
 		_ = util.DisplayLog(false, jobLogs, log.GetStderr(), o.componentName, 100)
 	}
-
-	spinner.End(err == nil)
 
 	return err
 }


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area UX
/area deploy

**What does this PR do / why we need it:**
I stumbled upon this issue while reviewing https://github.com/redhat-developer/odo/pull/6672.

Before the changes, the `Execution output:` message was displayed on the same line as the spinner, like so:

```
↪ Executing command:
◓  Executing command in container (command: exec-deploy)Execution output:
/bin/sh: line 1: helm: command not found
 ✗  Executing command in container (command: exec-deploy) [8s]
 ✗  failed to execute (command: exec-deploy)
```

This is now fixed by ending the spinner as soon as the command is done, and then displaying the command output. Example output:

```
↪ Executing command:
 ✗  Executing command in container (command: exec-deploy) [8s]
Execution output:
/bin/sh: line 1: helm: command not found
 ✗  failed to execute (command: exec-deploy)

```


**Which issue(s) this PR fixes:**
Related to https://github.com/redhat-developer/odo/issues/5701

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
