### PR TITLE
Fix: `odo init` does not ask for starter project if the Devfile stack contains extra files

### DIFF
--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -208,14 +208,10 @@ func (o *InitClient) downloadFromRegistry(ctx context.Context, registryName stri
 }
 
 // SelectStarterProject calls SelectStarterProject methods of the adequate backend
-func (o *InitClient) SelectStarterProject(devfile parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (*v1alpha2.StarterProject, error) {
+func (o *InitClient) SelectStarterProject(devfile parser.DevfileObj, flags map[string]string, isEmptyDir bool) (*v1alpha2.StarterProject, error) {
 	var backend backend.InitBackend
 
-	onlyDevfile, err := location.DirContainsOnlyDevfile(fs, dir)
-	if err != nil {
-		return nil, err
-	}
-	if onlyDevfile && len(flags) == 0 {
+	if isEmptyDir && len(flags) == 0 {
 		backend = o.interactiveBackend
 	} else if len(flags) == 0 {
 		backend = o.alizerBackend

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -45,7 +45,7 @@ type Client interface {
 
 	// SelectStarterProject selects a starter project from the devfile and returns information about the starter project,
 	// depending on the flags. If not starter project is selected, a nil starter is returned
-	SelectStarterProject(devfile parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (*v1alpha2.StarterProject, error)
+	SelectStarterProject(devfile parser.DevfileObj, flags map[string]string, isEmptyDir bool) (*v1alpha2.StarterProject, error)
 
 	// DownloadStarterProject downloads the starter project referenced in devfile and stores it in dest directory
 	// WARNING: This will first remove all the content of dest.

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -173,18 +173,18 @@ func (mr *MockClientMockRecorder) SelectDevfile(ctx, flags, fs, dir interface{})
 }
 
 // SelectStarterProject mocks base method.
-func (m *MockClient) SelectStarterProject(devfile parser.DevfileObj, flags map[string]string, fs filesystem.Filesystem, dir string) (*v1alpha2.StarterProject, error) {
+func (m *MockClient) SelectStarterProject(devfile parser.DevfileObj, flags map[string]string, isEmptyDir bool) (*v1alpha2.StarterProject, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectStarterProject", devfile, flags, fs, dir)
+	ret := m.ctrl.Call(m, "SelectStarterProject", devfile, flags, isEmptyDir)
 	ret0, _ := ret[0].(*v1alpha2.StarterProject)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SelectStarterProject indicates an expected call of SelectStarterProject.
-func (mr *MockClientMockRecorder) SelectStarterProject(devfile, flags, fs, dir interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) SelectStarterProject(devfile, flags, isEmptyDir interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectStarterProject", reflect.TypeOf((*MockClient)(nil).SelectStarterProject), devfile, flags, fs, dir)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectStarterProject", reflect.TypeOf((*MockClient)(nil).SelectStarterProject), devfile, flags, isEmptyDir)
 }
 
 // Validate mocks base method.

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -213,7 +213,7 @@ func (o *InitOptions) run(ctx context.Context) (devfileObj parser.DevfileObj, pa
 		return parser.DevfileObj{}, "", "", nil, nil, err
 	}
 
-	starterInfo, err = o.clientset.InitClient.SelectStarterProject(devfileObj, o.flags, o.clientset.FS, workingDir)
+	starterInfo, err = o.clientset.InitClient.SelectStarterProject(devfileObj, o.flags, isEmptyDir)
 	if err != nil {
 		return parser.DevfileObj{}, "", "", nil, nil, err
 	}

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -193,6 +193,41 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 			})
 
+			It("should ask to download the starter project when the devfile stack has extra files", func() {
+				command := []string{"odo", "init"}
+				starter := "go-starter"
+				componentName := "my-go-app"
+				devfileVersion := "2.0.0"
+
+				output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
+
+					helper.ExpectString(ctx, "Select language")
+					helper.SendLine(ctx, "Go")
+
+					helper.ExpectString(ctx, "Select project type")
+					helper.SendLine(ctx, "")
+
+					helper.ExpectString(ctx, "Select version")
+					helper.SendLine(ctx, devfileVersion)
+
+					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+					helper.SendLine(ctx, "")
+
+					helper.ExpectString(ctx, "Which starter project do you want to use")
+					helper.SendLine(ctx, starter)
+
+					helper.ExpectString(ctx, "Enter component name")
+					helper.SendLine(ctx, componentName)
+
+					helper.ExpectString(ctx, "Your new component 'my-go-app' is ready in the current directory")
+
+				})
+
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("Your new component 'my-go-app' is ready in the current directory"))
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml", "kubernetes", "docker", "go.mod", "main.go"))
+			})
+
 			It("should download correct devfile-starter", func() {
 
 				command := []string{"odo", "init"}


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #6638 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `odo init` in interactive mode from an empty dir and select latest Go/Java Springboot/Python devfile that has extra stack files. Ensure that you are asked to select a starter project.