### PR TITLE
Fix: `odo init` overwrites personalized configuration when downloading starter project

### DIFF
--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -221,15 +221,15 @@ func (o *InitClient) SelectStarterProject(devfile parser.DevfileObj, flags map[s
 	return backend.SelectStarterProject(devfile, flags)
 }
 
-func (o *InitClient) DownloadStarterProject(starter *v1alpha2.StarterProject, dest string) error {
+func (o *InitClient) DownloadStarterProject(starter *v1alpha2.StarterProject, dest string) (containsDevfile bool, err error) {
 	downloadSpinner := log.Spinnerf("Downloading starter project %q", starter.Name)
-	err := o.registryClient.DownloadStarterProject(starter, "", dest, false)
+	containsDevfile, err = o.registryClient.DownloadStarterProject(starter, "", dest, false)
 	if err != nil {
 		downloadSpinner.End(false)
-		return err
+		return containsDevfile, err
 	}
 	downloadSpinner.End(true)
-	return nil
+	return containsDevfile, nil
 }
 
 // PersonalizeName calls PersonalizeName methods of the adequate backend

--- a/pkg/init/init_test.go
+++ b/pkg/init/init_test.go
@@ -349,7 +349,7 @@ func TestInitClient_downloadStarterProject(t *testing.T) {
 			o := &InitClient{
 				registryClient: tt.fields.registryClient(ctrl),
 			}
-			if err := o.DownloadStarterProject(&tt.args.project, "dest"); (err != nil) != tt.wantErr {
+			if _, err := o.DownloadStarterProject(&tt.args.project, "dest"); (err != nil) != tt.wantErr {
 				t.Errorf("InitClient.downloadStarterProject() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/init/interface.go
+++ b/pkg/init/interface.go
@@ -49,7 +49,7 @@ type Client interface {
 
 	// DownloadStarterProject downloads the starter project referenced in devfile and stores it in dest directory
 	// WARNING: This will first remove all the content of dest.
-	DownloadStarterProject(project *v1alpha2.StarterProject, dest string) error
+	DownloadStarterProject(project *v1alpha2.StarterProject, dest string) (bool, error)
 
 	// PersonalizeName returns the customized Devfile Metadata Name.
 	// Depending on the flags, it may return a name set interactively or not.

--- a/pkg/init/mock.go
+++ b/pkg/init/mock.go
@@ -54,11 +54,12 @@ func (mr *MockClientMockRecorder) DownloadDevfile(ctx, devfileLocation, destDir 
 }
 
 // DownloadStarterProject mocks base method.
-func (m *MockClient) DownloadStarterProject(project *v1alpha2.StarterProject, dest string) error {
+func (m *MockClient) DownloadStarterProject(project *v1alpha2.StarterProject, dest string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadStarterProject", project, dest)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DownloadStarterProject indicates an expected call of DownloadStarterProject.

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -226,15 +226,16 @@ func (o *InitOptions) run(ctx context.Context) (devfileObj parser.DevfileObj, pa
 	}
 
 	if starterInfo != nil {
+		var containsDevfile bool
 		// WARNING: this will remove all the content of the destination directory, ie the devfile.yaml file
-		err = o.clientset.InitClient.DownloadStarterProject(starterInfo, workingDir)
+		containsDevfile, err = o.clientset.InitClient.DownloadStarterProject(starterInfo, workingDir)
 		if err != nil {
 			return parser.DevfileObj{}, "", "", nil, nil, fmt.Errorf("unable to download starter project %q: %w", starterInfo.Name, err)
 		}
 		starterDownloaded = true
 
 		// in case the starter project contains a devfile, read it again
-		if _, err = o.clientset.FS.Stat(devfilePath); err == nil {
+		if containsDevfile {
 			devfileObj, _, err = devfile.ParseDevfileAndValidate(parser.ParserArgs{
 				Path:               devfilePath,
 				FlattenedDevfile:   pointer.Bool(false),

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -13,7 +13,7 @@ import (
 type Client interface {
 	PullStackFromRegistry(registry string, stack string, destDir string, options library.RegistryOptions) error
 	DownloadFileInMemory(params dfutil.HTTPRequestParams) ([]byte, error)
-	DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedToken string, contextDir string, verbose bool) error
+	DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedToken string, contextDir string, verbose bool) (bool, error)
 	GetDevfileRegistries(registryName string) ([]api.Registry, error)
 	ListDevfileStacks(ctx context.Context, registryName, devfileFlag, filterFlag string, detailsFlag bool, withDevfileContent bool) (DevfileStackList, error)
 }

--- a/pkg/registry/mock.go
+++ b/pkg/registry/mock.go
@@ -54,11 +54,12 @@ func (mr *MockClientMockRecorder) DownloadFileInMemory(params interface{}) *gomo
 }
 
 // DownloadStarterProject mocks base method.
-func (m *MockClient) DownloadStarterProject(starterProject *v1alpha2.StarterProject, decryptedToken, contextDir string, verbose bool) error {
+func (m *MockClient) DownloadStarterProject(starterProject *v1alpha2.StarterProject, decryptedToken, contextDir string, verbose bool) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadStarterProject", starterProject, decryptedToken, contextDir, verbose)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DownloadStarterProject indicates an expected call of DownloadStarterProject.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -800,7 +800,7 @@ func TestRegistryClient_DownloadStarterProject(t *testing.T) {
 				t.Errorf("DownloadStarterProject() error = %v, wantErr %v", gotErr, tt.wantErr)
 				return
 			}
-			if tt.wantContainsDevfile && !gotContainsDevfile {
+			if tt.wantContainsDevfile != gotContainsDevfile {
 				t.Errorf("DownloadStarterProject() containsDevfile = %v, want = %v", gotContainsDevfile, tt.wantContainsDevfile)
 				return
 			}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -666,11 +666,12 @@ func TestRegistryClient_DownloadStarterProject(t *testing.T) {
 		verbose        bool
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    []string
-		wantErr bool
+		name                string
+		fields              fields
+		args                args
+		want                []string
+		wantContainsDevfile bool
+		wantErr             bool
 	}{
 		// TODO: Add test cases.
 		{
@@ -690,8 +691,9 @@ func TestRegistryClient_DownloadStarterProject(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{"devfile.yaml", "docker", filepath.Join("docker", "Dockerfile"), "README.md", "main.go", "go.mod", "someFile.txt"},
-			wantErr: false,
+			want:                []string{"devfile.yaml", "docker", filepath.Join("docker", "Dockerfile"), "README.md", "main.go", "go.mod", "someFile.txt"},
+			wantErr:             false,
+			wantContainsDevfile: true,
 		},
 		{
 			name: "Starter project has conflicting files",
@@ -793,8 +795,13 @@ func TestRegistryClient_DownloadStarterProject(t *testing.T) {
 				preferenceClient: tt.fields.preferenceClient,
 				kubeClient:       tt.fields.kubeClient,
 			}
-			if err := o.DownloadStarterProject(tt.args.starterProject, tt.args.decryptedToken, tt.args.contextDir, tt.args.verbose); (err != nil) != tt.wantErr {
-				t.Errorf("DownloadStarterProject() error = %v, wantErr %v", err, tt.wantErr)
+			gotContainsDevfile, gotErr := o.DownloadStarterProject(tt.args.starterProject, tt.args.decryptedToken, tt.args.contextDir, tt.args.verbose)
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("DownloadStarterProject() error = %v, wantErr %v", gotErr, tt.wantErr)
+				return
+			}
+			if tt.wantContainsDevfile && !gotContainsDevfile {
+				t.Errorf("DownloadStarterProject() containsDevfile = %v, want = %v", gotContainsDevfile, tt.wantContainsDevfile)
 				return
 			}
 			var got []string

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -81,67 +82,79 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 			})
 
-			It("should allow for personalizing configurations", func() {
-				command := []string{"odo", "init"}
-				output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
-
-					helper.ExpectString(ctx, "Select language")
-					helper.SendLine(ctx, "Javascript")
-
-					helper.ExpectString(ctx, "Select project type")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Select version")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
-					helper.ExpectString(ctx, "runtime")
-					helper.SendLine(ctx, "runtime")
-
-					helper.ExpectString(ctx, "What configuration do you want change")
-					helper.SendLine(ctx, "Add new port")
-
-					helper.ExpectString(ctx, "Enter port number:")
-					helper.SendLine(ctx, "5000")
-
-					helper.ExpectString(ctx, "What configuration do you want change")
-					helper.SendLine(ctx, "Delete port \"3000\"")
-
-					helper.ExpectString(ctx, "What configuration do you want change")
-					helper.SendLine(ctx, "Add new environment variable")
-
-					helper.ExpectString(ctx, "Enter new environment variable name: ")
-					helper.SendLine(ctx, "DEBUG_PROJECT_PORT")
-
-					helper.ExpectString(ctx, "Enter value for \"DEBUG_PROJECT_PORT\" environment variable:")
-					helper.SendLine(ctx, "5858")
-
-					helper.ExpectString(ctx, "What configuration do you want change")
-					helper.SendLine(ctx, "Delete environment variable \"DEBUG_PORT\"")
-
-					helper.ExpectString(ctx, "What configuration do you want change")
-					helper.SendLine(ctx, "NOTHING - configuration is correct")
-
-					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
-					helper.SendLine(ctx, "")
-
-					helper.ExpectString(ctx, "Which starter project do you want to use")
-					helper.SendLine(ctx, "nodejs-starter")
-
-					helper.ExpectString(ctx, "Enter component name:")
-					helper.SendLine(ctx, "my-nodejs-app")
-
-					helper.ExpectString(ctx, "Your new component 'my-nodejs-app' is ready in the current directory.")
-
+			Context("personalizing Devfile configuration", func() {
+				var hasMultipleVersions bool
+				BeforeEach(func() {
+					out := helper.Cmd("odo", "registry", "--devfile", "nodejs", "--devfile-registry", "DefaultDevfileRegistry").ShouldPass().Out()
+					// Version pattern has always been in the form of X.X.X
+					vMatch := regexp.MustCompile(`(\d.\d.\d)`)
+					if matches := vMatch.FindAll([]byte(out), -1); len(matches) > 1 {
+						hasMultipleVersions = true
+					}
 				})
-				Expect(err).To(BeNil())
-				Expect(output).To(ContainSubstring("odo init --name my-nodejs-app --devfile nodejs --devfile-registry DefaultDevfileRegistry --devfile-version 2.1.1 --starter nodejs-starter"))
-				Expect(output).To(ContainSubstring("Your new component 'my-nodejs-app' is ready in the current directory."))
-				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
-				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "5000")
-				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "3000")
-				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "DEBUG_PROJECT_PORT")
-				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "DEBUG_PORT")
+				It("should allow for personalizing configurations", func() {
+					command := []string{"odo", "init"}
+					output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
+
+						helper.ExpectString(ctx, "Select language")
+						helper.SendLine(ctx, "Javascript")
+
+						helper.ExpectString(ctx, "Select project type")
+						helper.SendLine(ctx, "")
+
+						if hasMultipleVersions {
+							helper.ExpectString(ctx, "Select version")
+							helper.SendLine(ctx, "")
+						}
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+						helper.ExpectString(ctx, "runtime")
+						helper.SendLine(ctx, "runtime")
+
+						helper.ExpectString(ctx, "What configuration do you want change")
+						helper.SendLine(ctx, "Add new port")
+
+						helper.ExpectString(ctx, "Enter port number:")
+						helper.SendLine(ctx, "5000")
+
+						helper.ExpectString(ctx, "What configuration do you want change")
+						helper.SendLine(ctx, "Delete port \"3000\"")
+
+						helper.ExpectString(ctx, "What configuration do you want change")
+						helper.SendLine(ctx, "Add new environment variable")
+
+						helper.ExpectString(ctx, "Enter new environment variable name: ")
+						helper.SendLine(ctx, "DEBUG_PROJECT_PORT")
+
+						helper.ExpectString(ctx, "Enter value for \"DEBUG_PROJECT_PORT\" environment variable:")
+						helper.SendLine(ctx, "5858")
+
+						helper.ExpectString(ctx, "What configuration do you want change")
+						helper.SendLine(ctx, "Delete environment variable \"DEBUG_PORT\"")
+
+						helper.ExpectString(ctx, "What configuration do you want change")
+						helper.SendLine(ctx, "NOTHING - configuration is correct")
+
+						helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+						helper.SendLine(ctx, "")
+
+						helper.ExpectString(ctx, "Which starter project do you want to use")
+						helper.SendLine(ctx, "nodejs-starter")
+
+						helper.ExpectString(ctx, "Enter component name:")
+						helper.SendLine(ctx, "my-nodejs-app")
+
+						helper.ExpectString(ctx, "Your new component 'my-nodejs-app' is ready in the current directory.")
+
+					})
+					Expect(err).To(BeNil())
+					Expect(output).To(ContainSubstring("Your new component 'my-nodejs-app' is ready in the current directory."))
+					Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+					helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "5000")
+					helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "3000")
+					helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "DEBUG_PROJECT_PORT")
+					helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "DEBUG_PORT")
+				})
 			})
 
 			It("should ask to re-enter the component name when an invalid value is passed", func() {

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -137,6 +137,10 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(output).To(ContainSubstring("odo init --name my-nodejs-app --devfile nodejs --devfile-registry DefaultDevfileRegistry --devfile-version 2.1.1 --starter nodejs-starter"))
 				Expect(output).To(ContainSubstring("Your new component 'my-nodejs-app' is ready in the current directory."))
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "5000")
+				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "3000")
+				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "\"DEBUG_PROJECT_PORT\"")
+				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "\"DEBUG_PORT\"")
 			})
 
 			It("should ask to re-enter the component name when an invalid value is passed", func() {
@@ -213,8 +217,7 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(output).To(ContainSubstring("odo init --name %s --devfile %s --devfile-registry DefaultDevfileRegistry --devfile-version %s --starter %s", componentName, devfileName, devfileVersion, starter))
 				Expect(output).To(ContainSubstring("Your new component 'my-go-app' is ready in the current directory"))
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
-				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "5000")
-				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "3000")
+
 			})
 
 			It("should download correct devfile", func() {

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -81,6 +81,64 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 			})
 
+			It("should allow for personalizing configurations", func() {
+				command := []string{"odo", "init"}
+				output, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
+
+					helper.ExpectString(ctx, "Select language")
+					helper.SendLine(ctx, "Javascript")
+
+					helper.ExpectString(ctx, "Select project type")
+					helper.SendLine(ctx, "")
+
+					helper.ExpectString(ctx, "Select version")
+					helper.SendLine(ctx, "")
+
+					helper.ExpectString(ctx, "? Select container for which you want to change configuration?")
+					helper.SendLine(ctx, "runtime")
+
+					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.SendLine(ctx, "Add new port")
+
+					helper.ExpectString(ctx, "? Enter port number:")
+					helper.SendLine(ctx, "5000")
+
+					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.SendLine(ctx, "Delete port \"3000\"")
+
+					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.SendLine(ctx, "Add new environment variable")
+
+					helper.ExpectString(ctx, "? Enter new environment variable name: ")
+					helper.SendLine(ctx, "DEBUG_PROJECT_PORT")
+
+					helper.ExpectString(ctx, "? Enter value for \"DEBUG_PROJECT_PORT\" environment variable:")
+					helper.SendLine(ctx, "5858")
+
+					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.SendLine(ctx, "Delete environment variable \"DEBUG_PORT\"")
+
+					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.SendLine(ctx, "NOTHING - configuration is correct")
+
+					helper.ExpectString(ctx, "? Select container for which you want to change configuration? ")
+					helper.SendLine(ctx, "")
+
+					helper.ExpectString(ctx, "? Which starter project do you want to use?")
+					helper.SendLine(ctx, "nodejs-starter")
+
+					helper.ExpectString(ctx, "? Enter component name:")
+					helper.SendLine(ctx, "my-nodejs-app")
+
+					helper.ExpectString(ctx, "Your new component 'my-nodejs-app' is ready in the current directory.")
+
+				})
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("odo init --name my-nodejs-app --devfile nodejs --devfile-registry DefaultDevfileRegistry --devfile-version 2.1.1 --starter nodejs-starter"))
+				Expect(output).To(ContainSubstring("Your new component 'my-nodejs-app' is ready in the current directory."))
+				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+			})
+
 			It("should ask to re-enter the component name when an invalid value is passed", func() {
 				command := []string{"odo", "init"}
 				_, err := helper.RunInteractive(command, nil, func(ctx helper.InteractiveContext) {
@@ -155,6 +213,8 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(output).To(ContainSubstring("odo init --name %s --devfile %s --devfile-registry DefaultDevfileRegistry --devfile-version %s --starter %s", componentName, devfileName, devfileVersion, starter))
 				Expect(output).To(ContainSubstring("Your new component 'my-go-app' is ready in the current directory"))
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
+				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "5000")
+				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "3000")
 			})
 
 			It("should download correct devfile", func() {

--- a/tests/integration/interactive_init_test.go
+++ b/tests/integration/interactive_init_test.go
@@ -94,40 +94,41 @@ var _ = Describe("odo init interactive command tests", func() {
 					helper.ExpectString(ctx, "Select version")
 					helper.SendLine(ctx, "")
 
-					helper.ExpectString(ctx, "? Select container for which you want to change configuration?")
+					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
+					helper.ExpectString(ctx, "runtime")
 					helper.SendLine(ctx, "runtime")
 
-					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.ExpectString(ctx, "What configuration do you want change")
 					helper.SendLine(ctx, "Add new port")
 
-					helper.ExpectString(ctx, "? Enter port number:")
+					helper.ExpectString(ctx, "Enter port number:")
 					helper.SendLine(ctx, "5000")
 
-					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.ExpectString(ctx, "What configuration do you want change")
 					helper.SendLine(ctx, "Delete port \"3000\"")
 
-					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.ExpectString(ctx, "What configuration do you want change")
 					helper.SendLine(ctx, "Add new environment variable")
 
-					helper.ExpectString(ctx, "? Enter new environment variable name: ")
+					helper.ExpectString(ctx, "Enter new environment variable name: ")
 					helper.SendLine(ctx, "DEBUG_PROJECT_PORT")
 
-					helper.ExpectString(ctx, "? Enter value for \"DEBUG_PROJECT_PORT\" environment variable:")
+					helper.ExpectString(ctx, "Enter value for \"DEBUG_PROJECT_PORT\" environment variable:")
 					helper.SendLine(ctx, "5858")
 
-					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.ExpectString(ctx, "What configuration do you want change")
 					helper.SendLine(ctx, "Delete environment variable \"DEBUG_PORT\"")
 
-					helper.ExpectString(ctx, "? What configuration do you want change?")
+					helper.ExpectString(ctx, "What configuration do you want change")
 					helper.SendLine(ctx, "NOTHING - configuration is correct")
 
-					helper.ExpectString(ctx, "? Select container for which you want to change configuration? ")
+					helper.ExpectString(ctx, "Select container for which you want to change configuration?")
 					helper.SendLine(ctx, "")
 
-					helper.ExpectString(ctx, "? Which starter project do you want to use?")
+					helper.ExpectString(ctx, "Which starter project do you want to use")
 					helper.SendLine(ctx, "nodejs-starter")
 
-					helper.ExpectString(ctx, "? Enter component name:")
+					helper.ExpectString(ctx, "Enter component name:")
 					helper.SendLine(ctx, "my-nodejs-app")
 
 					helper.ExpectString(ctx, "Your new component 'my-nodejs-app' is ready in the current directory.")
@@ -139,8 +140,8 @@ var _ = Describe("odo init interactive command tests", func() {
 				Expect(helper.ListFilesInDir(commonVar.Context)).To(ContainElements("devfile.yaml"))
 				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "5000")
 				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "3000")
-				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "\"DEBUG_PROJECT_PORT\"")
-				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "\"DEBUG_PORT\"")
+				helper.FileShouldContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "DEBUG_PROJECT_PORT")
+				helper.FileShouldNotContainSubstring(filepath.Join(commonVar.Context, "devfile.yaml"), "DEBUG_PORT")
 			})
 
 			It("should ask to re-enter the component name when an invalid value is passed", func() {


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind code-refactoring

Additionally, add one of the following areas if applicable:
/area documentation
/area testing

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #6799 
Fixes #6752

**PR acceptance criteria:**

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
