### PR TITLE
For custom port mapping, handle case where ranged random port matches a custom local port

### DIFF
--- a/pkg/odo/cli/dev/dev_test.go
+++ b/pkg/odo/cli/dev/dev_test.go
@@ -280,7 +280,7 @@ func Test_parsePortForwardFlag(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(gotForwardedPorts, tt.wantForwardedPorts); diff != "" {
-				t.Errorf("parsePortForwardFlag() gotForwardedPorts = %v, want %v", gotForwardedPorts, tt.wantForwardedPorts)
+				t.Errorf("parsePortForwardFlag() (got vs want) diff = %v", diff)
 			}
 		})
 	}

--- a/pkg/portForward/kubeportforward/portForward_test.go
+++ b/pkg/portForward/kubeportforward/portForward_test.go
@@ -51,12 +51,30 @@ func Test_getCompleteCustomPortPairs(t *testing.T) {
 				"tools":   {"5000:5000"},
 			},
 		},
+		{
+			name: "local ports in range [20001-30001] are provided as custom forward ports",
+			args: args{
+				definedPorts: []api.ForwardedPort{
+					{LocalPort: 20001, ContainerPort: 8000},
+					{LocalPort: 20002, ContainerPort: 9000},
+					{LocalPort: 5000, ContainerPort: 5000},
+				},
+				ceMapping: map[string][]v1alpha2.Endpoint{
+					"runtime": {{TargetPort: 8000}, {TargetPort: 9000}},
+					"tools":   {{TargetPort: 5000}, {TargetPort: 8080}},
+				},
+			},
+			wantPortPairs: map[string][]string{
+				"runtime": {"20001:8000", "20002:9000"},
+				"tools":   {"5000:5000", "20003:8080"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotPortPairs := getCustomPortPairs(tt.args.definedPorts, tt.args.ceMapping)
 			if diff := cmp.Diff(gotPortPairs, tt.wantPortPairs); diff != "" {
-				t.Errorf("getCompleteCustomPortPairs() = %v, want %v", gotPortPairs, tt.wantPortPairs)
+				t.Errorf("getCompleteCustomPortPairs() (got vs want) diff = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind code-refactoring

Additionally, add one of the following areas if applicable:
/area documentation
/area testing

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes part of #6479 

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
1. `odo init --devfile nodejs --starter nodejs-starter`
2. `odo dev --port-forward 20001:5858 --debug`
Resulting port mapping: 3000 -> 20002, 5858 -> 20001