### PR TITLE
Set 'mountSources' to 'true' in some example SpringBoot multi-container Devfiles

### DIFF
--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
@@ -28,7 +28,7 @@ components:
       volumeMounts:
         - name: springbootpvc
           path: /data/cache/.m2
-      mountSources: false
+      mountSources: true
   - name: springbootpvc
     volume:
       ephemeral: true

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
@@ -29,7 +29,7 @@ components:
       volumeMounts:
         - name: springbootpvc
           path: /data/cache/.m2
-      mountSources: false
+      mountSources: true
   - name: springbootpvc
     volume:
       ephemeral: true


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area testing

**What does this PR do / why we need it:**

In those examples, the build and run commands are running in
different container components.
Without mounting sources in the container used for the 'run' command,
this command will not start because Maven would not be able
to resolve the 'spring-boot' plugin:

```
 ✓  Building your application in container (command: defaultbuild) [39s]
 •  Executing the application (command: defaultrun)  ...
 ✗  Finished executing the application (command: defaultrun) [151ms]
 ⚠  Devfile command "defaultrun" exited with an error status in 20 second(s)
 ⚠  Last 100 lines of log:
 ✗  Waiting for the application to be ready [1m]
 ⚠  Port forwarding might not work correctly: timeout while checking for ports; ports not listening: (8080 in container "runtime"): context deadline exceeded
 ⚠  Running `odo logs --follow` might help in identifying the problem.

 -  Forwarding from 127.0.0.1:20001 -> 8080
```

This was not caught in the tests because failing to run the
'run' command current does not prevent the Dev session from starting.

This change might actually make the test faster as we would not have to wait 1 minute
to find out that the application port is not reachable.

```
 ✓  Building your application in container (command: defaultbuild) [44s]
 •  Executing the application (command: defaultrun)  ...
 ✓  Waiting for the application to be ready [1s]
 -  Forwarding from 127.0.0.1:20002 -> 8080
```

**Which issue(s) this PR fixes:**
Related to https://github.com/redhat-developer/odo/issues/6754

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```
odo init --name test-java-springboot \
  --devfile-path /path/to/odo/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml \
  --starter springbootproject

odo dev
```
