### PR TITLE
Set FsGroup for spring boot test

### DIFF
--- a/tests/documentation/user-guides/doc_user_guides_quickstart_test.go
+++ b/tests/documentation/user-guides/doc_user_guides_quickstart_test.go
@@ -241,6 +241,9 @@ var _ = Describe("User guides: Quickstart test", func() {
 				Expect(diff).To(BeEmpty(), file)
 			})
 			By("running odo dev", func() {
+				helper.UpdateDevfileContent("devfile.yaml", []helper.DevfileUpdater{
+					helper.SetFsGroup("tools", 2000),
+				})
 				devSession, err := helper.StartDevMode(helper.DevSessionOpts{TimeoutInSeconds: 420})
 				Expect(err).To(BeNil())
 				devSession.Stop()


### PR DESCRIPTION
**What type of PR is this:**
/area testing

**What does this PR do / why we need it:**

This PR fixes the following `Kubernetes-Docs-Integration-Tests` test, by setting an fsGroup to the container's pod.

```
 [FAILED] user-guides/quickstart/docs-mdx/java/java_odo_dev_output.mdx
  Expected
      <string>:   (
        	"""
        	... // 12 identical lines
        	✓  Pod is Running
        	✓  Syncing files into the container [1s]
      - 	✓  Building your application in container (command: build) [1s]
      - 	•  Executing the application (command: run)  ...
      - 	✓  Waiting for the application to be ready [1s]
      - 	-  Forwarding from 127.0.0.1:20001 -> 8080
      + 	✗  Building your application in container (command: build) [1s]
      + 	Error occurred on Push - watch command was unable to push component: unable to exec command [/bin/sh -c cd ${PROJECT_SOURCE} && (mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true) 1>>/proc/1/fd/1 2>>/proc/1/fd/2]: error while streaming command: command terminated with exit code 1
        	
        	
        	... // 9 identical lines
        	"""
        )
```

