### PR TITLE
Display outputs when executing `odo run`

### DIFF
--- a/docs/website/docs/command-reference/run.md
+++ b/docs/website/docs/command-reference/run.md
@@ -1,0 +1,41 @@
+---
+title: odo run
+---
+
+`odo run` is used to manually execute commands defined in a Devfile.
+
+<details>
+<summary>Example</summary>
+
+A command `connect` is defined in the Devfile, executing the `bash` command in the `runtime` component.
+
+```yaml
+schemaVersion: 2.2.0
+[...]
+commands:
+  - id: connect
+    exec:
+      component: runtime
+      commandLine: bash
+  [...]
+
+```
+
+```shell
+$ odo run connect
+bash-4.4$ 
+```
+
+</details>
+
+
+For `Exec` commands, `odo dev` needs to be running, and `odo run` 
+will execute commands in the containers deployed by the `odo dev` command. 
+
+Standard input is redirected to the command running in the container, and the terminal is configured in Raw mode. For these reasons, any character will be redirected to the command in container, including the Ctrl-c character which can thus be used to interrupt the command in container.
+
+The `odo run` command terminates when the command in container terminates, and the exit status of `odo run` will reflect the exit status of the distant command: it will be `0` if the command in container terminates with status `0` and will be `1` if the command in container terminates with any other status.
+
+Resources deployed with `Apply` commands will be deployed in *Dev mode*, 
+and these resources will be deleted when `odo dev` terminates.
+

--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -219,13 +219,15 @@ func (do *DeleteComponentClient) ExecutePreStopEvents(ctx context.Context, devfi
 		do.kubeClient,
 		do.execClient,
 		do.configAutomountClient,
-		pod.Name,
-		false,
-		component.GetContainersNames(pod),
-		"Executing pre-stop command in container",
 
-		// TODO(feloy) set these values when we want to support Apply Image/Kubernetes/OpenShift commands for PreStop events
-		nil, nil, parser.DevfileObj{}, "",
+		// TODO(feloy) set these values when we want to support Apply Image commands for PreStop events
+		nil, nil,
+
+		component.HandlerOptions{
+			PodName:           pod.Name,
+			ContainersRunning: component.GetContainersNames(pod),
+			Msg:               "Executing pre-stop command in container",
+		},
 	)
 	err = libdevfile.ExecPreStopEvents(ctx, devfileObj, handler)
 	if err != nil {

--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -219,7 +219,6 @@ func (do *DeleteComponentClient) ExecutePreStopEvents(ctx context.Context, devfi
 		do.kubeClient,
 		do.execClient,
 		do.configAutomountClient,
-
 		// TODO(feloy) set these values when we want to support Apply Image commands for PreStop events
 		nil, nil,
 

--- a/pkg/component/handler.go
+++ b/pkg/component/handler.go
@@ -41,23 +41,28 @@ type runHandler struct {
 
 var _ libdevfile.Handler = (*runHandler)(nil)
 
+type HandlerOptions struct {
+	PodName           string
+	ComponentExists   bool
+	ContainersRunning []string
+	Msg               string
+
+	// For apply Kubernetes / Openshift
+	Devfile parser.DevfileObj
+	Path    string
+}
+
 func NewRunHandler(
 	ctx context.Context,
 	platformClient platform.Client,
 	execClient exec.Client,
 	configAutomountClient configAutomount.Client,
-	podName string,
-	componentExists bool,
-	containersRunning []string,
-	msg string,
 
 	// For building images
 	fs filesystem.Filesystem,
 	imageBackend image.Backend,
 
-	// For apply Kubernetes / Openshift
-	devfile parser.DevfileObj,
-	path string,
+	options HandlerOptions,
 
 ) *runHandler {
 	return &runHandler{
@@ -65,16 +70,16 @@ func NewRunHandler(
 		platformClient:        platformClient,
 		execClient:            execClient,
 		configAutomountClient: configAutomountClient,
-		podName:               podName,
-		ComponentExists:       componentExists,
-		containersRunning:     containersRunning,
-		msg:                   msg,
+		podName:               options.PodName,
+		ComponentExists:       options.ComponentExists,
+		containersRunning:     options.ContainersRunning,
+		msg:                   options.Msg,
 
 		fs:           fs,
 		imageBackend: imageBackend,
 
-		devfile: devfile,
-		path:    path,
+		devfile: options.Devfile,
+		path:    options.Path,
 	}
 }
 

--- a/pkg/component/handler.go
+++ b/pkg/component/handler.go
@@ -31,6 +31,7 @@ type runHandler struct {
 	ComponentExists       bool
 	containersRunning     []string
 	msg                   string
+	showLogs              bool
 
 	fs           filesystem.Filesystem
 	imageBackend image.Backend
@@ -46,6 +47,7 @@ type HandlerOptions struct {
 	ComponentExists   bool
 	ContainersRunning []string
 	Msg               string
+	ShowLogs          bool
 
 	// For apply Kubernetes / Openshift
 	Devfile parser.DevfileObj
@@ -74,6 +76,7 @@ func NewRunHandler(
 		ComponentExists:       options.ComponentExists,
 		containersRunning:     options.ContainersRunning,
 		msg:                   options.Msg,
+		showLogs:              options.ShowLogs,
 
 		fs:           fs,
 		imageBackend: imageBackend,
@@ -134,7 +137,7 @@ func (a *runHandler) ExecuteTerminatingCommand(ctx context.Context, command devf
 		appName       = odocontext.GetApplication(a.ctx)
 	)
 	if isContainerRunning(command.Exec.Component, a.containersRunning) {
-		return ExecuteTerminatingCommand(ctx, a.execClient, a.platformClient, command, a.ComponentExists, a.podName, appName, componentName, a.msg, false)
+		return ExecuteTerminatingCommand(ctx, a.execClient, a.platformClient, command, a.ComponentExists, a.podName, appName, componentName, a.msg, a.showLogs)
 	}
 	switch platform := a.platformClient.(type) {
 	case kclient.ClientInterface:

--- a/pkg/component/handler.go
+++ b/pkg/component/handler.go
@@ -31,7 +31,7 @@ type runHandler struct {
 	ComponentExists       bool
 	containersRunning     []string
 	msg                   string
-	showLogs              bool
+	directRun             bool
 
 	fs           filesystem.Filesystem
 	imageBackend image.Backend
@@ -47,7 +47,7 @@ type HandlerOptions struct {
 	ComponentExists   bool
 	ContainersRunning []string
 	Msg               string
-	ShowLogs          bool
+	DirectRun         bool
 
 	// For apply Kubernetes / Openshift
 	Devfile parser.DevfileObj
@@ -76,7 +76,7 @@ func NewRunHandler(
 		ComponentExists:       options.ComponentExists,
 		containersRunning:     options.ContainersRunning,
 		msg:                   options.Msg,
-		showLogs:              options.ShowLogs,
+		directRun:             options.DirectRun,
 
 		fs:           fs,
 		imageBackend: imageBackend,
@@ -137,7 +137,7 @@ func (a *runHandler) ExecuteTerminatingCommand(ctx context.Context, command devf
 		appName       = odocontext.GetApplication(a.ctx)
 	)
 	if isContainerRunning(command.Exec.Component, a.containersRunning) {
-		return ExecuteTerminatingCommand(ctx, a.execClient, a.platformClient, command, a.ComponentExists, a.podName, appName, componentName, a.msg, a.showLogs)
+		return ExecuteTerminatingCommand(ctx, a.execClient, a.platformClient, command, a.ComponentExists, a.podName, appName, componentName, a.msg, a.directRun)
 	}
 	switch platform := a.platformClient.(type) {
 	case kclient.ClientInterface:

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -44,14 +44,12 @@ func (o *DeployClient) Deploy(ctx context.Context) error {
 		o.kubeClient,
 		nil,
 		o.configAutomountClient,
-		"",
-		false,
-		nil,
-		"",
 		o.fs,
 		image.SelectBackend(ctx),
-		*devfileObj,
-		path,
+		component.HandlerOptions{
+			Devfile: *devfileObj,
+			Path:    path,
+		},
 	)
 
 	err := o.buildPushAutoImageComponents(handler, *devfileObj)

--- a/pkg/dev/common/run.go
+++ b/pkg/dev/common/run.go
@@ -44,6 +44,7 @@ func Run(
 			PodName:           pod.Name,
 			ContainersRunning: component.GetContainersNames(pod),
 			Msg:               "Executing command in container",
+			ShowLogs:          true,
 			Devfile:           *devfileObj,
 			Path:              devfilePath,
 		},

--- a/pkg/dev/common/run.go
+++ b/pkg/dev/common/run.go
@@ -44,7 +44,7 @@ func Run(
 			PodName:           pod.Name,
 			ContainersRunning: component.GetContainersNames(pod),
 			Msg:               "Executing command in container",
-			ShowLogs:          true,
+			DirectRun:         true,
 			Devfile:           *devfileObj,
 			Path:              devfilePath,
 		},

--- a/pkg/dev/common/run.go
+++ b/pkg/dev/common/run.go
@@ -38,15 +38,15 @@ func Run(
 		platformClient,
 		execClient,
 		configAutomountClient,
-		pod.Name,
-		false,
-		component.GetContainersNames(pod),
-		"Executing command in container",
-
 		filesystem,
 		image.SelectBackend(ctx),
-		*devfileObj,
-		devfilePath,
+		component.HandlerOptions{
+			PodName:           pod.Name,
+			ContainersRunning: component.GetContainersNames(pod),
+			Msg:               "Executing command in container",
+			Devfile:           *devfileObj,
+			Path:              devfilePath,
+		},
 	)
 
 	return libdevfile.ExecuteCommandByName(ctx, *devfileObj, commandName, handler, false)

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -69,13 +69,13 @@ func (o *DevClient) reconcile(
 			o.podmanClient,
 			o.execClient,
 			nil, // TODO(feloy) set this value when we want to support exec on new container on podman
-			pod.Name,
-			false,
-			component.GetContainersNames(pod),
-			"Executing post-start command in container",
-
 			// TODO(feloy) set these values when we want to support Apply Image/Kubernetes/OpenShift commands for PostStart commands
-			nil, nil, parser.DevfileObj{}, "",
+			nil, nil,
+			component.HandlerOptions{
+				PodName:           pod.Name,
+				ContainersRunning: component.GetContainersNames(pod),
+				Msg:               "Executing post-start command in container",
+			},
 		)
 		err = libdevfile.ExecPostStartEvents(ctx, devfileObj, execHandler)
 		if err != nil {
@@ -91,13 +91,14 @@ func (o *DevClient) reconcile(
 				o.podmanClient,
 				o.execClient,
 				nil, // TODO(feloy) set this value when we want to support exec on new container on podman
-				pod.Name,
-				componentStatus.RunExecuted,
-				component.GetContainersNames(pod),
-				"Building your application in container",
-
 				// TODO(feloy) set these values when we want to support Apply Image/Kubernetes/OpenShift commands for PreStop events
-				nil, nil, parser.DevfileObj{}, "",
+				nil, nil,
+				component.HandlerOptions{
+					PodName:           pod.Name,
+					ComponentExists:   componentStatus.RunExecuted,
+					ContainersRunning: component.GetContainersNames(pod),
+					Msg:               "Building your application in container",
+				},
 			)
 			return libdevfile.Build(ctx, devfileObj, options.BuildCommand, execHandler)
 		}
@@ -119,16 +120,14 @@ func (o *DevClient) reconcile(
 			o.podmanClient,
 			o.execClient,
 			nil, // TODO(feloy) set this value when we want to support exec on new container on podman
-			pod.Name,
-			componentStatus.RunExecuted,
-			component.GetContainersNames(pod),
-			"",
-
 			o.fs,
 			image.SelectBackend(ctx),
-
 			// TODO(feloy) set to deploy Kubernetes/Openshift components
-			parser.DevfileObj{}, "",
+			component.HandlerOptions{
+				PodName:           pod.Name,
+				ComponentExists:   componentStatus.RunExecuted,
+				ContainersRunning: component.GetContainersNames(pod),
+			},
 		)
 		err = libdevfile.ExecuteCommandByNameAndKind(ctx, devfileObj, cmdName, cmdKind, cmdHandler, false)
 		if err != nil {

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
+	"k8s.io/kubectl/pkg/util/term"
 
 	"github.com/redhat-developer/odo/pkg/log"
 	"github.com/redhat-developer/odo/pkg/platform"
@@ -26,41 +27,57 @@ func NewExecClient(platformClient platform.Client) *ExecClient {
 
 // ExecuteCommand executes the given command in the pod's container,
 // writing the output to the specified respective pipe writers
-func (o ExecClient) ExecuteCommand(ctx context.Context, command []string, podName string, containerName string, showOutputs bool, stdoutWriter *io.PipeWriter, stderrWriter *io.PipeWriter) (stdout []string, stderr []string, err error) {
-	soutReader, soutWriter := io.Pipe()
-	serrReader, serrWriter := io.Pipe()
+// when directRun is true, will execute the command with terminal in Raw mode and connected to local standard I/Os
+// so input, including Ctrl-c, is sent to the remote process
+func (o ExecClient) ExecuteCommand(ctx context.Context, command []string, podName string, containerName string, directRun bool, stdoutWriter *io.PipeWriter, stderrWriter *io.PipeWriter) (stdout []string, stderr []string, err error) {
+	if !directRun {
+		soutReader, soutWriter := io.Pipe()
+		serrReader, serrWriter := io.Pipe()
 
-	klog.V(2).Infof("Executing command %v for pod: %v in container: %v", command, podName, containerName)
+		klog.V(2).Infof("Executing command %v for pod: %v in container: %v", command, podName, containerName)
 
-	// Read stdout and stderr, store their output in cmdOutput, and also pass output to consoleOutput Writers (if non-nil)
-	stdoutCompleteChannel := startReaderGoroutine(os.Stdout, soutReader, showOutputs, &stdout, stdoutWriter)
-	stderrCompleteChannel := startReaderGoroutine(os.Stderr, serrReader, showOutputs, &stderr, stderrWriter)
+		// Read stdout and stderr, store their output in cmdOutput, and also pass output to consoleOutput Writers (if non-nil)
+		stdoutCompleteChannel := startReaderGoroutine(os.Stdout, soutReader, directRun, &stdout, stdoutWriter)
+		stderrCompleteChannel := startReaderGoroutine(os.Stderr, serrReader, directRun, &stderr, stderrWriter)
 
-	err = o.platformClient.ExecCMDInContainer(ctx, containerName, podName, command, soutWriter, serrWriter, nil, false)
+		err = o.platformClient.ExecCMDInContainer(ctx, containerName, podName, command, soutWriter, serrWriter, nil, false)
 
-	// Block until we have received all the container output from each stream
-	_ = soutWriter.Close()
-	<-stdoutCompleteChannel
-	_ = serrWriter.Close()
-	<-stderrCompleteChannel
+		// Block until we have received all the container output from each stream
+		_ = soutWriter.Close()
+		<-stdoutCompleteChannel
+		_ = serrWriter.Close()
+		<-stderrCompleteChannel
 
-	// Details are displayed only if no outputs are displayed
-	if err != nil && !showOutputs {
-		// It is safe to read from stdout and stderr here, as the goroutines are guaranteed to have terminated at this point.
-		klog.V(2).Infof("ExecuteCommand returned an an err: %v. for command '%v'\nstdout: %v\nstderr: %v",
-			err, command, stdout, stderr)
+		// Details are displayed only if no outputs are displayed
+		if err != nil && !directRun {
+			// It is safe to read from stdout and stderr here, as the goroutines are guaranteed to have terminated at this point.
+			klog.V(2).Infof("ExecuteCommand returned an an err: %v. for command '%v'\nstdout: %v\nstderr: %v",
+				err, command, stdout, stderr)
 
-		msg := fmt.Sprintf("unable to exec command %v", command)
-		if len(stdout) != 0 {
-			msg += fmt.Sprintf("\n=== stdout===\n%s", strings.Join(stdout, "\n"))
+			msg := fmt.Sprintf("unable to exec command %v", command)
+			if len(stdout) != 0 {
+				msg += fmt.Sprintf("\n=== stdout===\n%s", strings.Join(stdout, "\n"))
+			}
+			if len(stderr) != 0 {
+				msg += fmt.Sprintf("\n=== stderr===\n%s", strings.Join(stderr, "\n"))
+			}
+			return stdout, stderr, fmt.Errorf("%s: %w", msg, err)
 		}
-		if len(stderr) != 0 {
-			msg += fmt.Sprintf("\n=== stderr===\n%s", strings.Join(stderr, "\n"))
-		}
-		return stdout, stderr, fmt.Errorf("%s: %w", msg, err)
+
+		return stdout, stderr, err
 	}
 
-	return stdout, stderr, err
+	tty := term.TTY{
+		Raw: true,
+		In:  os.Stdin,
+		Out: os.Stdout,
+	}
+
+	fn := func() error {
+		return o.platformClient.ExecCMDInContainer(ctx, containerName, podName, command, tty.Out, nil, tty.In, true)
+	}
+
+	return nil, nil, tty.Safe(fn)
 }
 
 // This goroutine will automatically pipe the output from the writer (passed into ExecCMDInContainer) to

--- a/pkg/podman/exec.go
+++ b/pkg/podman/exec.go
@@ -23,6 +23,7 @@ func (o *PodmanCli) ExecCMDInContainer(ctx context.Context, containerName, podNa
 	args = append(args, cmd...)
 
 	command := exec.CommandContext(ctx, o.podmanCmd, append(o.containerRunGlobalExtraArgs, args...)...)
+	command.Stderr = stderr
 	klog.V(3).Infof("executing %v", command.Args)
 	command.Stdin = stdin
 

--- a/pkg/podman/exec.go
+++ b/pkg/podman/exec.go
@@ -23,14 +23,9 @@ func (o *PodmanCli) ExecCMDInContainer(ctx context.Context, containerName, podNa
 	args = append(args, cmd...)
 
 	command := exec.CommandContext(ctx, o.podmanCmd, append(o.containerRunGlobalExtraArgs, args...)...)
+	command.Stdout = stdout
 	command.Stderr = stderr
-	klog.V(3).Infof("executing %v", command.Args)
 	command.Stdin = stdin
-
-	out, err := command.Output()
-	if err != nil {
-		return err
-	}
-	_, err = stdout.Write(out)
-	return err
+	klog.V(3).Infof("executing %v", command.Args)
+	return command.Run()
 }

--- a/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
@@ -82,3 +82,7 @@ commands:
   - id: build-image
     apply:
       component: image
+  - id: error-cmd
+    exec:
+      component: runtime
+      commandLine: ls /not-found

--- a/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-for-run.yaml
@@ -68,16 +68,14 @@ commands:
       workingDir: ${PROJECTS_ROOT}
       group:
         kind: run
-  - id: create-file
+  - id: list-files
     exec:
       component: runtime
-      commandLine: touch /tmp/new-file
-      workingDir: ${PROJECTS_ROOT}
-  - id: create-file-in-other-container
+      commandLine: ls /
+  - id: list-files-in-other-container
     exec:
       component: other-container
-      commandLine: touch /tmp/new-file-in-other-container
-      workingDir: ${PROJECTS_ROOT}
+      commandLine: ls /
   - id: deploy-config
     apply:
       component: config

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -3,9 +3,7 @@ package integration
 import (
 	"path/filepath"
 
-	"github.com/redhat-developer/odo/pkg/labels"
 	"github.com/redhat-developer/odo/tests/helper"
-	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -102,17 +100,13 @@ var _ = Describe("odo run command tests", func() {
 					}
 
 					By("executing an exec command", func() {
-						output := helper.Cmd("odo", "run", "create-file", "--platform", platform).ShouldPass().Out()
-						Expect(output).To(ContainSubstring("Executing command in container (command: create-file)"))
-						component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						component.Exec("runtime", []string{"ls", "/tmp/new-file"}, pointer.Bool(true))
+						output := helper.Cmd("odo", "run", "list-files", "--platform", platform).ShouldPass().Out()
+						Expect(output).To(ContainSubstring("etc"))
 					})
 
 					By("executing an exec command in another container", func() {
-						output := helper.Cmd("odo", "run", "create-file-in-other-container", "--platform", platform).ShouldPass().Out()
-						Expect(output).To(ContainSubstring("Executing command in container (command: create-file-in-other-container)"))
-						component := helper.NewComponent(cmpName, "app", labels.ComponentDevMode, commonVar.Project, commonVar.CliRunner)
-						component.Exec("other-container", []string{"ls", "/tmp/new-file-in-other-container"}, pointer.Bool(true))
+						output := helper.Cmd("odo", "run", "list-files-in-other-container", "--platform", platform).ShouldPass().Out()
+						Expect(output).To(ContainSubstring("etc"))
 					})
 
 					if !podman {

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -99,12 +99,12 @@ var _ = Describe("odo run command tests", func() {
 						platform = "podman"
 					}
 
-					By("executing an exec command", func() {
+					By("executing an exec command and displaying output", func() {
 						output := helper.Cmd("odo", "run", "list-files", "--platform", platform).ShouldPass().Out()
 						Expect(output).To(ContainSubstring("etc"))
 					})
 
-					By("executing an exec command in another container", func() {
+					By("executing an exec command in another container and displaying output", func() {
 						output := helper.Cmd("odo", "run", "list-files-in-other-container", "--platform", platform).ShouldPass().Out()
 						Expect(output).To(ContainSubstring("etc"))
 					})
@@ -134,6 +134,11 @@ var _ = Describe("odo run command tests", func() {
 
 						})
 					}
+
+					By("exiting with a status 1 when the exec command fails and displaying error output", func() {
+						stderr := helper.Cmd("odo", "run", "error-cmd", "--platform", platform).ShouldFail().Err()
+						Expect(stderr).To(ContainSubstring("No such file or directory"))
+					})
 				})
 			}))
 		}

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -136,8 +136,7 @@ var _ = Describe("odo run command tests", func() {
 					}
 
 					By("exiting with a status 1 when the exec command fails and displaying error output", func() {
-						// Err is in stdout and not stderr, as the terminal is set in raw mode
-						out := helper.Cmd("odo", "run", "error-cmd", "--platform", platform).ShouldFail().Out()
+						out := helper.Cmd("odo", "run", "error-cmd", "--platform", platform).ShouldFail().Err()
 						Expect(out).To(ContainSubstring("No such file or directory"))
 					})
 				})

--- a/tests/integration/cmd_run_test.go
+++ b/tests/integration/cmd_run_test.go
@@ -136,8 +136,9 @@ var _ = Describe("odo run command tests", func() {
 					}
 
 					By("exiting with a status 1 when the exec command fails and displaying error output", func() {
-						stderr := helper.Cmd("odo", "run", "error-cmd", "--platform", platform).ShouldFail().Err()
-						Expect(stderr).To(ContainSubstring("No such file or directory"))
+						// Err is in stdout and not stderr, as the terminal is set in raw mode
+						out := helper.Cmd("odo", "run", "error-cmd", "--platform", platform).ShouldFail().Out()
+						Expect(out).To(ContainSubstring("No such file or directory"))
 					})
 				})
 			}))


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**

This PR completes the implementation for #6568.

- odo run streams logs into the terminal and waits for the command to finish.
- user can interrupt the command by pressing  control-c; cleanup the resources.
- the exit code of odo run command reflect the exit code of the last devfile command executed. If the last command was apply and it was successful it returns 0, if failed returns 1
- Because odo dev is running, if Kubernetes/OpenShift resources are created with Apply commands, they should be deployed in "Dev" mode (to be cleanup when odo dev terminates) - make it clear it will be cleaned up.

**Which issue(s) this PR fixes:**

Fixes #6568

Doc: https://deploy-preview-6865--odo-docusaurus-preview.netlify.app/docs/command-reference/run

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**
