### PR TITLE
Make sure event is recorded whenever telemetry preference is changed

### DIFF
--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -165,7 +165,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) error {
 
 	scontext.SetFlags(ctx, cmd.Flags())
 	// set value for telemetry status in context so that we do not need to call IsTelemetryEnabled every time to check its status
-	scontext.SetTelemetryStatus(cmd.Context(), segment.IsTelemetryEnabled(userConfig, envConfig))
+	scontext.SetPreviousTelemetryStatus(ctx, segment.IsTelemetryEnabled(userConfig, envConfig))
 
 	scontext.SetExperimentalMode(ctx, envConfig.OdoExperimentalMode)
 

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -16,13 +16,12 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 
 	"github.com/redhat-developer/odo/pkg/machineoutput"
+	"github.com/redhat-developer/odo/pkg/version"
 
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/commonflags"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	commonutil "github.com/redhat-developer/odo/pkg/util"
-
-	"github.com/redhat-developer/odo/pkg/version"
 
 	"gopkg.in/AlecAivazis/survey.v1"
 
@@ -158,17 +157,17 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) error {
 	}
 
 	// We can dereference as there is a default value defined for this config field
-	err = scontext.SetCaller(cmd.Context(), envConfig.TelemetryCaller)
+	err = scontext.SetCaller(ctx, envConfig.TelemetryCaller)
 	if err != nil {
 		klog.V(3).Infof("error handling caller property for telemetry: %v", err)
 		err = nil
 	}
 
-	scontext.SetFlags(cmd.Context(), cmd.Flags())
+	scontext.SetFlags(ctx, cmd.Flags())
 	// set value for telemetry status in context so that we do not need to call IsTelemetryEnabled every time to check its status
 	scontext.SetTelemetryStatus(cmd.Context(), segment.IsTelemetryEnabled(userConfig, envConfig))
 
-	scontext.SetExperimentalMode(cmd.Context(), envConfig.OdoExperimentalMode)
+	scontext.SetExperimentalMode(ctx, envConfig.OdoExperimentalMode)
 
 	// Send data to telemetry in case of user interrupt
 	captureSignals := []os.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}
@@ -180,7 +179,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) error {
 				log.Errorf("error handling interrupt signal : %v", err)
 			}
 		}
-		scontext.SetSignal(cmd.Context(), receivedSignal)
+		scontext.SetSignal(ctx, receivedSignal)
 		startTelemetry(cmd, err, startTime)
 	})
 

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -20,19 +20,20 @@ import (
 )
 
 const (
-	Caller           = "caller"
-	ComponentType    = "componentType"
-	ClusterType      = "clusterType"
-	TelemetryStatus  = "isTelemetryEnabled"
-	DevfileName      = "devfileName"
-	Language         = "language"
-	ProjectType      = "projectType"
-	NOTFOUND         = "not-found"
-	InteractiveMode  = "interactive"
-	ExperimentalMode = "experimental"
-	Flags            = "flags"
-	Platform         = "platform"
-	PlatformVersion  = "platformVersion"
+	Caller                  = "caller"
+	ComponentType           = "componentType"
+	ClusterType             = "clusterType"
+	PreviousTelemetryStatus = "wasTelemetryEnabled"
+	TelemetryStatus         = "isTelemetryEnabled"
+	DevfileName             = "devfileName"
+	Language                = "language"
+	ProjectType             = "projectType"
+	NOTFOUND                = "not-found"
+	InteractiveMode         = "interactive"
+	ExperimentalMode        = "experimental"
+	Flags                   = "flags"
+	Platform                = "platform"
+	PlatformVersion         = "platformVersion"
 )
 
 const (
@@ -158,7 +159,12 @@ func setPlatformPodman(ctx context.Context, client podman.Client) {
 	setContextProperty(ctx, PlatformVersion, version.Client.Version)
 }
 
-// SetTelemetryStatus sets telemetry status before a command is run
+// SetPreviousTelemetryStatus sets telemetry status before a command is run
+func SetPreviousTelemetryStatus(ctx context.Context, isEnabled bool) {
+	setContextProperty(ctx, PreviousTelemetryStatus, isEnabled)
+}
+
+// SetTelemetryStatus sets telemetry status after a command is run
 func SetTelemetryStatus(ctx context.Context, isEnabled bool) {
 	setContextProperty(ctx, TelemetryStatus, isEnabled)
 }
@@ -222,7 +228,16 @@ func SetCaller(ctx context.Context, caller string) error {
 	return err
 }
 
-// GetTelemetryStatus gets the telemetry status that is set before a command is run
+// GetPreviousTelemetryStatus gets the telemetry status that was seen before a command is run
+func GetPreviousTelemetryStatus(ctx context.Context) bool {
+	wasEnabled, ok := GetContextProperties(ctx)[PreviousTelemetryStatus]
+	if ok {
+		return wasEnabled.(bool)
+	}
+	return false
+}
+
+// GetTelemetryStatus gets the current telemetry status that is set after a command is run
 func GetTelemetryStatus(ctx context.Context) bool {
 	isEnabled, ok := GetContextProperties(ctx)[TelemetryStatus]
 	if ok {

--- a/tests/helper/helper_telemetry.go
+++ b/tests/helper/helper_telemetry.go
@@ -24,7 +24,7 @@ func setDebugTelemetryFile(value string) error {
 
 // EnableTelemetryDebug creates a temp file to use for debugging telemetry.
 // it also sets up envs and cfg for the same
-func EnableTelemetryDebug() {
+func EnableTelemetryDebug() preference.Client {
 	Expect(os.Setenv(segment.TrackingConsentEnv, "yes")).NotTo(HaveOccurred())
 
 	ctx := context.Background()
@@ -39,6 +39,8 @@ func EnableTelemetryDebug() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(setDebugTelemetryFile(tempFile.Name())).NotTo(HaveOccurred())
 	Expect(tempFile.Close()).NotTo(HaveOccurred())
+
+	return cfg
 }
 
 func GetDebugTelemetryFile() string {


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area telemetry

**What does this PR do / why we need it:**
See #6790 for more context and reproduction steps.

**Which issue(s) this PR fixes:**
Fixes #6790 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
```shell
$ mkdir -p /tmp/6790
$ cd /tmp/6790

# Dedicated preferences file for this
$ export GLOBALODOCONFIG=`pwd`/my-odo-preferences.yaml 

# Store telemetry data in a local JSON file
$ export ODO_DEBUG_TELEMETRY_FILE=`pwd`/telemetry_data.json

# Enable telemetry
$ odo preference set ConsentTelemetry true --force

# Make sure telemetry data is recorded correctly
$ cat telemetry_data.json | jq       
{
  "event": "odo preference set",
  "properties": {
    "duration": 0,
    "error": "",
    "errortype": "",
    "success": true,
    "tty": true,
    "version": "odo v3.10.0 (38cac04c4)",
    "cmdProperties": {
      "caller": "",
      "experimental": false,
      "flags": "force",
      "isTelemetryEnabled": true,
      "wasTelemetryEnabled": false
    }
  }
}
# other commands should be recorded
# (because telemetry is disabled)
$ odo analyze -o json
$ cat telemetry_data.json | jq
{
  "event": "odo analyze",
  "properties": {
    "duration": 861,
    "error": "No valid devfile found for project in XXXX",
    "errortype": "*errors.errorString",
    "success": false,
    "tty": true,
    "version": "odo v3.10.0 (38cac04c4)",
    "cmdProperties": {
      "caller": "",
      "experimental": false,
      "flags": "o",
      "isTelemetryEnabled": true,
      "wasTelemetryEnabled": true
    }
  }
}

# ---

# Now disable telemetry
$ odo preference set ConsentTelemetry false --force

# Disabling telemetry again should still record the event, but not other commands
$ odo preference set ConsentTelemetry false --force
$ cat telemetry_data.json | jq
{
  "event": "odo preference set",
  "properties": {
    "duration": 0,
    "error": "",
    "errortype": "",
    "success": true,
    "tty": true,
    "version": "odo v3.10.0 (38cac04c4)",
    "cmdProperties": {
      "caller": "",
      "experimental": false,
      "flags": "force",
      "isTelemetryEnabled": false,
      "wasTelemetryEnabled": true
    }
  }
}

# subsequent commands should not be sent to telemetry
# (because telemetry is now disabled)
$ odo analyze -o json 
$ cat telemetry_data.json | jq
{
  "event": "odo preference set",
  "properties": {
    "duration": 0,
    "error": "",
    "errortype": "",
    "success": true,
    "tty": true,
    "version": "odo v3.10.0 (38cac04c4)",
    "cmdProperties": {
      "caller": "",
      "experimental": false,
      "flags": "force",
      "isTelemetryEnabled": false,
      "wasTelemetryEnabled": true
    }
  }
}

# ---

# Now re-enable telemetry
$ odo preference set ConsentTelemetry true --force

# Make sure telemetry data is recorded correctly
$ cat telemetry_data.json | jq       
{
  "event": "odo preference set",
  "properties": {
    "duration": 0,
    "error": "",
    "errortype": "",
    "success": true,
    "tty": true,
    "version": "odo v3.10.0 (38cac04c4)",
    "cmdProperties": {
      "caller": "",
      "experimental": false,
      "flags": "force",
      "isTelemetryEnabled": true,
      "wasTelemetryEnabled": false
    }
  }
}
# other commands should be recorded
# (because telemetry is disabled)
$ odo analyze -o json
$ cat telemetry_data.json | jq
{
  "event": "odo analyze",
  "properties": {
    "duration": 861,
    "error": "No valid devfile found for project in XXXX",
    "errortype": "*errors.errorString",
    "success": false,
    "tty": true,
    "version": "odo v3.10.0 (38cac04c4)",
    "cmdProperties": {
      "caller": "",
      "experimental": false,
      "flags": "o",
      "isTelemetryEnabled": true,
      "wasTelemetryEnabled": true
    }
  }
}
```