### PR TITLE
Speedup odo registry --details

### DIFF
--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -370,7 +370,7 @@ odo registry -o json
 ]
 ```
 
-Using the `--details` flag, you will also get information about the Devfile:
+Using the `--details` flag with `--devfile <name>`, you will also get information about the Devfile:
 
 ```shell
 odo registry --devfile java-springboot --details -o json

--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -351,7 +351,14 @@ odo registry -o json
         "schemaVersion": "2.1.0",
         "starterProjects": [
           "flask-example"
-        ]
+        ],
+        "commandGroups": {
+            "build": true,
+            "debug": true,
+            "deploy": false,
+            "run": true,
+            "test": false
+        }
       },
       {
         "version": "3.0.0",
@@ -359,7 +366,14 @@ odo registry -o json
         "schemaVersion": "2.2.0",
         "starterProjects": [
           "flask-example"
-        ]
+        ],
+        "commandGroups": {
+            "build": true,
+            "debug": true,
+            "deploy": false,
+            "run": true,
+            "test": false
+        }
       }
     ],
     "starterProjects": [
@@ -400,7 +414,14 @@ odo registry --devfile java-springboot --details -o json
         "schemaVersion": "2.1.0",
         "starterProjects": [
           "springbootproject"
-        ]
+        ],
+        "commandGroups": {
+            "build": true,
+            "debug": true,
+            "deploy": false,
+            "run": true,
+            "test": false
+        }
       },
       {
         "version": "2.0.0",
@@ -408,7 +429,14 @@ odo registry --devfile java-springboot --details -o json
         "schemaVersion": "2.2.0",
         "starterProjects": [
           "springbootproject"
-        ]
+        ],
+        "commandGroups": {
+            "build": true,
+            "debug": true,
+            "deploy": true,
+            "run": true,
+            "test": false
+        }
       }
     ],
     "starterProjects": [

--- a/docs/website/docs/command-reference/registry.md
+++ b/docs/website/docs/command-reference/registry.md
@@ -22,7 +22,7 @@ By default, the name, registry, description and versions of the Devfile stacks a
 
 The flags below let you change the content of the output:
 
-* `--details` to display details about the Devfile stacks
+* `--details` to display details about a specific Devfile stack (to be used only with `--devfile <name>`)
 * `-o json` to output the information in a JSON format
 
 ## Running the command

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/devfile/api/v2 v2.2.0
 	github.com/devfile/library/v2 v2.2.1-0.20230323124903-d36e409ff94f
-	github.com/devfile/registry-support/index/generator v0.0.0-20221018203505-df96d34d4273
+	github.com/devfile/registry-support/index/generator v0.0.0-20230322155332-33914affc83b
 	github.com/devfile/registry-support/registry-library v0.0.0-20221201200738-19293ac0b8ab
 	github.com/fatih/color v1.14.1
 	github.com/frapposelli/wwhrd v0.4.0
@@ -130,6 +130,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.4.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
@@ -142,12 +143,14 @@ require (
 	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/moby/buildkit v0.10.6 // indirect
 	github.com/moby/locker v1.0.1 // indirect
@@ -162,6 +165,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/openshift/library-go v0.0.0-20220210170159-18f172cff934 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -175,7 +179,11 @@ require (
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/viper v1.8.1 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
@@ -197,6 +205,7 @@ require (
 	google.golang.org/grpc v1.49.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -396,6 +396,8 @@ github.com/devfile/registry-support/index/generator v0.0.0-20220222194908-7a90a4
 github.com/devfile/registry-support/index/generator v0.0.0-20220527155645-8328a8a883be/go.mod h1:1fyDJL+fPHtcrYA6yjSVWeLmXmjCNth0d5Rq1rvtryc=
 github.com/devfile/registry-support/index/generator v0.0.0-20221018203505-df96d34d4273 h1:DXENQSRTEDsk9com38njPg5511DD12HPIgzyFUErnpM=
 github.com/devfile/registry-support/index/generator v0.0.0-20221018203505-df96d34d4273/go.mod h1:ZJnaSLjTKCvGJhWmYgQoQ1O3g78qBe4Va6ZugLmi4dE=
+github.com/devfile/registry-support/index/generator v0.0.0-20230322155332-33914affc83b h1:IhZQnmff1ntrzplcM10/mj7H3X6E4NA3+paxD4HXfzc=
+github.com/devfile/registry-support/index/generator v0.0.0-20230322155332-33914affc83b/go.mod h1:ZJnaSLjTKCvGJhWmYgQoQ1O3g78qBe4Va6ZugLmi4dE=
 github.com/devfile/registry-support/registry-library v0.0.0-20220627163229-4aa39fcb0c0a/go.mod h1:kmEjH5oO465vh36kcYdZLYeG8edVD6N/ZgzyLs1x7qs=
 github.com/devfile/registry-support/registry-library v0.0.0-20221018213054-47b3ffaeadba/go.mod h1:NOtmnbozFn15w/DPD/Urc+KDlNRP4JH5m+KC5GZoAWA=
 github.com/devfile/registry-support/registry-library v0.0.0-20221201200738-19293ac0b8ab h1:MBZdywPNNDf1f7V+plOOHqAiaY/C+IELrI4Rfdq78e4=
@@ -791,6 +793,7 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -890,6 +893,7 @@ github.com/lucasb-eyer/go-colorful v0.0.0-20180526135729-345fbb3dbcdb/go.mod h1:
 github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -944,6 +948,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
@@ -1092,6 +1097,8 @@ github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
+github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721/go.mod h1:jQyRpOpE/KbvPc0VKXjAqctYglwUO5W6zAcGcFfbvlo=
@@ -1217,6 +1224,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -1231,6 +1239,7 @@ github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1242,6 +1251,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
@@ -1266,6 +1276,7 @@ github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -2026,6 +2037,7 @@ gopkg.in/imdario/mergo.v0 v0.3.7/go.mod h1:9qPP6AGrlC1G2PTNXko614FwGZvorN7MiBU0E
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473/go.mod h1:N1eN2tsCx0Ydtgjl4cqmbRCsY4/+z4cYDeqwZTk6zog=

--- a/pkg/alizer/alizer.go
+++ b/pkg/alizer/alizer.go
@@ -31,7 +31,7 @@ func NewAlizerClient(registryClient registry.Client) *Alizer {
 // to use depending on the files in the path
 func (o *Alizer) DetectFramework(ctx context.Context, path string) (_ model.DevFileType, defaultVersion string, _ api.Registry, _ error) {
 	types := []model.DevFileType{}
-	components, err := o.registryClient.ListDevfileStacks(ctx, "", "", "", false)
+	components, err := o.registryClient.ListDevfileStacks(ctx, "", "", "", false, false)
 	if err != nil {
 		return model.DevFileType{}, defaultVersion, api.Registry{}, err
 	}

--- a/pkg/alizer/alizer_test.go
+++ b/pkg/alizer/alizer_test.go
@@ -116,7 +116,7 @@ func TestDetectFramework(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			registryClient := registry.NewMockClient(ctrl)
 			ctx := context.Background()
-			registryClient.EXPECT().ListDevfileStacks(ctx, "", "", "", false).Return(list, nil)
+			registryClient.EXPECT().ListDevfileStacks(ctx, "", "", "", false, false).Return(list, nil)
 			alizerClient := NewAlizerClient(registryClient)
 			// Run function DetectFramework
 			detected, _, registry, err := alizerClient.DetectFramework(ctx, tt.args.path)

--- a/pkg/api/registry.go
+++ b/pkg/api/registry.go
@@ -36,9 +36,9 @@ type DevfileStack struct {
 }
 
 type DevfileStackVersion struct {
-	Version         string   `json:"version,omitempty"`
-	IsDefault       bool     `json:"isDefault"`
-	SchemaVersion   string   `json:"schemaVersion,omitempty"`
-	StarterProjects []string `json:"starterProjects"`
-	CommandGroups   map[schema.CommandGroupKind]bool
+	Version         string                           `json:"version,omitempty"`
+	IsDefault       bool                             `json:"isDefault"`
+	SchemaVersion   string                           `json:"schemaVersion,omitempty"`
+	StarterProjects []string                         `json:"starterProjects"`
+	CommandGroups   map[schema.CommandGroupKind]bool `json:"commandGroups"`
 }

--- a/pkg/api/registry.go
+++ b/pkg/api/registry.go
@@ -1,5 +1,9 @@
 package api
 
+import (
+	schema "github.com/devfile/registry-support/index/generator/schema"
+)
+
 // Registry is the main struct of devfile registry
 type Registry struct {
 	Name   string `json:"name"`
@@ -36,4 +40,5 @@ type DevfileStackVersion struct {
 	IsDefault       bool     `json:"isDefault"`
 	SchemaVersion   string   `json:"schemaVersion,omitempty"`
 	StarterProjects []string `json:"starterProjects"`
+	CommandGroups   map[schema.CommandGroupKind]bool
 }

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -51,7 +51,7 @@ func (o *InteractiveBackend) Validate(flags map[string]string, fs filesystem.Fil
 
 func (o *InteractiveBackend) SelectDevfile(ctx context.Context, flags map[string]string, _ filesystem.Filesystem, _ string) (*api.DetectionResult, error) {
 	result := &api.DetectionResult{}
-	devfileEntries, _ := o.registryClient.ListDevfileStacks(ctx, "", "", "", false)
+	devfileEntries, _ := o.registryClient.ListDevfileStacks(ctx, "", "", "", false, false)
 
 	langs := devfileEntries.GetLanguages()
 	state := STATE_ASK_LANG

--- a/pkg/init/backend/interactive_test.go
+++ b/pkg/init/backend/interactive_test.go
@@ -47,7 +47,7 @@ func TestInteractiveBackend_SelectDevfile(t *testing.T) {
 				},
 				buildCatalogClient: func(ctrl *gomock.Controller) registry.Client {
 					client := registry.NewMockClient(ctrl)
-					client.EXPECT().ListDevfileStacks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+					client.EXPECT().ListDevfileStacks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 					return client
 				},
 			},
@@ -74,7 +74,7 @@ func TestInteractiveBackend_SelectDevfile(t *testing.T) {
 				},
 				buildCatalogClient: func(ctrl *gomock.Controller) registry.Client {
 					client := registry.NewMockClient(ctrl)
-					client.EXPECT().ListDevfileStacks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+					client.EXPECT().ListDevfileStacks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 					return client
 				},
 			},

--- a/pkg/odo/cli/registry/registry.go
+++ b/pkg/odo/cli/registry/registry.go
@@ -217,7 +217,7 @@ func (o *ListOptions) printDevfileList(DevfileList []api.DevfileStack) {
 				log.Sbold("Tags"), strings.Join(devfileComponent.Tags[:], ", "),
 				log.Sbold("Project Type"), devfileComponent.ProjectType,
 				log.Sbold("Language"), devfileComponent.Language,
-				log.Sbold("Starter Projects"), strings.Join(devfileComponent.DefaultStarterProjects, "\n  - "),
+				log.Sbold("Starter Projects"), strings.Join(defaultVersionDetails.StarterProjects, "\n  - "),
 				log.Sbold("Supported odo Features"),
 				boolToYesNo(devfileComponent.DevfileData.SupportedOdoFeatures.Dev),
 				boolToYesNo(devfileComponent.DevfileData.SupportedOdoFeatures.Deploy),

--- a/pkg/odo/cli/registry/registry.go
+++ b/pkg/odo/cli/registry/registry.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -272,5 +271,5 @@ func getVersion(stack api.DevfileStack, v string) (api.DevfileStackVersion, erro
 			return version, nil
 		}
 	}
-	return api.DevfileStackVersion{}, errors.New("version not found")
+	return api.DevfileStackVersion{}, fmt.Errorf("version %q not found in Devfile stack for %q", v, stack.Name)
 }

--- a/pkg/odo/cli/registry/registry.go
+++ b/pkg/odo/cli/registry/registry.go
@@ -32,8 +32,8 @@ var Example = `  # Get all devfile components
 # Filter by name and devfile registry
 %[1]s --filter nodejs --devfile-registry DefaultDevfileRegistry
 
-# Show more details
-%[1]s --details
+# Show more details from a specific devfile
+%[1]s --details --devfile nodejs
 
 # Show more details from a specific devfile and registry
 %[1]s --details --devfile nodejs --devfile-registry DefaultDevfileRegistry`
@@ -120,7 +120,7 @@ func NewCmdRegistry(name, fullName string) *cobra.Command {
 	listCmd.Flags().StringVar(&o.filterFlag, "filter", "", "Filter based on the name or description of the component")
 	listCmd.Flags().StringVar(&o.devfileFlag, "devfile", "", "Only the specific Devfile component")
 	listCmd.Flags().StringVar(&o.registryFlag, "devfile-registry", "", "Only show components from the specific Devfile registry")
-	listCmd.Flags().BoolVar(&o.detailsFlag, "details", false, "Show details of each component")
+	listCmd.Flags().BoolVar(&o.detailsFlag, "details", false, "Show details of a Devfile, to be used only with --devfile")
 
 	// Add a defined annotation in order to appear in the help menu
 	odoutil.SetCommandGroup(listCmd, odoutil.MainGroup)

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -15,5 +15,5 @@ type Client interface {
 	DownloadFileInMemory(params dfutil.HTTPRequestParams) ([]byte, error)
 	DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedToken string, contextDir string, verbose bool) error
 	GetDevfileRegistries(registryName string) ([]api.Registry, error)
-	ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag bool) (DevfileStackList, error)
+	ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag bool, withDevfileContent bool) (DevfileStackList, error)
 }

--- a/pkg/registry/mock.go
+++ b/pkg/registry/mock.go
@@ -83,18 +83,18 @@ func (mr *MockClientMockRecorder) GetDevfileRegistries(registryName interface{})
 }
 
 // ListDevfileStacks mocks base method.
-func (m *MockClient) ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag bool) (DevfileStackList, error) {
+func (m *MockClient) ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag, jsonOutput bool) (DevfileStackList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDevfileStacks", ctx, registryName, devfileFlag, filterFlag, detailsFlag)
+	ret := m.ctrl.Call(m, "ListDevfileStacks", ctx, registryName, devfileFlag, filterFlag, detailsFlag, jsonOutput)
 	ret0, _ := ret[0].(DevfileStackList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDevfileStacks indicates an expected call of ListDevfileStacks.
-func (mr *MockClientMockRecorder) ListDevfileStacks(ctx, registryName, devfileFlag, filterFlag, detailsFlag interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListDevfileStacks(ctx, registryName, devfileFlag, filterFlag, detailsFlag, jsonOutput interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDevfileStacks", reflect.TypeOf((*MockClient)(nil).ListDevfileStacks), ctx, registryName, devfileFlag, filterFlag, detailsFlag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDevfileStacks", reflect.TypeOf((*MockClient)(nil).ListDevfileStacks), ctx, registryName, devfileFlag, filterFlag, detailsFlag, jsonOutput)
 }
 
 // PullStackFromRegistry mocks base method.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +13,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -344,7 +345,7 @@ func TestListDevfileStacks(t *testing.T) {
 			catClient := NewRegistryClient(filesystem.NewFakeFs(), prefClient, nil)
 			ctx := context.Background()
 			ctx = envcontext.WithEnvConfig(ctx, config.Configuration{})
-			got, err := catClient.ListDevfileStacks(ctx, tt.registryName, tt.devfileName, tt.filter, false)
+			got, err := catClient.ListDevfileStacks(ctx, tt.registryName, tt.devfileName, tt.filter, false, false)
 			if err != nil {
 				t.Error(err)
 			}

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -96,6 +96,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 					helper.JsonPathContentContain(stdout, "0.projectType", "Node.js")
 					helper.JsonPathContentContain(stdout, "0.devfileData.devfile.metadata.name", "nodejs")
 					helper.JsonPathContentContain(stdout, "0.devfileData.supportedOdoFeatures.dev", "true")
+					helper.JsonPathContentContain(stdout, "0.versions.0.CommandGroups.run", "true")
 
 					defaultVersion := gjson.Get(stdout, "0.version").String()
 					By("returning backward-compatible information linked to the default stack version", func() {
@@ -277,6 +278,7 @@ spec:
 					helper.JsonPathContentContain(stdout, "0.projectType", "Node.js")
 					helper.JsonPathContentContain(stdout, "0.devfileData.devfile.metadata.name", "nodejs")
 					helper.JsonPathContentContain(stdout, "0.devfileData.supportedOdoFeatures.dev", "true")
+					helper.JsonPathContentContain(stdout, "0.versions.0.CommandGroups.run", "true")
 
 					defaultVersion := gjson.Get(stdout, "0.version").String()
 					By("returning backward-compatible information linked to the default stack version", func() {

--- a/tests/integration/cmd_devfile_registry_test.go
+++ b/tests/integration/cmd_devfile_registry_test.go
@@ -96,7 +96,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 					helper.JsonPathContentContain(stdout, "0.projectType", "Node.js")
 					helper.JsonPathContentContain(stdout, "0.devfileData.devfile.metadata.name", "nodejs")
 					helper.JsonPathContentContain(stdout, "0.devfileData.supportedOdoFeatures.dev", "true")
-					helper.JsonPathContentContain(stdout, "0.versions.0.CommandGroups.run", "true")
+					helper.JsonPathContentContain(stdout, "0.versions.0.commandGroups.run", "true")
 
 					defaultVersion := gjson.Get(stdout, "0.version").String()
 					By("returning backward-compatible information linked to the default stack version", func() {
@@ -278,7 +278,7 @@ spec:
 					helper.JsonPathContentContain(stdout, "0.projectType", "Node.js")
 					helper.JsonPathContentContain(stdout, "0.devfileData.devfile.metadata.name", "nodejs")
 					helper.JsonPathContentContain(stdout, "0.devfileData.supportedOdoFeatures.dev", "true")
-					helper.JsonPathContentContain(stdout, "0.versions.0.CommandGroups.run", "true")
+					helper.JsonPathContentContain(stdout, "0.versions.0.commandGroups.run", "true")
 
 					defaultVersion := gjson.Get(stdout, "0.version").String()
 					By("returning backward-compatible information linked to the default stack version", func() {

--- a/vendor/github.com/devfile/registry-support/index/generator/schema/schema.go
+++ b/vendor/github.com/devfile/registry-support/index/generator/schema/schema.go
@@ -98,6 +98,13 @@ Sample index file:
         "resources": [
           "devfile.yaml"
         ],
+		"commandGroups": {
+		  "build": true,
+		  "run": true,
+		  "test": false,
+		  "debug": false,
+		  "deploy": false
+		},
         "starterProjects": [
           "community",
           "redhat-product"
@@ -122,6 +129,7 @@ globalMemoryLimit: string - The devfile global memory limit
 projectType: string - The project framework that is used in the devfile
 language: string - The project language that is used in the devfile
 links: map[string]string - Links related to the devfile
+commandGroups: map[CommandGroupKind]bool - The command groups that are used in the devfile
 resources: []string - The file resources that compose a devfile stack.
 starterProjects: string[] - The project templates that can be used in the devfile
 git: *git - The information of remote repositories
@@ -131,25 +139,26 @@ versions: []Version - The list of stack versions information
 
 // Schema is the index file schema
 type Schema struct {
-	Name              string                 `yaml:"name,omitempty" json:"name,omitempty"`
-	Version           string                 `yaml:"version,omitempty" json:"version,omitempty"`
-	Attributes        map[string]apiext.JSON `yaml:"attributes,omitempty" json:"attributes,omitempty"`
-	DisplayName       string                 `yaml:"displayName,omitempty" json:"displayName,omitempty"`
-	Description       string                 `yaml:"description,omitempty" json:"description,omitempty"`
-	Type              DevfileType            `yaml:"type,omitempty" json:"type,omitempty"`
-	Tags              []string               `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Architectures     []string               `yaml:"architectures,omitempty" json:"architectures,omitempty"`
-	Icon              string                 `yaml:"icon,omitempty" json:"icon,omitempty"`
-	GlobalMemoryLimit string                 `yaml:"globalMemoryLimit,omitempty" json:"globalMemoryLimit,omitempty"`
-	ProjectType       string                 `yaml:"projectType,omitempty" json:"projectType,omitempty"`
-	Language          string                 `yaml:"language,omitempty" json:"language,omitempty"`
-	Links             map[string]string      `yaml:"links,omitempty" json:"links,omitempty"`
-	Resources         []string               `yaml:"resources,omitempty" json:"resources,omitempty"`
-	StarterProjects   []string               `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
-	Git               *Git                   `yaml:"git,omitempty" json:"git,omitempty"`
-	Provider          string                 `yaml:"provider,omitempty" json:"provider,omitempty"`
-	SupportUrl        string                 `yaml:"supportUrl,omitempty" json:"supportUrl,omitempty"`
-	Versions          []Version              `yaml:"versions,omitempty" json:"versions,omitempty"`
+	Name              string                    `yaml:"name,omitempty" json:"name,omitempty"`
+	Version           string                    `yaml:"version,omitempty" json:"version,omitempty"`
+	Attributes        map[string]apiext.JSON    `yaml:"attributes,omitempty" json:"attributes,omitempty"`
+	DisplayName       string                    `yaml:"displayName,omitempty" json:"displayName,omitempty"`
+	Description       string                    `yaml:"description,omitempty" json:"description,omitempty"`
+	Type              DevfileType               `yaml:"type,omitempty" json:"type,omitempty"`
+	Tags              []string                  `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Architectures     []string                  `yaml:"architectures,omitempty" json:"architectures,omitempty"`
+	Icon              string                    `yaml:"icon,omitempty" json:"icon,omitempty"`
+	GlobalMemoryLimit string                    `yaml:"globalMemoryLimit,omitempty" json:"globalMemoryLimit,omitempty"`
+	ProjectType       string                    `yaml:"projectType,omitempty" json:"projectType,omitempty"`
+	Language          string                    `yaml:"language,omitempty" json:"language,omitempty"`
+	Links             map[string]string         `yaml:"links,omitempty" json:"links,omitempty"`
+	CommandGroups     map[CommandGroupKind]bool `yaml:"commandGroups,omitempty" json:"commandGroups,omitempty"`
+	Resources         []string                  `yaml:"resources,omitempty" json:"resources,omitempty"`
+	StarterProjects   []string                  `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	Git               *Git                      `yaml:"git,omitempty" json:"git,omitempty"`
+	Provider          string                    `yaml:"provider,omitempty" json:"provider,omitempty"`
+	SupportUrl        string                    `yaml:"supportUrl,omitempty" json:"supportUrl,omitempty"`
+	Versions          []Version                 `yaml:"versions,omitempty" json:"versions,omitempty"`
 }
 
 // DevfileType describes the type of devfile
@@ -163,15 +172,46 @@ const (
 	StackDevfileType DevfileType = "stack"
 )
 
+// CommandGroupKind describes the kind of command group
+type CommandGroupKind string
+
+const (
+	BuildCommandGroupKind  CommandGroupKind = "build"
+	RunCommandGroupKind    CommandGroupKind = "run"
+	TestCommandGroupKind   CommandGroupKind = "test"
+	DebugCommandGroupKind  CommandGroupKind = "debug"
+	DeployCommandGroupKind CommandGroupKind = "deploy"
+)
+
 // StarterProject is the devfile starter project
 type StarterProject struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+// Commands stores the command information
+type Commands struct {
+	Id        string      `yaml:"id,omitempty" json:"id,omitempty"`
+	Exec      CommandType `yaml:"exec,omitempty" json:"exec,omitempty"`
+	Apply     CommandType `yaml:"apply,omitempty" json:"apply,omitempty"`
+	Composite CommandType `yaml:"composite,omitempty" json:"composite,omitempty"`
+}
+
+// CommandType stores the group for a command
+type CommandType struct {
+	Group CommandGroup `yaml:"group,omitempty" json:"group,omitempty"`
+}
+
+// CommandGroup stores the group information for a command
+type CommandGroup struct {
+	Kind      CommandGroupKind `yaml:"kind,omitempty" json:"kind,omitempty"`
+	IsDefault bool             `yaml:"isDefault,omitempty" json:"isDefault,omitempty"`
 }
 
 // Devfile is the devfile structure that is used by index component
 type Devfile struct {
 	Meta            Schema           `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 	StarterProjects []StarterProject `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	Commands        []Commands       `yaml:"commands,omitempty" json:"commands,omitempty"`
 	SchemaVersion   string           `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
 }
 
@@ -190,7 +230,7 @@ type ExtraDevfileEntries struct {
 	Stacks  []Schema `yaml:"stacks,omitempty" json:"stacks,omitempty"`
 }
 
-// Version stores the top-level stack information defined within stack.yaml
+// StackInfo stores the top-level stack information defined within stack.yaml
 type StackInfo struct {
 	Name        string    `yaml:"name,omitempty" json:"name,omitempty"`
 	DisplayName string    `yaml:"displayName,omitempty" json:"displayName,omitempty"`
@@ -201,15 +241,16 @@ type StackInfo struct {
 
 // Version stores the information for each stack version
 type Version struct {
-	Version         string            `yaml:"version,omitempty" json:"version,omitempty"`
-	SchemaVersion   string            `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
-	Default         bool              `yaml:"default,omitempty" json:"default,omitempty"`
-	Git             *Git              `yaml:"git,omitempty" json:"git,omitempty"`
-	Description     string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Tags            []string          `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Architectures   []string          `yaml:"architectures,omitempty" json:"architectures,omitempty"`
-	Icon            string            `yaml:"icon,omitempty" json:"icon,omitempty"`
-	Links           map[string]string `yaml:"links,omitempty" json:"links,omitempty"`
-	Resources       []string          `yaml:"resources,omitempty" json:"resources,omitempty"`
-	StarterProjects []string          `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	Version         string                    `yaml:"version,omitempty" json:"version,omitempty"`
+	SchemaVersion   string                    `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
+	Default         bool                      `yaml:"default,omitempty" json:"default,omitempty"`
+	Git             *Git                      `yaml:"git,omitempty" json:"git,omitempty"`
+	Description     string                    `yaml:"description,omitempty" json:"description,omitempty"`
+	Tags            []string                  `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Architectures   []string                  `yaml:"architectures,omitempty" json:"architectures,omitempty"`
+	Icon            string                    `yaml:"icon,omitempty" json:"icon,omitempty"`
+	Links           map[string]string         `yaml:"links,omitempty" json:"links,omitempty"`
+	CommandGroups   map[CommandGroupKind]bool `yaml:"commandGroups,omitempty" json:"commandGroups,omitempty"`
+	Resources       []string                  `yaml:"resources,omitempty" json:"resources,omitempty"`
+	StarterProjects []string                  `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -162,7 +162,7 @@ github.com/devfile/library/v2/pkg/devfile/validate
 github.com/devfile/library/v2/pkg/testingutil
 github.com/devfile/library/v2/pkg/testingutil/filesystem
 github.com/devfile/library/v2/pkg/util
-# github.com/devfile/registry-support/index/generator v0.0.0-20221018203505-df96d34d4273
+# github.com/devfile/registry-support/index/generator v0.0.0-20230322155332-33914affc83b
 ## explicit; go 1.14
 github.com/devfile/registry-support/index/generator/schema
 # github.com/devfile/registry-support/registry-library v0.0.0-20221201200738-19293ac0b8ab
@@ -428,6 +428,8 @@ github.com/hashicorp/go-multierror
 # github.com/hashicorp/go-version v1.4.0
 ## explicit
 github.com/hashicorp/go-version
+# github.com/hashicorp/hcl v1.0.0
+## explicit
 # github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 ## explicit; go 1.14
 # github.com/imdario/mergo v0.3.13
@@ -485,6 +487,8 @@ github.com/kubernetes-sigs/service-catalog/pkg/filter
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
+# github.com/magiconair/properties v1.8.5
+## explicit; go 1.13
 # github.com/mailru/easyjson v0.7.7
 ## explicit; go 1.12
 github.com/mailru/easyjson/buffer
@@ -508,6 +512,8 @@ github.com/mgutz/ansi
 # github.com/mitchellh/go-wordwrap v1.0.0
 ## explicit
 github.com/mitchellh/go-wordwrap
+# github.com/mitchellh/mapstructure v1.4.1
+## explicit; go 1.14
 # github.com/mitchellh/reflectwalk v1.0.1
 ## explicit
 github.com/mitchellh/reflectwalk
@@ -674,6 +680,8 @@ github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientse
 # github.com/pborman/uuid v1.2.1
 ## explicit
 github.com/pborman/uuid
+# github.com/pelletier/go-toml v1.9.4
+## explicit; go 1.12
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 ## explicit
 github.com/peterbourgon/diskv
@@ -789,16 +797,24 @@ github.com/skeema/knownhosts
 ## explicit; go 1.13
 github.com/spf13/afero
 github.com/spf13/afero/mem
+# github.com/spf13/cast v1.3.1
+## explicit
 # github.com/spf13/cobra v1.6.1
 ## explicit; go 1.15
 github.com/spf13/cobra
+# github.com/spf13/jwalterweatherman v1.1.0
+## explicit
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
+# github.com/spf13/viper v1.8.1
+## explicit; go 1.12
 # github.com/stretchr/testify v1.8.1
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
+# github.com/subosito/gotenv v1.2.0
+## explicit
 # github.com/tidwall/gjson v1.14.4
 ## explicit; go 1.12
 github.com/tidwall/gjson
@@ -998,6 +1014,8 @@ gopkg.in/AlecAivazis/survey.v1/terminal
 # gopkg.in/inf.v0 v0.9.1
 ## explicit
 gopkg.in/inf.v0
+# gopkg.in/ini.v1 v1.62.0
+## explicit
 # gopkg.in/segmentio/analytics-go.v3 v3.0.0-00010101000000-000000000000 => github.com/segmentio/analytics-go/v3 v3.2.1
 ## explicit; go 1.17
 gopkg.in/segmentio/analytics-go.v3


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

- `odo registry --details -o json` continues to make new calls to get Devfile content for all stacks of registries (to not break plugin compatibility). **This command will be deprecated**, as `--details` flag was not intended to be used without `--devfile` flag.
- `odo registry --details --devfile "name" -o json` continues to make a new call to get the "name" Devfile content (to not break plugin compatibility).
- `odo registry --details` do not make anymore new calls to get Devfile content for all stacks of registries. **This command will be deprecated**, as `--details` flag was not intended to be used without `--devfile` flag.
- `odo registry --details --devfile "name"` do not make anymore a new call to get the "name" Devfile content.


**Which issue(s) this PR fixes:**

Fixes #6401 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
