### PR TITLE
Fix e2e test failures and doc test failures due to updated devfile registry

### DIFF
--- a/docs/website/docs/command-reference/docs-mdx/init/registry_list_output.mdx
+++ b/docs/website/docs/command-reference/docs-mdx/init/registry_list_output.mdx
@@ -2,5 +2,5 @@
 $ odo registry --devfile nodejs-react
  NAME          REGISTRY                DESCRIPTION                                  VERSIONS
  nodejs-react  StagingRegistry         React is a free and open-source front-en...  2.0.2, 2.1.0
- nodejs-react  DefaultDevfileRegistry  React is a free and open-source front-en...  2.0.2
+ nodejs-react  DefaultDevfileRegistry  React is a free and open-source front-en...  2.0.2, 2.1.0
 ```


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind code-refactoring

Additionally, add one of the following areas if applicable:
/area documentation
/area testing

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**
This PR fixes e2e and doc test failures related to an update in the Devfile registry.

Prod/Staging Devfile registries updated all the JavaScript related Devfiles with a newer version, which is causing a failure in our tests.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
