### PR TITLE
Fix potential port conflict issue with the API server tests by using a random server port if `--random-ports` is set

### DIFF
--- a/pkg/odo/cli/apiserver/apiserver.go
+++ b/pkg/odo/cli/apiserver/apiserver.go
@@ -21,7 +21,10 @@ const (
 
 type ApiServerOptions struct {
 	clientset *clientset.Clientset
-	portFlag  int
+
+	// Flags
+	randomPortsFlag bool
+	portFlag        int
 }
 
 func NewApiServerOptions() *ApiServerOptions {
@@ -67,6 +70,7 @@ func (o *ApiServerOptions) Run(ctx context.Context) (err error) {
 	_, err = apiserver_impl.StartServer(
 		ctx,
 		cancel,
+		o.randomPortsFlag,
 		o.portFlag,
 		devfilePath,
 		devfileFiles,
@@ -114,6 +118,7 @@ func NewCmdApiServer(ctx context.Context, name, fullName string, testClientset c
 		clientset.STATE,
 		clientset.PREFERENCE,
 	)
+	apiserverCmd.Flags().BoolVar(&o.randomPortsFlag, "random-ports", false, "Assign a random API Server port.")
 	apiserverCmd.Flags().IntVar(&o.portFlag, "port", 0, "Define custom port for API Server.")
 	return apiserverCmd
 }

--- a/pkg/odo/cli/apiserver/apiserver.go
+++ b/pkg/odo/cli/apiserver/apiserver.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -44,6 +45,9 @@ func (o *ApiServerOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline
 }
 
 func (o *ApiServerOptions) Validate(ctx context.Context) error {
+	if o.randomPortsFlag && o.portFlag != 0 {
+		return errors.New("--random-ports and --port cannot be used together")
+	}
 	return nil
 }
 

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -271,6 +271,7 @@ func (o *DevOptions) Run(ctx context.Context) (err error) {
 		apiServer, err = apiserver_impl.StartServer(
 			ctx,
 			o.cancel,
+			o.randomPortsFlag,
 			o.apiServerPortFlag,
 			devfilePath,
 			devfileFiles,

--- a/pkg/odo/cli/dev/dev.go
+++ b/pkg/odo/cli/dev/dev.go
@@ -181,6 +181,9 @@ func (o *DevOptions) Validate(ctx context.Context) error {
 	}
 
 	if o.apiServerFlag && o.apiServerPortFlag != 0 {
+		if o.randomPortsFlag {
+			return errors.New("--random-ports and --api-server-port cannot be used together")
+		}
 		if !util.IsPortFree(o.apiServerPortFlag, "") {
 			return fmt.Errorf("port %d is not free; please try another port", o.apiServerPortFlag)
 		}

--- a/tests/integration/cmd_dev_api_server_test.go
+++ b/tests/integration/cmd_dev_api_server_test.go
@@ -53,6 +53,7 @@ var _ = Describe("odo dev command with api server tests", func() {
 						if customPort {
 							localPort = helper.GetCustomStartPort()
 							opts.APIServerPort = localPort
+							opts.NoRandomPorts = true
 						}
 						var err error
 						devSession, err = helper.StartDevMode(opts)

--- a/tests/integration/cmd_dev_api_server_test.go
+++ b/tests/integration/cmd_dev_api_server_test.go
@@ -42,6 +42,23 @@ var _ = Describe("odo dev command with api server tests", func() {
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"), cmpName)
 				})
+
+				if customPort {
+					It("should fail if --random-ports and --api-server-port are used together", func() {
+						args := []string{
+							"dev",
+							"--random-ports",
+							"--api-server",
+							fmt.Sprintf("--api-server-port=%d", helper.GetCustomStartPort()),
+						}
+						if podman {
+							args = append(args, "--platform=podman")
+						}
+						errOut := helper.Cmd("odo", args...).AddEnv("ODO_EXPERIMENTAL_MODE=true").ShouldFail().Err()
+						Expect(errOut).Should(ContainSubstring("--random-ports and --api-server-port cannot be used together"))
+					})
+				}
+
 				When(fmt.Sprintf("odo dev is run with --api-server flag (custom api server port=%v)", customPort), func() {
 					var devSession helper.DevSession
 					var localPort int


### PR DESCRIPTION
**What type of PR is this:**
/area testing
/kind bug

**What does this PR do / why we need it:**
This lets the OS assign a random ephemeral port to the API Server if `--random-ports` is specified when running `odo dev` or `odo api-server`.
This should hopefully fix the potential port conflict flaky issue we are seeing, especially on Windows.

**Which issue(s) this PR fixes:**
Fixes #6939 

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**