### PR TITLE
Build nightly binaries of odo and make them available (via IBM Cloud Object Storage)

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -58,7 +58,9 @@ jobs:
           fi
 
       - name: Cross-compile odo
-        run: make cross
+        run: |
+          export GITCOMMIT="$(git describe --no-match --always --abbrev=9 --dirty --broken)-nightly"
+          make cross
 
       - name: Upload binaries
         run: |

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -1,0 +1,71 @@
+name: Nightly builds
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+
+  nightly_build:
+    runs-on: ubuntu-latest
+
+    env:
+      IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY_NIGHTLY_BUILDS }}
+      IBM_CLOUD_RESOURCE_GROUP: ${{ secrets.IBM_CLOUD_RESOURCE_GROUP }}
+      IBM_CLOUD_REGION: eu-de
+      IBM_CLOUD_OBJET_STORAGE_SERVICE_INSTANCE: ${{ secrets.IBM_CLOUD_OBJET_STORAGE_SERVICE_INSTANCE }}
+      IBM_CLOUD_OBJECT_STORAGE_BUCKET: ${{ secrets.IBM_CLOUD_OBJECT_STORAGE_BUCKET }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install IBM Cloud CLI
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          ibmcloud --version
+          ibmcloud config --check-version=false
+          ibmcloud plugin install -f cloud-object-storage
+
+      - name: Authenticate with IBM Cloud CLI
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" -r "${IBM_CLOUD_REGION}" -g "${IBM_CLOUD_RESOURCE_GROUP}" --quiet
+
+      - name: Set CRN
+        run: |
+          CRN=$(ibmcloud resource service-instance "${IBM_CLOUD_OBJET_STORAGE_SERVICE_INSTANCE}" --output json | jq -r '.[0].guid | values')
+          if [[ -z "$CRN" ]]; then
+            echo "Unable to determine CRN for service instance ${IBM_CLOUD_OBJET_STORAGE_SERVICE_INSTANCE}"
+            exit 1
+          fi
+          ibmcloud cos config crn --crn "${CRN}"
+
+      - name: Check if bucket exists
+        run: |
+          if ! ibmcloud cos buckets | grep "${IBM_CLOUD_OBJECT_STORAGE_BUCKET}"; then
+            echo "Bucket not found: ${IBM_CLOUD_OBJECT_STORAGE_BUCKET}"
+            exit 1
+          fi
+
+      - name: Cross-compile odo
+        run: make cross
+
+      - name: Upload binaries
+        run: |
+          baseUrl="https://s3.${IBM_CLOUD_REGION}.cloud-object-storage.appdomain.cloud/${IBM_CLOUD_OBJECT_STORAGE_BUCKET}"
+          for f in `find ./dist/bin -type f -name 'odo*'`; do 
+            bin=$(realpath "$f")
+            targetName=$(basename "$f" .exe)-$(basename $(dirname "$f"))
+            if [[ "${targetName}" == "odo-windows-"* ]]; then
+              targetName="${targetName}.exe"
+            fi
+            ibmcloud cos upload --bucket "${IBM_CLOUD_OBJECT_STORAGE_BUCKET}" --key "${targetName}" --file "${bin}"
+            echo "Binary $bin uploaded successfully and available at: ${baseUrl}/${targetName}"
+          done

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "34 21 * * *"
 
 concurrency: ${{ github.workflow }}
 

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -1,6 +1,9 @@
 name: Nightly builds
 
 on:
+  # workflow_dispatch so that it can be triggered manually if needed
+  workflow_dispatch:
+
   schedule:
     - cron: "0 0 * * *"
 

--- a/docs/website/docs/overview/installation.md
+++ b/docs/website/docs/overview/installation.md
@@ -5,6 +5,9 @@ toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 `odo` can be used as either a [CLI tool](#cli-installation) or an [IDE plugin](#ide-installation) on [Mac](#macos), [Windows](#windows) or [Linux](#linux).
 
 Each release is *signed*, *checksummed*, *verified*, and then pushed to our [binary mirror](https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/).
@@ -14,9 +17,6 @@ For more information on the changes of each release, they can be viewed either o
 ## CLI Installation
 
 ### Linux
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <Tabs
 defaultValue="amd64"
@@ -344,3 +344,198 @@ asdf plugin add odo
 asdf install odo 3.11.0
 asdf global odo 3.11.0
 ```
+
+## Nightly builds
+
+Nightly builds of `odo` are also available. Note that these builds are provided as is and can be highly unstable.
+
+### Linux
+
+<Tabs
+defaultValue="amd64"
+values={[
+{label: 'Intel / AMD 64', value: 'amd64'},
+{label: 'ARM 64', value: 'arm64'},
+{label: 'PowerPC', value: 'ppc64le'},
+{label: 'IBM Z', value: 's390x'},
+]}>
+
+<TabItem value="amd64">
+
+Installing `odo` on `amd64` architecture:
+
+1. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64 -o odo
+```
+
+2. Install odo:
+```shell
+sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
+```
+
+3. (Optional) If you do not have root access, you can install `odo` to the local directory and add it to your `$PATH`:
+
+```shell
+mkdir -p $HOME/bin 
+cp ./odo $HOME/bin/odo
+export PATH=$PATH:$HOME/bin
+# (Optional) Add the $HOME/bin to your shell initialization file
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+```
+</TabItem>
+
+<TabItem value="arm64">
+
+Installing `odo` on `arm64` architecture:
+
+1. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-arm64 -o odo
+```
+
+2. Install odo:
+```shell
+sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
+```
+
+3(Optional) If you do not have root access, you can install `odo` to the local directory and add it to your `$PATH`:
+
+```shell
+mkdir -p $HOME/bin 
+cp ./odo $HOME/bin/odo
+export PATH=$PATH:$HOME/bin
+# (Optional) Add the $HOME/bin to your shell initialization file
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+```
+</TabItem>
+
+<TabItem value="ppc64le">
+
+Installing `odo` on `ppc64le` architecture:
+
+1. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-ppc64le -o odo
+```
+
+2. Install odo:
+```shell
+sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
+```
+
+3(Optional) If you do not have root access, you can install `odo` to the local directory and add it to your `$PATH`:
+
+```shell
+mkdir -p $HOME/bin 
+cp ./odo $HOME/bin/odo
+export PATH=$PATH:$HOME/bin
+# (Optional) Add the $HOME/bin to your shell initialization file
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+```
+</TabItem>
+
+<TabItem value="s390x">
+
+Installing `odo` on `s390x` architecture:
+
+1. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-s390x -o odo
+```
+
+2. Install odo:
+```shell
+sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
+```
+
+3. (Optional) If you do not have root access, you can install `odo` to the local directory and add it to your `$PATH`:
+
+```shell
+mkdir -p $HOME/bin 
+cp ./odo $HOME/bin/odo
+export PATH=$PATH:$HOME/bin
+# (Optional) Add the $HOME/bin to your shell initialization file
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+```
+</TabItem>
+
+</Tabs>
+
+---
+
+### MacOS
+
+<Tabs
+defaultValue="intel"
+values={[
+{label: 'Intel', value: 'intel'},
+{label: 'Apple Silicon', value: 'arm'},
+]}>
+
+<TabItem value="intel">
+
+Installing `odo` on `amd64` architecture:
+
+1. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-darwin-amd64 -o odo
+```
+
+2. Install odo:
+```shell
+chmod +x ./odo
+sudo mv ./odo /usr/local/bin/odo
+```
+
+3(Optional) If you do not have root access, you can install `odo` to the local directory and add it to your `$PATH`:
+
+```shell
+mkdir -p $HOME/bin 
+cp ./odo $HOME/bin/odo
+export PATH=$PATH:$HOME/bin
+# (Optional) Add the $HOME/bin to your shell initialization file
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+```
+</TabItem>
+
+<TabItem value="arm">
+
+Installing `odo` on `arm64` architecture:
+
+1. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-darwin-arm64 -o odo
+```
+
+2. Install odo:
+```shell
+chmod +x ./odo
+sudo mv ./odo /usr/local/bin/odo
+```
+
+3. (Optional) If you do not have root access, you can install `odo` to the local directory and add it to your `$PATH`:
+
+```shell
+mkdir -p $HOME/bin 
+cp ./odo $HOME/bin/odo
+export PATH=$PATH:$HOME/bin
+# (Optional) Add the $HOME/bin to your shell initialization file
+echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+```
+</TabItem>
+
+</Tabs>
+
+---
+
+### Windows
+
+1. Open a PowerShell terminal
+
+2. Download the latest nightly build:
+```shell
+curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-windows-amd64.exe -o odo.exe
+```
+
+3. Add the binary to your `PATH`


### PR DESCRIPTION
**What type of PR is this:**
/kind feature

**What does this PR do / why we need it:**
This adds a scheduled GitHub Workflow that builds `odo` for multiple platforms, and uploads those binaries to IBM Cloud Storage, so users can consume them.

**Which issue(s) this PR fixes:**
Fixes #6693 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] [Documentation](https://deploy-preview-6875--odo-docusaurus-preview.netlify.app/docs/overview/installation#nightly-builds) 

**How to test changes / Special notes to the reviewer:**
Example of job in action: https://github.com/rm3l/odo/actions/runs/5220887665/jobs/9424500936