### PR TITLE
Do not error out in port detection if any of the `/proc/net/{tc,ud}p{,6}` files are missing in the dev container

### DIFF
--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -272,7 +272,7 @@ func (o *DevClient) handleLoopbackPorts(ctx context.Context, options dev.StartOp
 
 	loopbackPorts, err := port.DetectRemotePortsBoundOnLoopback(ctx, o.execClient, pod.Name, pod.Spec.Containers[0].Name, fwPorts)
 	if err != nil {
-		return fmt.Errorf("unable to detect container ports bound on the loopback interface: %w", err)
+		log.Warningf("unable to detect container ports bound on the loopback interface: %v", err)
 	}
 
 	if len(loopbackPorts) == 0 {

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -100,7 +100,9 @@ func GetListeningConnections(ctx context.Context, execClient exec.Client, podNam
 func GetConnections(ctx context.Context, execClient exec.Client, podName string, containerName string, statePredicate func(state int) bool) ([]Connection, error) {
 	cmd := []string{
 		remotecmd.ShellExecutable, "-c",
-		"cat /proc/net/tcp /proc/net/udp /proc/net/tcp6 /proc/net/udp6",
+		// /proc/net/{tc,ud}p6 files might be missing if IPv6 is disabled in the host networking stack.
+		// Actually /proc/net/{tc,ud}p* files might be totally missing if network stats are disabled.
+		"for f in tcp udp tcp6 udp6; do cat /proc/net/$f || true; done",
 	}
 	stdout, _, err := execClient.ExecuteCommand(ctx, cmd, podName, containerName, false, nil, nil)
 	if err != nil {

--- a/pkg/port/port_test.go
+++ b/pkg/port/port_test.go
@@ -22,7 +22,7 @@ const (
 
 var cmd = []string{
 	remotecmd.ShellExecutable, "-c",
-	"cat /proc/net/tcp /proc/net/udp /proc/net/tcp6 /proc/net/udp6",
+	"for f in tcp udp tcp6 udp6; do cat /proc/net/$f || true; done",
 }
 
 const aggregatedContentFromProcNetFiles = `


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area odo-on-podman

**What does this PR do / why we need it:**
This PR makes port detection a bit resilient if any of the `/proc/net/{tc,ud}p*` are missing in the container.

For example, `/proc/net/{tc,ud}p6` files might be missing if IPv6 is disabled in the host networking stack, as reported by a user on RHEL (context of #6824). Actually, `/proc/net/{tc,ud}p*` files might even be totally missing if network stats are disabled.

**Which issue(s) this PR fixes:**
Related to #6824 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
