### PR TITLE
Replace deprecated `--slow-spec-threshold` Ginkgo flag with `--poll-progress-after`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ else
    PODMAN_EXEC_NODES := 1
 endif
 
-GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --poll-progress-after=$(POLL_PROGRESS_INTERVAL) -timeout $(TIMEOUT) --no-color
+GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --poll-progress-after=$(POLL_PROGRESS_INTERVAL) --poll-progress-interval=$(POLL_PROGRESS_INTERVAL) -timeout $(TIMEOUT) --no-color
 
 # Flags to run one test per core.
 GINKGO_FLAGS_AUTO = $(GINKGO_FLAGS_ALL) -p

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ else
    TEST_EXEC_NODES := 4
 endif
 
-# Slow spec threshold for ginkgo tests. After this time (in second), ginkgo marks test as slow
-SLOW_SPEC_THRESHOLD := 120s
+# After this time, Ginkgo will emit progress reports, so we can get visibility into long-running tests.
+POLL_PROGRESS_INTERVAL := 120s
 
 # Env variable GINKGO_TEST_ARGS is used to get control over enabling ginkgo test flags against each test target run.
 # For example:
@@ -53,7 +53,7 @@ else
    PODMAN_EXEC_NODES := 1
 endif
 
-GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --slow-spec-threshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT) --no-color
+GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --poll-progress-after=$(POLL_PROGRESS_INTERVAL) -timeout $(TIMEOUT) --no-color
 
 # Flags to run one test per core.
 GINKGO_FLAGS_AUTO = $(GINKGO_FLAGS_ALL) -p


### PR DESCRIPTION
**What type of PR is this:**
/area testing

**What does this PR do / why we need it:**
Per [1], this instructs Ginkgo to automatically emit a progress report whenever a node takes too long to complete.
The Progress Report includes information about which node is currently running and the exact line of code that it is currently executing, along with any relevant goroutines that were launched by the spec.

[1] https://onsi.github.io/ginkgo/#getting-visibility-into-long-running-specs

**Which issue(s) this PR fixes:**
Deprecation warnings as seen at the end of all our tests, like [here](https://github.com/redhat-developer/odo/actions/runs/5045832057/jobs/9053658068#step:5:24):
```
Ran 162 of 888 Specs in 1072.811 seconds
SUCCESS! -- [16](https://github.com/redhat-developer/odo/actions/runs/5045832057/jobs/9053658068#step:5:17)2 Passed | 0 Failed | 0 Pending | 726 Skipped


Ginkgo ran 1 suite in [18](https://github.com/redhat-developer/odo/actions/runs/5045832057/jobs/9053658068#step:5:19)m25.223387422s
Test Suite Passed
You're using deprecated Ginkgo functionality:
=============================================
  --slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.8.0
```

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
