### PR TITLE
Support variable substitution with `--var` and `--var-file` in `odo build-images`

### DIFF
--- a/docs/website/docs/command-reference/build-images.md
+++ b/docs/website/docs/command-reference/build-images.md
@@ -64,6 +64,13 @@ Successfully tagged quay.io/user/myimage:latest
 ```
 </details>
 
-
 ### Faking the image build
 You can also fake the image build by exporting `PODMAN_CMD=echo` or `DOCKER_CMD=echo` to your environment. Read [environment variables controlling `odo` behaviour](../overview/configure.md#environment-variables-controlling-odo-behavior) for more information.
+
+## Substituting variables
+
+The Devfile can define variables to make the Devfile parameterizable. The Devfile can define values for these variables, and you
+can override the values for variables from the command line when running `odo build-images`, using the `--var` and `--var-file` options.
+
+See [Substituting variables in `odo` dev](dev.md#substituting-variables) for more information.
+

--- a/pkg/odo/cli/build_images/build_images.go
+++ b/pkg/odo/cli/build_images/build_images.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/devfile/image"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
+	"github.com/redhat-developer/odo/pkg/odo/commonflags"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
@@ -82,6 +83,7 @@ func NewCmdBuildImages(name, fullName string) *cobra.Command {
 
 	util.SetCommandGroup(buildImagesCmd, util.MainGroup)
 	buildImagesCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
+	commonflags.UseVariablesFlags(buildImagesCmd)
 	buildImagesCmd.Flags().BoolVar(&o.pushFlag, "push", false, "If true, build and push the images")
 	clientset.Add(buildImagesCmd, clientset.FILESYSTEM)
 

--- a/tests/examples/source/devfiles/nodejs/devfile-variables.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-variables.yaml
@@ -1,10 +1,29 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.0
 metadata:
   name: nodejs
 variables:
   VARIABLE_TEST: FOO
   VALUE_TEST: bar
+  VARIABLE_CONTAINER_IMAGE_1: "my-image-1:1.2.3-rc4"
+  VARIABLE_CONTAINER_IMAGE_2: "my-image-2:2.3.4-alpha5"
+
 components:
+  - name: my-image-1
+    image:
+      autoBuild: false
+      imageName: "{{ VARIABLE_CONTAINER_IMAGE_1 }}"
+      dockerfile:
+        buildContext: ${PROJECT_SOURCE}
+        uri: ./Dockerfile
+
+  - name: my-image-2
+    image:
+      autoBuild: false
+      imageName: "{{ VARIABLE_CONTAINER_IMAGE_2 }}"
+      dockerfile:
+        buildContext: ${PROJECT_SOURCE}
+        uri: ./Dockerfile
+
   - name: runtime
     container:
       image: registry.access.redhat.com/ubi8/nodejs-12:1-36


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
Fixes #6274 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] [Documentation](https://deploy-preview-6776--odo-docusaurus-preview.netlify.app/docs/command-reference/build-images/#substituting-variables) 

**How to test changes / Special notes to the reviewer:**

You can run `odo build-images [--var ... | --var-file ...]` using the Devfile used in the tests (`tests/examples/source/devfiles/nodejs/devfile-variables.yaml`) or any Devfile where image names are variables (like in our [Advanced Guides for deploying apps](https://odo.dev/docs/user-guides/advanced/deploy/nodejs#step-3-modify-the-devfile))