### PR TITLE
Fix potential issue in `odo version` nightly tests if user does not have permission to get the OpenShift version

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/onsi/gomega/types"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/onsi/gomega/types"
 
 	"github.com/tidwall/gjson"
 
@@ -325,8 +326,8 @@ func JsonPathContentContain(json string, path string, value string) {
 	Expect(result.String()).To(ContainSubstring(value), fmt.Sprintf("content of path %q should contain %q but is %q", path, value, result.String()))
 }
 
-// JsonPathSatisfies expects content of the path to satisfy all the matchers passed to it
-func JsonPathSatisfies(json string, path string, matchers ...types.GomegaMatcher) {
+// JsonPathSatisfiesAll expects content of the path to satisfy all the matchers passed to it
+func JsonPathSatisfiesAll(json string, path string, matchers ...types.GomegaMatcher) {
 	result := gjson.Get(json, path)
 	Expect(result.String()).Should(SatisfyAll(matchers...))
 }

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -155,12 +155,12 @@ var _ = Describe("odo generic", func() {
 					By("checking the JSON output", func() {
 						odoVersion = helper.Cmd("odo", "version", "-o", "json").ShouldPass().Out()
 						Expect(helper.IsJSON(odoVersion)).To(BeTrue())
-						helper.JsonPathSatisfies(odoVersion, "version", MatchRegexp(reJSONVersion))
+						helper.JsonPathSatisfiesAll(odoVersion, "version", MatchRegexp(reJSONVersion))
 						helper.JsonPathExist(odoVersion, "gitCommit")
 						if podman {
-							helper.JsonPathSatisfies(odoVersion, "podman.client.version", MatchRegexp(reJSONVersion), Equal(helper.GetPodmanVersion()))
+							helper.JsonPathSatisfiesAll(odoVersion, "podman.client.version", MatchRegexp(reJSONVersion), Equal(helper.GetPodmanVersion()))
 						} else {
-							helper.JsonPathSatisfies(odoVersion, "cluster.kubernetes.version", MatchRegexp(reJSONVersion))
+							helper.JsonPathSatisfiesAll(odoVersion, "cluster.kubernetes.version", MatchRegexp(reJSONVersion))
 							serverURL := oc.GetCurrentServerURL()
 							helper.JsonPathContentIs(odoVersion, "cluster.serverURL", serverURL)
 							if !helper.IsKubernetesCluster() {
@@ -169,7 +169,7 @@ var _ = Describe("odo generic", func() {
 									// A blank serverVersion might indicate a user permission error on certain clusters (observed with a developer account on Prow nightly jobs)
 									m = Not(m)
 								}
-								helper.JsonPathSatisfies(odoVersion, "cluster.openshift", m)
+								helper.JsonPathSatisfiesAll(odoVersion, "cluster.openshift", m)
 							}
 						}
 					})
@@ -205,10 +205,10 @@ var _ = Describe("odo generic", func() {
 			By("checking JSON output", func() {
 				odoVersion := helper.Cmd("odo", "version", "--client", "-o", "json").ShouldPass().Out()
 				Expect(helper.IsJSON(odoVersion)).To(BeTrue())
-				helper.JsonPathSatisfies(odoVersion, "version", MatchRegexp(reJSONVersion))
+				helper.JsonPathSatisfiesAll(odoVersion, "version", MatchRegexp(reJSONVersion))
 				helper.JsonPathExist(odoVersion, "gitCommit")
-				helper.JsonPathSatisfies(odoVersion, "cluster", BeEmpty())
-				helper.JsonPathSatisfies(odoVersion, "podman", BeEmpty())
+				helper.JsonPathSatisfiesAll(odoVersion, "cluster", BeEmpty())
+				helper.JsonPathSatisfiesAll(odoVersion, "podman", BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area testing

**What does this PR do / why we need it:**
This fixes a potential issue with the `odo version` integration tests, which failed in the nightly jobs (running on Prow) because the `developer` user does not have the permissions to get the OpenShift version.

Based on what had been done in https://github.com/redhat-developer/odo/pull/6551 to fix a similar issue, it gets the version from `oc version` and if something is reported about the server, will check that `odo version` displays the right information about OpenShift. If not, then such information should be missing from the `odo version` output.

**Which issue(s) this PR fixes:**
- Fixes #6932 
- Related to https://github.com/redhat-developer/odo/pull/6913
- Related issue: [`Normal users have no way to get the OpenShift version`](https://issues.redhat.com/browse/OCPBUGS-8783)

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
