### PR TITLE
Allow to cancel execution of `odo dev` at any phase (e.g. if build command is taking long)

### DIFF
--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -180,7 +180,7 @@ func (do DeleteComponentClient) ListClusterResourcesToDeleteFromDevfile(devfileO
 }
 
 // ExecutePreStopEvents executes preStop events if any, as a precondition to deleting a devfile component deployment
-func (do *DeleteComponentClient) ExecutePreStopEvents(devfileObj parser.DevfileObj, appName string, componentName string) error {
+func (do *DeleteComponentClient) ExecutePreStopEvents(ctx context.Context, devfileObj parser.DevfileObj, appName string, componentName string) error {
 	if !libdevfile.HasPreStopEvents(devfileObj) {
 		return nil
 	}
@@ -216,8 +216,7 @@ func (do *DeleteComponentClient) ExecutePreStopEvents(devfileObj parser.DevfileO
 
 	klog.V(4).Infof("Executing %q event commands for component %q", libdevfile.PreStop, componentName)
 	// ignore the failures if any; delete should not fail because preStop events failed to execute
-	err = libdevfile.ExecPreStopEvents(devfileObj,
-		component.NewExecHandler(do.kubeClient, do.execClient, appName, componentName, pod.Name, "Executing pre-stop command in container", false))
+	err = libdevfile.ExecPreStopEvents(ctx, devfileObj, component.NewExecHandler(do.kubeClient, do.execClient, appName, componentName, pod.Name, "Executing pre-stop command in container", false))
 	if err != nil {
 		klog.V(4).Infof("Failed to execute %q event commands for component %q, cause: %v", libdevfile.PreStop, componentName, err.Error())
 	}

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -689,7 +689,7 @@ func TestDeleteComponentClient_ExecutePreStopEvents(t *testing.T) {
 					client.EXPECT().GetRunningPodFromSelector(selector).Return(odoTestingUtil.CreateFakePod(componentName, "runtime"), nil)
 
 					cmd := []string{"/bin/sh", "-c", "cd /projects/nodejs-starter && (echo \"Hello World!\") 1>>/proc/1/fd/1 2>>/proc/1/fd/2"}
-					client.EXPECT().ExecCMDInContainer("runtime", "runtime", cmd, gomock.Any(), gomock.Any(), nil, false).Return(nil)
+					client.EXPECT().ExecCMDInContainer(gomock.Any(), "runtime", "runtime", cmd, gomock.Any(), gomock.Any(), nil, false).Return(nil)
 
 					return client
 				},
@@ -733,7 +733,7 @@ func TestDeleteComponentClient_ExecutePreStopEvents(t *testing.T) {
 					client.EXPECT().GetPodLogs(fakePod.Name, gomock.Any(), gomock.Any()).Return(nil, errors.New("an error"))
 
 					cmd := []string{"/bin/sh", "-c", "cd /projects/nodejs-starter && (echo \"Hello World!\") 1>>/proc/1/fd/1 2>>/proc/1/fd/2"}
-					client.EXPECT().ExecCMDInContainer("runtime", "runtime", cmd, gomock.Any(), gomock.Any(), nil, false).Return(errors.New("some error"))
+					client.EXPECT().ExecCMDInContainer(gomock.Any(), "runtime", "runtime", cmd, gomock.Any(), gomock.Any(), nil, false).Return(errors.New("some error"))
 
 					return client
 				},
@@ -751,7 +751,7 @@ func TestDeleteComponentClient_ExecutePreStopEvents(t *testing.T) {
 			kubeClient := tt.fields.kubeClient(ctrl)
 			execClient := exec.NewExecClient(kubeClient)
 			do := NewDeleteComponentClient(kubeClient, nil, execClient)
-			if err := do.ExecutePreStopEvents(tt.args.devfileObj, tt.args.appName, tt.args.devfileObj.GetMetadataName()); (err != nil) != tt.wantErr {
+			if err := do.ExecutePreStopEvents(context.Background(), tt.args.devfileObj, tt.args.appName, tt.args.devfileObj.GetMetadataName()); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteComponent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/component/delete/interface.go
+++ b/pkg/component/delete/interface.go
@@ -16,7 +16,7 @@ type Client interface {
 	// set wait to true to wait for all the dependencies to be deleted
 	DeleteResources(resources []unstructured.Unstructured, wait bool) []unstructured.Unstructured
 	// ExecutePreStopEvents executes preStop events if any, as a precondition to deleting a devfile component deployment
-	ExecutePreStopEvents(devfileObj parser.DevfileObj, appName string, componentName string) error
+	ExecutePreStopEvents(ctx context.Context, devfileObj parser.DevfileObj, appName string, componentName string) error
 	// ListClusterResourcesToDeleteFromDevfile parses all the devfile components and returns a list of resources that are present on the cluster that can be deleted,
 	// and a bool that indicates if the devfile component has been pushed to the innerloop.
 	// The mode indicates which component to list, either Dev, Deploy or Any (using constant labels.Component*Mode).

--- a/pkg/component/delete/mock.go
+++ b/pkg/component/delete/mock.go
@@ -52,17 +52,17 @@ func (mr *MockClientMockRecorder) DeleteResources(resources, wait interface{}) *
 }
 
 // ExecutePreStopEvents mocks base method.
-func (m *MockClient) ExecutePreStopEvents(devfileObj parser.DevfileObj, appName, componentName string) error {
+func (m *MockClient) ExecutePreStopEvents(ctx context.Context, devfileObj parser.DevfileObj, appName, componentName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecutePreStopEvents", devfileObj, appName, componentName)
+	ret := m.ctrl.Call(m, "ExecutePreStopEvents", ctx, devfileObj, appName, componentName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExecutePreStopEvents indicates an expected call of ExecutePreStopEvents.
-func (mr *MockClientMockRecorder) ExecutePreStopEvents(devfileObj, appName, componentName interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ExecutePreStopEvents(ctx, devfileObj, appName, componentName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePreStopEvents", reflect.TypeOf((*MockClient)(nil).ExecutePreStopEvents), devfileObj, appName, componentName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePreStopEvents", reflect.TypeOf((*MockClient)(nil).ExecutePreStopEvents), ctx, devfileObj, appName, componentName)
 }
 
 // ListClusterResourcesToDelete mocks base method.

--- a/pkg/component/exec_handler.go
+++ b/pkg/component/exec_handler.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -52,7 +53,7 @@ func (o *execHandler) ApplyOpenShift(openshift v1alpha2.Component) error {
 	return nil
 }
 
-func (o *execHandler) Execute(command v1alpha2.Command) error {
+func (o *execHandler) Execute(ctx context.Context, command v1alpha2.Command) error {
 	msg := o.msg
 	if msg == "" {
 		msg = fmt.Sprintf("Executing %s command on container %q", command.Id, command.Exec.Component)
@@ -66,7 +67,7 @@ func (o *execHandler) Execute(command v1alpha2.Command) error {
 	stdoutWriter, stdoutChannel, stderrWriter, stderrChannel := logger.CreateContainerOutputWriter()
 
 	cmdline := getCmdline(command)
-	_, _, err := o.execClient.ExecuteCommand(cmdline, o.podName, command.Exec.Component, o.show, stdoutWriter, stderrWriter)
+	_, _, err := o.execClient.ExecuteCommand(ctx, cmdline, o.podName, command.Exec.Component, o.show, stdoutWriter, stderrWriter)
 
 	closeWriterAndWaitForAck(stdoutWriter, stdoutChannel, stderrWriter, stderrChannel)
 

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -67,7 +67,7 @@ func (o *DeployClient) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return libdevfile.Deploy(*devfileObj, handler)
+	return libdevfile.Deploy(ctx, *devfileObj, handler)
 }
 
 func (o *DeployClient) buildPushAutoImageComponents(handler *deployHandler, devfileObj parser.DevfileObj) error {
@@ -150,7 +150,7 @@ func (o *deployHandler) ApplyOpenShift(openshift v1alpha2.Component) error {
 }
 
 // Execute will deploy the listed information in the `exec` section of devfile.yaml
-func (o *deployHandler) Execute(command v1alpha2.Command) error {
+func (o *deployHandler) Execute(ctx context.Context, command v1alpha2.Command) error {
 	policy, err := o.kubeClient.GetCurrentNamespacePolicy()
 	if err != nil {
 		return err

--- a/pkg/dev/kubedev/cleanup.go
+++ b/pkg/dev/kubedev/cleanup.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"io"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/redhat-developer/odo/pkg/labels"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func (o *DevClient) CleanupResources(ctx context.Context, out io.Writer) error {
@@ -28,7 +29,7 @@ func (o *DevClient) CleanupResources(ctx context.Context, out io.Writer) error {
 	}
 	// if innerloop deployment resource is present, then execute preStop events
 	if isInnerLoopDeployed {
-		err = o.deleteClient.ExecutePreStopEvents(*devfileObj, appname, componentName)
+		err = o.deleteClient.ExecutePreStopEvents(ctx, *devfileObj, appname, componentName)
 		if err != nil {
 			fmt.Fprint(out, "Failed to execute preStop events")
 		}

--- a/pkg/dev/podmandev/command.go
+++ b/pkg/dev/podmandev/command.go
@@ -45,14 +45,6 @@ func (a commandHandler) ApplyOpenShift(openshift devfilev1.Component) error {
 	return nil
 }
 
-func (a commandHandler) Execute(devfileCmd devfilev1.Command) error {
-	return component.ExecuteRunCommand(
-		a.execClient,
-		a.platformClient,
-		devfileCmd,
-		a.componentExists,
-		a.podName,
-		a.appName,
-		a.componentName,
-	)
+func (a commandHandler) Execute(ctx context.Context, command devfilev1.Command) error {
+	return component.ExecuteRunCommand(ctx, a.execClient, a.platformClient, command, a.componentExists, a.podName, a.appName, a.componentName)
 }

--- a/pkg/dev/podmandev/podmandev.go
+++ b/pkg/dev/podmandev/podmandev.go
@@ -167,7 +167,7 @@ func (o *DevClient) syncFiles(ctx context.Context, options dev.StartOptions, pod
 		ForcePush: true,
 		Files:     adapters.GetSyncFilesFromAttributes(devfileCmd),
 	}
-	execRequired, err := o.syncClient.SyncFiles(syncParams)
+	execRequired, err := o.syncClient.SyncFiles(ctx, syncParams)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -75,7 +75,7 @@ func (o *DevClient) reconcile(
 			"Executing post-start command in container",
 			false, /* TODO */
 		)
-		err = libdevfile.ExecPostStartEvents(*devfileObj, execHandler)
+		err = libdevfile.ExecPostStartEvents(ctx, *devfileObj, execHandler)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func (o *DevClient) reconcile(
 				"Building your application in container",
 				false, /* TODO */
 			)
-			return libdevfile.Build(*devfileObj, options.BuildCommand, execHandler)
+			return libdevfile.Build(ctx, *devfileObj, options.BuildCommand, execHandler)
 		}
 		err = doExecuteBuildCommand()
 		if err != nil {
@@ -116,7 +116,7 @@ func (o *DevClient) reconcile(
 			appName:         appName,
 			componentName:   componentName,
 		}
-		err = libdevfile.ExecuteCommandByNameAndKind(*devfileObj, cmdName, cmdKind, &cmdHandler, false)
+		err = libdevfile.ExecuteCommandByNameAndKind(ctx, *devfileObj, cmdName, cmdKind, &cmdHandler, false)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func (o *DevClient) reconcile(
 	// By default, Podman will not forward to container applications listening on the loopback interface.
 	// So we are trying to detect such cases and act accordingly.
 	// See https://github.com/redhat-developer/odo/issues/6510#issuecomment-1439986558
-	err = o.handleLoopbackPorts(options, pod, fwPorts)
+	err = o.handleLoopbackPorts(ctx, options, pod, fwPorts)
 	if err != nil {
 		return err
 	}
@@ -260,12 +260,12 @@ func (o *DevClient) checkAppPorts(ctx context.Context, podName string, portsToFw
 // If that is the case, it will either return an error if options.IgnoreLocalhost is false, or no error otherwise.
 //
 // Note that this method should be called after the process representing the application (run or debug command) is actually started in the pod.
-func (o *DevClient) handleLoopbackPorts(options dev.StartOptions, pod *corev1.Pod, fwPorts []api.ForwardedPort) error {
+func (o *DevClient) handleLoopbackPorts(ctx context.Context, options dev.StartOptions, pod *corev1.Pod, fwPorts []api.ForwardedPort) error {
 	if len(pod.Spec.Containers) == 0 {
 		return nil
 	}
 
-	loopbackPorts, err := port.DetectRemotePortsBoundOnLoopback(o.execClient, pod.Name, pod.Spec.Containers[0].Name, fwPorts)
+	loopbackPorts, err := port.DetectRemotePortsBoundOnLoopback(ctx, o.execClient, pod.Name, pod.Spec.Containers[0].Name, fwPorts)
 	if err != nil {
 		return fmt.Errorf("unable to detect container ports bound on the loopback interface: %w", err)
 	}

--- a/pkg/devfile/adapters/kubernetes/component/handler.go
+++ b/pkg/devfile/adapters/kubernetes/component/handler.go
@@ -5,6 +5,7 @@ import (
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
+
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/devfile/image"
 	"github.com/redhat-developer/odo/pkg/exec"
@@ -43,15 +44,14 @@ func (a *runHandler) ApplyOpenShift(openshift devfilev1.Component) error {
 	return component.ApplyKubernetes(odolabels.ComponentDevMode, a.appName, a.componentName, a.devfile, openshift, a.kubeClient, a.path)
 }
 
-func (a *runHandler) Execute(devfileCmd devfilev1.Command) error {
-	return component.ExecuteRunCommand(a.execClient, a.kubeClient, devfileCmd, a.componentExists, a.podName, a.appName, a.componentName)
+func (a *runHandler) Execute(ctx context.Context, command devfilev1.Command) error {
+	return component.ExecuteRunCommand(ctx, a.execClient, a.kubeClient, command, a.componentExists, a.podName, a.appName, a.componentName)
 
 }
 
 // IsRemoteProcessForCommandRunning returns true if the command is running
-func (a *runHandler) IsRemoteProcessForCommandRunning(command devfilev1.Command, podName string) (bool, error) {
-	remoteProcess, err := remotecmd.NewKubeExecProcessHandler(a.execClient).GetProcessInfoForCommand(
-		remotecmd.CommandDefinition{Id: command.Id}, podName, command.Exec.Component)
+func (a *runHandler) IsRemoteProcessForCommandRunning(ctx context.Context, command devfilev1.Command, podName string) (bool, error) {
+	remoteProcess, err := remotecmd.NewKubeExecProcessHandler(a.execClient).GetProcessInfoForCommand(ctx, remotecmd.CommandDefinition{Id: command.Id}, podName, command.Exec.Component)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -19,7 +20,7 @@ type fakePlatform struct {
 	execCMDInContainer func(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error
 }
 
-func (o fakePlatform) ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error {
+func (o fakePlatform) ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
 	return o.execCMDInContainer(containerName, podName, cmd, stdout, stderr, stdin, tty)
 }
 
@@ -81,7 +82,7 @@ func TestExecuteCommand(t *testing.T) {
 			}
 
 			execClient := NewExecClient(platformClient)
-			stdout, stderr, err := execClient.ExecuteCommand(tt.cmd, _podName, _containerName, false, nil, nil)
+			stdout, stderr, err := execClient.ExecuteCommand(context.Background(), tt.cmd, _podName, _containerName, false, nil, nil)
 
 			if tt.wantErr != (err != nil) {
 				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)

--- a/pkg/exec/interface.go
+++ b/pkg/exec/interface.go
@@ -1,16 +1,12 @@
 package exec
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 type Client interface {
 	// ExecuteCommand executes the given command in the pod's container,
 	// writing the output to the specified respective pipe writers
-	ExecuteCommand(
-		command []string,
-		podName string,
-		containerName string,
-		show bool,
-		stdoutWriter *io.PipeWriter,
-		stderrWriter *io.PipeWriter,
-	) (stdout []string, stderr []string, err error)
+	ExecuteCommand(ctx context.Context, command []string, podName string, containerName string, show bool, stdoutWriter *io.PipeWriter, stderrWriter *io.PipeWriter) (stdout []string, stderr []string, err error)
 }

--- a/pkg/exec/mock.go
+++ b/pkg/exec/mock.go
@@ -5,6 +5,7 @@
 package exec
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -35,9 +36,9 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ExecuteCommand mocks base method.
-func (m *MockClient) ExecuteCommand(command []string, podName, containerName string, show bool, stdoutWriter, stderrWriter *io.PipeWriter) ([]string, []string, error) {
+func (m *MockClient) ExecuteCommand(ctx context.Context, command []string, podName, containerName string, show bool, stdoutWriter, stderrWriter *io.PipeWriter) ([]string, []string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecuteCommand", command, podName, containerName, show, stdoutWriter, stderrWriter)
+	ret := m.ctrl.Call(m, "ExecuteCommand", ctx, command, podName, containerName, show, stdoutWriter, stderrWriter)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].([]string)
 	ret2, _ := ret[2].(error)
@@ -45,7 +46,7 @@ func (m *MockClient) ExecuteCommand(command []string, podName, containerName str
 }
 
 // ExecuteCommand indicates an expected call of ExecuteCommand.
-func (mr *MockClientMockRecorder) ExecuteCommand(command, podName, containerName, show, stdoutWriter, stderrWriter interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ExecuteCommand(ctx, command, podName, containerName, show, stdoutWriter, stderrWriter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteCommand", reflect.TypeOf((*MockClient)(nil).ExecuteCommand), command, podName, containerName, show, stdoutWriter, stderrWriter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteCommand", reflect.TypeOf((*MockClient)(nil).ExecuteCommand), ctx, command, podName, containerName, show, stdoutWriter, stderrWriter)
 }

--- a/pkg/kclient/mock_Client.go
+++ b/pkg/kclient/mock_Client.go
@@ -318,17 +318,17 @@ func (mr *MockClientInterfaceMockRecorder) DeploymentWatcher(ctx, selector inter
 }
 
 // ExecCMDInContainer mocks base method.
-func (m *MockClientInterface) ExecCMDInContainer(containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
+func (m *MockClientInterface) ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecCMDInContainer", containerName, podName, cmd, stdout, stderr, stdin, tty)
+	ret := m.ctrl.Call(m, "ExecCMDInContainer", ctx, containerName, podName, cmd, stdout, stderr, stdin, tty)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExecCMDInContainer indicates an expected call of ExecCMDInContainer.
-func (mr *MockClientInterfaceMockRecorder) ExecCMDInContainer(containerName, podName, cmd, stdout, stderr, stdin, tty interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) ExecCMDInContainer(ctx, containerName, podName, cmd, stdout, stderr, stdin, tty interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCMDInContainer", reflect.TypeOf((*MockClientInterface)(nil).ExecCMDInContainer), containerName, podName, cmd, stdout, stderr, stdin, tty)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCMDInContainer", reflect.TypeOf((*MockClientInterface)(nil).ExecCMDInContainer), ctx, containerName, podName, cmd, stdout, stderr, stdin, tty)
 }
 
 // GeneratePortForwardReq mocks base method.

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -7,7 +7,6 @@ import (
 
 	// api resource types
 
-	"github.com/redhat-developer/odo/pkg/platform"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -15,10 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/redhat-developer/odo/pkg/platform"
 )
 
 // ExecCMDInContainer execute command in the container of a pod, pass an empty string for containerName to execute in the first container of the pod
-func (c *Client) ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error {
+func (c *Client) ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
 	podExecOptions := corev1.PodExecOptions{
 		Command: cmd,
 		Stdin:   stdin != nil,
@@ -51,8 +52,7 @@ func (c *Client) ExecCMDInContainer(containerName, podName string, cmd []string,
 		return fmt.Errorf("unable execute command via SPDY: %w", err)
 	}
 	// initialize the transport of the standard shell streams
-	// TODO(feloy) related to https://github.com/redhat-developer/odo/issues/6196
-	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  stdin,
 		Stdout: stdout,
 		Stderr: stderr,

--- a/pkg/libdevfile/command.go
+++ b/pkg/libdevfile/command.go
@@ -1,17 +1,19 @@
 package libdevfile
 
 import (
+	"context"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
+
 	"github.com/redhat-developer/odo/pkg/util"
 )
 
 type command interface {
 	CheckValidity() error
-	Execute(handler Handler) error
+	Execute(ctx context.Context, handler Handler) error
 }
 
 // newCommand returns a command implementation, depending on the type of the command

--- a/pkg/libdevfile/command_apply.go
+++ b/pkg/libdevfile/command_apply.go
@@ -1,6 +1,8 @@
 package libdevfile
 
 import (
+	"context"
+
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
@@ -26,7 +28,7 @@ func (o *applyCommand) CheckValidity() error {
 	return nil
 }
 
-func (o *applyCommand) Execute(handler Handler) error {
+func (o *applyCommand) Execute(ctx context.Context, handler Handler) error {
 	devfileComponents, err := o.devfileObj.Data.GetComponents(common.DevfileOptions{
 		FilterByName: o.command.Apply.Component,
 	})

--- a/pkg/libdevfile/command_apply_test.go
+++ b/pkg/libdevfile/command_apply_test.go
@@ -1,11 +1,13 @@
 package libdevfile
 
 import (
+	"context"
 	"testing"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
+
 	"github.com/redhat-developer/odo/pkg/libdevfile/generator"
 )
 
@@ -57,7 +59,7 @@ func Test_applyCommand_Execute(t *testing.T) {
 				devfileObj: tt.fields.devfileObj(),
 			}
 			// TODO handler
-			if err := o.Execute(nil); (err != nil) != tt.wantErr {
+			if err := o.Execute(context.Background(), nil); (err != nil) != tt.wantErr {
 				t.Errorf("applyCommand.Execute() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/libdevfile/command_composite.go
+++ b/pkg/libdevfile/command_composite.go
@@ -1,6 +1,7 @@
 package libdevfile
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -39,7 +40,7 @@ func (o *compositeCommand) CheckValidity() error {
 }
 
 // Execute loops over each command and executes them serially
-func (o *compositeCommand) Execute(handler Handler) error {
+func (o *compositeCommand) Execute(ctx context.Context, handler Handler) error {
 	allCommands, err := allCommandsMap(o.devfileObj)
 	if err != nil {
 		return err
@@ -49,7 +50,7 @@ func (o *compositeCommand) Execute(handler Handler) error {
 		if err != nil {
 			return err
 		}
-		err = cmd.Execute(handler)
+		err = cmd.Execute(ctx, handler)
 		if err != nil {
 			return err
 		}

--- a/pkg/libdevfile/command_composite_parallel.go
+++ b/pkg/libdevfile/command_composite_parallel.go
@@ -1,11 +1,13 @@
 package libdevfile
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
+
 	"github.com/redhat-developer/odo/pkg/util"
 )
 
@@ -40,7 +42,7 @@ func (o *parallelCompositeCommand) CheckValidity() error {
 }
 
 // Execute loops over each command and executes them in parallel
-func (o *parallelCompositeCommand) Execute(handler Handler) error {
+func (o *parallelCompositeCommand) Execute(ctx context.Context, handler Handler) error {
 	allCommands, err := allCommandsMap(o.devfileObj)
 	if err != nil {
 		return err
@@ -53,7 +55,7 @@ func (o *parallelCompositeCommand) Execute(handler Handler) error {
 		}
 		commandExecs.Add(util.ConcurrentTask{
 			ToRun: func(errChannel chan error) {
-				err3 := cmd.Execute(handler)
+				err3 := cmd.Execute(ctx, handler)
 				if err3 != nil {
 					errChannel <- err3
 				}

--- a/pkg/libdevfile/command_exec.go
+++ b/pkg/libdevfile/command_exec.go
@@ -1,6 +1,8 @@
 package libdevfile
 
 import (
+	"context"
+
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 )
@@ -26,6 +28,6 @@ func (o *execCommand) CheckValidity() error {
 	return nil
 }
 
-func (o *execCommand) Execute(handler Handler) error {
-	return handler.Execute(o.command)
+func (o *execCommand) Execute(ctx context.Context, handler Handler) error {
+	return handler.Execute(ctx, o.command)
 }

--- a/pkg/libdevfile/handler_mock.go
+++ b/pkg/libdevfile/handler_mock.go
@@ -5,6 +5,7 @@
 package libdevfile
 
 import (
+	context "context"
 	reflect "reflect"
 
 	v1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -77,15 +78,15 @@ func (mr *MockHandlerMockRecorder) ApplyOpenShift(openshift interface{}) *gomock
 }
 
 // Execute mocks base method.
-func (m *MockHandler) Execute(command v1alpha2.Command) error {
+func (m *MockHandler) Execute(ctx context.Context, command v1alpha2.Command) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", command)
+	ret := m.ctrl.Call(m, "Execute", ctx, command)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockHandlerMockRecorder) Execute(command interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Execute(ctx, command interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockHandler)(nil).Execute), command)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockHandler)(nil).Execute), ctx, command)
 }

--- a/pkg/libdevfile/libdevfile_test.go
+++ b/pkg/libdevfile/libdevfile_test.go
@@ -1,6 +1,7 @@
 package libdevfile
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -446,7 +447,7 @@ func TestDeploy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			if err := Deploy(tt.args.devfileObj(), tt.args.handler(ctrl)); (err != nil) != tt.wantErr {
+			if err := Deploy(context.Background(), tt.args.devfileObj(), tt.args.handler(ctrl)); (err != nil) != tt.wantErr {
 				t.Errorf("Deploy() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -507,9 +508,9 @@ func TestBuild(t *testing.T) {
 				},
 				handler: func(ctrl *gomock.Controller) Handler {
 					h := NewMockHandler(ctrl)
-					h.EXPECT().Execute(gomock.Eq(defaultBuildCommand)).Times(0)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(defaultBuildCommand)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
 					return h
 				},
 			},
@@ -527,9 +528,9 @@ func TestBuild(t *testing.T) {
 				},
 				handler: func(ctrl *gomock.Controller) Handler {
 					h := NewMockHandler(ctrl)
-					h.EXPECT().Execute(gomock.Eq(defaultBuildCommand)).Times(1)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(defaultBuildCommand)).Times(1)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
 					return h
 				},
 			},
@@ -547,9 +548,9 @@ func TestBuild(t *testing.T) {
 				},
 				handler: func(ctrl *gomock.Controller) Handler {
 					h := NewMockHandler(ctrl)
-					h.EXPECT().Execute(gomock.Eq(defaultBuildCommand)).Times(0)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(defaultBuildCommand)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandExplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
 					return h
 				},
 				cmdName: "my-explicit-non-default-build-command",
@@ -569,9 +570,9 @@ func TestBuild(t *testing.T) {
 				},
 				handler: func(ctrl *gomock.Controller) Handler {
 					h := NewMockHandler(ctrl)
-					h.EXPECT().Execute(gomock.Eq(defaultBuildCommand)).Times(0)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandExplicit)).Times(1)
-					h.EXPECT().Execute(gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(defaultBuildCommand)).Times(0)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandExplicit)).Times(1)
+					h.EXPECT().Execute(gomock.Any(), gomock.Eq(nonDefaultBuildCommandImplicit)).Times(0)
 					return h
 				},
 				cmdName: "my-explicit-non-default-build-command",
@@ -579,7 +580,7 @@ func TestBuild(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := Build(tt.args.devfileObj(), tt.args.cmdName, tt.args.handler(gomock.NewController(t)))
+			err := Build(context.Background(), tt.args.devfileObj(), tt.args.cmdName, tt.args.handler(gomock.NewController(t)))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -335,7 +335,7 @@ func (o *ComponentOptions) deleteDevfileComponent(ctx context.Context) ([]unstru
 
 			// if innerloop deployment resource is present, then execute preStop events
 			if isClusterInnerLoopDeployed {
-				err = o.clientset.DeleteClient.ExecutePreStopEvents(*devfileObj, appName, componentName)
+				err = o.clientset.DeleteClient.ExecutePreStopEvents(ctx, *devfileObj, appName, componentName)
 				if err != nil {
 					log.Errorf("Failed to execute preStop events: %v", err)
 				}

--- a/pkg/odo/cli/delete/component/component_test.go
+++ b/pkg/odo/cli/delete/component/component_test.go
@@ -427,7 +427,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 					Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(gomock.Any(), compName, projectName, labels.ComponentAnyMode).
 					Return(resources, nil)
-				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				deleteClient.EXPECT().DeleteResources(resources, false).Return([]unstructured.Unstructured{})
 				return deleteClient
 			},
@@ -444,7 +444,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 					Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(gomock.Any(), compName, projectName, labels.ComponentDevMode).
 					Return(resources, nil)
-				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				deleteClient.EXPECT().DeleteResources(resources, false).Return([]unstructured.Unstructured{})
 				return deleteClient
 			},
@@ -462,7 +462,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 					Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(gomock.Any(), compName, projectName, labels.ComponentDeployMode).
 					Return(resources, nil)
-				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				deleteClient.EXPECT().DeleteResources(resources, false).Return([]unstructured.Unstructured{})
 				return deleteClient
 			},
@@ -495,7 +495,7 @@ func TestComponentOptions_deleteDevfileComponent(t *testing.T) {
 				deleteClient := _delete.NewMockClient(ctrl)
 				deleteClient.EXPECT().ListClusterResourcesToDeleteFromDevfile(gomock.Any(), appName, gomock.Any(), labels.ComponentAnyMode).Return(true, resources, nil)
 				deleteClient.EXPECT().ListClusterResourcesToDelete(gomock.Any(), compName, projectName, labels.ComponentAnyMode).Return(resources, nil)
-				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), appName, gomock.Any()).Return(errors.New("some error"))
+				deleteClient.EXPECT().ExecutePreStopEvents(gomock.Any(), gomock.Any(), appName, gomock.Any()).Return(errors.New("some error"))
 				deleteClient.EXPECT().DeleteResources(resources, false).Return(nil)
 				return deleteClient
 			},

--- a/pkg/platform/interface.go
+++ b/pkg/platform/interface.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"io"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,7 +13,7 @@ type Client interface {
 
 	// ExecCMDInContainer executes the specified command in the container of a pod.
 	// If an empty string is passed as container name, the command will be executed in the first container found in the pod.
-	ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error
+	ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error
 
 	// GetPodLogs returns the logs of the specified pod container.
 	// All logs for all containers part of the pod are returned if an empty string is provided as container name.

--- a/pkg/podman/exec.go
+++ b/pkg/podman/exec.go
@@ -22,7 +22,7 @@ func (o *PodmanCli) ExecCMDInContainer(ctx context.Context, containerName, podNa
 	args = append(args, name)
 	args = append(args, cmd...)
 
-	command := exec.Command(o.podmanCmd, args...)
+	command := exec.CommandContext(ctx, o.podmanCmd, args...)
 	klog.V(3).Infof("executing %v", command.Args)
 	command.Stdin = stdin
 

--- a/pkg/podman/exec.go
+++ b/pkg/podman/exec.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
@@ -8,7 +9,7 @@ import (
 	"k8s.io/klog"
 )
 
-func (o *PodmanCli) ExecCMDInContainer(containerName, podName string, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error {
+func (o *PodmanCli) ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
 	options := []string{}
 	if tty {
 		options = append(options, "--tty")

--- a/pkg/podman/mock.go
+++ b/pkg/podman/mock.go
@@ -5,6 +5,7 @@
 package podman
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -52,17 +53,17 @@ func (mr *MockClientMockRecorder) CleanupPodResources(pod interface{}) *gomock.C
 }
 
 // ExecCMDInContainer mocks base method.
-func (m *MockClient) ExecCMDInContainer(containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
+func (m *MockClient) ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecCMDInContainer", containerName, podName, cmd, stdout, stderr, stdin, tty)
+	ret := m.ctrl.Call(m, "ExecCMDInContainer", ctx, containerName, podName, cmd, stdout, stderr, stdin, tty)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExecCMDInContainer indicates an expected call of ExecCMDInContainer.
-func (mr *MockClientMockRecorder) ExecCMDInContainer(containerName, podName, cmd, stdout, stderr, stdin, tty interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ExecCMDInContainer(ctx, containerName, podName, cmd, stdout, stderr, stdin, tty interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCMDInContainer", reflect.TypeOf((*MockClient)(nil).ExecCMDInContainer), containerName, podName, cmd, stdout, stderr, stdin, tty)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCMDInContainer", reflect.TypeOf((*MockClient)(nil).ExecCMDInContainer), ctx, containerName, podName, cmd, stdout, stderr, stdin, tty)
 }
 
 // GetAllPodsInNamespaceMatchingSelector mocks base method.

--- a/pkg/port/port_test.go
+++ b/pkg/port/port_test.go
@@ -82,7 +82,7 @@ func TestDetectRemotePortsBoundOnLoopback(t *testing.T) {
 			name: "error while executing command",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(nil, nil, errors.New("some-err"))
 				},
 				podName:       podName,
@@ -95,7 +95,7 @@ func TestDetectRemotePortsBoundOnLoopback(t *testing.T) {
 			name: "no active connections",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(`
 sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
 sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
@@ -114,7 +114,7 @@ sl  local_address                         remote_address                        
 			name: "no input ports",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Times(0)
 				},
 				podName:       podName,
@@ -128,7 +128,7 @@ sl  local_address                         remote_address                        
 			name: "with different connections",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil)
 				},
 				podName:       podName,
@@ -149,7 +149,7 @@ sl  local_address                         remote_address                        
 			execClient := exec.NewMockClient(ctrl)
 			tt.args.execClientCustomizer(execClient)
 
-			got, err := DetectRemotePortsBoundOnLoopback(execClient, tt.args.podName, tt.args.containerName, tt.args.ports)
+			got, err := DetectRemotePortsBoundOnLoopback(context.Background(), execClient, tt.args.podName, tt.args.containerName, tt.args.ports)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("detectRemotePortsBoundOnLoopback() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -177,7 +177,7 @@ func TestGetListeningConnections(t *testing.T) {
 			name: "error while executing command",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(nil, nil, errors.New("some-err"))
 				},
 				podName:       podName,
@@ -189,7 +189,7 @@ func TestGetListeningConnections(t *testing.T) {
 			name: "no active connections",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(`
 sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
 sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
@@ -207,7 +207,7 @@ sl  local_address                         remote_address                        
 			name: "with different connections",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil)
 				},
 				podName:       podName,
@@ -249,7 +249,7 @@ sl  local_address                         remote_address                        
 			execClient := exec.NewMockClient(ctrl)
 			tt.args.execClientCustomizer(execClient)
 
-			got, err := GetListeningConnections(execClient, tt.args.podName, tt.args.containerName)
+			got, err := GetListeningConnections(context.Background(), execClient, tt.args.podName, tt.args.containerName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getListeningConnections() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -278,7 +278,7 @@ func TestGetConnections(t *testing.T) {
 			name: "error while executing command",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(nil, nil, errors.New("some-err"))
 				},
 				podName:       podName,
@@ -290,7 +290,7 @@ func TestGetConnections(t *testing.T) {
 			name: "no active connections",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(`
 sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
 sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
@@ -308,7 +308,7 @@ sl  local_address                         remote_address                        
 			name: "non-matching filter on state",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil)
 				},
 				podName:       podName,
@@ -324,7 +324,7 @@ sl  local_address                         remote_address                        
 			name: "filter on state: ESTABLISHED",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil)
 				},
 				podName:       podName,
@@ -343,7 +343,7 @@ sl  local_address                         remote_address                        
 			name: "all connections",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil)
 				},
 				podName:       podName,
@@ -403,7 +403,7 @@ sl  local_address                         remote_address                        
 			execClient := exec.NewMockClient(ctrl)
 			tt.args.execClientCustomizer(execClient)
 
-			got, err := GetConnections(execClient, tt.args.podName, tt.args.containerName, tt.args.statePredicate)
+			got, err := GetConnections(context.Background(), execClient, tt.args.podName, tt.args.containerName, tt.args.statePredicate)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getListeningConnections() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -445,7 +445,7 @@ func TestCheckAppPortsListening(t *testing.T) {
 			name: "error while checking for ports",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Any(), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Any(), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(nil, []string{"an error"}, errors.New("some error")).AnyTimes()
 				},
 				containerPortMapping: map[string][]int{
@@ -461,7 +461,7 @@ func TestCheckAppPortsListening(t *testing.T) {
 			name: "too small timeout reached while checking for ports, even if they are all opened",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Any(), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Any(), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(nil, []string{"an error"}, errors.New("some error")).AnyTimes()
 				},
 				containerPortMapping: map[string][]int{
@@ -478,9 +478,9 @@ func TestCheckAppPortsListening(t *testing.T) {
 			name: "at least one of the ports are not opened",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq("my-other-cont"), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq("my-other-cont"), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
 				},
 				containerPortMapping: map[string][]int{
@@ -497,9 +497,9 @@ func TestCheckAppPortsListening(t *testing.T) {
 			name: "all ports are opened in the container",
 			args: args{
 				execClientCustomizer: func(client *exec.MockClient) {
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq(containerName), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
-					client.EXPECT().ExecuteCommand(gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq("my-other-cont"), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
+					client.EXPECT().ExecuteCommand(gomock.Any(), gomock.Eq(cmd), gomock.Eq(podName), gomock.Eq("my-other-cont"), gomock.Eq(false), gomock.Nil(), gomock.Nil()).
 						Return(strings.Split(aggregatedContentFromProcNetFiles, "\n"), nil, nil).AnyTimes()
 				},
 				containerPortMapping: map[string][]int{

--- a/pkg/portForward/interface.go
+++ b/pkg/portForward/interface.go
@@ -28,7 +28,7 @@ type Client interface {
 	) error
 
 	// StopPortForwarding stops the port forwarding for the specified component.
-	StopPortForwarding(componentName string)
+	StopPortForwarding(ctx context.Context, componentName string)
 
 	// GetForwardedPorts returns the list of ports for each container currently forwarded.
 	GetForwardedPorts() map[string][]v1alpha2.Endpoint

--- a/pkg/portForward/kubeportforward/portForward.go
+++ b/pkg/portForward/kubeportforward/portForward.go
@@ -65,7 +65,7 @@ func (o *PFClient) StartPortForwarding(ctx context.Context, devFileObj parser.De
 
 	o.appliedEndpoints = ceMapping
 
-	o.StopPortForwarding(componentName)
+	o.StopPortForwarding(ctx, componentName)
 
 	if len(ceMapping) == 0 {
 		klog.V(4).Infof("no endpoint declared in the component, no ports are forwarded")
@@ -147,7 +147,7 @@ func (o *PFClient) StartPortForwarding(ctx context.Context, devFileObj parser.De
 	}
 }
 
-func (o *PFClient) StopPortForwarding(componentName string) {
+func (o *PFClient) StopPortForwarding(ctx context.Context, componentName string) {
 	if o.stopChan == nil {
 		return
 	}

--- a/pkg/portForward/podmanportforward/portForward.go
+++ b/pkg/portForward/podmanportforward/portForward.go
@@ -55,7 +55,7 @@ func (o *PFClient) StartPortForwarding(
 		return nil
 	}
 
-	o.StopPortForwarding(componentName)
+	o.StopPortForwarding(ctx, componentName)
 
 	outputHandler := func(fwPort api.ForwardedPort) remotecmd.CommandOutputHandler {
 		return func(status remotecmd.RemoteProcessStatus, stdout []string, stderr []string, err error) {
@@ -75,7 +75,7 @@ func (o *PFClient) StartPortForwarding(
 	}
 
 	for _, port := range definedPorts {
-		err := o.remoteProcessHandler.StartProcessForCommand(getCommandDefinition(port), getPodName(componentName), pfHelperContainer, outputHandler(port))
+		err := o.remoteProcessHandler.StartProcessForCommand(ctx, getCommandDefinition(port), getPodName(componentName), pfHelperContainer, outputHandler(port))
 		if err != nil {
 			return fmt.Errorf("error while creating port-forwarding for container port %d: %w", port.ContainerPort, err)
 		}
@@ -84,7 +84,7 @@ func (o *PFClient) StartPortForwarding(
 	return nil
 }
 
-func (o *PFClient) StopPortForwarding(componentName string) {
+func (o *PFClient) StopPortForwarding(ctx context.Context, componentName string) {
 	if len(o.appliedPorts) == 0 {
 		return
 	}
@@ -95,7 +95,7 @@ func (o *PFClient) StopPortForwarding(componentName string) {
 		port := port
 		go func() {
 			defer wg.Done()
-			err := o.remoteProcessHandler.StopProcessForCommand(getCommandDefinition(port), getPodName(componentName), pfHelperContainer)
+			err := o.remoteProcessHandler.StopProcessForCommand(ctx, getCommandDefinition(port), getPodName(componentName), pfHelperContainer)
 			if err != nil {
 				klog.V(4).Infof("error while stopping port-forwarding for container port %d: %v", port.ContainerPort, err)
 			}

--- a/pkg/remotecmd/interface.go
+++ b/pkg/remotecmd/interface.go
@@ -1,28 +1,17 @@
 package remotecmd
 
+import "context"
+
 // RemoteProcessHandler is an interface for managing processes that are intended to be executed remotely,
 // independently of container orchestrator
 type RemoteProcessHandler interface {
 
 	// GetProcessInfoForCommand returns information about the process representing the given command.
-	GetProcessInfoForCommand(
-		def CommandDefinition,
-		podName string,
-		containerName string,
-	) (RemoteProcessInfo, error)
+	GetProcessInfoForCommand(ctx context.Context, def CommandDefinition, podName string, containerName string) (RemoteProcessInfo, error)
 
 	// StartProcessForCommand starts a process with the provided Devfile command to execute remotely.
-	StartProcessForCommand(
-		def CommandDefinition,
-		podName string,
-		containerName string,
-		outputHandler CommandOutputHandler,
-	) error
+	StartProcessForCommand(ctx context.Context, def CommandDefinition, podName string, containerName string, outputHandler CommandOutputHandler) error
 
 	// StopProcessForCommand stops the process representing the given Devfile command.
-	StopProcessForCommand(
-		def CommandDefinition,
-		podName string,
-		containerName string,
-	) error
+	StopProcessForCommand(ctx context.Context, def CommandDefinition, podName string, containerName string) error
 }

--- a/pkg/sync/interface.go
+++ b/pkg/sync/interface.go
@@ -1,6 +1,9 @@
 package sync
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // ComponentInfo is a struct that holds information about a component i.e.; component name, pod name, container name, and source mount (if applicable)
 type ComponentInfo struct {
@@ -25,5 +28,5 @@ type SyncParameters struct {
 }
 
 type Client interface {
-	SyncFiles(syncParameters SyncParameters) (bool, error)
+	SyncFiles(ctx context.Context, syncParameters SyncParameters) (bool, error)
 }

--- a/pkg/sync/mock.go
+++ b/pkg/sync/mock.go
@@ -5,6 +5,7 @@
 package sync
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -34,16 +35,16 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // SyncFiles mocks base method.
-func (m *MockClient) SyncFiles(syncParameters SyncParameters) (bool, error) {
+func (m *MockClient) SyncFiles(ctx context.Context, syncParameters SyncParameters) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncFiles", syncParameters)
+	ret := m.ctrl.Call(m, "SyncFiles", ctx, syncParameters)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SyncFiles indicates an expected call of SyncFiles.
-func (mr *MockClientMockRecorder) SyncFiles(syncParameters interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) SyncFiles(ctx, syncParameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFiles", reflect.TypeOf((*MockClient)(nil).SyncFiles), syncParameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFiles", reflect.TypeOf((*MockClient)(nil).SyncFiles), ctx, syncParameters)
 }

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -93,7 +94,7 @@ func TestSyncFiles(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	kc := kclient.NewMockClientInterface(ctrl)
-	kc.EXPECT().ExecCMDInContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+	kc.EXPECT().ExecCMDInContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).AnyTimes()
 
 	// Assert that Bar() is invoked.
@@ -171,7 +172,7 @@ func TestSyncFiles(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			execClient := exec.NewExecClient(kc)
 			syncAdapter := NewSyncClient(kc, execClient)
-			isPushRequired, err := syncAdapter.SyncFiles(tt.syncParameters)
+			isPushRequired, err := syncAdapter.SyncFiles(context.Background(), tt.syncParameters)
 			if !tt.wantErr && err != nil {
 				t.Errorf("TestSyncFiles error: unexpected error when syncing files %v", err)
 			} else if !tt.wantErr && isPushRequired != tt.wantIsPushRequired {
@@ -200,7 +201,7 @@ func TestPushLocal(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	kc := kclient.NewMockClientInterface(ctrl)
-	kc.EXPECT().ExecCMDInContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+	kc.EXPECT().ExecCMDInContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).AnyTimes()
 
 	// Assert that Bar() is invoked.
@@ -303,7 +304,7 @@ func TestPushLocal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			execClient := exec.NewExecClient(kc)
 			syncAdapter := NewSyncClient(kc, execClient)
-			err := syncAdapter.pushLocal(tt.path, tt.files, tt.delFiles, tt.isForcePush, []string{}, tt.compInfo, util.IndexerRet{})
+			err := syncAdapter.pushLocal(context.Background(), tt.path, tt.files, tt.delFiles, tt.isForcePush, []string{}, tt.compInfo, util.IndexerRet{})
 			if !tt.wantErr && err != nil {
 				t.Errorf("TestPushLocal error: error pushing files: %v", err)
 			}

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -3065,7 +3065,7 @@ CMD ["npm", "start"]
 			It("should fail running a second session on the same platform", func() {
 				_, _, _, err := helper.WaitForDevModeToContain(helper.DevSessionOpts{
 					RunOnPodman: podman,
-				}, "unable to save state file", true)
+				}, "unable to save state file", true, true)
 				Expect(err).To(HaveOccurred())
 			})
 


### PR DESCRIPTION
**What type of PR is this:**
/kind bug

**What does this PR do / why we need it:**
This works by passing a context around to relevant functions and methods, to allow handling cancellations properly.

**Which issue(s) this PR fixes:**
Fixes #6196 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
See #6196 