### PR TITLE
Cleanup OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,14 +2,10 @@
 
 approvers:
 - kadel
-- valaparthvi
 - feloy
 - rm3l
-- anandrkskd
 
 reviewers:
 - kadel
-- valaparthvi
 - feloy
 - rm3l
-- anandrkskd

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- valaparthvi
-- rm3l
-- feloy
 - kadel
+- feloy
+- rm3l

--- a/docs/website/OWNERS
+++ b/docs/website/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 reviewers:
-- valaparthvi
-- feloy
 - kadel
+- feloy
 - rm3l

--- a/openshift-ci/build-root/OWNERS
+++ b/openshift-ci/build-root/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- anandrkskd
 - feloy
+- rm3l
 
 reviewers:
-- anandrkskd
 - feloy
+- rm3l

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -1,11 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- rnapoles-rh
-- anandrkskd
-
+- feloy
+- rm3l
 
 reviewers:
-- anandrkskd
-- rnapoles-rh
-- ritudes
+- feloy
+- rm3l

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- anandrkskd
-- rnapoles-rh
+- feloy
+- rm3l
 
 reviewers:
-- rnapoles-rh
-- anandrkskd
-- valaparthvi
 - feloy
-- ritudes
+- rm3l


### PR DESCRIPTION
**What type of PR is this:**

**What does this PR do / why we need it:**
This makes sure the list is accurate, to avoid requesting PR reviews
from people no longer maintaining the project.
Ideally, I would put a GitHub team,
but this does not seem to be supported [1].
It can be done via an additional OWNERS_ALIASES file [2],
but this is yet to be tested.

[1] https://www.kubernetes.dev/docs/guide/owners/
[2] https://www.kubernetes.dev/docs/guide/owners/#owners_aliases

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
