### PR TITLE
Temporarily downgrade Podman on GitHub to fix CI failures for Podman tests

### DIFF
--- a/.github/workflows/podman-test.yaml
+++ b/.github/workflows/podman-test.yaml
@@ -15,28 +15,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - run: cat /etc/os-release || true
+
     - run: podman info
 
+    # TODO(rm3l): workaround for https://github.com/actions/runner-images/issues/7753 (caused by https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394).
+    #   Remove this when this issue is fixed and available in the ubuntu runner image
+    - run: |
+        sudo apt install podman=3.4.4+ds1-1ubuntu1 --allow-downgrades
+        podman info
+
     - name: Checkout
-      # TODO(rm3l): Remove the line below
-      if: false
       uses: actions/checkout@v3
 
     - name: Setup Go
-      # TODO(rm3l): Remove the line below
-      if: false
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
 
     - name: Build odo
-      # TODO(rm3l): Remove the line below
-      if: false
       run: make install
 
     - name: Run Integration tests
-      # TODO(rm3l): Remove the line below
-      if: false
       env:
         # This should ideally be a configuration in the GH repo (secret or variable).
         # This is currently hard-coded because GH won't expose secrets or variables to PRs created from forks.
@@ -46,9 +46,7 @@ jobs:
       run: make test-integration-podman
 
     - name: List and stop remaining containers
-      # TODO(rm3l): Remove the line below
-      if: false
-#      if: ${{ always() }}
+      if: ${{ always() }}
       run: |
         podman pod ls --format '{{.Name}}' | xargs -I '{}' podman pod inspect '{}'
         podman pod ls --format '{{.Name}}' | xargs podman pod stop || true

--- a/.github/workflows/podman-test.yaml
+++ b/.github/workflows/podman-test.yaml
@@ -15,18 +15,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - run: podman info
+
     - name: Checkout
+      # TODO(rm3l): Remove the line below
+      if: false
       uses: actions/checkout@v3
 
     - name: Setup Go
+      # TODO(rm3l): Remove the line below
+      if: false
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
 
     - name: Build odo
+      # TODO(rm3l): Remove the line below
+      if: false
       run: make install
 
     - name: Run Integration tests
+      # TODO(rm3l): Remove the line below
+      if: false
       env:
         # This should ideally be a configuration in the GH repo (secret or variable).
         # This is currently hard-coded because GH won't expose secrets or variables to PRs created from forks.
@@ -36,7 +46,9 @@ jobs:
       run: make test-integration-podman
 
     - name: List and stop remaining containers
-      if: ${{ always() }}
+      # TODO(rm3l): Remove the line below
+      if: false
+#      if: ${{ always() }}
       run: |
         podman pod ls --format '{{.Name}}' | xargs -I '{}' podman pod inspect '{}'
         podman pod ls --format '{{.Name}}' | xargs podman pod stop || true


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area testing
/area infra
/area odo-on-podman

**What does this PR do / why we need it:**

As reported in https://github.com/redhat-developer/odo/issues/6927, the tests on Podman have been consistently failing since a few days, due to an error: `Error: k8s.gcr.io/pause:3.5: image not known`
A regression in `libpod` has been identified in Ubuntu 22.04.1 LTS and reported [1][2]. Though not strictly the same error as the one we observed, I think this regression might affect networking.
As suggested in [3], I'm trying to downgrade Podman to see if it helps. 🤞🏿 

[1] https://github.com/actions/runner-images/issues/7753
[2] https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394
[2] https://github.com/actions/runner-images/issues/7753#issuecomment-1600764394

EDIT: the Podman tests are now passing with the changes here. Let's merge this as it is. I'm still keeping an eye out on [1] and will revert the changes here once it is fixed and made available in the runner images.

**Which issue(s) this PR fixes:**
Fixes #6927

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
