### PR TITLE
Fix flaky `odo dev` test on Podman by randomizing component names

### DIFF
--- a/tests/e2escenarios/e2e_test.go
+++ b/tests/e2escenarios/e2e_test.go
@@ -140,7 +140,7 @@ var _ = Describe("E2E Test", func() {
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(componentName))
+				componentName)
 
 			stdout = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 			Expect(stdout).To(ContainSubstring("Your Devfile has been successfully deployed"))
@@ -269,7 +269,7 @@ var _ = Describe("E2E Test", func() {
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "springboot", "devfile-deploy.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(componentName))
+				componentName)
 
 			stdout = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 			Expect(stdout).To(ContainSubstring("Your Devfile has been successfully deployed"))

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -141,9 +141,9 @@ func GetExamplePath(args ...string) string {
 }
 
 // CopyExampleDevFile copies an example devfile from tests/examples/source/devfiles/<componentName>/devfile.yaml into targetDst.
-// The Devfile updaters allow to perform operations against the target Devfile, like updating the component name (via DevfileMetadataNameSetter) or
-// removing the component name (via DevfileMetadataNameRemover).
-func CopyExampleDevFile(devfilePath, targetDst string, devfileUpdaters ...DevfileUpdater) {
+// If newName is not empty, it will replace the component name in the target Devfile.
+// The Devfile updaters allow to perform operations against the target Devfile, like removing the component name (via DevfileMetadataNameRemover).
+func CopyExampleDevFile(devfilePath, targetDst string, newName string, updaters ...DevfileUpdater) {
 	// filename of this file
 	_, filename, _, _ := runtime.Caller(0)
 	// path to the examples directory
@@ -155,9 +155,13 @@ func CopyExampleDevFile(devfilePath, targetDst string, devfileUpdaters ...Devfil
 
 	err = dfutil.CopyFile(src, targetDst, info)
 	Expect(err).NotTo(HaveOccurred())
-	if len(devfileUpdaters) != 0 {
-		UpdateDevfileContent(targetDst, devfileUpdaters)
+
+	var devfileUpdaters []DevfileUpdater
+	if newName != "" {
+		devfileUpdaters = append(devfileUpdaters, DevfileMetadataNameSetter(newName))
 	}
+	devfileUpdaters = append(devfileUpdaters, updaters...)
+	UpdateDevfileContent(targetDst, devfileUpdaters)
 }
 
 // FileShouldContainSubstring check if file contains subString

--- a/tests/integration/cmd_delete_test.go
+++ b/tests/integration/cmd_delete_test.go
@@ -104,7 +104,7 @@ var _ = Describe("odo delete command tests", func() {
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 					path.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				if withDotOdoDir {
 					helper.MakeDir(filepath.Join(commonVar.Context, util.DotOdoDirectory))
 				}
@@ -735,7 +735,7 @@ var _ = Describe("odo delete command tests", func() {
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-exec.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), `image: registry.access.redhat.com/ubi8/nodejs-14:latest`, `image: registry.access.redhat.com/ubi8/nodejs-does-not-exist-14:latest`)
 			// We terminate after 5 seconds because the job should have been created by then and is bound to fail.
 			helper.Cmd("odo", "deploy").WithTerminate(5, nil).ShouldRun()

--- a/tests/integration/cmd_describe_component_test.go
+++ b/tests/integration/cmd_describe_component_test.go
@@ -491,7 +491,7 @@ var _ = Describe("odo describe component command tests", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", ctx.devfile),
 						path.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(componentName))
+						componentName)
 					helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
 				})
 				It(fmt.Sprintf("should show the %s in odo describe component output", ctx.title), func() {

--- a/tests/integration/cmd_dev_debug_test.go
+++ b/tests/integration/cmd_dev_debug_test.go
@@ -205,7 +205,7 @@ var _ = Describe("odo dev debug command tests", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRunAndDebug.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
@@ -284,7 +284,7 @@ var _ = Describe("odo dev debug command tests", func() {
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-commands.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 			session, sessionOut, _, ports, err = helper.StartDevMode(helper.DevSessionOpts{
 				EnvVars:     []string{"PODMAN_CMD=echo"},
 				CmdlineArgs: []string{"--debug"},
@@ -371,7 +371,7 @@ var _ = Describe("odo dev debug command tests", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileCompositeBuildRunDebugInMultiContainersAndSharedVolume.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
@@ -469,7 +469,7 @@ var _ = Describe("odo dev debug command tests", func() {
 					helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-autobuild-deploybydefault.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(cmpName))
+						cmpName)
 				})
 
 				When("running odo dev with some components not referenced in the Devfile", func() {

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -898,7 +898,7 @@ ComponentSettings:
 						helper.CopyExampleDevFile(
 							filepath.Join("source", "devfiles", "nodejs", devfile.devfileName),
 							filepath.Join(commonVar.Context, "devfile.yaml"),
-							helper.DevfileMetadataNameSetter(cmpName))
+							cmpName)
 						devSession, _, _, _, err = helper.StartDevMode(helper.DevSessionOpts{
 							EnvVars: devfile.envvars,
 						})
@@ -960,7 +960,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", ctx.devfile),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				devSession, out, _, _, err = helper.StartDevMode(helper.DevSessionOpts{})
 				Expect(err).To(BeNil())
 			})
@@ -1009,12 +1009,12 @@ ComponentSettings:
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), nodejsProject)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 					filepath.Join(nodejsProject, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName+"-nodejs"),
+					cmpName+"-nodejs",
 				)
 				helper.CopyExample(filepath.Join("source", "go"), goProject)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "go-devfiles", "devfile.yaml"),
 					filepath.Join(goProject, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName+"-go"),
+					cmpName+"-go",
 				)
 			})
 			AfterEach(func() {
@@ -1423,7 +1423,7 @@ ComponentSettings:
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-variables.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -1539,7 +1539,7 @@ ComponentSettings:
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-single-env.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -1565,7 +1565,7 @@ ComponentSettings:
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-multiple-envs.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -1591,7 +1591,7 @@ ComponentSettings:
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-env-with-space.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -1622,7 +1622,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -1694,7 +1694,7 @@ ComponentSettings:
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-with-service-binding-files.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -1758,7 +1758,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -1851,7 +1851,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfileSourceMapping.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -1893,7 +1893,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -1930,7 +1930,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -1965,7 +1965,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-multiple-projects.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -2000,7 +2000,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -2033,7 +2033,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-volumes.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -2111,7 +2111,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(devfileCmpName))
+					devfileCmpName)
 				if devfileHandlerCtx.sourceHandler != nil {
 					devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 				}
@@ -2157,7 +2157,7 @@ ComponentSettings:
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-commands.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		for _, tt := range []struct {
@@ -2445,7 +2445,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommands.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -2478,7 +2478,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommandsParallel.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -2510,7 +2510,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -2544,7 +2544,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRunAndDebug.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
@@ -2606,7 +2606,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfileCompositeBuildRunDebugInMultiContainersAndSharedVolume.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
@@ -2671,7 +2671,7 @@ CMD ["npm", "start"]
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-preStart.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 			})
 
 			It("should not correctly execute PreStart commands", func() {
@@ -2697,7 +2697,7 @@ CMD ["npm", "start"]
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
 				var err error
 				session, _, initErr, _, err = helper.StartDevMode(helper.DevSessionOpts{
@@ -2735,7 +2735,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(cmpName))
+						cmpName)
 					helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm install", "npm install-does-not-exist")
 
 					var err error
@@ -2913,7 +2913,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-with-alternative-commands.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
@@ -3216,7 +3216,7 @@ CMD ["npm", "start"]
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-with-MR-CL-CR.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				var err error
 				session, _, _, _, err = helper.StartDevMode(helper.DevSessionOpts{
 					RunOnPodman: podman,
@@ -3236,7 +3236,10 @@ CMD ["npm", "start"]
 				When("Update the devfile.yaml, and waiting synchronization", func() {
 
 					BeforeEach(func() {
-						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-MR-CL-CR-modified.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+						helper.CopyExampleDevFile(
+							filepath.Join("source", "devfiles", "nodejs", "devfile-with-MR-CL-CR-modified.yaml"),
+							filepath.Join(commonVar.Context, "devfile.yaml"),
+							cmpName)
 						var err error
 						_, _, _, err = session.WaitSync()
 						Expect(err).ToNot(HaveOccurred())
@@ -3375,7 +3378,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "issue-5620-devfile-with-container-command-args.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(devfileCmpName))
+						devfileCmpName)
 					if devfileHandlerCtx.sourceHandler != nil {
 						devfileHandlerCtx.sourceHandler(commonVar.Context, devfileCmpName)
 					}
@@ -3521,11 +3524,11 @@ CMD ["npm", "start"]
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-child.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-parent.yaml"),
 					filepath.Join(commonVar.Context, "devfile-parent.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName+"-parent")
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 				var err error
 				devSession, _, _, _, err = helper.StartDevMode(helper.DevSessionOpts{
@@ -3574,7 +3577,7 @@ CMD ["npm", "start"]
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-composite-apply-different-commandgk.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName),
+				cmpName,
 			)
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), imgName, customImgName)
 			var err error
@@ -3695,6 +3698,7 @@ CMD ["npm", "start"]
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-no-metadata-name.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
+					cmpName,
 					helper.DevfileMetadataNameRemover)
 			})
 
@@ -3911,7 +3915,7 @@ CMD ["npm", "start"]
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", t.devfile),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(cmpName))
+						cmpName)
 				})
 
 				When("running odo dev", func() {
@@ -3981,7 +3985,10 @@ CMD ["npm", "start"]
 		Context("Devfile contains pod-overrides and container-overrides attributes", helper.LabelPodmanIf(ctx.podman, func() {
 			BeforeEach(func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", ctx.devfile), filepath.Join(commonVar.Context, "devfile.yaml"), helper.DevfileMetadataNameSetter(cmpName))
+				helper.CopyExampleDevFile(
+					filepath.Join("source", "devfiles", "nodejs", ctx.devfile),
+					filepath.Join(commonVar.Context, "devfile.yaml"),
+					cmpName)
 			})
 			It("should override the content in the pod it creates for the component on the cluster", func() {
 				err := helper.RunDevMode(helper.DevSessionOpts{
@@ -4001,7 +4008,7 @@ CMD ["npm", "start"]
 		BeforeEach(func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 		It("should fail to run odo dev", func() {
 			errOut := helper.Cmd("odo", "dev", "--platform", "podman").WithEnv("PODMAN_CMD=echo").ShouldFail().Err()
@@ -4013,7 +4020,7 @@ CMD ["npm", "start"]
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "registry.access.redhat.com/ubi8/nodejs", "registry.access.redhat.com/ubi8/nose")
 		})
 		It("should fail with an error", func() {
@@ -4036,7 +4043,7 @@ CMD ["npm", "start"]
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project-with-endpoint-on-loopback"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-endpoint-on-loopback.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		haveHttpResponse := func(status int, body string) types.GomegaMatcher {
@@ -4294,7 +4301,7 @@ CMD ["npm", "start"]
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-autobuild-deploybydefault.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 			})
 
 			When("running odo dev with some components not referenced in the Devfile", func() {
@@ -4565,7 +4572,7 @@ CMD ["npm", "start"]
 						filepath.Join(commonVar.Context, "kubernetes", "devfile-image-names-as-selectors"))
 					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-image-names-as-selectors.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(cmpName))
+						cmpName)
 				})
 
 				When("adding a local registry for images", func() {

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -1007,9 +1007,15 @@ ComponentSettings:
 				nodejsProject = helper.CreateNewContext()
 				goProject = helper.CreateNewContext()
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), nodejsProject)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(nodejsProject, "devfile.yaml"))
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
+					filepath.Join(nodejsProject, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName+"-nodejs"),
+				)
 				helper.CopyExample(filepath.Join("source", "go"), goProject)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "go-devfiles", "devfile.yaml"), filepath.Join(goProject, "devfile.yaml"))
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "go-devfiles", "devfile.yaml"),
+					filepath.Join(goProject, "devfile.yaml"),
+					helper.DevfileMetadataNameSetter(cmpName+"-go"),
+				)
 			})
 			AfterEach(func() {
 				helper.DeleteDir(nodejsProject)

--- a/tests/integration/cmd_devfile_build_images_test.go
+++ b/tests/integration/cmd_devfile_build_images_test.go
@@ -210,7 +210,7 @@ var _ = Describe("odo devfile build-images command tests", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(cmpName))
+						cmpName)
 					helper.CreateLocalEnv(commonVar.Context, "aname", commonVar.Project)
 				})
 
@@ -262,7 +262,7 @@ var _ = Describe("odo devfile build-images command tests", func() {
 						helper.CopyExampleDevFile(
 							filepath.Join("source", "devfiles", "nodejs", "devfile-outerloop.yaml"),
 							path.Join(commonVar.Context, "devfile.yaml"),
-							helper.DevfileMetadataNameSetter(cmpName))
+							cmpName)
 					})
 
 					When("remote server returns an error", func() {
@@ -351,7 +351,7 @@ CMD ["npm", "start"]
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-autobuild-deploybydefault.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		When("building images", func() {
@@ -403,7 +403,7 @@ CMD ["npm", "start"]
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-variables.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		checkOutput := func(stdout string, images []string, push bool) {

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -112,7 +112,7 @@ var _ = Describe("odo devfile deploy command tests", func() {
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", ctx.devfileName),
 					path.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 			})
 
 			for _, tt := range []struct {
@@ -239,7 +239,7 @@ ComponentSettings:
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-with-two-deploy-commands.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 		It("should run odo deploy", func() {
 			stdout := helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
@@ -260,7 +260,7 @@ ComponentSettings:
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 			helper.EnableTelemetryDebug()
 			helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
 		})
@@ -364,7 +364,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", ctx.devfile),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				out = helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass().Out()
 				resources = []string{"Deployment/my-component", "Service/my-component-svc"}
 			})
@@ -401,7 +401,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-with-SB.yaml"),
 					filepath.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 				helper.Cmd("odo", "deploy").AddEnv("PODMAN_CMD=echo").ShouldPass()
 			})
 			It("should successfully deploy the ServiceBinding resource", func() {
@@ -420,7 +420,7 @@ ComponentSettings:
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "issue-5600-devfile-with-image-component-and-no-buildContext.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		for _, scope := range []struct {
@@ -475,7 +475,7 @@ ComponentSettings:
 				helper.CopyExampleDevFile(
 					filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
 					path.Join(commonVar.Context, "devfile.yaml"),
-					helper.DevfileMetadataNameSetter(cmpName))
+					cmpName)
 			})
 
 			When("remote server returns an error", func() {
@@ -549,7 +549,7 @@ CMD ["npm", "start"]
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-exec.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 		for _, ctx := range []struct {
 			title, compName string
@@ -656,7 +656,7 @@ CMD ["npm", "start"]
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy-exec-long.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		When("pod security is enforced as restricted", func() {
@@ -705,7 +705,7 @@ CMD ["npm", "start"]
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-autobuild-deploybydefault.yaml"),
 				filepath.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(cmpName))
+				cmpName)
 		})
 
 		When("running odo deploy with some components not referenced in the Devfile", func() {

--- a/tests/integration/cmd_devfile_init_test.go
+++ b/tests/integration/cmd_devfile_init_test.go
@@ -77,7 +77,8 @@ var _ = Describe("odo devfile init command tests", func() {
 				By("running odo init in a directory containing a devfile.yaml", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"),
-						filepath.Join(commonVar.Context, "devfile.yaml"))
+						filepath.Join(commonVar.Context, "devfile.yaml"),
+						"")
 					defer os.Remove(filepath.Join(commonVar.Context, "devfile.yaml"))
 					err := helper.Cmd("odo", "init").ShouldFail().Err()
 					Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))
@@ -86,7 +87,8 @@ var _ = Describe("odo devfile init command tests", func() {
 				By("running odo init in a directory containing a .devfile.yaml", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"),
-						filepath.Join(commonVar.Context, ".devfile.yaml"))
+						filepath.Join(commonVar.Context, ".devfile.yaml"),
+						"")
 					defer helper.DeleteFile(filepath.Join(commonVar.Context, ".devfile.yaml"))
 					err := helper.Cmd("odo", "init").ShouldFail().Err()
 					Expect(err).To(ContainSubstring("a devfile already exists in the current directory"))
@@ -218,7 +220,8 @@ var _ = Describe("odo devfile init command tests", func() {
 					BeforeEach(func() {
 						newContext = helper.CreateNewContext()
 						newDevfilePath := filepath.Join(newContext, "devfile.yaml")
-						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), newDevfilePath)
+						helper.CopyExampleDevFile(
+							filepath.Join("source", "devfiles", "nodejs", "devfile-registry.yaml"), newDevfilePath, "")
 						helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", newDevfilePath).ShouldPass()
 					})
 					AfterEach(func() {
@@ -343,7 +346,7 @@ var _ = Describe("odo devfile init command tests", func() {
 					var out string
 
 					BeforeEach(func() {
-						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), devfilePath)
+						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), devfilePath, "")
 						out = helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", devfilePath).ShouldPass().Out()
 					})
 
@@ -361,7 +364,7 @@ var _ = Describe("odo devfile init command tests", func() {
 					var out string
 
 					BeforeEach(func() {
-						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), devfilePath)
+						helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"), devfilePath, "")
 						out = helper.Cmd("odo", "init", "--name", "aname", "--devfile-path", devfilePath).ShouldPass().Out()
 					})
 

--- a/tests/integration/cmd_devfile_list_test.go
+++ b/tests/integration/cmd_devfile_list_test.go
@@ -104,7 +104,7 @@ var _ = Describe("odo list with devfile", func() {
 			helper.CopyExampleDevFile(
 				filepath.Join("source", "devfiles", "nodejs", "devfile-deploy.yaml"),
 				path.Join(commonVar.Context, "devfile.yaml"),
-				helper.DevfileMetadataNameSetter(componentName))
+				componentName)
 			helper.Chdir(commonVar.Context)
 		})
 

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -149,7 +149,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 					helper.CopyExampleDevFile(
 						filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"),
 						filepath.Join(commonVar.Context, "devfile.yaml"),
-						helper.DevfileMetadataNameSetter(cmpName))
+						cmpName)
 					helper.Chdir(commonVar.Context)
 
 					// Bootstrap the component with a .odo/env/env.yaml file


### PR DESCRIPTION
**What type of PR is this:**
/kind flake
/kind bug
/area testing

**What does this PR do / why we need it:**

This fixes the flakiness of the test reported in #6832, by randomizing the component names used in this test.

It also changes the signature of `helper.CopyExampleDevfile` so as to make sure we don't forget to set a component name when copying an example Devfile.

**Which issue(s) this PR fixes:**
Fixes #6832 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
