### PR TITLE
Wait until expected ports are opened in the container before starting port-forwarding

### DIFF
--- a/docs/website/docs/user-guides/quickstart/docs-mdx/dotnet/dotnet_odo_dev_output.mdx
+++ b/docs/website/docs/user-guides/quickstart/docs-mdx/dotnet/dotnet_odo_dev_output.mdx
@@ -13,6 +13,7 @@ $ odo dev
  ✓  Syncing files into the container [171ms]
  ✓  Building your application in container (command: build) [7s]
  •  Executing the application (command: run)  ...
+ ✓  Waiting for the application to be ready [1s]
  -  Forwarding from 127.0.0.1:20001 -> 8080
 
 

--- a/docs/website/docs/user-guides/quickstart/docs-mdx/go/go_odo_dev_output.mdx
+++ b/docs/website/docs/user-guides/quickstart/docs-mdx/go/go_odo_dev_output.mdx
@@ -13,6 +13,7 @@ $ odo dev
  ✓  Syncing files into the container [113ms]
  ✓  Building your application in container (command: build) [422ms]
  •  Executing the application (command: run)  ...
+ ✓  Waiting for the application to be ready [1s]
  -  Forwarding from 127.0.0.1:20001 -> 8080
 
 

--- a/docs/website/docs/user-guides/quickstart/docs-mdx/java/java_odo_dev_output.mdx
+++ b/docs/website/docs/user-guides/quickstart/docs-mdx/java/java_odo_dev_output.mdx
@@ -14,6 +14,7 @@ $ odo dev
  ✓  Syncing files into the container [167ms]
  ✓  Building your application in container (command: build) [3m]
  •  Executing the application (command: run)  ...
+ ✓  Waiting for the application to be ready [1s]
  -  Forwarding from 127.0.0.1:20001 -> 8080
 
 

--- a/docs/website/docs/user-guides/quickstart/docs-mdx/nodejs/nodejs_odo_dev_output.mdx
+++ b/docs/website/docs/user-guides/quickstart/docs-mdx/nodejs/nodejs_odo_dev_output.mdx
@@ -13,6 +13,7 @@ $ odo dev
  ✓  Syncing files into the container [193ms]
  ✓  Building your application in container (command: install) [5s]
  •  Executing the application (command: run)  ...
+ ✓  Waiting for the application to be ready [1s]
  -  Forwarding from 127.0.0.1:20001 -> 3000
 
 

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -129,7 +129,7 @@ func (o *DevClient) reconcile(
 	appReadySpinner.End(err == nil)
 	if err != nil {
 		log.Warningf("Port forwarding might not work correctly: %v", err)
-		log.Info("Running `odo logs --follow --platform podman` might help in identifying the problem.")
+		log.Warning("Running `odo logs --follow --platform podman` might help in identifying the problem.")
 		fmt.Fprintln(out)
 	}
 

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"time"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
@@ -122,6 +123,15 @@ func (o *DevClient) reconcile(
 		componentStatus.RunExecuted = true
 	}
 
+	// Check that the application is actually listening on the ports declared in the Devfile, so we are sure that port-forwarding will work
+	appReadySpinner := log.Spinner("Waiting for the application to be ready")
+	defer appReadySpinner.End(false)
+	err = o.checkAppPorts(pod.Name, fwPorts)
+	if err != nil {
+		return err
+	}
+	appReadySpinner.End(true)
+
 	// By default, Podman will not forward to container applications listening on the loopback interface.
 	// So we are trying to detect such cases and act accordingly.
 	// See https://github.com/redhat-developer/odo/issues/6510#issuecomment-1439986558
@@ -234,6 +244,14 @@ func (o *DevClient) deployPod(ctx context.Context, options dev.StartOptions) (*c
 
 	spinner.End(true)
 	return pod, fwPorts, nil
+}
+
+func (o *DevClient) checkAppPorts(podName string, portsToFwd []api.ForwardedPort) error {
+	containerPortsMapping := make(map[string][]int)
+	for _, p := range portsToFwd {
+		containerPortsMapping[p.ContainerName] = append(containerPortsMapping[p.ContainerName], p.ContainerPort)
+	}
+	return port.CheckAppPortsListening(o.execClient, podName, containerPortsMapping, 1*time.Minute)
 }
 
 // handleLoopbackPorts tries to detect if any of the ports to forward (in fwPorts) is actually bound to the loopback interface within the specified pod.

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -128,7 +128,9 @@ func (o *DevClient) reconcile(
 	err = o.checkAppPorts(ctx, pod.Name, fwPorts)
 	appReadySpinner.End(err == nil)
 	if err != nil {
-		log.Warningf("Port Forwarding might not work correctly: %v", err)
+		log.Warningf("Port forwarding might not work correctly: %v", err)
+		log.Info("Running `odo logs --follow --platform podman` might help in identifying the problem.")
+		fmt.Fprintln(out)
 	}
 
 	// By default, Podman will not forward to container applications listening on the loopback interface.

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -358,7 +358,7 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 	appReadySpinner.End(err == nil)
 	if err != nil {
 		log.Warningf("Port forwarding might not work correctly: %v", err)
-		log.Info("Running `odo logs --follow` might help in identifying the problem.")
+		log.Warning("Running `odo logs --follow` might help in identifying the problem.")
 		fmt.Fprintln(log.GetStdout())
 	}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -357,7 +357,9 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 	err = a.checkAppPorts(ctx, pod.Name, portsToForward)
 	appReadySpinner.End(err == nil)
 	if err != nil {
-		log.Warningf("Port Forwarding might not work correctly: %v", err)
+		log.Warningf("Port forwarding might not work correctly: %v", err)
+		log.Info("Running `odo logs --follow` might help in identifying the problem.")
+		fmt.Fprintln(log.GetStdout())
 	}
 
 	err = a.portForwardClient.StartPortForwarding(a.Devfile, a.ComponentName, parameters.Debug, parameters.RandomPorts, log.GetStdout(), parameters.ErrOut, parameters.CustomForwardedPorts)

--- a/pkg/port/port_test.go
+++ b/pkg/port/port_test.go
@@ -1,9 +1,11 @@
 package port
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -408,6 +410,110 @@ sl  local_address                         remote_address                        
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("getListeningConnections() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckAppPortsListening(t *testing.T) {
+	type args struct {
+		execClientCustomizer func(client *exec.MockClient)
+		containerPortMapping map[string][]int
+		timeout              time.Duration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "no container port mapping",
+			wantErr: false,
+		},
+		{
+			name: "error while checking for ports",
+			args: args{
+				execClientCustomizer: func(client *exec.MockClient) {
+					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Any(), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+						Return(nil, []string{"an error"}, errors.New("some error")).AnyTimes()
+				},
+				containerPortMapping: map[string][]int{
+					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					containerName: {20001, 6443, 22},
+					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					"my-other-cont": {5355},
+				},
+				timeout: 5 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "too small timeout reached while checking for ports, even if they are all opened",
+			args: args{
+				execClientCustomizer: func(client *exec.MockClient) {
+					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Any(), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+						Return(nil, []string{"an error"}, errors.New("some error")).AnyTimes()
+				},
+				containerPortMapping: map[string][]int{
+					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					containerName: {20001, 6443, 22},
+					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					"my-other-cont": {5355},
+				},
+				timeout: 1 * time.Millisecond,
+			},
+			wantErr: true,
+		},
+		{
+			name: "at least one of the ports are not opened",
+			args: args{
+				execClientCustomizer: func(client *exec.MockClient) {
+					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
+					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq("my-other-cont"), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
+				},
+				containerPortMapping: map[string][]int{
+					// all ports are coming from aggregatedContentFromProcNetFiles
+					containerName: {20001, 6443, 22},
+					// port 5355 is coming from aggregatedContentFromProcNetFiles, but 12345 is intentionally not there
+					"my-other-cont": {5355, 12345},
+				},
+				timeout: 5 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "all ports are opened in the container",
+			args: args{
+				execClientCustomizer: func(client *exec.MockClient) {
+					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
+					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq("my-other-cont"), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
+				},
+				containerPortMapping: map[string][]int{
+					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					containerName: {20001, 6443, 22},
+					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					"my-other-cont": {5355},
+				},
+				timeout: 6 * time.Second,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			execClient := exec.NewMockClient(ctrl)
+			if tt.args.execClientCustomizer != nil {
+				tt.args.execClientCustomizer(execClient)
+			}
+
+			gotErr := CheckAppPortsListening(context.Background(), execClient, podName, tt.args.containerPortMapping, tt.args.timeout)
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("CheckAppPortsListening() error = %v, wantErr %v", gotErr, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/port/port_test.go
+++ b/pkg/port/port_test.go
@@ -431,6 +431,17 @@ func TestCheckAppPortsListening(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "container with no ports",
+			wantErr: false,
+			args: args{
+				containerPortMapping: map[string][]int{
+					containerName:   {},
+					"my-other-cont": {},
+				},
+				timeout: 5 * time.Second,
+			},
+		},
+		{
 			name: "error while checking for ports",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
@@ -439,8 +450,7 @@ func TestCheckAppPortsListening(t *testing.T) {
 				},
 				containerPortMapping: map[string][]int{
 					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
-					containerName: {20001, 6443, 22},
-					// all ports are opened, as decoded from aggregatedContentFromProcNetFiles
+					containerName:   {20001, 6443, 22},
 					"my-other-cont": {5355},
 				},
 				timeout: 5 * time.Second,

--- a/tests/helper/helper_documentation.go
+++ b/tests/helper/helper_documentation.go
@@ -38,10 +38,14 @@ func StripSpinner(docString string) (returnString string) {
 		// This check is to avoid spinner statements in the cmd output
 		// currently it does so for init and dev
 		// e.g. " •  Syncing file changes ..."
-		if (strings.HasPrefix(line, "•  Downloading") || strings.HasPrefix(line, "•  Syncing") || strings.HasPrefix(line, "•  Building")) && strings.HasSuffix(line, "...") {
+		if (strings.HasPrefix(line, "•  Downloading") ||
+			strings.HasPrefix(line, "•  Syncing") ||
+			strings.HasPrefix(line, "•  Building") ||
+			strings.HasPrefix(line, "•  Waiting for the application")) &&
+			strings.HasSuffix(line, "...") {
 			continue
 		}
-		// Remove warnings, execpt "Pod is Pending"
+		// Remove warnings, except "Pod is Pending"
 		if strings.HasPrefix(line, "⚠") && !strings.Contains(line, "Pod is Pending") {
 			continue
 		}

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -557,7 +557,12 @@ ComponentSettings:
 			var ports map[string]string
 
 			BeforeEach(func() {
-				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "sleep 20 ; npm start")
+				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"),
+					"npm start",
+					// odo dev now waits some time until the app is ready or a timeout (current set to 1m) expires before starting port-forwarding.
+					// So we are sleeping more than the timeout.
+					// See https://github.com/redhat-developer/odo/issues/6667
+					"sleep 80 ; npm start")
 
 				var err error
 				devSession, _, _, ports, err = helper.StartDevMode(helper.DevSessionOpts{})


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area dev

**What does this PR do / why we need it:**
To fix some flaky behavior due to the app sometimes not being ready when sending out requests to the local forwarded ports, this PR leverages the port detector (introduced in #6620 to detect if container ports are bound on the container loopback interface) to wait until the container ports are actually opened before trying to start the port forwarding logic. See https://github.com/redhat-developer/odo/issues/6667#issuecomment-1478256277
For consistency, this is done on both Kubernetes and Podman platforms.

At the moment, this additional check will not prevent `odo dev` from starting, but a warning will just be displayed if the timeout (arbitrarily set to `1m`) is reached and the port is not opened yet in the container, e.g.:
```
$ odo dev

↪ Running on the cluster in Dev mode
 •  Waiting for Kubernetes resources  ...
 ⚠  Pod is Pending
 ✓  Pod is Running
 ✓  Syncing files into the container [122ms]
 ✓  Building your application in container (command: install) [3s]
 •  Executing the application (command: run)  ...
 ✗  Waiting for the application to be ready [1m]
 ⚠  Port Forwarding might not work correctly: timeout while checking for ports in container "runtime"; ports not listening: 3000: context deadline exceeded
 -  Forwarding from 127.0.0.1:20002 -> 3000

↪ Dev mode
 Status:
 Watching for changes in the current directory /home/asoro/work/tmp/6667-wait-until-expected-ports-are-opened-before-starting-port-forwarding/nodejs
```

**Which issue(s) this PR fixes:**
Fixes #6667 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

Run `odo dev` against any project on either Kubernetes or Podman. A new ` Waiting for the application to be ready` check will be displayed in the output and should timeout if the container port (declared in the Devfile) cannot be opened after 1 minute.
