### PR TITLE
Revert "Add DEVFILE_REGISTRY env var for periodic tests (#6709)"

### DIFF
--- a/scripts/openshiftci-Nightly-SBO-tests.sh
+++ b/scripts/openshiftci-Nightly-SBO-tests.sh
@@ -27,8 +27,6 @@ oc login -u developer -p password@123 --insecure-skip-tls-verify
 # Check login user name for debugging purpose
 oc whoami
 
-source ./scripts/openshiftci-config.sh
-
 # Operatorhub integration tests
 make test-integration
 make test-e2e

--- a/scripts/openshiftci-config.sh
+++ b/scripts/openshiftci-config.sh
@@ -1,0 +1,1 @@
+export DEVFILE_REGISTRY=https://devfile-registry-ci-devfile-registry.odo-test-kubernetes-clust-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/

--- a/scripts/openshiftci-config.sh
+++ b/scripts/openshiftci-config.sh
@@ -1,1 +1,0 @@
-export DEVFILE_REGISTRY=https://devfile-registry-ci-devfile-registry.odo-test-kubernetes-clust-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/

--- a/scripts/openshiftci-periodic-tests.sh
+++ b/scripts/openshiftci-periodic-tests.sh
@@ -26,8 +26,6 @@ oc login -u developer -p password@123 --insecure-skip-tls-verify
 # Check login user name for debugging purpose
 oc whoami
 
-source ./scripts/openshiftci-config.sh
-
 # Integration tests
 make test-integration || error=true
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -32,8 +32,6 @@ oc login -u developer -p password@123 --insecure-skip-tls-verify
 # Check login user name for debugging purpose
 oc whoami
 
-source ./scripts/openshiftci-config.sh
-
 if [ "${ARCH}" == "s390x" ]; then
     # Integration tests
     make test-integration

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# This file is used for InterOP testing, i.e. testing odo with unreleased OpenShift versions.
+
 # fail if some commands fails
 set -e
 # show commands
@@ -32,6 +34,8 @@ oc login -u developer -p password@123 --insecure-skip-tls-verify
 # Check login user name for debugging purpose
 oc whoami
 
+# We want to use a stable Devfile registry for InterOP testing, and so we use the custom Devfile Registry setup on IBM cloud
+source ./scripts/openshiftci-config.sh
 if [ "${ARCH}" == "s390x" ]; then
     # Integration tests
     make test-integration


### PR DESCRIPTION
This reverts commit f0bf9ee1dd86eba0c6917f0b857ea5840d9bb314.

<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind code-refactoring

Additionally, add one of the following areas if applicable:
/area documentation
/area testing

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
PR #6709 modified the periodic tests to use the Devfile registry setup on IBM cloud because of the broken Staging Registry. But it would be helpful to have our tests use the Staging Registry in order to catch any problem with it early on before it propagates to the Production Registry.

This PR reverts back to using the Staging Registry.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
