### PR TITLE
Document and return JSON data for API errors

### DIFF
--- a/ododevapispec.yaml
+++ b/ododevapispec.yaml
@@ -172,6 +172,14 @@ paths:
                   },
                   "managedBy": "odo"
                }
+        '500':
+          description: error getting the description of the component
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+              example:
+                message: "error getting the description of the component"
 
   /component/command:
     post:
@@ -198,6 +206,22 @@ paths:
                 $ref: '#/components/schemas/GeneralSuccess'
               example:
                 message: "push was successfully executed"
+        '400':
+          description: command name not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+              example:
+                message: "command name 'unknown' not supported. Supported values are: \"push\""
+        '429':
+          description: a push operation is not possible at this time. Please retry later
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+              example:
+                message: "a push operation is not possible at this time. Please retry later"
 
 components:
   schemas:

--- a/pkg/apiserver-gen/README.md
+++ b/pkg/apiserver-gen/README.md
@@ -14,6 +14,7 @@ To see how to make this your own, look here:
 
 - API version: 0.1
 
+
 ### Running the server
 To run the server, follow these simple steps:
 

--- a/pkg/apiserver-impl/api_default_service.go
+++ b/pkg/apiserver-impl/api_default_service.go
@@ -57,7 +57,9 @@ func (s *DefaultApiService) ComponentCommandPost(ctx context.Context, componentC
 		}
 
 	default:
-		return openapi.Response(http.StatusBadRequest, nil), fmt.Errorf("command name %q not supported. Supported values are: %q", componentCommandPostRequest.Name, "push")
+		return openapi.Response(http.StatusBadRequest, openapi.GeneralError{
+			Message: fmt.Sprintf("command name %q not supported. Supported values are: %q", componentCommandPostRequest.Name, "push"),
+		}), nil
 	}
 }
 
@@ -65,7 +67,9 @@ func (s *DefaultApiService) ComponentCommandPost(ctx context.Context, componentC
 func (s *DefaultApiService) ComponentGet(ctx context.Context) (openapi.ImplResponse, error) {
 	value, _, err := describe.DescribeDevfileComponent(ctx, s.kubeClient, s.podmanClient, s.stateClient)
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, ""), fmt.Errorf("error getting the description of the component: %w", err)
+		return openapi.Response(http.StatusInternalServerError, openapi.GeneralError{
+			Message: fmt.Sprintf("error getting the description of the component: %s", err),
+		}), nil
 	}
 	return openapi.Response(http.StatusOK, value), nil
 }


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

Fixes the API response data for the error cases, and documents these error responses in the openapi spec