### PR TITLE
Improve website PR preview workflow

### DIFF
--- a/.github/workflows/pr-website.yaml
+++ b/.github/workflows/pr-website.yaml
@@ -31,10 +31,11 @@ jobs:
   authorize:
     # The 'external' environment is configured with the odo-maintainers team as required reviewers.
     # All the subsequent jobs in this workflow 'need' this job, which will require manual approval for PRs coming from external forks.
+    # TODO(rm3l): list of authorized users that do not require manual review comes from the maintainers team and various robot accounts that handle automation in the repo => find a better way not to hardcode this list!
     environment:
-      ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || 'internal' }}
+      ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
+        contains(fromJSON('["odo-robot[bot]", "dependabot[bot]", "openshift-ci[bot]", "openshift-merge-robot", "openshift-ci-robot", "feloy", "kadel", "rm3l", "valaparthvi", "ritudes"]'), github.actor)) && 
+      'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo ✓

--- a/.github/workflows/pr-website.yaml
+++ b/.github/workflows/pr-website.yaml
@@ -10,12 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, closed]
     branches: [ main ]
     paths:
-      - 'cmd/**'
-      - 'docs/**'
-      - 'pkg/**'
-      - 'vendor/**'
-      - 'go.mod'
-      - 'go.sum'
+      - 'docs/website/**'
       - '.github/workflows/pr-website.yaml'
 
 env:


### PR DESCRIPTION
**What type of PR is this:**
/area testing 

**What does this PR do / why we need it:**
This improves the website PR preview workflow introduced in https://github.com/redhat-developer/odo/pull/6871 by:
- triggering it only when there are actual changes in the `docs/website/` folder. Initially, I wanted to take this as a way to test `odo deploy` against any PR changing the source code  and/or the website, but this might create useless deployments. We should already have other E2E tests running `odo deploy`.
- auto-approving preview deployments for PRs coming from authorized users (us as odo maintainers or certain robot accounts that can manipulate PRs). This way, we won't need to manually approve them. Previously, only PRs created from branches in the same `redhat-developer/odo` repo would not require human approval to trigger this workflow. 

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
