### PR TITLE
Display list of `commands` from the local devfile in `odo describe component` output

### DIFF
--- a/docs/website/docs/command-reference/describe-component.md
+++ b/docs/website/docs/command-reference/describe-component.md
@@ -33,6 +33,32 @@ Supported odo features:
 •  Deploy: true
 •  Debug: true
 
+Commands:
+ •  my-install
+      Type: exec
+      Group: build
+      Command Line: "npm install"
+      Component: runtime
+      Component Type: container
+ •  my-run
+      Type: exec
+      Group: run
+      Command Line: "npm start"
+      Component: runtime
+      Component Type: container
+ •  build-image
+      Type: apply
+      Component: prod-image
+      Component Type: image
+      Image Name: devfile-nodejs-deploy:latest
+ •  deploy-deployment
+      Type: apply
+      Component: outerloop-deploy
+      Component Type: kubernetes
+ •  deploy
+      Type: composite
+      Group: deploy
+
 Container components:
 •  runtime
 
@@ -55,6 +81,7 @@ Kubernetes Routes:
 This command returns information extracted from the Devfile:
 - metadata (name, display name, project type, language, version, description and tags)
 - supported odo features, indicating if the Devfile defines necessary information to run `odo dev`, `odo dev --debug` and `odo deploy`
+- the list of commands, if any, along with some useful information about each command
 - the list of container components,
 - the list of Kubernetes components.
 - the list of forwarded ports if the component is running in Dev mode.

--- a/docs/website/docs/command-reference/json-output.md
+++ b/docs/website/docs/command-reference/json-output.md
@@ -139,6 +139,7 @@ When the `describe component` command is executed without parameter from a direc
   - the path of the Devfile,
   - the content of the Devfile,
   - supported `odo` features, indicating if the Devfile defines necessary information to run `odo dev`, `odo dev --debug` and `odo deploy`
+  - the list of commands, if any, along with some useful information about each command
   - ingress or routes created in Deploy mode
 - the status of the component
   - the forwarded ports if odo is currently running in Dev mode,
@@ -155,6 +156,45 @@ odo describe component -o json
 			"schemaVersion": "2.0.0",
 			[ devfile.yaml file content ]
 		},
+		"commands": [
+            {
+                "name": "my-install",
+                "type": "exec",
+                "group": "build",
+                "isDefault": true,
+                "commandLine": "npm install",
+                "component": "runtime",
+                "componentType": "container"
+            },
+            {
+                "name": "my-run",
+                "type": "exec",
+                "group": "run",
+                "isDefault": true,
+                "commandLine": "npm start",
+                "component": "runtime",
+                "componentType": "container"
+            },
+            {
+                "name": "build-image",
+                "type": "apply",
+                "component": "prod-image",
+                "componentType": "image",
+                "imageName": "devfile-nodejs-deploy"
+            },
+            {
+                "name": "deploy-deployment",
+                "type": "apply",
+                "component": "outerloop-deploy",
+                "componentType": "kubernetes"
+            },
+            {
+                "name": "deploy",
+                "type": "composite",
+                "group": "deploy",
+                "isDefault": true
+            }
+        ],
 		"supportedOdoFeatures": {
 			"dev": true,
 			"deploy": false,

--- a/pkg/api/devfile-data.go
+++ b/pkg/api/devfile-data.go
@@ -5,6 +5,7 @@ import "github.com/devfile/library/v2/pkg/devfile/parser/data"
 // DevfileData describes a devfile content
 type DevfileData struct {
 	Devfile              data.DevfileData      `json:"devfile"`
+	Commands             []DevfileCommand      `json:"commands,omitempty"`
 	SupportedOdoFeatures *SupportedOdoFeatures `json:"supportedOdoFeatures,omitempty"`
 }
 
@@ -14,3 +15,41 @@ type SupportedOdoFeatures struct {
 	Deploy bool `json:"deploy"`
 	Debug  bool `json:"debug"`
 }
+
+type DevfileCommand struct {
+	Name          string               `json:"name,omitempty"`
+	Type          DevfileCommandType   `json:"type,omitempty"`
+	Group         DevfileCommandGroup  `json:"group,omitempty"`
+	IsDefault     *bool                `json:"isDefault,omitempty"`
+	CommandLine   string               `json:"commandLine,omitempty"`
+	Component     string               `json:"component,omitempty"`
+	ComponentType DevfileComponentType `json:"componentType,omitempty"`
+	ImageName     string               `json:"imageName,omitempty"`
+}
+
+type DevfileCommandType string
+
+const (
+	ExecCommandType      DevfileCommandType = "exec"
+	ApplyCommandType     DevfileCommandType = "apply"
+	CompositeCommandType DevfileCommandType = "composite"
+)
+
+type DevfileCommandGroup string
+
+const (
+	BuildCommandGroup  DevfileCommandGroup = "build"
+	RunCommandGroup    DevfileCommandGroup = "run"
+	TestCommandGroup   DevfileCommandGroup = "test"
+	DebugCommandGroup  DevfileCommandGroup = "debug"
+	DeployCommandGroup DevfileCommandGroup = "deploy"
+)
+
+type DevfileComponentType string
+
+const (
+	ImageComponentType      DevfileComponentType = "image"
+	ContainerComponentType  DevfileComponentType = "container"
+	KubernetesComponentType DevfileComponentType = "kubernetes"
+	OpenshiftComponentType  DevfileComponentType = "openshift"
+)

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -1,16 +1,24 @@
 package api
 
 import (
+	v1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
+	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
+
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 )
 
-func GetDevfileData(devfileObj parser.DevfileObj) *DevfileData {
+func GetDevfileData(devfileObj parser.DevfileObj) (*DevfileData, error) {
+	commands, err := getDevfileCommands(devfileObj.Data)
+	if err != nil {
+		return nil, err
+	}
 	return &DevfileData{
 		Devfile:              devfileObj.Data,
+		Commands:             commands,
 		SupportedOdoFeatures: getSupportedOdoFeatures(devfileObj.Data),
-	}
+	}, nil
 }
 
 func getSupportedOdoFeatures(devfileData data.DevfileData) *SupportedOdoFeatures {
@@ -19,4 +27,93 @@ func getSupportedOdoFeatures(devfileData data.DevfileData) *SupportedOdoFeatures
 		Deploy: libdevfile.HasDeployCommand(devfileData),
 		Debug:  libdevfile.HasDebugCommand(devfileData),
 	}
+}
+
+func getDevfileCommands(devfileData data.DevfileData) ([]DevfileCommand, error) {
+	commands, err := devfileData.GetCommands(common.DevfileOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	toGroupFn := func(g *v1alpha2.CommandGroup) (group DevfileCommandGroup, isDefault *bool) {
+		if g == nil {
+			return "", nil
+		}
+		switch g.Kind {
+		case v1alpha2.BuildCommandGroupKind:
+			group = BuildCommandGroup
+		case v1alpha2.RunCommandGroupKind:
+			group = RunCommandGroup
+		case v1alpha2.DebugCommandGroupKind:
+			group = DebugCommandGroup
+		case v1alpha2.TestCommandGroupKind:
+			group = TestCommandGroup
+		case v1alpha2.DeployCommandGroupKind:
+			group = DeployCommandGroup
+		}
+
+		return group, g.IsDefault
+	}
+
+	var result []DevfileCommand
+	for _, cmd := range commands {
+		var (
+			cmdType      DevfileCommandType
+			cmdComponent string
+			cmdCompType  DevfileComponentType
+			cmdLine      string
+		)
+		var cmdGroup *v1alpha2.CommandGroup
+		switch {
+		case cmd.Apply != nil:
+			cmdType = ApplyCommandType
+			cmdComponent = cmd.Apply.Component
+			cmdGroup = cmd.Apply.Group
+		case cmd.Exec != nil:
+			cmdType = ExecCommandType
+			cmdComponent = cmd.Exec.Component
+			cmdGroup = cmd.Exec.Group
+			cmdLine = cmd.Exec.CommandLine
+		case cmd.Composite != nil:
+			cmdType = CompositeCommandType
+			cmdGroup = cmd.Composite.Group
+		}
+
+		var imageName string
+		var comp v1alpha2.Component
+		if cmdComponent != "" {
+			var ok bool
+			comp, ok, err = libdevfile.FindComponentByName(devfileData, cmdComponent)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				switch {
+				case comp.Kubernetes != nil:
+					cmdCompType = KubernetesComponentType
+				case comp.Openshift != nil:
+					cmdCompType = OpenshiftComponentType
+				case comp.Container != nil:
+					cmdCompType = ContainerComponentType
+				case comp.Image != nil:
+					cmdCompType = ImageComponentType
+					imageName = comp.Image.ImageName
+				}
+			}
+		}
+		g, isDefault := toGroupFn(cmdGroup)
+		c := DevfileCommand{
+			Name:          cmd.Id,
+			Type:          cmdType,
+			Group:         g,
+			IsDefault:     isDefault,
+			CommandLine:   cmdLine,
+			Component:     cmdComponent,
+			ComponentType: cmdCompType,
+			ImageName:     imageName,
+		}
+		result = append(result, c)
+	}
+
+	return result, nil
 }

--- a/pkg/component/describe/describe.go
+++ b/pkg/component/describe/describe.go
@@ -9,6 +9,8 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/generator"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
+	"k8s.io/klog"
+
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/kclient"
@@ -20,7 +22,6 @@ import (
 	odocontext "github.com/redhat-developer/odo/pkg/odo/context"
 	"github.com/redhat-developer/odo/pkg/podman"
 	"github.com/redhat-developer/odo/pkg/state"
-	"k8s.io/klog"
 )
 
 // DescribeDevfileComponent describes the component defined by the devfile in the current directory
@@ -35,6 +36,11 @@ func DescribeDevfileComponent(
 		devfilePath   = odocontext.GetDevfilePath(ctx)
 		componentName = odocontext.GetComponentName(ctx)
 	)
+
+	devfileData, err := api.GetDevfileData(*devfileObj)
+	if err != nil {
+		return api.Component{}, nil, err
+	}
 
 	isPlatformFeatureEnabled := feature.IsEnabled(ctx, feature.GenericPlatformFlag)
 	platform := fcontext.GetPlatform(ctx, "")
@@ -115,7 +121,7 @@ func DescribeDevfileComponent(
 
 	cmp := api.Component{
 		DevfilePath:       devfilePath,
-		DevfileData:       api.GetDevfileData(*devfileObj),
+		DevfileData:       devfileData,
 		DevForwardedPorts: forwardedPorts,
 		RunningIn:         api.MergeRunningModes(runningOn),
 		RunningOn:         runningOn,

--- a/pkg/libdevfile/libdevfile.go
+++ b/pkg/libdevfile/libdevfile.go
@@ -451,6 +451,20 @@ func GetContainerComponentsForCommand(devfileObj parser.DevfileObj, cmd v1alpha2
 	}
 }
 
+// FindComponentByName returns the Devfile component that matches the specified name.
+func FindComponentByName(d data.DevfileData, n string) (v1alpha2.Component, bool, error) {
+	comps, err := d.GetComponents(common.DevfileOptions{})
+	if err != nil {
+		return v1alpha2.Component{}, false, err
+	}
+	for _, c := range comps {
+		if c.Name == n {
+			return c, true, nil
+		}
+	}
+	return v1alpha2.Component{}, false, nil
+}
+
 // GetK8sManifestsWithVariablesSubstituted returns the full content of either a Kubernetes or an Openshift
 // Devfile component, either Inlined or referenced via a URI.
 // No matter how the component is defined, it returns the content with all variables substituted

--- a/pkg/odo/cli/describe/component.go
+++ b/pkg/odo/cli/describe/component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/pointer"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/component/describe"
@@ -189,6 +190,36 @@ func printHumanReadableOutput(ctx context.Context, cmp api.Component, devfileObj
 		log.Printf("Dev: Unknown")
 		log.Printf("Deploy: Unknown")
 		log.Printf("Debug: Unknown")
+	}
+	fmt.Println()
+
+	if cmp.DevfileData != nil && len(cmp.DevfileData.Commands) != 0 {
+		log.Info("Commands:")
+		for _, cmd := range cmp.DevfileData.Commands {
+			item := cmd.Name
+			if pointer.BoolDeref(cmd.IsDefault, false) {
+				item = log.Sbold(cmd.Name)
+			}
+			if cmd.Type != "" {
+				item += fmt.Sprintf("\n      Type: %s", cmd.Type)
+			}
+			if cmd.Group != "" {
+				item += fmt.Sprintf("\n      Group: %s", cmd.Group)
+			}
+			if cmd.CommandLine != "" {
+				item += fmt.Sprintf("\n      Command Line: %q", cmd.CommandLine)
+			}
+			if cmd.Component != "" {
+				item += fmt.Sprintf("\n      Component: %s", cmd.Component)
+			}
+			if cmd.ComponentType != "" {
+				item += fmt.Sprintf("\n      Component Type: %s", cmd.ComponentType)
+			}
+			if cmd.ImageName != "" {
+				item += fmt.Sprintf("\n      Image Name: %s", cmd.ImageName)
+			}
+			log.Printf(item)
+		}
 	}
 	fmt.Println()
 

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -161,9 +161,13 @@ func (o *InitOptions) RunForJsonOutput(ctx context.Context) (out interface{}, er
 	if err != nil {
 		return nil, err
 	}
+	devfileData, err := api.GetDevfileData(devfileObj)
+	if err != nil {
+		return nil, err
+	}
 	return api.Component{
 		DevfilePath:       devfilePath,
-		DevfileData:       api.GetDevfileData(devfileObj),
+		DevfileData:       devfileData,
 		DevForwardedPorts: []api.ForwardedPort{},
 		RunningIn:         api.NewRunningModes(),
 		ManagedBy:         "odo",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -445,5 +445,10 @@ func (o RegistryClient) retrieveDevfileDataFromRegistry(ctx context.Context, reg
 
 	// Convert DevfileObj to DevfileData
 	// use api.GetDevfileData to get supported features
-	return *api.GetDevfileData(devfileObj), nil
+	devfileData, err := api.GetDevfileData(devfileObj)
+	if err != nil {
+		return api.DevfileData{}, err
+	}
+
+	return *devfileData, nil
 }

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -355,6 +355,13 @@ func JsonPathContentIsValidUserPort(json string, path string) {
 	))
 }
 
+func JsonPathContentHasLen(json string, path string, len int) {
+	result := gjson.Get(json, path+".#")
+	intVal, err := strconv.Atoi(result.String())
+	Expect(err).ToNot(HaveOccurred())
+	Expect(intVal).To(Equal(len), fmt.Sprintf("%q should contain exactly %d elements", path, len))
+}
+
 // GetProjectName sets projectNames based on the name of the test file name (without path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
 func GetProjectName() string {
 	//Get current test filename and remove file path, file extension and replace undescores with hyphens


### PR DESCRIPTION
**What type of PR is this:**

/kind feature

**What does this PR do / why we need it:**
This adds information about commands defined in the Devfile fro; the `odo describe component` output.

**Which issue(s) this PR fixes:**
Fixes #6892 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [x] Documentation
  - [JSON output](https://odo-dev-pr-6944.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/docs/command-reference/json-output#odo-describe-component--o-json)
  - [Human-readable output](https://odo-dev-pr-6944.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/docs/command-reference/describe-component#describe-with-access-to-devfile)

**How to test changes / Special notes to the reviewer:**
See #6892 for more context. When executed from a directory containing a Devfile, `odo describe component` should now display the list of commands that are defined in the Devfile, if any.
In the JSON output, this is available under a new `.devfileData.commands` field.

<details>
<summary>odo describe component -o json | jq -r '.devfileData.commands'</summary>

```json
[                                                                                                                                                                                              
  {                                                                                                                                                                                            
    "name": "install",                                                                                                                                                                         
    "type": "exec",                                                                                                                                                                            
    "group": "build",                                                                                                                                                                          
    "isDefault": true,                                                                                                                                                                         
    "commandLine": "npm install",                                                                                                                                                              
    "component": "runtime",                                                                                                                                                                    
    "componentType": "container"                                                                                                                                                               
  },                                                                                                                                                                                           
  {                                                                                                                                                                                            
    "name": "innerloop-pod-command",                                                                                                                                                           
    "type": "apply",                                                                                                                                                                           
    "group": "test",                                                                                                                                                                           
    "isDefault": false,                                                                                                                                                                        
    "component": "innerloop-pod",                                                                                                                                                              
    "componentType": "kubernetes"                                                                                                                                                              
  },                                                                                                                                                                                           
  {                                                                                                                                                                                            
    "name": "start",                                                                                                                                                                           
    "type": "exec",                                                                                                                                                                            
    "commandLine": "npm start",                                                                                                                                                                
    "component": "runtime",                                                                                                                                                                    
    "componentType": "container"                                                                                                                                                               
  },
  {
    "name": "run",
    "type": "composite",
    "group": "run",
    "isDefault": true
  },
  {
    "name": "build-image",
    "type": "apply",
    "component": "prod-image",
    "componentType": "image",
    "imageName": "quay.io/tkral/devfile-nodejs-deploy:latest"
  },
  {
    "name": "deploy-deployment",
    "type": "apply",
    "component": "outerloop-deploy",
    "componentType": "kubernetes"
  },
  {
    "name": "deploy-another-deployment",
    "type": "apply",
    "component": "another-deployment",
    "componentType": "kubernetes"
  },
  {
    "name": "outerloop-pod-command",
    "type": "apply",
    "component": "outerloop-pod",
    "componentType": "kubernetes"
  },
  {
    "name": "deploy",
    "type": "composite",
    "group": "deploy",
    "isDefault": true
  }
]
```

</details>