### PR TITLE
Fix flaky tests using custom port mapping when running specs in parallel

### DIFF
--- a/tests/helper/helper_http.go
+++ b/tests/helper/helper_http.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -50,10 +48,11 @@ func HttpWaitForWithStatus(url string, match string, maxRetry int, interval int,
 	Fail(fmt.Sprintf("Failed after %d retries. Content in %s doesn't include '%s'.", maxRetry, url, match))
 }
 
-var startPort int64 = 30000
-
-// GetRandomFreePort increases the counter of global variable startPort, and returns.
-func GetRandomFreePort() string {
-	atomic.AddInt64(&startPort, 1)
-	return strconv.FormatInt(startPort, 10)
+// GetCustomStartPort returns a port that can be used as starting value for custom port mapping.
+// Because of the way Ginkgo runs specs in parallel (by isolating them in different processes),
+// this function needs to be called in a Before* node or test spec.
+// It returns a starting value that aims at minimizing the probability of collisions.
+// Callers can then safely increment the returned value in their specs if needed.
+func GetCustomStartPort() int {
+	return 30000 + 100*GinkgoParallelProcess()
 }

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"k8s.io/utils/pointer"
@@ -47,8 +48,8 @@ var _ = Describe("odo dev debug command tests", func() {
 					ports      map[string]string
 				)
 				var (
-					LocalPort      = helper.GetRandomFreePort()
-					LocalDebugPort = helper.GetRandomFreePort()
+					LocalPort      int
+					LocalDebugPort int
 				)
 				const (
 					ContainerPort      = "3000"
@@ -56,7 +57,9 @@ var _ = Describe("odo dev debug command tests", func() {
 				)
 
 				BeforeEach(func() {
-					opts := []string{"--debug", fmt.Sprintf("--port-forward=%s:%s", LocalPort, ContainerPort), fmt.Sprintf("--port-forward=%s:%s", LocalDebugPort, ContainerDebugPort)}
+					LocalPort = helper.GetCustomStartPort()
+					LocalDebugPort = LocalPort + 1
+					opts := []string{"--debug", fmt.Sprintf("--port-forward=%d:%s", LocalPort, ContainerPort), fmt.Sprintf("--port-forward=%d:%s", LocalDebugPort, ContainerDebugPort)}
 					if podman {
 						opts = append(opts, "--forward-localhost")
 					}
@@ -82,7 +85,7 @@ var _ = Describe("odo dev debug command tests", func() {
 						// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
 						// We are just using this to validate if nodejs agent is listening on the other side
 						url := fmt.Sprintf("http://%s", ports[ContainerDebugPort])
-						Expect(url).To(ContainSubstring(LocalDebugPort))
+						Expect(url).To(ContainSubstring(strconv.Itoa(LocalDebugPort)))
 
 						helper.HttpWaitForWithStatus(url, "WebSockets request was expected", 12, 5, 400)
 					})


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area testing

**What does this PR do / why we need it:**
Using a global counter currently does not work
because Ginkgo runs parallel specs by isolating them in
completely different processes [1].
This relies on the parallel process index returned by Ginkgo
to get a value that can be used as starting port.

[1] https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-runs-parallel-specs

**Which issue(s) this PR fixes:**
Fixes #6758 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```
ginkgo -v -nodes=3 \
  -focus 'port-forwarding for the component' --label-filter='podman' \
  --output-interceptor-mode=none \
  tests/integration/
```