### PR TITLE
[Dogfooding] Create website deploy previews for PRs using `odo deploy`

### DIFF
--- a/.github/workflows/pr-website.yaml
+++ b/.github/workflows/pr-website.yaml
@@ -23,7 +23,6 @@ env:
   ODO_TRACKING_CONSENT: "no"
   IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
   IKS_CLUSTER: ${{ secrets.IBM_CLOUD_IKS_CLUSTER_FOR_WEBSITE_DEPLOY_PREVIEWS }}
-  DEPLOY_CONTAINER_IMAGE: "ttl.sh/odo-dev-website-pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}:3h"
   DEPLOY_RESOURCE_NAME: "odo-dev-pr-${{ github.event.number }}"
   NAMESPACE: "odo-dev-pr-${{ github.event.number }}"
   PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -131,12 +130,24 @@ jobs:
           fi
           ~/.local/bin/odo set namespace "$NAMESPACE"
 
+      - name: Login to Container Image Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: odo-dev+gh
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: quay.io/odo-dev
+
+      - name: Set Image Registry in odo preference
+        # Setting this will make odo treat relative image names in the Devfile as a selector.
+        # See https://odo.dev/docs/development/devfile#how-odo-handles-image-names for more details.
+        run: |
+          odo preference set ImageRegistry quay.io/odo-dev --force
+
       - name: Deploy with odo
         run: |
           cd docs/website/ && \
           ~/.local/bin/odo deploy \
             --var DEPLOY_RESOURCE_NAME \
-            --var DEPLOY_CONTAINER_IMAGE \
             --var DEPLOY_INGRESS_DOMAIN
 
       - run: echo "PR_PREVIEW_URL=https://$DEPLOY_RESOURCE_NAME.$DEPLOY_INGRESS_DOMAIN/" >> "$GITHUB_ENV"

--- a/.github/workflows/pr-website.yaml
+++ b/.github/workflows/pr-website.yaml
@@ -86,8 +86,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - run: yq -i '.metadata.name = "${{ env.DEPLOY_RESOURCE_NAME }}"' docs/website/devfile.yaml
-
       - name: Install IBM Cloud CLI
         run: |
           curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
@@ -150,7 +148,7 @@ jobs:
 
       - name: Deploy with odo
         run: |
-          cd docs/website/ && \
+          cd docs/website/
           odo deploy \
             --var DEPLOY_RESOURCE_NAME \
             --var DEPLOY_INGRESS_DOMAIN
@@ -246,21 +244,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           reactions: recycle
 
-      - run: yq -i '.metadata.name = "${{ env.DEPLOY_RESOURCE_NAME }}"' docs/website/devfile.yaml
-
-      - name: Delete component
+      - name: Delete component in namespace
         run: |
-          mkdir -p /tmp && cd /tmp
-          odo delete component \
-            --namespace "$NAMESPACE" \
-            --name "${{ env.DEPLOY_RESOURCE_NAME }}" \
-            --force \
-            --wait
+          if odo list namespaces | grep "$NAMESPACE"; then
+            odo set namespace "$NAMESPACE"
+            cd docs/website/
+            odo delete component --force --wait
+          fi
 
       - name: Delete namespace
         if: ${{ always() }}
         run: |
-          odo delete namespace "$NAMESPACE" \
-            --wait \
-            --force \
-          || echo "Could not delete namespace $NAMESPACE - please delete it manually!"
+          if odo list namespaces | grep "$NAMESPACE"; then
+            odo delete namespace "$NAMESPACE" \
+              --wait \
+              --force \
+            || echo "Could not delete namespace $NAMESPACE - please delete it manually."
+          fi

--- a/.github/workflows/pr-website.yaml
+++ b/.github/workflows/pr-website.yaml
@@ -1,0 +1,245 @@
+name: Pull Request Website Preview
+
+on:
+  # /!\ Warning: using the pull_request_target event to be able to read secrets. But using this event without the cautionary measures described below
+  # may allow unauthorized GitHub users to open a “pwn request” and exfiltrate secrets.
+  # As recommended in https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets,
+  # we are adding an 'authorize' job that checks if the workflow was triggered from a fork PR. In that case, the "external" environment
+  # will prevent the job from running until it's approved manually by human intervention.
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, closed]
+    branches: [ main ]
+    paths:
+      - 'cmd/**'
+      - 'docs/**'
+      - 'pkg/**'
+      - 'vendor/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/pr-website.yaml'
+
+env:
+  ODO_LOG_LEVEL: "4"
+  ODO_TRACKING_CONSENT: "no"
+  IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+  IKS_CLUSTER: ${{ secrets.IBM_CLOUD_IKS_CLUSTER_FOR_WEBSITE_DEPLOY_PREVIEWS }}
+  DEPLOY_CONTAINER_IMAGE: "ttl.sh/odo-dev-website-pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}:3h"
+  DEPLOY_RESOURCE_NAME: "odo-dev-pr-${{ github.event.number }}"
+  NAMESPACE: "odo-dev-pr-${{ github.event.number }}"
+  PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  PR_NUMBER: ${{ github.event.number }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    # The 'external' environment is configured with the odo-maintainers team as required reviewers.
+    # All the subsequent jobs in this workflow 'need' this job, which will require manual approval for PRs coming from external forks.
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ✓
+
+  build_odo:
+    runs-on: ubuntu-latest
+    needs: authorize
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build odo
+        run: make bin
+
+      - run: |
+          chmod +x ./odo
+          ./odo version
+
+      - name: 'Upload odo'
+        uses: actions/upload-artifact@v3
+        with:
+          name: odo_bin
+          path: odo
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy-preview:
+    if: ${{ github.event.pull_request.state == 'open' }}
+    needs: [authorize, build_odo]
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - run: yq -i '.metadata.name = "${{ env.DEPLOY_RESOURCE_NAME }}"' docs/website/devfile.yaml
+
+      - name: Install IBM Cloud CLI
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          ibmcloud --version
+          ibmcloud config --check-version=false
+          ibmcloud plugin install -f kubernetes-service
+
+      - name: Authenticate with IBM Cloud CLI
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" --no-region --quiet
+
+      - name: Generate Kubeconfig
+        run: |
+          ibmcloud ks cluster config --cluster $IKS_CLUSTER
+          kubectl config current-context
+
+      - name: Get ingress domain
+        run: |
+          ingressDomain=$(ibmcloud ks cluster get --cluster $IKS_CLUSTER --output json | jq -r '.ingress.hostname')
+          if [[ -z "$ingressDomain" ]]; then
+            echo "Could not get ingress domain"
+            exit 1
+          fi
+          echo "DEPLOY_INGRESS_DOMAIN=$ingressDomain" >> "$GITHUB_ENV"
+
+      - name: Download odo from previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: odo_bin
+
+      - run: mkdir -p ~/.local/bin/ && mv ./odo ~/.local/bin/odo && chmod +x ~/.local/bin/odo
+
+      - name: Create and set namespace
+        run: |
+          if ~/.local/bin/odo list namespaces | grep "$NAMESPACE"; then
+            echo "Namespace $NAMESPACE already exists."
+          else
+            echo "Namespace $NAMESPACE *not* found => creating it."
+            ~/.local/bin/odo create namespace "$NAMESPACE" --wait
+          fi
+          ~/.local/bin/odo set namespace "$NAMESPACE"
+
+      - name: Deploy with odo
+        run: |
+          cd docs/website/ && \
+          ~/.local/bin/odo deploy \
+            --var DEPLOY_RESOURCE_NAME \
+            --var DEPLOY_CONTAINER_IMAGE \
+            --var DEPLOY_INGRESS_DOMAIN
+
+      - run: echo "PR_PREVIEW_URL=https://$DEPLOY_RESOURCE_NAME.$DEPLOY_INGRESS_DOMAIN/" >> "$GITHUB_ENV"
+
+      - name: Test access
+        run: |
+          wget --no-check-certificate \
+            --tries=20 \
+            --retry-on-host-error \
+            --retry-on-http-error=404,502,503 \
+            -S \
+            -O - \
+            "${{ env.PR_PREVIEW_URL }}" || exit 1
+
+      - name: Add PR comment with preview URL
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            ### <span aria-hidden="true">✅</span> Deploy Preview on internal cluster ready!
+
+            |  Name | Link |
+            |---------------------------------|------------------------|
+            |<span aria-hidden="true">🔨</span> Latest commit | ${{ env.PR_HEAD_SHA }} |
+            |<span aria-hidden="true">😎</span> Deploy Preview | [${{ env.PR_PREVIEW_URL }}](${{ env.PR_PREVIEW_URL }}) |
+          comment_includes: 'Deploy Preview'
+          pr_number: ${{ env.PR_NUMBER }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          reactions: rocket
+
+  delete_resources_for_pr:
+    if: ${{ github.event.pull_request.state == 'closed' }}
+    needs: [authorize, build_odo]
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Download odo from previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: odo_bin
+
+      - run: mkdir -p ~/.local/bin/ && mv ./odo ~/.local/bin/odo && chmod +x ~/.local/bin/odo
+
+      - name: Install IBM Cloud CLI
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          ibmcloud --version
+          ibmcloud config --check-version=false
+          ibmcloud plugin install -f kubernetes-service
+
+      - name: Authenticate with IBM Cloud CLI
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" --no-region --quiet
+
+      - name: Generate Kubeconfig
+        run: |
+          ibmcloud ks cluster config --cluster $IKS_CLUSTER
+          kubectl config current-context
+
+      - name: Get ingress domain
+        run: |
+          ingressDomain=$(ibmcloud ks cluster get --cluster $IKS_CLUSTER --output json | jq -r '.ingress.hostname')
+          if [[ -z "$ingressDomain" ]]; then
+            echo "Could not get ingress domain"
+            exit 1
+          fi
+          echo "DEPLOY_INGRESS_DOMAIN=$ingressDomain" >> "$GITHUB_ENV"
+
+      - run: echo "PR_PREVIEW_URL=https://$DEPLOY_RESOURCE_NAME.$DEPLOY_INGRESS_DOMAIN/" >> "$GITHUB_ENV"
+
+      - name: Update PR comment about preview URL
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            ### <span aria-hidden="true">🔨</span> Deploy Preview deleted from internal cluster!
+
+            |  Name | Link |
+            |---------------------------------|------------------------|
+            |<span aria-hidden="true">🔨</span> Latest commit | ${{ env.PR_HEAD_SHA }} |
+            |<span aria-hidden="true">😎</span> Deploy Preview | ~[${{ env.PR_PREVIEW_URL }}](${{ env.PR_PREVIEW_URL }})~ |
+          comment_includes: 'Deploy Preview'
+          pr_number: ${{ env.PR_NUMBER }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          reactions: recycle
+
+      - run: yq -i '.metadata.name = "${{ env.DEPLOY_RESOURCE_NAME }}"' docs/website/devfile.yaml
+
+      - name: Delete component
+        run: |
+          mkdir -p /tmp && cd /tmp
+          ~/.local/bin/odo delete component \
+            --namespace "$NAMESPACE" \
+            --name "${{ env.DEPLOY_RESOURCE_NAME }}" \
+            --force \
+            --wait
+
+      - name: Delete namespace
+        if: ${{ always() }}
+        run: |
+          ~/.local/bin/odo delete namespace "$NAMESPACE" \
+            --wait \
+            --force \
+          || echo "Could not delete namespace $NAMESPACE - please delete it manually!"

--- a/.github/workflows/pr-website.yaml
+++ b/.github/workflows/pr-website.yaml
@@ -118,17 +118,22 @@ jobs:
         with:
           name: odo_bin
 
-      - run: mkdir -p ~/.local/bin/ && mv ./odo ~/.local/bin/odo && chmod +x ~/.local/bin/odo
+      - name: Set odo in system path
+        run: |
+          mkdir -p "$HOME/.local/bin/"
+          mv ./odo "$HOME/.local/bin/odo"
+          chmod +x "$HOME/.local/bin/odo"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Create and set namespace
         run: |
-          if ~/.local/bin/odo list namespaces | grep "$NAMESPACE"; then
+          if odo list namespaces | grep "$NAMESPACE"; then
             echo "Namespace $NAMESPACE already exists."
           else
             echo "Namespace $NAMESPACE *not* found => creating it."
-            ~/.local/bin/odo create namespace "$NAMESPACE" --wait
+            odo create namespace "$NAMESPACE" --wait
           fi
-          ~/.local/bin/odo set namespace "$NAMESPACE"
+          odo set namespace "$NAMESPACE"
 
       - name: Login to Container Image Registry
         uses: redhat-actions/podman-login@v1
@@ -146,7 +151,7 @@ jobs:
       - name: Deploy with odo
         run: |
           cd docs/website/ && \
-          ~/.local/bin/odo deploy \
+          odo deploy \
             --var DEPLOY_RESOURCE_NAME \
             --var DEPLOY_INGRESS_DOMAIN
 
@@ -192,7 +197,12 @@ jobs:
         with:
           name: odo_bin
 
-      - run: mkdir -p ~/.local/bin/ && mv ./odo ~/.local/bin/odo && chmod +x ~/.local/bin/odo
+      - name: Set odo in system path
+        run: |
+          mkdir -p "$HOME/.local/bin/"
+          mv ./odo "$HOME/.local/bin/odo"
+          chmod +x "$HOME/.local/bin/odo"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install IBM Cloud CLI
         run: |
@@ -241,7 +251,7 @@ jobs:
       - name: Delete component
         run: |
           mkdir -p /tmp && cd /tmp
-          ~/.local/bin/odo delete component \
+          odo delete component \
             --namespace "$NAMESPACE" \
             --name "${{ env.DEPLOY_RESOURCE_NAME }}" \
             --force \
@@ -250,7 +260,7 @@ jobs:
       - name: Delete namespace
         if: ${{ always() }}
         run: |
-          ~/.local/bin/odo delete namespace "$NAMESPACE" \
+          odo delete namespace "$NAMESPACE" \
             --wait \
             --force \
           || echo "Could not delete namespace $NAMESPACE - please delete it manually!"

--- a/docs/website/.dockerignore
+++ b/docs/website/.dockerignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules
+
+# Production
+build
+
+# Generated files
+.docusaurus
+.cache-loader
+!.docusaurus.config.js
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+.odo
+
+devfile.yaml
+Dockerfile
+.kubernetes

--- a/docs/website/.kubernetes/resources.yaml
+++ b/docs/website/.kubernetes/resources.yaml
@@ -1,0 +1,64 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: "{{DEPLOY_RESOURCE_NAME}}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "{{DEPLOY_RESOURCE_NAME}}"
+  template:
+    metadata:
+      labels:
+        app: "{{DEPLOY_RESOURCE_NAME}}"
+    spec:
+      containers:
+      - name: "{{DEPLOY_RESOURCE_NAME}}"
+        image: "{{DEPLOY_CONTAINER_IMAGE}}"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{DEPLOY_RESOURCE_NAME}}"
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: "{{DEPLOY_RESOURCE_NAME}}"
+  type: ClusterIP
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{DEPLOY_RESOURCE_NAME}}"
+spec:
+  tls:
+  - hosts:
+    - "{{DEPLOY_RESOURCE_NAME}}.{{DEPLOY_INGRESS_DOMAIN}}"
+
+  rules:
+  - host: "{{DEPLOY_RESOURCE_NAME}}.{{DEPLOY_INGRESS_DOMAIN}}"
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: "{{DEPLOY_RESOURCE_NAME}}"
+            port:
+              number: 8080

--- a/docs/website/Dockerfile
+++ b/docs/website/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS website-builder
+
+RUN npm install --global yarn
+
+RUN mkdir -p /tmp/website
+WORKDIR /tmp/website
+
+COPY . .
+
+RUN yarn && \
+    npx docusaurus build
+
+FROM registry.access.redhat.com/ubi8/httpd-24:latest
+
+COPY --from=website-builder /tmp/website/build /var/www/html

--- a/docs/website/devfile.yaml
+++ b/docs/website/devfile.yaml
@@ -1,15 +1,20 @@
 schemaVersion: 2.2.0
 metadata:
-  name: odo.dev
+  name: odo-dev
   description: Website for odo, the developer-focused CLI for container development
   displayName: odo.dev
   icon: https://odo.dev/img/logo.png
-  version: 3.6.0
+  version: 3.12.0
   tags:
   - NodeJS
   - React
   - Docusaurus
   - odo
+
+variables:
+  DEPLOY_RESOURCE_NAME: odo-dev
+  DEPLOY_CONTAINER_IMAGE: odo-dev-webapp
+  DEPLOY_INGRESS_DOMAIN: 127.0.0.1.nip.io
 
 components:
 - name: doc-runtime
@@ -21,6 +26,18 @@ components:
     endpoints:
       - name: http-doc
         targetPort: 3000
+
+- name: outerloop-build
+  image:
+    imageName: "{{DEPLOY_CONTAINER_IMAGE}}"
+    dockerfile:
+      uri: ./Dockerfile
+      buildContext: ${PROJECT_SOURCE}
+      rootRequired: false
+
+- name: outerloop-resources
+  kubernetes:
+    uri: ".kubernetes/resources.yaml"
 
 commands:
 
@@ -53,6 +70,26 @@ commands:
     group:
       kind: run
       isDefault: true
+
+#
+# Deploy
+#
+- id: 2-deploy
+  composite:
+    commands:
+      - 20-build-image
+      - 21-k8s-resources
+    group:
+      isDefault: true
+      kind: deploy
+
+- id: 20-build-image
+  apply:
+    component: outerloop-build
+
+- id: 21-k8s-resources
+  apply:
+    component: outerloop-resources
 
 events:
   postStart:


### PR DESCRIPTION
**What type of PR is this:**
/area testing

**What does this PR do / why we need it:**
This is a follow-up to the Dogfooding idea started with https://github.com/redhat-developer/odo/pull/6564
I wanted to take this opportunity to try odo as an outer-loop tool from a user perspective.
This PR adds a 'deploy' command to the website Devfile, and adds a GitHub Workflow that is triggered on PR events, and uses this Devfile to run `odo deploy` against our internal Kubernetes cluster, in order to create Deploy Previews for PRs (similar to what Netlify currently does).
Once a PR is open, a dedicated namespace is created, and `odo deploy` is run against it. If deployment is successful (and the preview URL is reachable), a comment with the preview URL is automatically added to the PR.
Once a PR is closed, the dedicated namespace is deleted.

**NOTE**: for security purposes, PRs from external forks will need a manual review and approval to be deployed (because this operation requires access to the GitHub Repository Secrets).

Examples of such PRs:
- https://github.com/rm3l/odo/pull/65
- https://github.com/rm3l/odo/pull/66 (from external fork)

**Which issue(s) this PR fixes:**
DevTools week idea.

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
- Locally:
You should be able to run `odo deploy` from the `docs/website` folder.
Note that this leverages the [Image Name as selector](https://odo.dev/docs/development/devfile#how-odo-handles-image-names) feature to keep the Devfile portable. That is, the container image used in the image component is relative, and will be substituted in all matching components accordingly. For this to work,  you need to set the `ImageRegistry` preference, e.g.:
```shell
# Make sure you are logged into the registry
# Set the ImageRegistry preference, e.g.:
$ odo preference set ImageRegistry quay.io/$USER
```

```
$ cd docs/website
$ odo deploy --var DEPLOY_INGRESS_DOMAIN=<ingressDomain, e.g.: 127.0.0.1.nip.io or ${minikubeIp}.nip.io>
# Access the URL accessible via the Ingress resource reported by this command:
$ odo describe component
```

- Once this PR is merged in, any PRs updating the website will be deployed into our test Kubernetes cluster, and a comment with the preview URL will be added to the PR.