### PR TITLE
Exit a test early if a session has exited while waiting for an output to contain a substring

### DIFF
--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -176,6 +176,9 @@ func (o DevSession) Kill() {
 
 // Stop a Dev session cleanly (equivalent as hitting Ctrl-c)
 func (o *DevSession) Stop() {
+	if o.session == nil {
+		return
+	}
 	if o.console != nil {
 		err := o.console.Close()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -183,13 +186,14 @@ func (o *DevSession) Stop() {
 	if o.stopped {
 		return
 	}
+
 	err := terminateProc(o.session)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	o.stopped = true
 }
 
 func (o *DevSession) PressKey(p byte) {
-	if o.console == nil {
+	if o.console == nil || o.session == nil {
 		return
 	}
 	_, err := o.console.Write([]byte{p})
@@ -197,6 +201,9 @@ func (o *DevSession) PressKey(p byte) {
 }
 
 func (o DevSession) WaitEnd() {
+	if o.session == nil {
+		return
+	}
 	o.session.Wait(3 * time.Minute)
 }
 

--- a/tests/helper/helper_run.go
+++ b/tests/helper/helper_run.go
@@ -42,10 +42,13 @@ func CmdRunner(program string, args ...string) *gexec.Session {
 	return session
 }
 
-// WaitForOutputToContain waits for the session stdout output to contain a particular substring
+// WaitForOutputToContain waits for the session stdout output to contain a particular substring;
+// if the session exits, it checks for the substring and returns early
 func WaitForOutputToContain(substring string, timeoutInSeconds int, intervalInSeconds int, session *gexec.Session) {
-
 	Eventually(func() string {
+		if session.ExitCode() != -1 {
+			Expect(string(session.Out.Contents())).To(ContainSubstring(substring), "session exited, but substring not found")
+		}
 		contents := string(session.Out.Contents())
 		return contents
 	}, timeoutInSeconds, intervalInSeconds).Should(ContainSubstring(substring))
@@ -59,15 +62,22 @@ func WaitForOutputToContainOne(substrings []string, timeoutInSeconds int, interv
 		matchers = append(matchers, ContainSubstring(substring))
 	}
 	Eventually(func() string {
+		if session.ExitCode() != -1 {
+			Expect(string(session.Out.Contents())).To(SatisfyAny(matchers...), "session exited, but substring not found")
+		}
 		contents := string(session.Out.Contents())
 		return contents
 	}, timeoutInSeconds, intervalInSeconds).Should(SatisfyAny(matchers...))
 }
 
 // WaitForErroutToContain waits for the session stdout output to contain a particular substring
+// if the session exits, it checks for the substring and returns early
 func WaitForErroutToContain(substring string, timeoutInSeconds int, intervalInSeconds int, session *gexec.Session) {
 
 	Eventually(func() string {
+		if session.ExitCode() != -1 {
+			Expect(string(session.Err.Contents())).To(ContainSubstring(substring), "session exited, but substring not found")
+		}
 		contents := string(session.Err.Contents())
 		return contents
 	}, timeoutInSeconds, intervalInSeconds).Should(ContainSubstring(substring))


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind tests

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind tests
/kind code-refactoring

For documentation, add the following label:
/area documentation

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR extends the helper functions `WaitForOutputToContain` and the likes to exit early if a session has exited due to an error.

The motivation behind adding this change is while developing a new feature, in my case #6704, I had run into a case where `--port-forward` was given an invalid value, and `odo dev` exited, but the test session running `StartDevMode` and in turn running `WaitForOutputToContain` still kept running and waiting for the output to contain a given substring. It would save a lot of time while developing a new test if the test exited early.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
Add the following test to a test file(perhaps `cmd_dev_test.go`):
```go
	FIt("should exit early", func() {
		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
		helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml")).ShouldPass()
		sess, _, _, _, err := helper.StartDevMode(helper.DevSessionOpts{CmdlineArgs: []string{"--ignore-localhost", "--forward-localhost"}, RunOnPodman: true})
		defer sess.Stop()
		Expect(err).To(HaveOccurred())
	})
```