### PR TITLE
Add new `--run-port` flag to `odo init` to set ports non-interactively

### DIFF
--- a/docs/website/docs/command-reference/docs-mdx/init/devfile_with_run-port_output.mdx
+++ b/docs/website/docs/command-reference/docs-mdx/init/devfile_with_run-port_output.mdx
@@ -1,0 +1,14 @@
+```console
+$ odo init --devfile go --name my-go-app --run-port 3456 --run-port 9876
+  __
+ /  \__     Initializing a new component
+ \__/  \
+ /  \__/    odo version: v3.12.0
+ \__/
+
+ ✓  Downloading devfile "go" [48ms]
+
+Your new component 'my-go-app' is ready in the current directory.
+To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
+Changes will be directly reflected on the cluster.
+```

--- a/docs/website/docs/command-reference/init.md
+++ b/docs/website/docs/command-reference/init.md
@@ -67,10 +67,10 @@ import NonEmptyDirectoryOutput from './docs-mdx/init/interactive_mode_directory_
 In non-interactive mode, you will have to specify from the command-line the information needed to get a devfile.
 
 If you want to download a devfile from a registry, you must specify the devfile name with the `--devfile` flag. The devfile with the specified name will be searched in the registries referenced (using `odo preference view`), and the first one matching will be downloaded.
-If you want to download the devfile from a specific registry in the list or referenced registries, you can use the `--devfile-registry` flag to specify the name of this registry. By default odo uses official devfile registry [registry.devfile.io](https://registry.devfile.io). You can use registry's [web interface](https://registry.devfile.io/viewer) to view its content.
-If you want to download a version devfile, you must specify the version with `--devfile-version` flag.
+If you want to download the devfile from a specific registry in the list or referenced registries, you can use the `--devfile-registry` flag to specify the name of this registry. By default, `odo` uses the official devfile registry [registry.devfile.io](https://registry.devfile.io). You can use the registry [web interface](https://registry.devfile.io/viewer) to view its content.
+If you want to download a specific version of a devfile, you can specify the version with the `--devfile-version` flag.
 
-If you prefer to download a devfile from an URL or from the local filesystem, you can use the `--devfile-path` instead.
+If you prefer to download a devfile from a URL or from the local filesystem, you can use the `--devfile-path` instead.
 
 The `--starter` flag indicates the name of the starter project (as referenced in the selected devfile), that you want to use to start your development. To see the available starter projects for devfile stacks in the official devfile registry use its [web interface](https://registry.devfile.io/viewer) to view its content.  
 

--- a/docs/website/docs/command-reference/init.md
+++ b/docs/website/docs/command-reference/init.md
@@ -76,6 +76,11 @@ The `--starter` flag indicates the name of the starter project (as referenced in
 
 The required `--name` flag indicates how the component initialized by this command should be named. The name must follow the [Kubernetes naming convention](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) and not be all-numeric.
 
+If you know what ports your application uses, you can specify the `--run-port` flag to initialize the Devfile with the specified ports, instead of the default ones set in the registry.
+The `--run-port` flag is a repeatable flag that will make `odo` read the downloaded Devfile and look for the container component referenced by the default `run` command.
+It will then overwrite the container component endpoints with the ports specified.
+As such, it requires the default `run` command to be an `exec` command pointing to a `container` component.
+
 #### Fetch Devfile from any registry of the list
 
 In this example, the devfile will be downloaded from the **StagingRegistry** registry, which is the first one in the list containing the `nodejs-react` devfile.
@@ -156,3 +161,26 @@ Use "latest" as the version name to fetch the latest version of a given Devfile.
 
 </details>
 :::
+
+#### Specify the application ports
+
+
+```console
+odo init \
+    --devfile <devfile-name> \
+    --name <component-name> \
+    --run-port <port> [--run-port ANOTHER_PORT] \
+    [--starter STARTER]
+```
+
+In this example, `odo` will download the Devfile from the registry and overwrite the container endpoints with the ones specified in `--run-port`.
+This works because the Devfile downloaded from the registry defines a default `run` command of type `exec` and referencing a `container` component.
+
+<details>
+<summary>Example</summary>
+
+import DevfileWithRunPortOutput from './docs-mdx/init/devfile_with_run-port_output.mdx';
+
+<DevfileWithRunPortOutput />
+
+</details>

--- a/pkg/init/init.go
+++ b/pkg/init/init.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/AlecAivazis/survey/v2/terminal"
 	"net/url"
 	"path/filepath"
 	"strings"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
@@ -40,6 +41,17 @@ type InitClient struct {
 
 var _ Client = (*InitClient)(nil)
 
+// Explicit list of tags useful to select the right backend
+var _initFlags = []string{
+	backend.FLAG_NAME,
+	backend.FLAG_DEVFILE,
+	backend.FLAG_DEVFILE_REGISTRY,
+	backend.FLAG_STARTER,
+	backend.FLAG_DEVFILE_PATH,
+	backend.FLAG_DEVFILE_VERSION,
+	backend.FLAG_RUN_PORT,
+}
+
 func NewInitClient(fsys filesystem.Filesystem, preferenceClient preference.Client, registryClient registry.Client, alizerClient alizer.Client) *InitClient {
 	// We create the asker client and the backends here and not at the CLI level, as we want to hide these details to the CLI
 	askerClient := asker.NewSurveyAsker()
@@ -57,9 +69,13 @@ func NewInitClient(fsys filesystem.Filesystem, preferenceClient preference.Clien
 // It ignores all the flags except the ones specific to init operation, for e.g. verbosity flag
 func (o *InitClient) GetFlags(flags map[string]string) map[string]string {
 	initFlags := map[string]string{}
+outer:
 	for flag, value := range flags {
-		if flag == backend.FLAG_NAME || flag == backend.FLAG_DEVFILE || flag == backend.FLAG_DEVFILE_REGISTRY || flag == backend.FLAG_STARTER || flag == backend.FLAG_DEVFILE_PATH || flag == backend.FLAG_DEVFILE_VERSION {
-			initFlags[flag] = value
+		for _, f := range _initFlags {
+			if flag == f {
+				initFlags[flag] = value
+				continue outer
+			}
 		}
 	}
 	return initFlags

--- a/pkg/libdevfile/libdevfile.go
+++ b/pkg/libdevfile/libdevfile.go
@@ -95,7 +95,9 @@ func executeCommand(ctx context.Context, devfileObj parser.DevfileObj, command v
 }
 
 // GetCommand iterates through the devfile commands and returns the devfile command with the specified name and group kind.
-// If commandName is empty, it returns the default command for the group kind or returns an error if there is no default command.
+// If commandName is empty, it returns the default command for the group kind; or, if there is only one command for the specified kind, it will return that
+// (even if it is not marked as the default).
+// It returns an error if there is more than one default command.
 func GetCommand(
 	devfileObj parser.DevfileObj,
 	commandName string,

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -285,6 +285,7 @@ func NewCmdInit(name, fullName string, testClientset clientset.Clientset) *cobra
 	initCmd.Flags().String(backend.FLAG_STARTER, "", "name of the starter project")
 	initCmd.Flags().String(backend.FLAG_DEVFILE_PATH, "", "path to a devfile. This is an alternative to using devfile from Devfile registry. It can be local filesystem path or http(s) URL")
 	initCmd.Flags().String(backend.FLAG_DEVFILE_VERSION, "", "version of the devfile stack; use \"latest\" to dowload the latest stack")
+	initCmd.Flags().StringArray(backend.FLAG_RUN_PORT, []string{}, "ports used by the application (via the 'run' command)")
 
 	commonflags.UseOutputFlag(initCmd)
 	// Add a defined annotation in order to appear in the help menu

--- a/tests/documentation/command-reference/doc_command_reference_init_test.go
+++ b/tests/documentation/command-reference/doc_command_reference_init_test.go
@@ -212,6 +212,16 @@ var _ = Describe("doc command reference odo init", Label(helper.LabelNoCluster),
 			diff := cmp.Diff(want, got)
 			Expect(diff).To(BeEmpty(), file)
 		})
+
+		It("set application ports after fetching Devfile", func() {
+			args := []string{"init", "--devfile", "go", "--name", "my-go-app", "--run-port", "3456", "--run-port", "9876"}
+			out := helper.Cmd("odo", args...).ShouldPass().Out()
+			got := fmt.Sprintf(outputStringFormat, strings.Join(args, " "), helper.StripSpinner(out))
+			file := "devfile_with_run-port_output.mdx"
+			want := helper.GetMDXContent(filepath.Join(commonPath, file))
+			diff := cmp.Diff(want, got)
+			Expect(diff).To(BeEmpty(), file)
+		})
 	})
 
 })

--- a/tests/helper/helper_devfile.go
+++ b/tests/helper/helper_devfile.go
@@ -10,6 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/redhat-developer/odo/pkg/devfile"
 )
 
 // DevfileUpdater is a helper type that can mutate a Devfile object.
@@ -104,4 +106,11 @@ func SetFsGroup(containerName string, fsGroup int) DevfileUpdater {
 		Expect(err).NotTo(HaveOccurred())
 		return nil
 	}
+}
+
+// ReadRawDevfile parses and validates the Devfile specified and returns its raw content.
+func ReadRawDevfile(devfilePath string) parser.DevfileObj {
+	d, err := devfile.ParseAndValidateFromFile(devfilePath, "", false)
+	Expect(err).ToNot(HaveOccurred())
+	return d
 }


### PR DESCRIPTION
**What type of PR is this:**
/kind feature
/area init

**What does this PR do / why we need it:**
This introduces a new `--run-port` repeatable flag to `odo init`, allowing to set application ports non-interactively. It looks into the fetched Devfile for any default (or single non-default) run command; and, if it is an exec command, tries to find the referenced container component to overwrite its endpoints.

More context in https://github.com/redhat-developer/odo/issues/6925

**Which issue(s) this PR fixes:**
Fixes #6925 

**PR acceptance criteria:**

- [x] Unit test 

- [x] Integration test 

- [x] Documentation
  - https://odo-dev-pr-6953.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/docs/command-reference/init#non-interactive-mode
  - [Specify the application ports](https://odo-dev-pr-6953.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/docs/command-reference/init#specify-the-application-ports)

**How to test changes / Special notes to the reviewer:**
- No error if the Devfile does not have a run command;
```
$ odo init --name udi --devfile udi --run-port 8080 --run-port 9090
  __
 /  \__     Initializing a new component
 \__/  \    
 /  \__/    odo version: v3.12.0
 \__/

 ✓  Downloading devfile "udi" [16ms]

Your new component 'udi' is ready in the current directory.
To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.

$ yq '.components[] | select(has("container")) | del(.container.env) | del(.container.volumeMounts) | split_doc' devfile.yaml
container:
  cpuLimit: 4000m
  cpuRequest: 1000m
  image: quay.io/devfile/universal-developer-image:ubi8-latest
  memoryLimit: 6G
  memoryRequest: 512Mi
  mountSources: true
name: tools
```

- It should overwrite the container endpoints with the ones coming from `--run-port`
```
$ odo init --name my-nodejs --devfile nodejs --run-port 18080 --run-port 28080 --run-port 38080
  __
 /  \__     Initializing a new component
 \__/  \    
 /  \__/    odo version: v3.12.0
 \__/

 ✓  Downloading devfile "nodejs" [18ms]

Your new component 'my-nodejs' is ready in the current directory.
To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.

$ yq '.components[] | select(has("container")) | del(.container.env) | del(.container.volumeMounts) | split_doc' devfile.yaml
container:
  args:
    - tail
    - -f
    - /dev/null
  endpoints:
    - name: port-18080-tcp
      protocol: tcp
      targetPort: 18080
    - name: port-28080-tcp
      protocol: tcp
      targetPort: 28080
    - name: port-38080-tcp
      protocol: tcp
      targetPort: 38080
  image: registry.access.redhat.com/ubi8/nodejs-16:latest
  memoryLimit: 1024Mi
  mountSources: true
name: runtime
```

- It should overwrite the container endpoints with the ones coming from `--run-port`, even if the Devfile stack in the registry has many container components; example with [`java-wildfly`](https://registry.devfile.io/viewer/devfiles/community/java-wildfly):
```
$ odo init --name my-java-wildfly --devfile java-wildfly --run-port 1234 --run-port 5678 --run-port 9012
  __
 /  \__     Initializing a new component
 \__/  \    
 /  \__/    odo version: v3.12.0
 \__/

 ✓  Downloading devfile "java-wildfly" [44ms]

Your new component 'my-java-wildfly' is ready in the current directory.
To start editing your component, use 'odo dev' and open this folder in your favorite IDE.
Changes will be directly reflected on the cluster.

$ yq '.components[] | select(has("container")) | del(.container.env) | del(.container.volumeMounts) | split_doc' devfile.yaml
container:
  endpoints:
    - name: port-1234-tcp
      protocol: tcp
      targetPort: 1234
    - name: port-5678-tcp
      protocol: tcp
      targetPort: 5678
    - name: port-9012-tcp
      protocol: tcp
      targetPort: 9012
  image: quay.io/wildfly/wildfly-centos7:26.1
  memoryLimit: 1512Mi
  mountSources: true
name: wildfly
---
container:
  endpoints:
    - name: tracing-ui-wild
      targetPort: 16686
  image: quay.io/jaegertracing/all-in-one:1.27
  memoryLimit: 128Mi
name: jaeger
```