### PR TITLE
Disable service binding related integration tests

### DIFF
--- a/.ibm/pipelines/windows-test-script.ps1
+++ b/.ibm/pipelines/windows-test-script.ps1
@@ -57,6 +57,7 @@ function Run-Test {
     [Environment]::SetEnvironmentVariable("TEST_EXEC_NODES", "$TEST_EXEC_NODES") 
     [Environment]::SetEnvironmentVariable("SKIP_USER_LOGIN_TESTS","true")
     [Environment]::SetEnvironmentVariable("SKIP_WELCOMING_MESSAGES","true")
+    [Environment]::SetEnvironmentVariable("SKIP_SERVICE_BINDING_TESTS","$SKIP_SERVICE_BINDING_TESTS" )
     # Integration tests detecting key press when running DevSession are not working on Windows
     [Environment]::SetEnvironmentVariable("SKIP_KEY_PRESS","true")
     [Environment]::SetEnvironmentVariable("DEVFILE_REGISTRY", "$DEVFILE_REGISTRY") 

--- a/.ibm/pipelines/windows-test.sh
+++ b/.ibm/pipelines/windows-test.sh
@@ -18,7 +18,7 @@ sshpass -p $WINDOWS_PASSWORD scp -o StrictHostKeyChecking=no ./.ibm/pipelines/wi
 
 #execute test from the test script
 export TEST_EXEC_NODES=${TEST_EXEC_NODES:-"16"}
-sshpass -p $WINDOWS_PASSWORD ssh Administrator@$WINDOWS_IP -o StrictHostKeyChecking=no powershell /tmp/windows-test-script.ps1 "${GIT_PR_NUMBER}" "${BUILD_NUMBER}" "${API_KEY_QE}" "${IBM_OPENSHIFT_ENDPOINT}" "${LOGFILE}" "${REPO}" "${CLUSTER_ID}" "${TEST_EXEC_NODES}" "${DEVFILE_REGISTRY}"
+sshpass -p $WINDOWS_PASSWORD ssh Administrator@$WINDOWS_IP -o StrictHostKeyChecking=no powershell /tmp/windows-test-script.ps1 "${GIT_PR_NUMBER}" "${BUILD_NUMBER}" "${API_KEY_QE}" "${IBM_OPENSHIFT_ENDPOINT}" "${LOGFILE}" "${REPO}" "${CLUSTER_ID}" "${TEST_EXEC_NODES}" "${DEVFILE_REGISTRY}" "${SKIP_SERVICE_BINDING_TESTS}"
 RESULT=$?
 echo "RESULT: $RESULT"
 

--- a/scripts/ansible/Cluster/kubernetes-cluster/README.md
+++ b/scripts/ansible/Cluster/kubernetes-cluster/README.md
@@ -172,3 +172,9 @@ to user agents beginning with `containerd` or `Go-http-client`.
 
 The integration tests are able to detect the presence of the Load Balancer service and use the proxy if the service is present
 and providing an external address.
+
+## Devfile registry
+
+Install a local Devvile registry in the cluster with the instructions provoded at https://devfile.io/docs/2.1.0/deploying-a-devfile-registry 
+and the configuration in /scripts/devfile-registry/ci-values.yaml. You will need to modify the field `global.ingress.domain` in the configuration file.
+

--- a/scripts/devfile-registry/ci-values.yaml
+++ b/scripts/devfile-registry/ci-values.yaml
@@ -16,7 +16,7 @@
 global:
   ingress:
     class: 'public-iks-k8s-nginx'
-    domain: 'odo-test-kubernetes-clust-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud'
+    domain: 'odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud'
     secretName: ''
   isOpenShift: false
   tlsEnabled: false

--- a/tests/examples/source/devfiles/nodejs/devfile-fsgroup.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-fsgroup.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  projectType: nodejs
+  language: nodejs
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000-tcp"
+          targetPort: 3000
+      mountSources: true
+    attributes:
+      pod-overrides:
+        spec:
+          securityContext:
+            fsGroup: 2000
+commands:
+  - id: devbuild
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: true
+  - id: build
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+  - id: devrun
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run

--- a/tests/integration/cmd_add_binding_test.go
+++ b/tests/integration/cmd_add_binding_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,6 +21,11 @@ var _ = Describe("odo add binding command tests", func() {
 	var err error
 
 	var _ = BeforeEach(func() {
+		skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+		if skipLogin == "true" {
+			Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+		}
+
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 		// Ensure that the operators are installed

--- a/tests/integration/cmd_describe_list_binding_test.go
+++ b/tests/integration/cmd_describe_list_binding_test.go
@@ -17,6 +17,11 @@ var _ = Describe("odo describe/list binding command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
+		skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+		if skipLogin == "true" {
+			Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+		}
+
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 	})

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -1786,6 +1786,11 @@ ComponentSettings:
 
 		When("Starting a PostgreSQL service", func() {
 			BeforeEach(func() {
+				skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+				if skipLogin == "true" {
+					Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+				}
+
 				// Ensure that the operators are installed
 				commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")
 				commonVar.CliRunner.EnsureOperatorIsInstalled("cloud-native-postgresql")

--- a/tests/integration/cmd_dev_test.go
+++ b/tests/integration/cmd_dev_test.go
@@ -71,7 +71,11 @@ var _ = Describe("odo dev command tests", func() {
 	When("a component is bootstrapped", func() {
 		BeforeEach(func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml")).ShouldPass()
+			devfile := "devfile.yaml"
+			if os.Getenv("KUBERNETES") == "true" {
+				devfile = "devfile-fsgroup.yaml"
+			}
+			helper.Cmd("odo", "init", "--name", cmpName, "--devfile-path", helper.GetExamplePath("source", "devfiles", "nodejs", devfile)).ShouldPass()
 			Expect(helper.VerifyFileExists(".odo/env/env.yaml")).To(BeFalse())
 		})
 

--- a/tests/integration/cmd_devfile_deploy_test.go
+++ b/tests/integration/cmd_devfile_deploy_test.go
@@ -385,6 +385,11 @@ ComponentSettings:
 	When("deploying a ServiceBinding k8s resource", func() {
 		const serviceBindingName = "my-nodejs-app-cluster-sample" // hard-coded from devfile-deploy-with-SB.yaml
 		BeforeEach(func() {
+			skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+			if skipLogin == "true" {
+				Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+			}
+
 			commonVar.CliRunner.EnsureOperatorIsInstalled("service-binding-operator")
 			commonVar.CliRunner.EnsureOperatorIsInstalled("cloud-native-postgresql")
 			Eventually(func() string {

--- a/tests/integration/cmd_list_services_test.go
+++ b/tests/integration/cmd_list_services_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/odo/tests/helper"
@@ -12,6 +14,11 @@ var _ = Describe("odo list services tests", func() {
 	var randomProject string
 
 	BeforeEach(func() {
+		skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+		if skipLogin == "true" {
+			Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+		}
+
 		commonVar = helper.CommonBeforeEach()
 
 		// Ensure that the operators are installed

--- a/tests/integration/cmd_remove_binding_test.go
+++ b/tests/integration/cmd_remove_binding_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +15,11 @@ var _ = Describe("odo remove binding command tests", func() {
 	var commonVar helper.CommonVar
 
 	var _ = BeforeEach(func() {
+		skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+		if skipLogin == "true" {
+			Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+		}
+
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 		// Note: We do not add any operators here because `odo remove binding` is simply about removing the ServiceBinding from devfile.

--- a/tests/integration/interactive_add_binding_test.go
+++ b/tests/integration/interactive_add_binding_test.go
@@ -20,6 +20,11 @@ var _ = Describe("odo add binding interactive command tests", func() {
 
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
+		skipLogin := os.Getenv("SKIP_SERVICE_BINDING_TESTS")
+		if skipLogin == "true" {
+			Skip("Skipping service binding tests as SKIP_SERVICE_BINDING_TESTS is true")
+		}
+
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
 


### PR DESCRIPTION
**What type of PR is this:**

/area testing

The purpose of this PR is to test the impact of removing the integration tests related to service binding.

It introduces an `SKIP_SERVICE_BINDING_TESTS` environment variable which indidate to skip tests related to service binding.

This variable has been set to `true` for *Kubernetes*, *OpenShift* and *Windows* tests on IBM Cloud, to disable these tests for PRs.

The tests will still run during the nightly tests.

