### PR TITLE
Check latest version from index instead of using hardcoded value

### DIFF
--- a/tests/helper/helper_registry.go
+++ b/tests/helper/helper_registry.go
@@ -1,0 +1,47 @@
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/redhat-developer/odo/pkg/api"
+)
+
+type Registry struct {
+	url string
+}
+
+func NewRegistry(url string) Registry {
+	return Registry{
+		url: url,
+	}
+}
+
+func (o Registry) GetIndex() ([]api.DevfileStack, error) {
+	resp, err := http.Get(o.url + "/v2index")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var target []api.DevfileStack
+	err = json.NewDecoder(resp.Body).Decode(&target)
+	if err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+func (o Registry) GetStack(name string) (api.DevfileStack, error) {
+	index, err := o.GetIndex()
+	if err != nil {
+		return api.DevfileStack{}, err
+	}
+	for _, stack := range index {
+		if stack.Name == name {
+			return stack, nil
+		}
+	}
+	return api.DevfileStack{}, fmt.Errorf("stack %q not found", name)
+}

--- a/tests/helper/helper_registry.go
+++ b/tests/helper/helper_registry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/redhat-developer/odo/pkg/api"
 )
@@ -19,7 +20,11 @@ func NewRegistry(url string) Registry {
 }
 
 func (o Registry) GetIndex() ([]api.DevfileStack, error) {
-	resp, err := http.Get(o.url + "/v2index")
+	url, err := url.JoinPath(o.url, "v2index")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
 	"gopkg.in/yaml.v2"
 
 	"github.com/redhat-developer/odo/pkg/config"
@@ -157,25 +158,34 @@ var _ = Describe("odo devfile init command tests", func() {
 					})
 				})
 
+				const (
+					devfileName = "go"
+				)
 				for _, ctx := range []struct {
 					title, devfileVersion, requiredVersion string
-					gotLatest                              bool
+					checkVersion                           func(metadataVersion string)
 				}{
 					{
 						title:          "to download the latest version",
 						devfileVersion: "latest",
-						gotLatest:      true,
+						checkVersion: func(metadataVersion string) {
+							reg := helper.NewRegistry(helper.GetDevfileRegistryURL())
+							stack, err := reg.GetStack(devfileName)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(len(stack.Versions)).ToNot(BeZero())
+							lastVersion := stack.Versions[0]
+							Expect(metadataVersion).To(BeEquivalentTo(lastVersion.Version))
+						},
 					},
 					{
-						title:           "to download a specific version",
-						devfileVersion:  "1.0.2",
-						requiredVersion: "1.0.2",
+						title:          "to download a specific version",
+						devfileVersion: "1.0.2",
+						checkVersion: func(metadataVersion string) {
+							Expect(metadataVersion).To(BeEquivalentTo("1.0.2"))
+						},
 					},
 				} {
 					ctx := ctx
-					const (
-						devfileName = "go"
-					)
 					When(fmt.Sprintf("using --devfile-version flag %s", ctx.title), func() {
 						BeforeEach(func() {
 							helper.Cmd("odo", "init", "--name", "aname", "--devfile", devfileName, "--devfile-version", ctx.devfileVersion).ShouldPass()
@@ -185,17 +195,7 @@ var _ = Describe("odo devfile init command tests", func() {
 							files := helper.ListFilesInDir(commonVar.Context)
 							Expect(files).To(ContainElements("devfile.yaml"))
 							metadata := helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
-							if ctx.requiredVersion != "" {
-								Expect(metadata.Version).To(BeEquivalentTo(ctx.requiredVersion))
-							}
-							if ctx.gotLatest {
-								reg := helper.NewRegistry(helper.GetDevfileRegistryURL())
-								stack, err := reg.GetStack(devfileName)
-								Expect(err).ToNot(HaveOccurred())
-								Expect(len(stack.Versions)).ToNot(BeZero())
-								lastVersion := stack.Versions[0]
-								Expect(metadata.Version).To(BeEquivalentTo(lastVersion.Version))
-							}
+							ctx.checkVersion(metadata.Version)
 						})
 					})
 
@@ -208,17 +208,7 @@ var _ = Describe("odo devfile init command tests", func() {
 						It("should show the requested devfile version", func() {
 							stdout := res.Out()
 							Expect(helper.IsJSON(stdout)).To(BeTrue())
-							if ctx.requiredVersion != "" {
-								helper.JsonPathContentIs(stdout, "devfileData.devfile.metadata.version", ctx.requiredVersion)
-							}
-							if ctx.gotLatest {
-								reg := helper.NewRegistry(helper.GetDevfileRegistryURL())
-								stack, err := reg.GetStack(devfileName)
-								Expect(err).ToNot(HaveOccurred())
-								Expect(len(stack.Versions)).ToNot(BeZero())
-								lastVersion := stack.Versions[0]
-								helper.JsonPathContentIs(stdout, "devfileData.devfile.metadata.version", lastVersion.Version)
-							}
+							ctx.checkVersion(gjson.Get(stdout, "devfileData.devfile.metadata.version").String())
 						})
 					})
 				}


### PR DESCRIPTION

**What type of PR is this:**

/kind bug
/area testing


**What does this PR do / why we need it:**

An integration test is failing after registry is updated and the Go stack got a new version.

```
[FAILED] Expected
      <string>: 2.1.0
  to be equivalent to
      <string>: 2.0.0
  In [It] at: /go/src/github.com/redhat-developer/odo/tests/integration/cmd_devfile_init_test.go:187 @ 05/04/23 00:38:54.514
```

Instead of hardcoding the value of the latest version of the Go stack, the latest value is obtained by reading the index of the Devfile Registry.



**Which issue(s) this PR fixes:**

Fixes #

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
