### PR TITLE
Do not run 'odo-infra-stage-test' Workflow on PRs if not needed

### DIFF
--- a/.github/workflows/infra-test.yaml
+++ b/.github/workflows/infra-test.yaml
@@ -1,15 +1,11 @@
 name: odo-infra-stage-test
 on:
-  push:
-    paths:
-      - scripts/ansible
-      - '!scripts/ansible/Cluster/kubernetes-cluster/manual-changes/Readme.md'
-      - '!scripts/ansible/Cluster/openshift-cluster/manual-changes/Readme.md'
-      - '!scripts/ansible/Cluster/NFS-vm/manual-changes/Readme.md'
-      - '!scripts/ansible/Cluster/windows-openshift-cluster/manual-changes/Readme.md'
   pull_request:
     branches:
       - main
+    paths:
+      - 'scripts/ansible/**'
+      - '!scripts/ansible/**/*.md'
 
 jobs:
   kubernetes-infra-stage-test:


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area infra
/area testing

**What does this PR do / why we need it:**
Currently, the `odo-infra-stage-test` job runs on *all* PRs (and ends up failing), even if the PR has not changed anything in `scripts/ansible`:

![image](https://github.com/redhat-developer/odo/assets/593208/f563162f-8468-41be-9145-020521ddb815)

The job ends up failing and we manually have to override it.

This PR makes sure not to run it if not needed.

There is one additional point related to this job (see https://github.com/redhat-developer/odo/issues/6813#issuecomment-1549859387), but that can be addressed later.

**Which issue(s) this PR fixes:**
Related to #6813 

This way, we won't need to manually override this job on all PRs.

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
