### PR TITLE
Fix GitHub labels in release changelog generator script and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,11 @@ If you are pushing a change to documentation, please read: https://github.com/re
 Add one of the following kinds:
 /kind bug
 /kind feature
-/kind code-refactoring
 
 Additionally, add one of the following areas if applicable:
 /area documentation
 /area testing
+/area refactoring
 
 Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Add one of the following kinds:
 /kind bug
 /kind feature
 
-Additionally, add one of the following areas if applicable:
+Additionally, add one or more [`area/*` label(s)](https://github.com/redhat-developer/odo/labels?q=area%2F) if applicable. For example:
 /area documentation
 /area testing
 /area refactoring

--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -62,7 +62,7 @@ $RUN_GITHUB_CHANGELOG_GENERATOR \
 --enhancement-labels "kind/feature" \
 --bugs-label "**Bugs:**" \
 --bug-labels "kind/bug" \
---add-sections '{"documentation":{"prefix":"**Documentation:**","labels":["area/documentation"]}, "tests": {"prefix": "**Testing/CI:**", "labels": ["kind/tests"]}, "cleanup": {"prefix": "**Cleanup/Refactor:**", "labels": ["kind/code-refactoring"]}}'
+--add-sections '{"documentation":{"prefix":"**Documentation:**","labels":["area/documentation"]}, "tests": {"prefix": "**Testing/CI:**", "labels": ["area/testing"]}, "cleanup": {"prefix": "**Cleanup/Refactor:**", "labels": ["area/refactoring"]}}'
 
 echo "---------------------------------------"
 cat release-changelog.md


### PR DESCRIPTION
**What type of PR is this:**
/area refactoring
/area release-eng

**What does this PR do / why we need it:**
This fixes the remaining places, after cleaning up all the labels we use in the repo: https://github.com/redhat-developer/odo/labels?sort=name-asc
I wanted to delete the `kind/code-refactoring` label (superseded by `area/refactoring`), but it was still being used here.
Also, the `kind/tests` label had been removed already in the past, but the changelog script was not updated accordingly.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
