### PR TITLE
Add an `odo run` command to manually execute command during `odo dev`

### DIFF
--- a/cmd/odo/help_test.go
+++ b/cmd/odo/help_test.go
@@ -34,6 +34,7 @@ Examples:
   init         Init bootstraps a new project
   logs         Show logs of all containers of the component
   registry     List all components from the Devfile registry
+  run          Run a specific command in the Dev mode
 
 `
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -94,11 +94,7 @@ func Log(platformClient platform.Client, componentName string, appName string, f
 
 	pod, err := platformClient.GetRunningPodFromSelector(odolabels.GetSelector(componentName, appName, odolabels.ComponentDevMode, false))
 	if err != nil {
-		return nil, fmt.Errorf("the component %s doesn't exist on the cluster", componentName)
-	}
-
-	if pod.Status.Phase != corev1.PodRunning {
-		return nil, fmt.Errorf("unable to show logs, component is not in running state. current status=%v", pod.Status.Phase)
+		return nil, fmt.Errorf("a running component %s doesn't exist on the cluster: %w", componentName, err)
 	}
 
 	containerName := command.Exec.Component

--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -212,12 +212,6 @@ func (do *DeleteComponentClient) ExecutePreStopEvents(ctx context.Context, devfi
 		return fmt.Errorf("unable to determine if component %s exists; cause: %v", componentName, err.Error())
 	}
 
-	// do not fail Delete operation if if the pod is not running or if the event execution fails
-	if pod.Status.Phase != corev1.PodRunning {
-		klog.V(4).Infof("unable to execute preStop events, pod for component %q is not running", componentName)
-		return nil
-	}
-
 	klog.V(4).Infof("Executing %q event commands for component %q", libdevfile.PreStop, componentName)
 	// ignore the failures if any; delete should not fail because preStop events failed to execute
 	handler := component.NewRunHandler(

--- a/pkg/component/delete/delete_test.go
+++ b/pkg/component/delete/delete_test.go
@@ -701,25 +701,6 @@ func TestDeleteComponentClient_ExecutePreStopEvents(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "did not execute PreStopEvents because the pod is not in the running state",
-			fields: fields{
-				kubeClient: func(ctrl *gomock.Controller) kclient.ClientInterface {
-					client := kclient.NewMockClientInterface(ctrl)
-
-					selector := odolabels.GetSelector(componentName, "app", odolabels.ComponentDevMode, false)
-					pod := odoTestingUtil.CreateFakePod(componentName, "mypod", "runtime")
-					pod.Status.Phase = corev1.PodFailed
-					client.EXPECT().GetRunningPodFromSelector(selector).Return(pod, nil)
-					return client
-				},
-			},
-			args: args{
-				devfileObj: devfileObjWithPreStopEvents,
-				appName:    appName,
-			},
-			wantErr: false,
-		},
-		{
 			name: "failed to execute PreStopEvents because it failed to execute the command inside the container, but no error returned",
 			fields: fields{
 				kubeClient: func(ctrl *gomock.Controller) kclient.ClientInterface {

--- a/pkg/dev/common/run.go
+++ b/pkg/dev/common/run.go
@@ -30,7 +30,7 @@ func Run(
 
 	pod, err := platformClient.GetPodUsingComponentName(componentName)
 	if err != nil {
-		return fmt.Errorf("unable to get pod for component %s: %w", componentName, err)
+		return fmt.Errorf("unable to get pod for component %s: %w. Please check the command odo dev is running", componentName, err)
 	}
 
 	handler := component.NewRunHandler(

--- a/pkg/dev/common/run.go
+++ b/pkg/dev/common/run.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/configAutomount"
+	"github.com/redhat-developer/odo/pkg/devfile/image"
+	"github.com/redhat-developer/odo/pkg/exec"
+	"github.com/redhat-developer/odo/pkg/libdevfile"
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
+	"github.com/redhat-developer/odo/pkg/platform"
+	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
+)
+
+func Run(
+	ctx context.Context,
+	commandName string,
+	platformClient platform.Client,
+	execClient exec.Client,
+	configAutomountClient configAutomount.Client,
+	filesystem filesystem.Filesystem,
+) error {
+	var (
+		componentName = odocontext.GetComponentName(ctx)
+		devfileObj    = odocontext.GetEffectiveDevfileObj(ctx)
+		devfilePath   = odocontext.GetDevfilePath(ctx)
+	)
+
+	pod, err := platformClient.GetPodUsingComponentName(componentName)
+	if err != nil {
+		return fmt.Errorf("unable to get pod for component %s: %w", componentName, err)
+	}
+
+	handler := component.NewRunHandler(
+		ctx,
+		platformClient,
+		execClient,
+		configAutomountClient,
+		pod.Name,
+		false,
+		component.GetContainersNames(pod),
+		"Executing command in container",
+
+		filesystem,
+		image.SelectBackend(ctx),
+		*devfileObj,
+		devfilePath,
+	)
+
+	return libdevfile.ExecuteCommandByName(ctx, *devfileObj, commandName, handler, false)
+}

--- a/pkg/dev/common/run.go
+++ b/pkg/dev/common/run.go
@@ -30,7 +30,7 @@ func Run(
 
 	pod, err := platformClient.GetPodUsingComponentName(componentName)
 	if err != nil {
-		return fmt.Errorf("unable to get pod for component %s: %w. Please check the command odo dev is running", componentName, err)
+		return fmt.Errorf("unable to get pod for component %s: %w. Please check the command 'odo dev' is running", componentName, err)
 	}
 
 	handler := component.NewRunHandler(

--- a/pkg/dev/interface.go
+++ b/pkg/dev/interface.go
@@ -48,6 +48,11 @@ type Client interface {
 		options StartOptions,
 	) error
 
+	Run(
+		ctx context.Context,
+		commandName string,
+	) error
+
 	// CleanupResources deletes the component created using the context's devfile and writes any outputs to out
 	CleanupResources(ctx context.Context, out io.Writer) error
 }

--- a/pkg/dev/kubedev/run.go
+++ b/pkg/dev/kubedev/run.go
@@ -2,12 +2,8 @@ package kubedev
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/redhat-developer/odo/pkg/devfile/image"
-	"github.com/redhat-developer/odo/pkg/libdevfile"
-	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
+	"github.com/redhat-developer/odo/pkg/dev/common"
 	"k8s.io/klog"
 )
 
@@ -15,34 +11,13 @@ func (o *DevClient) Run(
 	ctx context.Context,
 	commandName string,
 ) error {
-	var (
-		componentName = odocontext.GetComponentName(ctx)
-		devfileObj    = odocontext.GetEffectiveDevfileObj(ctx)
-		devfilePath   = odocontext.GetDevfilePath(ctx)
-	)
-
 	klog.V(4).Infof("running command %q on cluster", commandName)
-
-	pod, err := o.kubernetesClient.GetPodUsingComponentName(componentName)
-	if err != nil {
-		return fmt.Errorf("unable to get pod for component %s: %w", componentName, err)
-	}
-
-	handler := component.NewRunHandler(
+	return common.Run(
 		ctx,
+		commandName,
 		o.kubernetesClient,
 		o.execClient,
 		o.configAutomountClient,
-		pod.Name,
-		false,
-		component.GetContainersNames(pod),
-		"Executing command in container",
-
 		o.filesystem,
-		image.SelectBackend(ctx),
-		*devfileObj,
-		devfilePath,
 	)
-
-	return libdevfile.ExecuteCommandByName(ctx, *devfileObj, commandName, handler, false)
 }

--- a/pkg/dev/kubedev/run.go
+++ b/pkg/dev/kubedev/run.go
@@ -2,7 +2,12 @@ package kubedev
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/devfile/image"
+	"github.com/redhat-developer/odo/pkg/libdevfile"
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"k8s.io/klog"
 )
 
@@ -10,6 +15,34 @@ func (o *DevClient) Run(
 	ctx context.Context,
 	commandName string,
 ) error {
+	var (
+		componentName = odocontext.GetComponentName(ctx)
+		devfileObj    = odocontext.GetEffectiveDevfileObj(ctx)
+		devfilePath   = odocontext.GetDevfilePath(ctx)
+	)
+
 	klog.V(4).Infof("running command %q on cluster", commandName)
-	return nil
+
+	pod, err := o.kubernetesClient.GetPodUsingComponentName(componentName)
+	if err != nil {
+		return fmt.Errorf("unable to get pod for component %s: %w", componentName, err)
+	}
+
+	handler := component.NewRunHandler(
+		ctx,
+		o.kubernetesClient,
+		o.execClient,
+		o.configAutomountClient,
+		pod.Name,
+		false,
+		component.GetContainersNames(pod),
+		"Executing command in container",
+
+		o.filesystem,
+		image.SelectBackend(ctx),
+		*devfileObj,
+		devfilePath,
+	)
+
+	return libdevfile.ExecuteCommandByName(ctx, *devfileObj, commandName, handler, false)
 }

--- a/pkg/dev/kubedev/run.go
+++ b/pkg/dev/kubedev/run.go
@@ -1,0 +1,15 @@
+package kubedev
+
+import (
+	"context"
+
+	"k8s.io/klog"
+)
+
+func (o *DevClient) Run(
+	ctx context.Context,
+	commandName string,
+) error {
+	klog.V(4).Infof("running command %q on cluster", commandName)
+	return nil
+}

--- a/pkg/dev/mock.go
+++ b/pkg/dev/mock.go
@@ -49,6 +49,20 @@ func (mr *MockClientMockRecorder) CleanupResources(ctx, out interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupResources", reflect.TypeOf((*MockClient)(nil).CleanupResources), ctx, out)
 }
 
+// Run mocks base method.
+func (m *MockClient) Run(ctx context.Context, commandName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Run", ctx, commandName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Run indicates an expected call of Run.
+func (mr *MockClientMockRecorder) Run(ctx, commandName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockClient)(nil).Run), ctx, commandName)
+}
+
 // Start mocks base method.
 func (m *MockClient) Start(ctx context.Context, options StartOptions) error {
 	m.ctrl.T.Helper()

--- a/pkg/dev/podmandev/run.go
+++ b/pkg/dev/podmandev/run.go
@@ -2,12 +2,8 @@ package podmandev
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/redhat-developer/odo/pkg/component"
-	"github.com/redhat-developer/odo/pkg/devfile/image"
-	"github.com/redhat-developer/odo/pkg/libdevfile"
-	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
+	"github.com/redhat-developer/odo/pkg/dev/common"
 	"k8s.io/klog"
 )
 
@@ -15,34 +11,13 @@ func (o *DevClient) Run(
 	ctx context.Context,
 	commandName string,
 ) error {
-	var (
-		componentName = odocontext.GetComponentName(ctx)
-		devfileObj    = odocontext.GetEffectiveDevfileObj(ctx)
-		devfilePath   = odocontext.GetDevfilePath(ctx)
-	)
-
 	klog.V(4).Infof("running command %q on cluster", commandName)
-
-	pod, err := o.podmanClient.GetPodUsingComponentName(componentName)
-	if err != nil {
-		return fmt.Errorf("unable to get pod for component %s: %w", componentName, err)
-	}
-
-	handler := component.NewRunHandler(
+	return common.Run(
 		ctx,
+		commandName,
 		o.podmanClient,
 		o.execClient,
 		nil, // TODO(feloy) set when running on new container is supported on podman
-		pod.Name,
-		false,
-		component.GetContainersNames(pod),
-		"Executing command in container",
-
 		o.fs,
-		image.SelectBackend(ctx),
-		*devfileObj,
-		devfilePath,
 	)
-
-	return libdevfile.ExecuteCommandByName(ctx, *devfileObj, commandName, handler, false)
 }

--- a/pkg/dev/podmandev/run.go
+++ b/pkg/dev/podmandev/run.go
@@ -2,7 +2,12 @@ package podmandev
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/redhat-developer/odo/pkg/component"
+	"github.com/redhat-developer/odo/pkg/devfile/image"
+	"github.com/redhat-developer/odo/pkg/libdevfile"
+	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"k8s.io/klog"
 )
 
@@ -10,6 +15,34 @@ func (o *DevClient) Run(
 	ctx context.Context,
 	commandName string,
 ) error {
-	klog.V(4).Infof("running command %q on podman", commandName)
-	return nil
+	var (
+		componentName = odocontext.GetComponentName(ctx)
+		devfileObj    = odocontext.GetEffectiveDevfileObj(ctx)
+		devfilePath   = odocontext.GetDevfilePath(ctx)
+	)
+
+	klog.V(4).Infof("running command %q on cluster", commandName)
+
+	pod, err := o.podmanClient.GetPodUsingComponentName(componentName)
+	if err != nil {
+		return fmt.Errorf("unable to get pod for component %s: %w", componentName, err)
+	}
+
+	handler := component.NewRunHandler(
+		ctx,
+		o.podmanClient,
+		o.execClient,
+		nil, // TODO(feloy) set when running on new container is supported on podman
+		pod.Name,
+		false,
+		component.GetContainersNames(pod),
+		"Executing command in container",
+
+		o.fs,
+		image.SelectBackend(ctx),
+		*devfileObj,
+		devfilePath,
+	)
+
+	return libdevfile.ExecuteCommandByName(ctx, *devfileObj, commandName, handler, false)
 }

--- a/pkg/dev/podmandev/run.go
+++ b/pkg/dev/podmandev/run.go
@@ -11,7 +11,7 @@ func (o *DevClient) Run(
 	ctx context.Context,
 	commandName string,
 ) error {
-	klog.V(4).Infof("running command %q on cluster", commandName)
+	klog.V(4).Infof("running command %q on podman", commandName)
 	return common.Run(
 		ctx,
 		commandName,

--- a/pkg/dev/podmandev/run.go
+++ b/pkg/dev/podmandev/run.go
@@ -1,0 +1,15 @@
+package podmandev
+
+import (
+	"context"
+
+	"k8s.io/klog"
+)
+
+func (o *DevClient) Run(
+	ctx context.Context,
+	commandName string,
+) error {
+	klog.V(4).Infof("running command %q on podman", commandName)
+	return nil
+}

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -44,6 +44,10 @@ func (o fakePlatform) GetRunningPodFromSelector(selector string) (*corev1.Pod, e
 	panic("not implemented yet")
 }
 
+func (o fakePlatform) GetPodUsingComponentName(componentName string) (*corev1.Pod, error) {
+	panic("not implemented yet")
+}
+
 func TestExecuteCommand(t *testing.T) {
 	for _, tt := range []struct {
 		name               string

--- a/pkg/libdevfile/errors.go
+++ b/pkg/libdevfile/errors.go
@@ -22,6 +22,9 @@ func (e NoCommandFoundError) Error() string {
 	if e.name == "" {
 		return fmt.Sprintf("no %s command found in devfile", e.kind)
 	}
+	if e.kind == "" {
+		return fmt.Sprintf("no command named %q found in devfile", e.name)
+	}
 	return fmt.Sprintf("no %s command with name %q found in Devfile", e.kind, e.name)
 }
 

--- a/pkg/libdevfile/libdevfile.go
+++ b/pkg/libdevfile/libdevfile.go
@@ -66,8 +66,7 @@ func ExecuteCommandByNameAndKind(ctx context.Context, devfileObj parser.DevfileO
 	return executeCommand(ctx, devfileObj, cmd, handler)
 }
 
-// ExecuteCommandByNameAndKind executes the specified command cmdName of the given kind in the Devfile.
-// If cmdName is empty, it executes the default command for the given kind or returns an error if there is no default command.
+// ExecuteCommandByName executes the specified command cmdName in the Devfile.
 // If ignoreCommandNotFound is true, nothing is executed if the command is not found and no error is returned.
 func ExecuteCommandByName(ctx context.Context, devfileObj parser.DevfileObj, cmdName string, handler Handler, ignoreCommandNotFound bool) error {
 	commands, err := devfileObj.Data.GetCommands(

--- a/pkg/libdevfile/libdevfile.go
+++ b/pkg/libdevfile/libdevfile.go
@@ -66,6 +66,26 @@ func ExecuteCommandByNameAndKind(ctx context.Context, devfileObj parser.DevfileO
 	return executeCommand(ctx, devfileObj, cmd, handler)
 }
 
+// ExecuteCommandByNameAndKind executes the specified command cmdName of the given kind in the Devfile.
+// If cmdName is empty, it executes the default command for the given kind or returns an error if there is no default command.
+// If ignoreCommandNotFound is true, nothing is executed if the command is not found and no error is returned.
+func ExecuteCommandByName(ctx context.Context, devfileObj parser.DevfileObj, cmdName string, handler Handler, ignoreCommandNotFound bool) error {
+	commands, err := devfileObj.Data.GetCommands(
+		common.DevfileOptions{
+			FilterByName: cmdName,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if len(commands) != 1 {
+		return NewNoCommandFoundError("", cmdName)
+	}
+
+	cmd := commands[0]
+	return executeCommand(ctx, devfileObj, cmd, handler)
+}
+
 // executeCommand executes a specific command of a devfile using handler as backend
 func executeCommand(ctx context.Context, devfileObj parser.DevfileObj, command v1alpha2.Command, handler Handler) error {
 	cmd, err := newCommand(devfileObj, command)

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/redhat-developer/odo/pkg/odo/cli/logs"
+	"github.com/redhat-developer/odo/pkg/odo/cli/run"
 	"github.com/redhat-developer/odo/pkg/odo/commonflags"
 
 	"github.com/redhat-developer/odo/pkg/log"
@@ -195,6 +196,7 @@ func odoRootCmd(ctx context.Context, name, fullName string) *cobra.Command {
 		set.NewCmdSet(set.RecommendedCommandName, util.GetFullName(fullName, set.RecommendedCommandName)),
 		logs.NewCmdLogs(logs.RecommendedCommandName, util.GetFullName(fullName, logs.RecommendedCommandName)),
 		completion.NewCmdCompletion(completion.RecommendedCommandName, util.GetFullName(fullName, completion.RecommendedCommandName)),
+		run.NewCmdRun(run.RecommendedCommandName, util.GetFullName(fullName, run.RecommendedCommandName)),
 	)
 
 	// Add all subcommands to base commands

--- a/pkg/odo/cli/errors/errors.go
+++ b/pkg/odo/cli/errors/errors.go
@@ -19,6 +19,20 @@ func (o NoCommandInDevfileError) Error() string {
 	return fmt.Sprintf("no command of kind %q found in the devfile", o.command)
 }
 
+type NoCommandNameInDevfileError struct {
+	name string
+}
+
+func NewNoCommandNameInDevfileError(name string) NoCommandNameInDevfileError {
+	return NoCommandNameInDevfileError{
+		name: name,
+	}
+}
+
+func (o NoCommandNameInDevfileError) Error() string {
+	return fmt.Sprintf("no command named %q found in the devfile", o.name)
+}
+
 type Warning struct {
 	msg string
 	err error

--- a/pkg/odo/cli/run/run.go
+++ b/pkg/odo/cli/run/run.go
@@ -7,13 +7,17 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 	"github.com/spf13/cobra"
 
+	"github.com/redhat-developer/odo/pkg/kclient"
 	"github.com/redhat-developer/odo/pkg/odo/cli/errors"
 	"github.com/redhat-developer/odo/pkg/odo/cmdline"
 	"github.com/redhat-developer/odo/pkg/odo/commonflags"
+	fcontext "github.com/redhat-developer/odo/pkg/odo/commonflags/context"
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
+	"github.com/redhat-developer/odo/pkg/podman"
+	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -54,6 +58,7 @@ func (o *RunOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline, args
 func (o *RunOptions) Validate(ctx context.Context) error {
 	var (
 		devfileObj = odocontext.GetEffectiveDevfileObj(ctx)
+		platform   = fcontext.GetPlatform(ctx, commonflags.PlatformCluster)
 	)
 
 	if devfileObj == nil {
@@ -65,6 +70,21 @@ func (o *RunOptions) Validate(ctx context.Context) error {
 	})
 	if err != nil || len(commands) != 1 {
 		return errors.NewNoCommandNameInDevfileError(o.commandName)
+	}
+
+	switch platform {
+
+	case commonflags.PlatformCluster:
+		if o.clientset.KubernetesClient == nil {
+			return kclient.NewNoConnectionError()
+		}
+		scontext.SetPlatform(ctx, o.clientset.KubernetesClient)
+
+	case commonflags.PlatformPodman:
+		if o.clientset.PodmanClient == nil {
+			return podman.NewPodmanNotFoundError(nil)
+		}
+		scontext.SetPlatform(ctx, o.clientset.PodmanClient)
 	}
 	return nil
 }
@@ -87,6 +107,8 @@ func NewCmdRun(name, fullName string) *cobra.Command {
 	}
 	clientset.Add(runCmd,
 		clientset.FILESYSTEM,
+		clientset.KUBERNETES_NULLABLE,
+		clientset.PODMAN_NULLABLE,
 	)
 
 	odoutil.SetCommandGroup(runCmd, odoutil.MainGroup)

--- a/pkg/odo/cli/run/run.go
+++ b/pkg/odo/cli/run/run.go
@@ -90,7 +90,7 @@ func (o *RunOptions) Validate(ctx context.Context) error {
 }
 
 func (o *RunOptions) Run(ctx context.Context) (err error) {
-	return nil
+	return o.clientset.DevClient.Run(ctx, o.commandName)
 }
 
 func NewCmdRun(name, fullName string) *cobra.Command {
@@ -109,6 +109,7 @@ func NewCmdRun(name, fullName string) *cobra.Command {
 		clientset.FILESYSTEM,
 		clientset.KUBERNETES_NULLABLE,
 		clientset.PODMAN_NULLABLE,
+		clientset.DEV,
 	)
 
 	odoutil.SetCommandGroup(runCmd, odoutil.MainGroup)

--- a/pkg/odo/cli/run/run.go
+++ b/pkg/odo/cli/run/run.go
@@ -68,7 +68,10 @@ func (o *RunOptions) Validate(ctx context.Context) error {
 	commands, err := devfileObj.Data.GetCommands(common.DevfileOptions{
 		FilterByName: o.commandName,
 	})
-	if err != nil || len(commands) != 1 {
+	if err != nil {
+		return err
+	}
+	if len(commands) != 1 {
 		return errors.NewNoCommandNameInDevfileError(o.commandName)
 	}
 

--- a/pkg/odo/cli/run/run.go
+++ b/pkg/odo/cli/run/run.go
@@ -1,0 +1,74 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/odo/pkg/odo/cmdline"
+	"github.com/redhat-developer/odo/pkg/odo/commonflags"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
+	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
+
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+)
+
+const (
+	RecommendedCommandName = "run"
+)
+
+type RunOptions struct {
+	// Clients
+	clientset *clientset.Clientset
+}
+
+var _ genericclioptions.Runnable = (*RunOptions)(nil)
+
+func NewRunOptions() *RunOptions {
+	return &RunOptions{}
+}
+
+var runExample = ktemplates.Examples(`
+	# Run the command "my-command" in the Dev mode
+	%[1]s my-command
+
+`)
+
+func (o *RunOptions) SetClientset(clientset *clientset.Clientset) {
+	o.clientset = clientset
+}
+
+func (o *RunOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline, args []string) error {
+	return nil
+}
+
+func (o *RunOptions) Validate(ctx context.Context) error {
+	return nil
+}
+
+func (o *RunOptions) Run(ctx context.Context) (err error) {
+	return nil
+}
+
+func NewCmdRun(name, fullName string) *cobra.Command {
+	o := NewRunOptions()
+	runCmd := &cobra.Command{
+		Use:     name,
+		Short:   "Run a specific command in the Dev mode",
+		Long:    `odo run executes a specific command of the Devfile during the Dev mode ("odo dev" needs to be running)`,
+		Example: fmt.Sprintf(runExample, fullName),
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return genericclioptions.GenericRun(o, cmd, args)
+		},
+	}
+	//	clientset.Add(devCmd,
+	//	)
+
+	odoutil.SetCommandGroup(runCmd, odoutil.MainGroup)
+	runCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
+	commonflags.UsePlatformFlag(runCmd)
+	return runCmd
+}

--- a/pkg/platform/interface.go
+++ b/pkg/platform/interface.go
@@ -31,4 +31,6 @@ type Client interface {
 	// GetRunningPodFromSelector returns any pod matching the given label selector.
 	// If multiple pods are found, implementations might have different behavior, by either returning an error or returning any element.
 	GetRunningPodFromSelector(selector string) (*corev1.Pod, error)
+
+	GetPodUsingComponentName(componentName string) (*corev1.Pod, error)
 }

--- a/pkg/platform/mock.go
+++ b/pkg/platform/mock.go
@@ -96,6 +96,21 @@ func (mr *MockClientMockRecorder) GetPodLogs(podName, containerName, followLog i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockClient)(nil).GetPodLogs), podName, containerName, followLog)
 }
 
+// GetPodUsingComponentName mocks base method.
+func (m *MockClient) GetPodUsingComponentName(componentName string) (*v1.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodUsingComponentName", componentName)
+	ret0, _ := ret[0].(*v1.Pod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPodUsingComponentName indicates an expected call of GetPodUsingComponentName.
+func (mr *MockClientMockRecorder) GetPodUsingComponentName(componentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodUsingComponentName", reflect.TypeOf((*MockClient)(nil).GetPodUsingComponentName), componentName)
+}
+
 // GetPodsMatchingSelector mocks base method.
 func (m *MockClient) GetPodsMatchingSelector(selector string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/podman/component.go
+++ b/pkg/podman/component.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
 	"github.com/redhat-developer/odo/pkg/api"
@@ -15,8 +16,13 @@ import (
 
 // ListPodsReport contains the result of the `podman pod ps --format json` command
 type ListPodsReport struct {
-	Name   string
-	Labels map[string]string
+	Name       string
+	Labels     map[string]string
+	Containers []ListPodsContainer `json:"Containers,omitempty"`
+}
+
+type ListPodsContainer struct {
+	Names string `json:"Names,omitempty"`
 }
 
 func (o *PodmanCli) ListAllComponents() ([]api.ComponentAbstract, error) {
@@ -85,4 +91,9 @@ func (o *PodmanCli) ListAllComponents() ([]api.ComponentAbstract, error) {
 	}
 
 	return components, nil
+}
+
+func (o *PodmanCli) GetPodUsingComponentName(componentName string) (*corev1.Pod, error) {
+	podSelector := fmt.Sprintf("component=%s", componentName)
+	return o.GetRunningPodFromSelector(podSelector)
 }

--- a/pkg/podman/interface.go
+++ b/pkg/podman/interface.go
@@ -38,5 +38,7 @@ type Client interface {
 
 	ListAllComponents() ([]api.ComponentAbstract, error)
 
+	GetPodUsingComponentName(componentName string) (*corev1.Pod, error)
+
 	Version(ctx context.Context) (SystemVersionReport, error)
 }

--- a/pkg/podman/interface.go
+++ b/pkg/podman/interface.go
@@ -38,7 +38,5 @@ type Client interface {
 
 	ListAllComponents() ([]api.ComponentAbstract, error)
 
-	GetPodUsingComponentName(componentName string) (*corev1.Pod, error)
-
 	Version(ctx context.Context) (SystemVersionReport, error)
 }

--- a/pkg/podman/mock.go
+++ b/pkg/podman/mock.go
@@ -111,6 +111,21 @@ func (mr *MockClientMockRecorder) GetPodLogs(podName, containerName, followLog i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockClient)(nil).GetPodLogs), podName, containerName, followLog)
 }
 
+// GetPodUsingComponentName mocks base method.
+func (m *MockClient) GetPodUsingComponentName(componentName string) (*v1.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodUsingComponentName", componentName)
+	ret0, _ := ret[0].(*v1.Pod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPodUsingComponentName indicates an expected call of GetPodUsingComponentName.
+func (mr *MockClientMockRecorder) GetPodUsingComponentName(componentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodUsingComponentName", reflect.TypeOf((*MockClient)(nil).GetPodUsingComponentName), componentName)
+}
+
 // GetPodsMatchingSelector mocks base method.
 func (m *MockClient) GetPodsMatchingSelector(selector string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/podman/pods.go
+++ b/pkg/podman/pods.go
@@ -95,6 +95,16 @@ func (o *PodmanCli) GetRunningPodFromSelector(selector string) (*corev1.Pod, err
 	if inspect.State == "Running" {
 		pod.Status.Phase = corev1.PodRunning
 	}
+
+	for _, container := range podReport.Containers {
+		// Names of users containers are prefixed with pod name by podman
+		if !strings.HasPrefix(container.Names, podReport.Name+"-") {
+			continue
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+			Name: strings.TrimPrefix(container.Names, podReport.Name+"-"),
+		})
+	}
 	return &pod, nil
 }
 

--- a/pkg/podman/pods.go
+++ b/pkg/podman/pods.go
@@ -92,8 +92,8 @@ func (o *PodmanCli) GetRunningPodFromSelector(selector string) (*corev1.Pod, err
 	if err != nil {
 		return nil, err
 	}
-	if inspect.State == "Running" {
-		pod.Status.Phase = corev1.PodRunning
+	if inspect.State != "Running" {
+		return nil, fmt.Errorf("a pod exists but is not in Running state. Current status=%v", inspect.State)
 	}
 
 	for _, container := range podReport.Containers {

--- a/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: nodejs
   projectType: nodejs
@@ -17,6 +17,20 @@ components:
         - name: "3000-tcp"
           targetPort: 3000
       mountSources: true
+  - name: config
+    kubernetes:
+      inlined: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: my-config
+  - name: image
+    image:
+      imageName: my-image
+      dockerfile:
+        uri: ./Dockerfile
+        buildContext: ${PROJECTS_ROOT}
+        rootRequired: false
 commands:
   - id: devbuild
     exec:
@@ -53,3 +67,9 @@ commands:
       component: runtime
       commandLine: touch /tmp/new-file
       workingDir: ${PROJECTS_ROOT}
+  - id: deploy-config
+    apply:
+      component: config
+  - id: build-image
+    apply:
+      component: image

--- a/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
@@ -17,6 +17,12 @@ components:
         - name: "3000-tcp"
           targetPort: 3000
       mountSources: true
+  - name: other-container
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      command: ["tail"]
+      args: ["-f", "/dev/null"]
+      memoryLimit: 1024Mi
   - name: config
     kubernetes:
       inlined: |
@@ -66,6 +72,11 @@ commands:
     exec:
       component: runtime
       commandLine: touch /tmp/new-file
+      workingDir: ${PROJECTS_ROOT}
+  - id: create-file-in-other-container
+    exec:
+      component: other-container
+      commandLine: touch /tmp/new-file-in-other-container
       workingDir: ${PROJECTS_ROOT}
   - id: deploy-config
     apply:

--- a/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  projectType: nodejs
+  language: nodejs
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000-tcp"
+          targetPort: 3000
+      mountSources: true
+commands:
+  - id: devbuild
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: true
+  - id: build
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+  - id: devrun
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+  - id: create-file
+    exec:
+      component: runtime
+      commandLine: touch /tmp/new-file
+      workingDir: ${PROJECTS_ROOT}

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -68,7 +68,7 @@ var _ = Describe("odo run command tests", func() {
 			})
 		})
 
-		for _, podman := range []bool{false} { // TODO add true
+		for _, podman := range []bool{false, true} {
 			podman := podman
 			When("odo dev is executed and ready", helper.LabelPodmanIf(podman, func() {
 

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -73,7 +73,7 @@ var _ = Describe("odo run command tests", func() {
 		It("should fail if odo dev is not running", func() {
 			output := helper.Cmd("odo", "run", "build").ShouldFail().Err()
 			Expect(output).To(ContainSubstring(`unable to get pod for component`))
-			Expect(output).To(ContainSubstring(`Please check the command odo dev is running`))
+			Expect(output).To(ContainSubstring(`Please check the command 'odo dev' is running`))
 		})
 
 		for _, podman := range []bool{false, true} {
@@ -106,6 +106,13 @@ var _ = Describe("odo run command tests", func() {
 						Expect(output).To(ContainSubstring("Executing command in container (command: create-file)"))
 						component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
 						component.Exec("runtime", []string{"ls", "/tmp/new-file"}, pointer.Bool(true))
+					})
+
+					By("executing an exec command in another container", func() {
+						output := helper.Cmd("odo", "run", "create-file-in-other-container", "--platform", platform).ShouldPass().Out()
+						Expect(output).To(ContainSubstring("Executing command in container (command: create-file-in-other-container)"))
+						component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
+						component.Exec("other-container", []string{"ls", "/tmp/new-file-in-other-container"}, pointer.Bool(true))
 					})
 
 					if !podman {

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -3,7 +3,9 @@ package integration
 import (
 	"path/filepath"
 
+	"github.com/redhat-developer/odo/pkg/labels"
 	"github.com/redhat-developer/odo/tests/helper"
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -94,8 +96,9 @@ var _ = Describe("odo run command tests", func() {
 					}
 					output := helper.Cmd("odo", "run", "create-file", "--platform", platform).ShouldPass().Out()
 					Expect(output).To(ContainSubstring("Executing command in container (command: create-file)"))
+					component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
+					component.Exec("runtime", []string{"ls", "/tmp/new-file"}, pointer.Bool(true))
 				})
-
 			}))
 		}
 	})

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -1,0 +1,55 @@
+package integration
+
+import (
+	"path/filepath"
+
+	"github.com/redhat-developer/odo/tests/helper"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo run command tests", func() {
+	var cmpName string
+	var commonVar helper.CommonVar
+
+	// This is run before every Spec (It)
+	var _ = BeforeEach(func() {
+		commonVar = helper.CommonBeforeEach()
+		cmpName = helper.RandString(6)
+		_ = cmpName // TODO remove when used
+		helper.Chdir(commonVar.Context)
+		Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
+	})
+
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.CommonAfterEach(commonVar)
+	})
+
+	When("directory is empty", Label(helper.LabelNoCluster), func() {
+		BeforeEach(func() {
+			Expect(helper.ListFilesInDir(commonVar.Context)).To(HaveLen(0))
+		})
+
+		It("should error", func() {
+			output := helper.Cmd("odo", "run", "my-command").ShouldFail().Err()
+			Expect(output).To(ContainSubstring("The current directory does not represent an odo component"))
+		})
+	})
+
+	When("a component is bootstrapped", func() {
+		BeforeEach(func() {
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml")).ShouldPass()
+			Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
+		})
+
+		It("should fail if command is not found in devfile", Label(helper.LabelNoCluster), func() {
+			output := helper.Cmd("odo", "run", "unknown-command").ShouldFail().Err()
+			Expect(output).To(ContainSubstring(`no command named "unknown-command" found in the devfile`))
+
+		})
+	})
+
+})

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -50,6 +50,23 @@ var _ = Describe("odo run command tests", func() {
 			Expect(output).To(ContainSubstring(`no command named "unknown-command" found in the devfile`))
 
 		})
+
+		It("should fail if platform is not available", Label(helper.LabelNoCluster), func() {
+			By("failing when trying to run on default platform", func() {
+				output := helper.Cmd("odo", "run", "build").ShouldFail().Err()
+				Expect(output).To(ContainSubstring(`unable to access the cluster`))
+
+			})
+			By("failing when trying to run on cluster", func() {
+				output := helper.Cmd("odo", "run", "build", "--platform", "cluster").ShouldFail().Err()
+				Expect(output).To(ContainSubstring(`unable to access the cluster`))
+
+			})
+			By("failing when trying to run on podman", func() {
+				output := helper.Cmd("odo", "run", "build", "--platform", "podman").ShouldFail().Err()
+				Expect(output).To(ContainSubstring(`unable to access podman`))
+			})
+		})
 	})
 
 })


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**

Fixes partially #6568 

The points covered by this PR are:

- there should be a command (odo run for example) that takes one argument that is the command name and executes the command defined in devfile
- odo run assumes that odo dev is running in a separate terminal, if odo dev is not running (resources not present on the cluster) odo run errors out and tells the user to run odo dev first.
- if the command is exec command and the container where the program needs to be started is not running, the command should be executed as a Job; for podman this can be running inside a pod/container (this case is not possible currently: odo dev includes **all** the containers defined in the Devfile).
- if the command is exec and the container is already running, it should be just executed inside the running container
- if command is apply it just applies what it needs to :-) kubernetes/openshift components get created, container component gets turned into Deployment is dedicatedPod: true
- if command is composite that it performs all action based on the above rules

This PR does not completely covers #6568. Points not implemented/tested yet are:

- odo run streams logs into the terminal and waits for the command to finish.
- user can interrupt the command by pressing  control-c; cleanup the resources.
- the exit code of odo run command reflect the exit code of the last devfile command executed. If the last command was apply and it was successful it returns 0, if failed returns 1
- Because odo dev is running, if Kubernetes/OpenShift resources are created with Apply commands, they should be deployed in "Dev" mode (to be cleanup when odo dev terminates) - make it clear it will be cleaned up.


**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
