### PR TITLE
Fix CI Devfile Registry URL used in OCP interop tests

### DIFF
--- a/scripts/openshiftci-config.sh
+++ b/scripts/openshiftci-config.sh
@@ -1,1 +1,1 @@
-export DEVFILE_REGISTRY=https://devfile-registry-ci-devfile-registry.odo-test-kubernetes-clust-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/
+export DEVFILE_REGISTRY=https://devfile-registry-ci-devfile-registry.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/


### PR DESCRIPTION
**What type of PR is this:**
/area testing
/kind bug

**What does this PR do / why we need it:**

We had a lot of failures because the OCP Interop tests were still using the old Devfile registry URL, which is no longer reachable since we created a new cluster.

See https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-redhat-developer-odo-main-odo-ocp4.14-lp-interop-odo-scenario-aws/1675746432100864000

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
