### PR TITLE
Bump Devfile library to latest commit (04a8b3f)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Xuanwo/go-locale v1.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/devfile/api/v2 v2.2.1-alpha.0.20230413012049-a6c32fca0dbd
-	github.com/devfile/library/v2 v2.2.1-0.20230515084048-f041d798707c
+	github.com/devfile/library/v2 v2.2.1-0.20230524160049-04a8b3fc66c0
 	github.com/devfile/registry-support/index/generator v0.0.0-20230322155332-33914affc83b
 	github.com/devfile/registry-support/registry-library v0.0.0-20221201200738-19293ac0b8ab
 	github.com/fatih/color v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,8 @@ github.com/devfile/api/v2 v2.2.1-alpha.0.20230413012049-a6c32fca0dbd/go.mod h1:q
 github.com/devfile/library v1.2.1-0.20211104222135-49d635cb492f/go.mod h1:uFZZdTuRqA68FVe/JoJHP92CgINyQkyWnM2Qyiim+50=
 github.com/devfile/library v1.2.1-0.20220308191614-f0f7e11b17de/go.mod h1:GSPfJaBg0+bBjBHbwBE5aerJLH6tWGQu2q2rHYd9czM=
 github.com/devfile/library/v2 v2.0.1/go.mod h1:paJ0PARAVy0br13VpBEQ4fO3rZVDxWtooQ29+23PNBk=
-github.com/devfile/library/v2 v2.2.1-0.20230515084048-f041d798707c h1:WXsJ/mP865odQ6yxP9MKULBg6N6lPmoBzMZ/Ur2y/5I=
-github.com/devfile/library/v2 v2.2.1-0.20230515084048-f041d798707c/go.mod h1:7oEhkC6GW6OKmAP8HbxbaQ+nFbnACQuU7anYhJroltQ=
+github.com/devfile/library/v2 v2.2.1-0.20230524160049-04a8b3fc66c0 h1:cZPTQyQqZD6zTbrNhS5MU1j/tE+kyDIOgYqeBCu+2to=
+github.com/devfile/library/v2 v2.2.1-0.20230524160049-04a8b3fc66c0/go.mod h1:7oEhkC6GW6OKmAP8HbxbaQ+nFbnACQuU7anYhJroltQ=
 github.com/devfile/registry-support/index/generator v0.0.0-20220222194908-7a90a4214f3e/go.mod h1:iRPBxs+ZjfLEduVXpCCIOzdD2588Zv9OCs/CcXMcCCY=
 github.com/devfile/registry-support/index/generator v0.0.0-20220527155645-8328a8a883be/go.mod h1:1fyDJL+fPHtcrYA6yjSVWeLmXmjCNth0d5Rq1rvtryc=
 github.com/devfile/registry-support/index/generator v0.0.0-20221018203505-df96d34d4273/go.mod h1:ZJnaSLjTKCvGJhWmYgQoQ1O3g78qBe4Va6ZugLmi4dE=

--- a/vendor/github.com/devfile/library/v2/pkg/devfile/parser/parse.go
+++ b/vendor/github.com/devfile/library/v2/pkg/devfile/parser/parse.go
@@ -50,12 +50,12 @@ import (
 var downloadGitRepoResources = func(url string, destDir string, httpTimeout *int, token string) error {
 	var returnedErr error
 
-	gitUrl, err := git.NewGitUrlWithURL(url)
-	if err != nil {
-		return err
-	}
+	if util.IsGitProviderRepo(url) {
+		gitUrl, err := git.NewGitUrlWithURL(url)
+		if err != nil {
+			return err
+		}
 
-	if gitUrl.IsGitProviderRepo() {
 		if !gitUrl.IsFile || gitUrl.Revision == "" || !strings.Contains(gitUrl.Path, OutputDevfileYamlPath) {
 			return fmt.Errorf("error getting devfile from url: failed to retrieve %s", url)
 		}

--- a/vendor/github.com/devfile/library/v2/pkg/git/git.go
+++ b/vendor/github.com/devfile/library/v2/pkg/git/git.go
@@ -139,13 +139,13 @@ func (g *GitUrl) CloneGitRepo(destDir string) error {
 	}
 
 	if g.Revision != "" {
-		_, err := execute(destDir, "git", "switch", "--detach", "origin/"+g.Revision)
+		_, err := execute(destDir, "git", "checkout", g.Revision)
 		if err != nil {
 			err = os.RemoveAll(destDir)
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("failed to switch repo to revision. repo dir: %v, revision: %v", destDir, g.Revision)
+			return fmt.Errorf("failed to switch repo to revision. repo dir: %v, revision: %v, error: %v", destDir, g.Revision, err)
 		}
 	}
 

--- a/vendor/github.com/devfile/library/v2/pkg/git/mock.go
+++ b/vendor/github.com/devfile/library/v2/pkg/git/mock.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 type MockGitUrl struct {
@@ -70,8 +69,8 @@ var mockExecute = func(baseDir string, cmd CommandType, args ...string) ([]byte,
 			return []byte(""), nil
 		}
 
-		if len(args) > 0 && args[0] == "switch" {
-			revision := strings.TrimPrefix(args[2], "origin/")
+		if len(args) > 0 && args[0] == "checkout" {
+			revision := args[1]
 			if revision != "invalid-revision" {
 				resourceFile, err := os.OpenFile(filepath.Clean(baseDir)+"/resource.file", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 				if err != nil {
@@ -122,7 +121,7 @@ func (m *MockGitUrl) CloneGitRepo(destDir string) error {
 	}
 
 	if m.Revision != "" {
-		_, err := mockExecute(destDir, "git", "switch", "--detach", "origin/"+m.Revision)
+		_, err := mockExecute(destDir, "git", "checkout", m.Revision)
 		if err != nil {
 			return fmt.Errorf("failed to switch repo to revision. repo dir: %v, revision: %v", destDir, m.Revision)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -146,7 +146,7 @@ github.com/devfile/api/v2/pkg/utils/overriding
 github.com/devfile/api/v2/pkg/utils/unions
 github.com/devfile/api/v2/pkg/validation
 github.com/devfile/api/v2/pkg/validation/variables
-# github.com/devfile/library/v2 v2.2.1-0.20230515084048-f041d798707c
+# github.com/devfile/library/v2 v2.2.1-0.20230524160049-04a8b3fc66c0
 ## explicit; go 1.18
 github.com/devfile/library/v2/pkg/devfile
 github.com/devfile/library/v2/pkg/devfile/generator


### PR DESCRIPTION
**What type of PR is this:**
/area dependency

**What does this PR do / why we need it:**
This bumps the Devfile library to the latest commit [1], which fixes the issue with parsing child Devfiles
referencing parents via URIs (GitHub blob, raw or any hosted URL).
See [2] for more context.

[1] https://github.com/devfile/library/commit/04a8b3fc66c0ca7a33d03190f3a026a3d9e6a940
[2] https://github.com/devfile/api/issues/1119


**Which issue(s) this PR fixes:**
Related to https://github.com/devfile/api/issues/1119

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**

Given the following Devfile:
```yaml
metadata:
  description: Java application using Spring Boot® and OpenJDK 17
  name: my-java-sb
  version: 1.3.0
parent:
  components:
  - container:
      image: registry.access.redhat.com/ubi9/openjdk-17:latest
    name: tools
  uri: https://registry.stage.devfile.io/devfiles/java-springboot/1.2.0
schemaVersion: 2.1.0
```

Before this PR, `odo dev` won't be able to parse it:
```
$ odo dev
 ✗  failed to parse the devfile /tmp/bug-odo-parent/devfile.yaml: failed to populateAndParseDevfile: url host should be a valid GitHub, GitLab, or Bitbucket host; received: registry.stage.devfile.io
```

It should now work with this update of the Devfile library:
```
$ odo dev
  __
 /  \__     Developing using the "my-java-sb" Devfile
 \__/  \    Namespace: default
 /  \__/    odo version: v3.10.0
 \__/

 ⚠  You are using "default" namespace, odo may not work as expected in the default namespace.
 ⚠  You may set a new namespace by running `odo create namespace <name>`, or set an existing one by running `odo set namespace <name>`

↪ Running on the cluster in Dev mode
 •  Waiting for Kubernetes resources  ...
 ✓  Added storage m2 to component
 ⚠  Pod is Pending

...
```