### PR TITLE
odo dev/deploy should display a warning about default namespace on cluster

### DIFF
--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -63,6 +63,8 @@ func (o *DeployOptions) Validate(ctx context.Context) error {
 	if devfileObj == nil {
 		return genericclioptions.NewNoDevfileError(odocontext.GetWorkingDirectory(ctx))
 	}
+
+	genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
 	componentName := odocontext.GetComponentName(ctx)
 	err := dfutil.ValidateK8sResourceName("component name", componentName)
 	return err

--- a/pkg/odo/cli/deploy/deploy.go
+++ b/pkg/odo/cli/deploy/deploy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	dfutil "github.com/devfile/library/v2/pkg/util"
+	"github.com/redhat-developer/odo/pkg/kclient"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/log"
@@ -63,8 +64,9 @@ func (o *DeployOptions) Validate(ctx context.Context) error {
 	if devfileObj == nil {
 		return genericclioptions.NewNoDevfileError(odocontext.GetWorkingDirectory(ctx))
 	}
-
-	genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
+	if o.clientset.KubernetesClient == nil {
+		return kclient.NewNoConnectionError()
+	}
 	componentName := odocontext.GetComponentName(ctx)
 	err := dfutil.ValidateK8sResourceName("component name", componentName)
 	return err
@@ -86,6 +88,8 @@ func (o *DeployOptions) Run(ctx context.Context) error {
 	log.Title("Running the application in Deploy mode using "+devfileName+" Devfile",
 		"Namespace: "+namespace,
 		"odo version: "+version.VERSION)
+
+	genericclioptions.WarnIfDefaultNamespace(namespace, o.clientset.KubernetesClient)
 
 	// Run actual deploy command to be used
 	err := o.clientset.DeployClient.Deploy(ctx)

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -118,7 +118,6 @@ func (o *DevOptions) Validate(ctx context.Context) error {
 			return kclient.NewNoConnectionError()
 		}
 		scontext.SetPlatform(ctx, o.clientset.KubernetesClient)
-		genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
 	case commonflags.PlatformPodman:
 		if o.ignoreLocalhostFlag && o.forwardLocalhostFlag {
 			return errors.New("--ignore-localhost and --forward-localhost cannot be used together")
@@ -158,6 +157,8 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 	log.Title("Developing using the \""+componentName+"\" Devfile",
 		dest,
 		"odo version: "+version.VERSION)
+
+	genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
 
 	// check for .gitignore file and add odo-file-index.json to .gitignore.
 	// In case the .gitignore was created by odo, it is purposely not reported as candidate for deletion (via a call to files.ReportLocalFileGeneratedByOdo)

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -157,9 +157,9 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 	log.Title("Developing using the \""+componentName+"\" Devfile",
 		dest,
 		"odo version: "+version.VERSION)
-
-	genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
-
+	if platform == commonflags.PlatformCluster {
+		genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
+	}
 	// check for .gitignore file and add odo-file-index.json to .gitignore.
 	// In case the .gitignore was created by odo, it is purposely not reported as candidate for deletion (via a call to files.ReportLocalFileGeneratedByOdo)
 	// because a .gitignore file is more likely to be modified by the user afterward (for another usage).

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -118,6 +118,7 @@ func (o *DevOptions) Validate(ctx context.Context) error {
 			return kclient.NewNoConnectionError()
 		}
 		scontext.SetPlatform(ctx, o.clientset.KubernetesClient)
+		genericclioptions.WarnIfDefaultNamespace(odocontext.GetNamespace(ctx), o.clientset.KubernetesClient)
 	case commonflags.PlatformPodman:
 		if o.ignoreLocalhostFlag && o.forwardLocalhostFlag {
 			return errors.New("--ignore-localhost and --forward-localhost cannot be used together")

--- a/pkg/odo/genericclioptions/util.go
+++ b/pkg/odo/genericclioptions/util.go
@@ -1,6 +1,8 @@
 package genericclioptions
 
 import (
+	"github.com/redhat-developer/odo/pkg/kclient"
+	"github.com/redhat-developer/odo/pkg/log"
 	pkgUtil "github.com/redhat-developer/odo/pkg/util"
 
 	dfutil "github.com/devfile/library/v2/pkg/util"
@@ -33,4 +35,17 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 	}
 
 	return nil
+}
+
+// WarnIfDefaultNamespace warns when user tries to run `odo dev` or `odo deploy` in the default namespace
+func WarnIfDefaultNamespace(namespace string, kubeClient kclient.ClientInterface) {
+	if namespace == "default" {
+		noun := "namespace"
+		if isOC, _ := kubeClient.IsProjectSupported(); isOC {
+			noun = "project"
+		}
+
+		log.Warningf("You are using \"default\" %[1]s, odo may not work as expected in the default %[1]s.", noun)
+		log.Warningf("You may set a new %[1]s by running `odo create %[1]s <name>`, or set an existing one by running `odo set %[1]s <name>`", noun)
+	}
 }

--- a/pkg/odo/genericclioptions/util.go
+++ b/pkg/odo/genericclioptions/util.go
@@ -1,9 +1,11 @@
 package genericclioptions
 
 import (
+	"fmt"
 	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/log"
 	pkgUtil "github.com/redhat-developer/odo/pkg/util"
+	v1 "k8s.io/api/core/v1"
 
 	dfutil "github.com/devfile/library/v2/pkg/util"
 )
@@ -39,12 +41,12 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 
 // WarnIfDefaultNamespace warns when user tries to run `odo dev` or `odo deploy` in the default namespace
 func WarnIfDefaultNamespace(namespace string, kubeClient kclient.ClientInterface) {
-	if namespace == "default" {
+	if namespace == v1.NamespaceDefault {
 		noun := "namespace"
 		if isOC, _ := kubeClient.IsProjectSupported(); isOC {
 			noun = "project"
 		}
-
+		fmt.Println()
 		log.Warningf("You are using \"default\" %[1]s, odo may not work as expected in the default %[1]s.", noun)
 		log.Warningf("You may set a new %[1]s by running `odo create %[1]s <name>`, or set an existing one by running `odo set %[1]s <name>`", noun)
 	}

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -255,18 +255,22 @@ func RunDevMode(options DevSessionOpts, inside func(session *gexec.Session, outC
 	return nil
 }
 
-// DevModeShouldFail runs `odo dev` with an intention to fail, and checks for a given substring
+// WaitForDevModeToContain runs `odo dev` until it contains a given substring in output or errOut(depending on checkErrOut arg).
 // `odo dev` runs in an infinite reconciliation loop, and hence running it with Cmd will not work for a lot of failing cases,
 // this function is helpful in such cases.
 // TODO(pvala): Modify StartDevMode to take substring arg into account, and replace this method with it.
-func DevModeShouldFail(options DevSessionOpts, substring string) (DevSession, []byte, []byte, error) {
+func WaitForDevModeToContain(options DevSessionOpts, substring string, checkErrOut bool) (DevSession, []byte, []byte, error) {
 	args := []string{"dev", "--random-ports"}
 	args = append(args, options.CmdlineArgs...)
 	if options.RunOnPodman {
 		args = append(args, "--platform", "podman")
 	}
 	session := Cmd("odo", args...).AddEnv(options.EnvVars...).Runner().session
-	WaitForOutputToContain(substring, 360, 10, session)
+	if checkErrOut {
+		WaitForErroutToContain(substring, 360, 10, session)
+	} else {
+		WaitForOutputToContain(substring, 360, 10, session)
+	}
 	result := DevSession{
 		session: session,
 	}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -347,7 +347,11 @@ func RunTestSpecs(t *testing.T, description string) {
 }
 
 func IsKubernetesCluster() bool {
-	return os.Getenv("KUBERNETES") == "true"
+	k8s, err := strconv.ParseBool(os.Getenv("KUBERNETES"))
+	if err != nil {
+		return false
+	}
+	return k8s
 }
 
 type ResourceInfo struct {

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -43,22 +43,20 @@ var _ = Describe("odo devfile deploy command tests", func() {
 
 		})
 	})
-	When("using a default namespace", func() {
+	When("a component is bootstrapped", func() {
 		BeforeEach(func() {
-			commonVar.CliRunner.SetProject("default")
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile-deploy.yaml")).ShouldPass()
 		})
-		AfterEach(func() {
-			helper.Cmd("odo", "delete", "component", "-f").ShouldPass()
-			commonVar.CliRunner.SetProject(commonVar.Project)
-		})
-		When("deploying a devfile with deploy command", func() {
+		When("using a default namespace", func() {
 			BeforeEach(func() {
-				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-				helper.CopyExampleDevFile(
-					filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
-					path.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+				commonVar.CliRunner.SetProject("default")
 			})
+			AfterEach(func() {
+				helper.Cmd("odo", "delete", "component", "-f").ShouldPass()
+				commonVar.CliRunner.SetProject(commonVar.Project)
+			})
+
 			It("should display warning when running the deploy command", func() {
 				errOut := helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldRun().Err()
 				namespace := "project"
@@ -68,7 +66,10 @@ var _ = Describe("odo devfile deploy command tests", func() {
 				Expect(errOut).To(ContainSubstring(fmt.Sprintf("You are using \"default\" %[1]s, odo may not work as expected in the default %[1]s.", namespace)))
 			})
 		})
-
+		It("should fail to run odo deploy when not connected to any cluster", Label(helper.LabelNoCluster), func() {
+			errOut := helper.Cmd("odo", "deploy").ShouldFail().Err()
+			Expect(errOut).To(ContainSubstring("unable to access the cluster"))
+		})
 	})
 	for _, ctx := range []struct {
 		title       string

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -43,7 +43,33 @@ var _ = Describe("odo devfile deploy command tests", func() {
 
 		})
 	})
+	When("using a default namespace", func() {
+		BeforeEach(func() {
+			commonVar.CliRunner.SetProject("default")
+		})
+		AfterEach(func() {
+			helper.Cmd("odo", "delete", "component", "-f").ShouldPass()
+			commonVar.CliRunner.SetProject(commonVar.Project)
+		})
+		When("deploying a devfile with deploy command", func() {
+			BeforeEach(func() {
+				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
+					path.Join(commonVar.Context, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName))
+			})
+			It("should display warning when running the deploy command", func() {
+				errOut := helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldRun().Err()
+				namespace := "project"
+				if helper.IsKubernetesCluster() {
+					namespace = "namespace"
+				}
+				Expect(errOut).To(ContainSubstring(fmt.Sprintf("You are using \"default\" %[1]s, odo may not work as expected in the default %[1]s.", namespace)))
+			})
+		})
 
+	})
 	for _, ctx := range []struct {
 		title       string
 		devfileName string


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR adds a warning if the user is using a default namespace.
This PR also modifies `helper.IsKubernetesCluster` to work if `KUBERNETES=true,t,1,T,true,True,TRUE`.
**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #5591 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `odo set namespace default`
2. `odo init --devfile go --starter go-starter --devfile-version latest`
3. `odo dev` should display the warning right away
4. `PODMAN_CMD=echo odo deploy` should display the warning right away.
If you are on an OpenShift cluster, it will use `project` instead of `namespace`.