### PR TITLE
Add `.gitattributes` file with Git-style path matchers customizing how PR changed files appear on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Attributes per path
+
+# This allows for example for customizing how changed files appear on GitHub.
+# See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+
+# linguist-generated marks matching paths as ignored for the repo language stats and hidden by default in diffs.
+# See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#overrides
+
+**/go.sum linguist-generated=true
+**/vendor/**/* linguist-generated=true
+pkg/apiserver-gen/**/* linguist-generated=true
+pkg/**/mock.go linguist-generated=true
+pkg/**/mock_Backend.go linguist-generated=true
+pkg/**/mock_Client.go linguist-generated=true


### PR DESCRIPTION
**What type of PR is this:**
/kind task

**What does this PR do / why we need it:**
GitHub UI is terribly slow when reviewing/commenting on PRs that contain a lot of changes in the vendored directories, like in https://github.com/redhat-developer/odo/pull/6937
As suggested, we can keep certain files from displaying in diffs by default, by using a standard `.gitattributes` file.
This should make it easier to review large PRs with a lot of changes from certain files (like in `**/vendor/**`), by hiding them by default.
See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github for more details.

This is how matching files would appear if `linguist-generated` attribute is `true`; so it will still be possible to show the diff on demand if needed:
![image](https://github.com/redhat-developer/odo/assets/593208/139a20b7-9856-4a83-8f5e-ea12110aa274)


**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
