### PR TITLE
Use devstats.PID.json as devstate

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/odo/cli"
 	"github.com/redhat-developer/odo/pkg/odo/cli/version"
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/odo/util/completion"
 	"github.com/redhat-developer/odo/pkg/preference"
@@ -31,6 +32,7 @@ func main() {
 		util.LogErrorAndExit(err, "")
 	}
 	ctx = envcontext.WithEnvConfig(ctx, *envConfig)
+	ctx = odocontext.WithPID(ctx, os.Getpid())
 
 	// create the complete command
 	klog.InitFlags(nil)

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -144,7 +143,7 @@ func (o *DevClient) reconcile(
 
 	if options.ForwardLocalhost {
 		// Port-forwarding is enabled by executing dedicated socat commands
-		err = o.portForwardClient.StartPortForwarding(*devfileObj, componentName, options.Debug, options.RandomPorts, out, errOut, fwPorts)
+		err = o.portForwardClient.StartPortForwarding(ctx, *devfileObj, componentName, options.Debug, options.RandomPorts, out, errOut, fwPorts)
 		if err != nil {
 			return adapters.NewErrPortForward(err)
 		}
@@ -154,7 +153,7 @@ func (o *DevClient) reconcile(
 		s := fmt.Sprintf("Forwarding from %s:%d -> %d", fwPort.LocalAddress, fwPort.LocalPort, fwPort.ContainerPort)
 		fmt.Fprintf(out, " -  %s", log.SboldColor(color.FgGreen, s))
 	}
-	err = o.stateClient.SetForwardedPorts(os.Getpid(), fwPorts)
+	err = o.stateClient.SetForwardedPorts(ctx, fwPorts)
 	if err != nil {
 		return err
 	}

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -153,7 +154,7 @@ func (o *DevClient) reconcile(
 		s := fmt.Sprintf("Forwarding from %s:%d -> %d", fwPort.LocalAddress, fwPort.LocalPort, fwPort.ContainerPort)
 		fmt.Fprintf(out, " -  %s", log.SboldColor(color.FgGreen, s))
 	}
-	err = o.stateClient.SetForwardedPorts(fwPorts)
+	err = o.stateClient.SetForwardedPorts(os.Getpid(), fwPorts)
 	if err != nil {
 		return err
 	}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -366,7 +366,7 @@ func (a Adapter) Push(ctx context.Context, parameters adapters.PushParameters, c
 		fmt.Fprintln(log.GetStdout())
 	}
 
-	err = a.portForwardClient.StartPortForwarding(a.Devfile, a.ComponentName, parameters.Debug, parameters.RandomPorts, log.GetStdout(), parameters.ErrOut, parameters.CustomForwardedPorts)
+	err = a.portForwardClient.StartPortForwarding(ctx, a.Devfile, a.ComponentName, parameters.Debug, parameters.RandomPorts, log.GetStdout(), parameters.ErrOut, parameters.CustomForwardedPorts)
 	if err != nil {
 		return adapters.NewErrPortForward(err)
 	}

--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -242,7 +242,7 @@ func (o *ComponentOptions) describeDevfileComponent(ctx context.Context) (result
 	}
 
 	// TODO(feloy) Pass PID with `--pid` flag
-	allFwdPorts, err := o.clientset.StateClient.GetForwardedPorts(0)
+	allFwdPorts, err := o.clientset.StateClient.GetForwardedPorts(ctx)
 	if err != nil {
 		return api.Component{}, nil, err
 	}

--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -242,7 +241,8 @@ func (o *ComponentOptions) describeDevfileComponent(ctx context.Context) (result
 		kubeClient = nil
 	}
 
-	allFwdPorts, err := o.clientset.StateClient.GetForwardedPorts(os.Getpid())
+	// TODO(feloy) Pass PID with `--pid` flag
+	allFwdPorts, err := o.clientset.StateClient.GetForwardedPorts(0)
 	if err != nil {
 		return api.Component{}, nil, err
 	}

--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -241,7 +242,7 @@ func (o *ComponentOptions) describeDevfileComponent(ctx context.Context) (result
 		kubeClient = nil
 	}
 
-	allFwdPorts, err := o.clientset.StateClient.GetForwardedPorts()
+	allFwdPorts, err := o.clientset.StateClient.GetForwardedPorts(os.Getpid())
 	if err != nil {
 		return api.Component{}, nil, err
 	}

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -260,7 +259,7 @@ func (o *DevOptions) Cleanup(ctx context.Context, commandError error) {
 	if commandError != nil {
 		_ = o.clientset.DevClient.CleanupResources(ctx, log.GetStdout())
 	}
-	_ = o.clientset.StateClient.SaveExit(os.Getpid())
+	_ = o.clientset.StateClient.SaveExit(ctx)
 }
 
 // NewCmdDev implements the odo dev command

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -232,7 +232,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 
 	err = o.clientset.StateClient.Init(ctx)
 	if err != nil {
-		err = fmt.Errorf("unable to save state file: %v", err)
+		err = fmt.Errorf("unable to save state file: %w", err)
 		return err
 	}
 

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -232,6 +232,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 
 	err = o.clientset.StateClient.Init(ctx)
 	if err != nil {
+		err = fmt.Errorf("unable to save state file: %v", err)
 		return err
 	}
 

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -12,13 +13,11 @@ import (
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"k8s.io/klog"
-
-	"github.com/redhat-developer/odo/pkg/api"
-
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
+	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/dev"
 	"github.com/redhat-developer/odo/pkg/kclient"
@@ -261,7 +260,7 @@ func (o *DevOptions) Cleanup(ctx context.Context, commandError error) {
 	if commandError != nil {
 		_ = o.clientset.DevClient.CleanupResources(ctx, log.GetStdout())
 	}
-	_ = o.clientset.StateClient.SaveExit()
+	_ = o.clientset.StateClient.SaveExit(os.Getpid())
 }
 
 // NewCmdDev implements the odo dev command

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/redhat-developer/odo/pkg/api"
@@ -33,6 +33,7 @@ import (
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
 	"github.com/redhat-developer/odo/pkg/podman"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
+	"github.com/redhat-developer/odo/pkg/state"
 	"github.com/redhat-developer/odo/pkg/util"
 	"github.com/redhat-developer/odo/pkg/version"
 )
@@ -229,6 +230,11 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 
 	log.Sectionf("Running on %s in Dev mode", deployingTo)
 
+	err = o.clientset.StateClient.Init(ctx)
+	if err != nil {
+		return err
+	}
+
 	return o.clientset.DevClient.Start(
 		o.ctx,
 		o.out,
@@ -256,6 +262,10 @@ func (o *DevOptions) HandleSignal() error {
 }
 
 func (o *DevOptions) Cleanup(ctx context.Context, commandError error) {
+	if errors.As(commandError, &state.ErrAlreadyRunningOnPlatform{}) {
+		klog.V(4).Info("session already running, no need to cleanup")
+		return
+	}
 	if commandError != nil {
 		_ = o.clientset.DevClient.CleanupResources(ctx, log.GetStdout())
 	}

--- a/pkg/odo/context/odo.go
+++ b/pkg/odo/context/odo.go
@@ -9,6 +9,7 @@ import (
 type (
 	applicationKeyType   struct{}
 	cwdKeyType           struct{}
+	pidKeyType           struct{}
 	devfilePathKeyType   struct{}
 	devfileObjKeyType    struct{}
 	componentNameKeyType struct{}
@@ -17,6 +18,7 @@ type (
 var (
 	applicationKey   applicationKeyType
 	cwdKey           cwdKeyType
+	pidKey           pidKeyType
 	devfilePathKey   devfilePathKeyType
 	devfileObjKey    devfileObjKeyType
 	componentNameKey componentNameKeyType
@@ -55,6 +57,23 @@ func GetWorkingDirectory(ctx context.Context) string {
 		return cast
 	}
 	panic("this should not happen, either the original context is not passed or WithWorkingDirectory is not called as it should. Check that FILESYSTEM dependency is added to the command")
+}
+
+// WithPID sets the value of the PID in ctx
+// This function must be used before calling GetPID
+// Use this function only with a context obtained from Complete/Validate/Run/... methods of Runnable interface
+func WithPID(ctx context.Context, val int) context.Context {
+	return context.WithValue(ctx, pidKey, val)
+}
+
+// GetPID gets the PID value in ctx
+// This function will panic if the context does not contain the value
+func GetPID(ctx context.Context) int {
+	value := ctx.Value(pidKey)
+	if cast, ok := value.(int); ok {
+		return cast
+	}
+	panic("this should not happen, either the original context is not passed or WithPID is not called as it should")
 }
 
 // WithDevfilePath sets the value of the devfile path in ctx

--- a/pkg/portForward/interface.go
+++ b/pkg/portForward/interface.go
@@ -1,6 +1,7 @@
 package portForward
 
 import (
+	"context"
 	"io"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -16,6 +17,7 @@ type Client interface {
 	// output will be written to errOut writer
 	// definedPorts allows callers to explicitly define the mapping they want to set.
 	StartPortForwarding(
+		ctx context.Context,
 		devFileObj parser.DevfileObj,
 		componentName string,
 		debug bool,

--- a/pkg/portForward/kubeportforward/portForward.go
+++ b/pkg/portForward/kubeportforward/portForward.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"sort"
 	"time"
@@ -114,7 +115,7 @@ func (o *PFClient) StartPortForwarding(devFileObj parser.DevfileObj, componentNa
 
 			go func() {
 				portsBuf.Wait()
-				err = o.stateClient.SetForwardedPorts(portsBuf.GetForwardedPorts())
+				err = o.stateClient.SetForwardedPorts(os.Getpid(), portsBuf.GetForwardedPorts())
 				if err != nil {
 					err = fmt.Errorf("unable to save forwarded ports to state file: %v", err)
 				}

--- a/pkg/portForward/kubeportforward/portForward.go
+++ b/pkg/portForward/kubeportforward/portForward.go
@@ -1,10 +1,10 @@
 package kubeportforward
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"reflect"
 	"sort"
 	"time"
@@ -50,7 +50,7 @@ func NewPFClient(kubernetesClient kclient.ClientInterface, stateClient state.Cli
 	}
 }
 
-func (o *PFClient) StartPortForwarding(devFileObj parser.DevfileObj, componentName string, debug bool, randomPorts bool, out io.Writer, errOut io.Writer, definedPorts []api.ForwardedPort) error {
+func (o *PFClient) StartPortForwarding(ctx context.Context, devFileObj parser.DevfileObj, componentName string, debug bool, randomPorts bool, out io.Writer, errOut io.Writer, definedPorts []api.ForwardedPort) error {
 	if randomPorts && len(definedPorts) != 0 {
 		return errors.New("cannot use randomPorts and custom definePorts together")
 	}
@@ -115,7 +115,7 @@ func (o *PFClient) StartPortForwarding(devFileObj parser.DevfileObj, componentNa
 
 			go func() {
 				portsBuf.Wait()
-				err = o.stateClient.SetForwardedPorts(os.Getpid(), portsBuf.GetForwardedPorts())
+				err = o.stateClient.SetForwardedPorts(ctx, portsBuf.GetForwardedPorts())
 				if err != nil {
 					err = fmt.Errorf("unable to save forwarded ports to state file: %v", err)
 				}

--- a/pkg/portForward/podmanportforward/portForward.go
+++ b/pkg/portForward/podmanportforward/portForward.go
@@ -1,6 +1,7 @@
 package podmanportforward
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -36,6 +37,7 @@ func NewPFClient(execClient exec.Client) *PFClient {
 }
 
 func (o *PFClient) StartPortForwarding(
+	ctx context.Context,
 	devFileObj parser.DevfileObj,
 	componentName string,
 	debug bool,

--- a/pkg/registry/mock.go
+++ b/pkg/registry/mock.go
@@ -83,18 +83,18 @@ func (mr *MockClientMockRecorder) GetDevfileRegistries(registryName interface{})
 }
 
 // ListDevfileStacks mocks base method.
-func (m *MockClient) ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag, jsonOutput bool) (DevfileStackList, error) {
+func (m *MockClient) ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag, withDevfileContent bool) (DevfileStackList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDevfileStacks", ctx, registryName, devfileFlag, filterFlag, detailsFlag, jsonOutput)
+	ret := m.ctrl.Call(m, "ListDevfileStacks", ctx, registryName, devfileFlag, filterFlag, detailsFlag, withDevfileContent)
 	ret0, _ := ret[0].(DevfileStackList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDevfileStacks indicates an expected call of ListDevfileStacks.
-func (mr *MockClientMockRecorder) ListDevfileStacks(ctx, registryName, devfileFlag, filterFlag, detailsFlag, jsonOutput interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListDevfileStacks(ctx, registryName, devfileFlag, filterFlag, detailsFlag, withDevfileContent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDevfileStacks", reflect.TypeOf((*MockClient)(nil).ListDevfileStacks), ctx, registryName, devfileFlag, filterFlag, detailsFlag, jsonOutput)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDevfileStacks", reflect.TypeOf((*MockClient)(nil).ListDevfileStacks), ctx, registryName, devfileFlag, filterFlag, detailsFlag, withDevfileContent)
 }
 
 // PullStackFromRegistry mocks base method.

--- a/pkg/state/const.go
+++ b/pkg/state/const.go
@@ -1,3 +1,4 @@
 package state
 
 const _filepath = "./.odo/devstate.json"
+const _filepathPid = "./.odo/devstate.%d.json"

--- a/pkg/state/const.go
+++ b/pkg/state/const.go
@@ -1,4 +1,5 @@
 package state
 
+const _dirpath = "./.odo"
 const _filepath = "./.odo/devstate.json"
 const _filepathPid = "./.odo/devstate.%d.json"

--- a/pkg/state/doc.go
+++ b/pkg/state/doc.go
@@ -1,2 +1,5 @@
 // Package state gives access to the state of the odo process stored in a local file
+// The state of an instance is stored in a file .odo/devstate.${PID}.json.
+// For compatibility with previous versions of odo, the `devstate.json` file contains
+// the state of the first instance of odo.
 package state

--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -4,12 +4,13 @@ import "fmt"
 
 type ErrAlreadyRunningOnPlatform struct {
 	platform string
+	pid      int
 }
 
-func NewErrAlreadyRunningOnPlatform(platform string) ErrAlreadyRunningOnPlatform {
+func NewErrAlreadyRunningOnPlatform(platform string, pid int) ErrAlreadyRunningOnPlatform {
 	return ErrAlreadyRunningOnPlatform{platform: platform}
 }
 
 func (e ErrAlreadyRunningOnPlatform) Error() string {
-	return fmt.Sprintf("a session is already running on platform %q", e.platform)
+	return fmt.Sprintf("a session with PID %d is already running on platform %q", e.pid, e.platform)
 }

--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -8,7 +8,10 @@ type ErrAlreadyRunningOnPlatform struct {
 }
 
 func NewErrAlreadyRunningOnPlatform(platform string, pid int) ErrAlreadyRunningOnPlatform {
-	return ErrAlreadyRunningOnPlatform{platform: platform}
+	return ErrAlreadyRunningOnPlatform{
+		platform: platform,
+		pid:      pid,
+	}
 }
 
 func (e ErrAlreadyRunningOnPlatform) Error() string {

--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -1,0 +1,15 @@
+package state
+
+import "fmt"
+
+type ErrAlreadyRunningOnPlatform struct {
+	platform string
+}
+
+func NewErrAlreadyRunningOnPlatform(platform string) ErrAlreadyRunningOnPlatform {
+	return ErrAlreadyRunningOnPlatform{platform: platform}
+}
+
+func (e ErrAlreadyRunningOnPlatform) Error() string {
+	return fmt.Sprintf("a session is already running on platform %q", e.platform)
+}

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -4,11 +4,11 @@ import "github.com/redhat-developer/odo/pkg/api"
 
 type Client interface {
 	// SetForwardedPorts sets the forwarded ports in the state file and saves it to the file, updating the metadata
-	SetForwardedPorts(fwPorts []api.ForwardedPort) error
+	SetForwardedPorts(pid int, fwPorts []api.ForwardedPort) error
 
 	// GetForwardedPorts returns the ports forwarded by the current odo dev session
-	GetForwardedPorts() ([]api.ForwardedPort, error)
+	GetForwardedPorts(pid int) ([]api.ForwardedPort, error)
 
 	// SaveExit resets the state file to indicate odo is not running
-	SaveExit() error
+	SaveExit(pid int) error
 }

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -7,6 +7,9 @@ import (
 )
 
 type Client interface {
+	// Init creates a devstate file for the process
+	Init(ctx context.Context) error
+
 	// SetForwardedPorts sets the forwarded ports in the state file and saves it to the file, updating the metadata
 	SetForwardedPorts(ctx context.Context, fwPorts []api.ForwardedPort) error
 

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -1,14 +1,18 @@
 package state
 
-import "github.com/redhat-developer/odo/pkg/api"
+import (
+	"context"
+
+	"github.com/redhat-developer/odo/pkg/api"
+)
 
 type Client interface {
 	// SetForwardedPorts sets the forwarded ports in the state file and saves it to the file, updating the metadata
-	SetForwardedPorts(pid int, fwPorts []api.ForwardedPort) error
+	SetForwardedPorts(ctx context.Context, fwPorts []api.ForwardedPort) error
 
 	// GetForwardedPorts returns the ports forwarded by the current odo dev session
-	GetForwardedPorts(pid int) ([]api.ForwardedPort, error)
+	GetForwardedPorts(ctx context.Context) ([]api.ForwardedPort, error)
 
 	// SaveExit resets the state file to indicate odo is not running
-	SaveExit(pid int) error
+	SaveExit(ctx context.Context) error
 }

--- a/pkg/state/process_unix.go
+++ b/pkg/state/process_unix.go
@@ -1,0 +1,38 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris zos
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func pidExists(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid pid %v", pid)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, nil
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true, nil
+	}
+	if err.Error() == "os: process already finished" {
+		return false, nil
+	}
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return false, err
+	}
+	switch errno {
+	case syscall.ESRCH:
+		return false, nil
+	case syscall.EPERM:
+		return true, nil
+	}
+	return false, err
+}

--- a/pkg/state/process_windows.go
+++ b/pkg/state/process_windows.go
@@ -1,0 +1,17 @@
+package state
+
+import (
+	"fmt"
+	"os"
+)
+
+func pidExists(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid pid %v", pid)
+	}
+	_, err := os.FindProcess(pid)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/redhat-developer/odo/pkg/api"
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
@@ -25,14 +27,20 @@ func NewStateClient(fs filesystem.Filesystem) *State {
 	}
 }
 
-func (o *State) SetForwardedPorts(pid int, fwPorts []api.ForwardedPort) error {
+func (o *State) SetForwardedPorts(ctx context.Context, fwPorts []api.ForwardedPort) error {
+	var (
+		pid = odocontext.GetPID(ctx)
+	)
 	// TODO(feloy) When other data is persisted into the state file, it will be needed to read the file first
 	o.content.ForwardedPorts = fwPorts
 	o.content.PID = pid
 	return o.save(pid)
 }
 
-func (o *State) GetForwardedPorts(pid int) ([]api.ForwardedPort, error) {
+func (o *State) GetForwardedPorts(ctx context.Context) ([]api.ForwardedPort, error) {
+	var (
+		pid = odocontext.GetPID(ctx)
+	)
 	err := o.read(pid)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -43,7 +51,10 @@ func (o *State) GetForwardedPorts(pid int) ([]api.ForwardedPort, error) {
 	return o.content.ForwardedPorts, err
 }
 
-func (o *State) SaveExit(pid int) error {
+func (o *State) SaveExit(ctx context.Context) error {
+	var (
+		pid = odocontext.GetPID(ctx)
+	)
 	o.content.ForwardedPorts = nil
 	o.content.PID = 0
 	err := o.delete(pid)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -137,10 +137,8 @@ func (o *State) read(platform string) (Content, error) {
 		if err != nil {
 			return Content{}, err
 		}
-		err = json.Unmarshal(jsonContent, &content)
-		if err != nil {
-			return Content{}, err
-		}
+		// Ignore error, to handle empty file
+		_ = json.Unmarshal(jsonContent, &content)
 		if content.Platform == platform {
 			break
 		} else {
@@ -194,10 +192,8 @@ func (o *State) isFreeOrOwnedBy(pid int) (bool, error) {
 		return false, err
 	}
 	var savedContent Content
-	err = json.Unmarshal(jsonContent, &savedContent)
-	if err != nil {
-		return false, err
-	}
+	// Ignore error, to handle empty file
+	_ = json.Unmarshal(jsonContent, &savedContent)
 	if savedContent.PID == 0 {
 		// PID is 0 in file, it is free
 		return true, nil
@@ -240,10 +236,8 @@ func (o *State) checkFirstInPlatform(ctx context.Context) error {
 			return err
 		}
 		var content Content
-		err = json.Unmarshal(jsonContent, &content)
-		if err != nil {
-			return err
-		}
+		// Ignore error, to handle empty file
+		_ = json.Unmarshal(jsonContent, &content)
 		if content.Platform == platform {
 			if content.PID == pid {
 				continue

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -154,5 +154,15 @@ func (o *State) isFreeOrOwnedBy(pid int) (bool, error) {
 		// File is owned by process
 		return true, nil
 	}
+
+	exists, err := pidExists(savedContent.PID)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		// Process already finished
+		return true, nil
+	}
+
 	return false, nil
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -87,6 +87,9 @@ func (o *State) delete(pid int) error {
 }
 
 func getFilename(pid int) string {
+	if pid == 0 {
+		return _filepath
+	}
 	return fmt.Sprintf(_filepathPid, pid)
 }
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 
 	"github.com/redhat-developer/odo/pkg/api"
+	"github.com/redhat-developer/odo/pkg/odo/commonflags"
+	fcontext "github.com/redhat-developer/odo/pkg/odo/commonflags/context"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
@@ -29,11 +31,13 @@ func NewStateClient(fs filesystem.Filesystem) *State {
 
 func (o *State) SetForwardedPorts(ctx context.Context, fwPorts []api.ForwardedPort) error {
 	var (
-		pid = odocontext.GetPID(ctx)
+		pid      = odocontext.GetPID(ctx)
+		platform = fcontext.GetPlatform(ctx, commonflags.PlatformCluster)
 	)
 	// TODO(feloy) When other data is persisted into the state file, it will be needed to read the file first
 	o.content.ForwardedPorts = fwPorts
 	o.content.PID = pid
+	o.content.Platform = platform
 	return o.save(pid)
 }
 
@@ -57,6 +61,7 @@ func (o *State) SaveExit(ctx context.Context) error {
 	)
 	o.content.ForwardedPorts = nil
 	o.content.PID = 0
+	o.content.Platform = ""
 	err := o.delete(pid)
 	if err != nil {
 		return err

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -105,10 +105,10 @@ func (o *State) save(ctx context.Context, pid int) error {
 		return err
 	}
 
-	return writeStateFile(getFilename(pid))
+	return o.writeStateFile(getFilename(pid))
 }
 
-func writeStateFile(path string) error {
+func (o *State) writeStateFile(path string) error {
 	jsonContent, err := json.MarshalIndent(o.content, "", " ")
 	if err != nil {
 		return err
@@ -173,7 +173,7 @@ func (o *State) saveCommonIfOwner(pid int) error {
 		return nil
 	}
 
-	return writeStateFile(_filepath)
+	return o.writeStateFile(_filepath)
 }
 
 func (o *State) isFreeOrOwnedBy(pid int) (bool, error) {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -154,12 +154,24 @@ func TestState_SaveExit(t *testing.T) {
 }
 
 func TestState_GetForwardedPorts(t *testing.T) {
-	content1 := Content{
+	contentPodman := Content{
+		Platform: "podman",
 		ForwardedPorts: []api.ForwardedPort{
 			{
 				ContainerName: "acontainer",
 				LocalAddress:  "localhost",
 				LocalPort:     20001,
+				ContainerPort: 3000,
+			},
+		},
+	}
+	contentCluster := Content{
+		Platform: "cluster",
+		ForwardedPorts: []api.ForwardedPort{
+			{
+				ContainerName: "acontainer",
+				LocalAddress:  "localhost",
+				LocalPort:     20002,
 				ContainerPort: 3000,
 			},
 		},
@@ -175,12 +187,12 @@ func TestState_GetForwardedPorts(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "get forwarded ports",
+			name: "get forwarded ports, only deployed on podman",
 			fields: fields{
 				content: Content{},
 				fs: func(t *testing.T) filesystem.Filesystem {
 					fs := filesystem.NewFakeFs()
-					jsonContent, err := json.Marshal(content1)
+					jsonContent, err := json.Marshal(contentPodman)
 					if err != nil {
 						t.Errorf("Error marshaling data")
 					}
@@ -192,7 +204,61 @@ func TestState_GetForwardedPorts(t *testing.T) {
 					return fs
 				},
 			},
-			want:    content1.ForwardedPorts,
+			want:    contentPodman.ForwardedPorts,
+			wantErr: false,
+		},
+		{
+			name: "get forwarded ports, only deployed on cluster",
+			fields: fields{
+				content: Content{},
+				fs: func(t *testing.T) filesystem.Filesystem {
+					fs := filesystem.NewFakeFs()
+					jsonContent, err := json.Marshal(contentCluster)
+					if err != nil {
+						t.Errorf("Error marshaling data")
+					}
+					pid := 1
+					err = fs.WriteFile(getFilename(pid), jsonContent, 0644)
+					if err != nil {
+						t.Errorf("Error saving content to file")
+					}
+					return fs
+				},
+			},
+			want:    contentCluster.ForwardedPorts,
+			wantErr: false,
+		},
+		{
+			name: "get forwarded ports, deployed on both podman and cluster",
+			fields: fields{
+				content: Content{},
+				fs: func(t *testing.T) filesystem.Filesystem {
+					fs := filesystem.NewFakeFs()
+
+					pidCluster := 1
+					jsonContentCluster, err := json.Marshal(contentCluster)
+					if err != nil {
+						t.Errorf("Error marshaling data")
+					}
+					err = fs.WriteFile(getFilename(pidCluster), jsonContentCluster, 0644)
+					if err != nil {
+						t.Errorf("Error saving content to file")
+					}
+
+					pidPodman := 2
+					jsonContentPodman, err := json.Marshal(contentPodman)
+					if err != nil {
+						t.Errorf("Error marshaling data")
+					}
+					err = fs.WriteFile(getFilename(pidPodman), jsonContentPodman, 0644)
+					if err != nil {
+						t.Errorf("Error saving content to file")
+					}
+
+					return fs
+				},
+			},
+			want:    append(append([]api.ForwardedPort{}, contentCluster.ForwardedPorts...), contentPodman.ForwardedPorts...),
 			wantErr: false,
 		},
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/redhat-developer/odo/pkg/api"
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 )
 
@@ -77,7 +79,9 @@ func TestState_SetForwardedPorts(t *testing.T) {
 			o := State{
 				fs: fs,
 			}
-			if err := o.SetForwardedPorts(1, tt.args.fwPorts); (err != nil) != tt.wantErr {
+			ctx := context.Background()
+			ctx = odocontext.WithPID(ctx, 1)
+			if err := o.SetForwardedPorts(ctx, tt.args.fwPorts); (err != nil) != tt.wantErr {
 				t.Errorf("State.SetForwardedPorts() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if check := tt.checkState(fs); check != nil {
@@ -136,9 +140,10 @@ func TestState_SaveExit(t *testing.T) {
 			o := State{
 				fs: fs,
 			}
-			pid := 1
-			_ = o.SetForwardedPorts(pid, nil)
-			if err := o.SaveExit(pid); (err != nil) != tt.wantErr {
+			ctx := context.Background()
+			ctx = odocontext.WithPID(ctx, 1)
+			_ = o.SetForwardedPorts(ctx, nil)
+			if err := o.SaveExit(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("State.SaveExit() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if check := tt.checkState(fs); check != nil {
@@ -197,8 +202,9 @@ func TestState_GetForwardedPorts(t *testing.T) {
 				content: tt.fields.content,
 				fs:      tt.fields.fs(t),
 			}
-			pid := 1
-			got, err := o.GetForwardedPorts(pid)
+			ctx := context.Background()
+			ctx = odocontext.WithPID(ctx, 1)
+			got, err := o.GetForwardedPorts(ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("State.GetForwardedPorts() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -77,7 +77,7 @@ func TestState_SetForwardedPorts(t *testing.T) {
 			o := State{
 				fs: fs,
 			}
-			if err := o.SetForwardedPorts(tt.args.fwPorts); (err != nil) != tt.wantErr {
+			if err := o.SetForwardedPorts(1, tt.args.fwPorts); (err != nil) != tt.wantErr {
 				t.Errorf("State.SetForwardedPorts() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if check := tt.checkState(fs); check != nil {
@@ -136,7 +136,9 @@ func TestState_SaveExit(t *testing.T) {
 			o := State{
 				fs: fs,
 			}
-			if err := o.SaveExit(); (err != nil) != tt.wantErr {
+			pid := 1
+			_ = o.SetForwardedPorts(pid, nil)
+			if err := o.SaveExit(pid); (err != nil) != tt.wantErr {
 				t.Errorf("State.SaveExit() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if check := tt.checkState(fs); check != nil {
@@ -177,7 +179,8 @@ func TestState_GetForwardedPorts(t *testing.T) {
 					if err != nil {
 						t.Errorf("Error marshaling data")
 					}
-					err = fs.WriteFile(_filepath, jsonContent, 0644)
+					pid := 1
+					err = fs.WriteFile(getFilename(pid), jsonContent, 0644)
 					if err != nil {
 						t.Errorf("Error saving content to file")
 					}
@@ -194,7 +197,8 @@ func TestState_GetForwardedPorts(t *testing.T) {
 				content: tt.fields.content,
 				fs:      tt.fields.fs(t),
 			}
-			got, err := o.GetForwardedPorts()
+			pid := 1
+			got, err := o.GetForwardedPorts(pid)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("State.GetForwardedPorts() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -7,6 +7,8 @@ import (
 type Content struct {
 	// PID is the ID of the process to which the state belongs
 	PID int `json:"pid"`
+	// Platform indicates on which platform the session works
+	Platform string `json:"platform"`
 	// ForwardedPorts are the ports forwarded during odo dev session
 	ForwardedPorts []api.ForwardedPort `json:"forwardedPorts"`
 }

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Content struct {
+	// PID is the ID of the process to which the state belongs
+	PID int `json:"pid"`
 	// ForwardedPorts are the ports forwarded during odo dev session
 	ForwardedPorts []api.ForwardedPort `json:"forwardedPorts"`
 }

--- a/tests/helper/helper_dev.go
+++ b/tests/helper/helper_dev.go
@@ -191,8 +191,10 @@ func (o *DevSession) Stop() {
 		return
 	}
 
-	err := terminateProc(o.session)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	if o.session.ExitCode() == -1 {
+		err := terminateProc(o.session)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 	o.stopped = true
 }
 

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -277,7 +277,7 @@ var _ = Describe("odo dev command tests", func() {
 				stdout := res.Out()
 				stderr := res.Err()
 				Expect(stdout).To(ContainSubstring("Cleaning"))
-				Expect(stderr).To(ContainSubstring("unable to save forwarded ports to state file"))
+				Expect(stderr).To(ContainSubstring("unable to save state file"))
 			})
 		})
 


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

State of `odo dev` if now saved in a file `.odo/devstate.${PID}.json`, to be able to run multiple instances and state for each of them.

For compatibility, the file `.odo/devstate.json` is also used for the first instance of `odo dev`.

One drawback is that if an instance of `odo dev` is killed, the `devstate.json` file won't be overwritten. One possibility would be to delete it when running `odo delete component` and the process with registered PID into devstate.json is not existing.

**Which issue(s) this PR fixes:**

Fixes #6494 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
