### PR TITLE
Use image selector feature in "Deploying application" guides

### DIFF
--- a/docs/website/docs/user-guides/advanced/deploy/deploy.md
+++ b/docs/website/docs/user-guides/advanced/deploy/deploy.md
@@ -2,7 +2,7 @@
 title: Deploying an Application
 ---
 
-In this guide, we will be using `odo` to deploy to production a "Hello World" application.
+In this guide, we will be using `odo` to run a "Hello World" application into a production-like mode.
 
 You are expected to complete the [quickstart](../../quickstart) guide first with the respective example.
 

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/accessing_application.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/accessing_application.mdx
@@ -1,5 +1,6 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
 
 You can now determine how to access the application by running `odo describe component`:
 
@@ -20,3 +21,41 @@ Check for _Kubernetes Ingresses_ if you are on a Kubernetes cluster or _OpenShif
         </TabItem>
     </Tabs>
 </details>
+
+
+<Tabs groupId="quickstart">
+  <TabItem value="kubernetes" label="Kubernetes">
+
+Since we are using Ingress, we can check if an IP address has been set.
+
+<div>
+<CodeBlock language="console">
+{`
+$ kubectl get ingress my-`}{props.name}{`-app
+NAME            CLASS     HOSTS                ADDRESS      PORTS   AGE
+my-`}{props.name}{`-app   traefik   `}{props.name}{`.example.com   172.19.0.2   80      2m2s
+`}
+</CodeBlock>
+</div>
+
+Once the IP address appears, you can now access the application, like so:
+
+<div>
+<CodeBlock language="console">
+{`curl --resolve "`}{props.name}{`.example.com:80:172.19.0.2" -i http://`}{props.name}{`.example.com/`}
+</CodeBlock>
+</div>
+
+  </TabItem>
+  <TabItem value="openshift" label="OpenShift">
+
+We can directly access the application by using the OpenShift Route displayed in the `odo describe component` output above:
+
+<div>
+<CodeBlock language="console">
+{`curl -i http://my-`}{props.name}{`-app-user-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/`}
+</CodeBlock>
+</div>
+
+</TabItem>
+</Tabs>

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_Dockerfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_Dockerfile.mdx
@@ -1,9 +1,8 @@
-```dockerfile
+```docker
 FROM registry.access.redhat.com/ubi8/dotnet-60:6.0 as builder
 WORKDIR /opt/app-root/src
 COPY --chown=1001 . .
 RUN dotnet publish -c Release
-
 
 FROM registry.access.redhat.com/ubi8/dotnet-60:6.0
 EXPOSE 8080

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_deploy_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_deploy_output.mdx
@@ -6,12 +6,12 @@ $ odo deploy
  /  \__/    odo version: v3.13.0
  \__/
 
-↪ Building & Pushing Container: quay.io/MYUSERNAME/dotnet-odo-example
+↪ Building & Pushing Container: ttl.sh/my-dotnet-app-my-dotnet-app:411242
  •  Building image locally  ...
-build -t quay.io/MYUSERNAME/dotnet-odo-example -f /home/user/quickstart-demo/dotnet-demo/Dockerfile /home/user/quickstart-demo/dotnet-demo
+build -t ttl.sh/my-dotnet-app-my-dotnet-app -f /home/user/quickstart-demo/dotnet-demo/Dockerfile /home/user/quickstart-demo/dotnet-demo
  ✓  Building image locally
  •  Pushing image to container registry  ...
-push quay.io/MYUSERNAME/dotnet-odo-example
+push ttl.sh/my-dotnet-app-my-dotnet-app
  ✓  Pushing image to container registry
 
 ↪ Deploying Kubernetes Component: my-dotnet-app

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_describe_component_kubernetes_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_describe_component_kubernetes_output.mdx
@@ -22,8 +22,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 Kubernetes Ingresses:
  •  my-dotnet-app: dotnet.example.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_describe_component_openshift_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_describe_component_openshift_output.mdx
@@ -22,8 +22,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 OpenShift Routes:
- •  my-dotnet-app: my-dotnet-app-pvala-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+ •  my-dotnet-app: my-dotnet-app-user-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_kubernetes.mdx
@@ -18,6 +18,8 @@ commands:
       kind: run
     workingDir: ${PROJECT_SOURCE}
   id: run
+
+# highlight-start
 # This is the main "composite" command that will run all below commands
 - id: deploy
   composite:
@@ -42,6 +44,7 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 components:
 - container:
     args:
@@ -63,6 +66,8 @@ components:
     image: registry.access.redhat.com/ubi8/dotnet-60:6.0
     mountSources: true
   name: dotnet
+
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -140,6 +145,7 @@ components:
                       name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
+# highlight-end
 metadata:
   description: Stack with .NET 6.0
   displayName: .NET 6.0
@@ -150,6 +156,7 @@ metadata:
   tags:
   - .NET
   version: 1.0.2
+# highlight-next-line
 schemaVersion: 2.2.0
 starterProjects:
 - git:
@@ -160,9 +167,10 @@ starterProjects:
       origin: https://github.com/redhat-developer/s2i-dotnetcore-ex
   name: dotnet60-example
   subDir: app
-# Add the following variables code anywhere in devfile.yaml
+# highlight-start
 variables:
   APP_NAME: my-dotnet-app
   CONTAINER_PORT: "8080"
   DOMAIN_NAME: dotnet.example.com
+# highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_kubernetes.mdx
@@ -70,7 +70,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -79,20 +79,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -111,7 +111,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -119,7 +119,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -127,7 +127,7 @@ components:
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         rules:
           - host: "{{DOMAIN_NAME}}"
@@ -137,7 +137,7 @@ components:
                   pathType: Prefix
                   backend:
                     service:
-                      name: {{RESOURCE_NAME}}
+                      name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
 metadata:
@@ -161,10 +161,8 @@ starterProjects:
   name: dotnet60-example
   subDir: app
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/dotnet-odo-example
-  RESOURCE_NAME: my-dotnet-app
+  APP_NAME: my-dotnet-app
   CONTAINER_PORT: "8080"
   DOMAIN_NAME: dotnet.example.com
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_openshift.mdx
@@ -18,6 +18,7 @@ commands:
       kind: run
     workingDir: ${PROJECT_SOURCE}
   id: run
+# highlight-start
 # This is the main "composite" command that will run all below commands
 - id: deploy
   composite:
@@ -42,6 +43,7 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 components:
 - container:
     args:
@@ -63,6 +65,7 @@ components:
     image: registry.access.redhat.com/ubi8/dotnet-60:6.0
     mountSources: true
   name: dotnet
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -135,6 +138,8 @@ components:
           name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
+
+# highlight-end
 metadata:
   description: Stack with .NET 6.0
   displayName: .NET 6.0
@@ -145,6 +150,7 @@ metadata:
   tags:
   - .NET
   version: 1.0.2
+# highlight-next-line
 schemaVersion: 2.2.0
 starterProjects:
 - git:
@@ -155,8 +161,10 @@ starterProjects:
       origin: https://github.com/redhat-developer/s2i-dotnetcore-ex
   name: dotnet60-example
   subDir: app
-# Add the following variables code anywhere in devfile.yaml
+
+# highlight-start
 variables:
   APP_NAME: my-dotnet-app
   CONTAINER_PORT: "8080"
+# highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/dotnet/dotnet_final_devfile_openshift.mdx
@@ -70,7 +70,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -79,20 +79,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -111,7 +111,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -119,7 +119,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -127,12 +127,12 @@ components:
       apiVersion: route.openshift.io/v1
       kind: Route
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         path: /
         to:
           kind: Service
-          name: {{RESOURCE_NAME}}
+          name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
 metadata:
@@ -156,9 +156,7 @@ starterProjects:
   name: dotnet60-example
   subDir: app
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/dotnet-odo-example
-  RESOURCE_NAME: my-dotnet-app
+  APP_NAME: my-dotnet-app
   CONTAINER_PORT: "8080"
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/editing_devfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/editing_devfile.mdx
@@ -36,6 +36,7 @@ Add the commands used to deploy:
 ```yaml
 # This is the main "composite" command that will run all below commands
 commands:
+# highlight-start
 - id: deploy
   composite:
     commands:
@@ -60,12 +61,14 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 ```
 
 Add the Docker image location as well as Kubernetes Deployment and Service resources to `components`:
 ```yaml
 components:
 
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -125,6 +128,8 @@ components:
         selector:
           app: {{APP_NAME}}
         type: NodePort
+
+# highlight-end
 ```
 
 To be able to access our application we need to add one more `component` to the Devfile.

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/editing_devfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/editing_devfile.mdx
@@ -24,6 +24,8 @@ Add the `variables` and change them appropriately:
 variables:
   APP_NAME: my-`}{props.name}{`-app
   CONTAINER_PORT: "`}{props.port}{`"
+  # The ingress domain name is not necessary when deploying to an OpenShift Cluster.
+  # OpenShift will provide us with a dynamic URL to access the application.
   DOMAIN_NAME: `}{props.name}{`.example.com
 `}
 </CodeBlock>

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/editing_devfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/editing_devfile.mdx
@@ -20,11 +20,9 @@ Add the `variables` and change them appropriately:
 <div>
 <CodeBlock language="yaml">
 {`
-# Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
+# Add the following variables section anywhere in devfile.yaml
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/`}{props.name}{`-odo-example
-  RESOURCE_NAME: my-`}{props.name}{`-app
+  APP_NAME: my-`}{props.name}{`-app
   CONTAINER_PORT: "`}{props.port}{`"
   DOMAIN_NAME: `}{props.name}{`.example.com
 `}
@@ -73,7 +71,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 
 # This will create a Deployment in order to run your container image across
 # the cluster.
@@ -83,20 +81,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -115,7 +113,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -123,7 +121,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 ```
 
@@ -140,7 +138,7 @@ For OpenShift cluster we add Route. For Kubernetes cluster we add Ingress.
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         rules:
           - host: "{{DOMAIN_NAME}}"
@@ -150,7 +148,7 @@ For OpenShift cluster we add Route. For Kubernetes cluster we add Ingress.
                   pathType: Prefix
                   backend:
                     service:
-                      name: {{RESOURCE_NAME}} 
+                      name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
 ```
@@ -164,12 +162,12 @@ For OpenShift cluster we add Route. For Kubernetes cluster we add Ingress.
       apiVersion: route.openshift.io/v1
       kind: Route
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         path: /
         to:
           kind: Service
-          name: {{RESOURCE_NAME}}
+          name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_Dockerfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_Dockerfile.mdx
@@ -1,4 +1,4 @@
-```dockerfile
+```docker
 # This Dockerfile is referenced from:
 # https://github.com/GoogleCloudPlatform/golang-samples/blob/main/run/helloworld/Dockerfile
 

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_deploy_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_deploy_output.mdx
@@ -6,12 +6,12 @@ $ odo deploy
  /  \__/    odo version: v3.13.0
  \__/
 
-↪ Building & Pushing Container: quay.io/MYUSERNAME/go-odo-example
+↪ Building & Pushing Container: ttl.sh/my-go-app-my-go-app:511242
  •  Building image locally  ...
-build -t quay.io/MYUSERNAME/go-odo-example -f /home/user/quickstart-demo/go-demo/Dockerfile /home/user/quickstart-demo/go-demo
+build -t ttl.sh/my-go-app-my-go-app -f /home/user/quickstart-demo/go-demo/Dockerfile /home/user/quickstart-demo/go-demo
  ✓  Building image locally
  •  Pushing image to container registry  ...
-push quay.io/MYUSERNAME/go-odo-example
+push ttl.sh/my-go-app-my-go-app
  ✓  Pushing image to container registry
 
 ↪ Deploying Kubernetes Component: my-go-app

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_describe_component_kubernetes_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_describe_component_kubernetes_output.mdx
@@ -22,8 +22,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 Kubernetes Ingresses:
  •  my-go-app: go.example.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_describe_component_openshift_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_describe_component_openshift_output.mdx
@@ -22,8 +22,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 OpenShift Routes:
- •  my-go-app: my-go-app-pvala-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+ •  my-go-app: my-go-app-user-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_kubernetes.mdx
@@ -65,7 +65,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -74,20 +74,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -105,7 +105,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -113,7 +113,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -121,7 +121,7 @@ components:
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         rules:
           - host: "{{DOMAIN_NAME}}"
@@ -131,7 +131,7 @@ components:
                   pathType: Prefix
                   backend:
                     service:
-                      name: {{RESOURCE_NAME}}
+                      name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
 metadata:
@@ -157,10 +157,8 @@ starterProjects:
       origin: https://github.com/devfile-samples/devfile-stack-go.git
   name: go-starter
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/go-odo-example
-  RESOURCE_NAME: my-go-app
+  APP_NAME: my-go-app
   CONTAINER_PORT: "8080"
   DOMAIN_NAME: go.example.com
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_kubernetes.mdx
@@ -21,6 +21,7 @@ commands:
       kind: run
     workingDir: ${PROJECT_SOURCE}
   id: run
+# highlight-start
 # This is the main "composite" command that will run all below commands
 - id: deploy
   composite:
@@ -45,6 +46,7 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 components:
 - container:
     args:
@@ -58,6 +60,7 @@ components:
     memoryLimit: 1024Mi
     mountSources: true
   name: runtime
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -134,6 +137,7 @@ components:
                       name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
+# highlight-end
 metadata:
   description: Go is an open source programming language that makes it easy to build
     simple, reliable, and efficient software.
@@ -146,7 +150,7 @@ metadata:
   tags:
   - Go
   version: 1.0.2
-# Deploy "kind" ID's use schema 2.2.0+
+# highlight-next-line
 schemaVersion: 2.2.0
 starterProjects:
 - description: A Go project with a simple HTTP server
@@ -156,9 +160,10 @@ starterProjects:
     remotes:
       origin: https://github.com/devfile-samples/devfile-stack-go.git
   name: go-starter
-# Add the following variables code anywhere in devfile.yaml
+# highlight-start
 variables:
   APP_NAME: my-go-app
   CONTAINER_PORT: "8080"
   DOMAIN_NAME: go.example.com
+# highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_openshift.mdx
@@ -21,6 +21,7 @@ commands:
       kind: run
     workingDir: ${PROJECT_SOURCE}
   id: run
+# highlight-start
 # This is the main "composite" command that will run all below commands
 - id: deploy
   composite:
@@ -45,6 +46,7 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 components:
 - container:
     args:
@@ -58,6 +60,7 @@ components:
     memoryLimit: 1024Mi
     mountSources: true
   name: runtime
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -129,6 +132,7 @@ components:
           name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
+# highlight-end
 metadata:
   description: Go is an open source programming language that makes it easy to build
     simple, reliable, and efficient software.
@@ -141,7 +145,7 @@ metadata:
   tags:
   - Go
   version: 1.0.2
-# Deploy "kind" ID's use schema 2.2.0+
+# highlight-next-line
 schemaVersion: 2.2.0
 starterProjects:
 - description: A Go project with a simple HTTP server
@@ -151,8 +155,9 @@ starterProjects:
     remotes:
       origin: https://github.com/devfile-samples/devfile-stack-go.git
   name: go-starter
-# Add the following variables code anywhere in devfile.yaml
+# highlight-start
 variables:
   APP_NAME: my-go-app
   CONTAINER_PORT: "8080"
+# highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/go/go_final_devfile_openshift.mdx
@@ -65,7 +65,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -74,20 +74,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -105,7 +105,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -113,7 +113,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -121,12 +121,12 @@ components:
       apiVersion: route.openshift.io/v1
       kind: Route
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         path: /
         to:
           kind: Service
-          name: {{RESOURCE_NAME}}
+          name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
 metadata:
@@ -152,9 +152,7 @@ starterProjects:
       origin: https://github.com/devfile-samples/devfile-stack-go.git
   name: go-starter
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/go-odo-example
-  RESOURCE_NAME: my-go-app
+  APP_NAME: my-go-app
   CONTAINER_PORT: "8080"
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_Dockerfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_Dockerfile.mdx
@@ -1,4 +1,4 @@
-```dockerfile
+```docker
 FROM registry.access.redhat.com/ubi8/openjdk-11 as builder
 
 USER jboss

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_deploy_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_deploy_output.mdx
@@ -6,12 +6,12 @@ $ odo deploy
  /  \__/    odo version: v3.13.0
  \__/
 
-↪ Building & Pushing Container: quay.io/MYUSERNAME/java-odo-example
+↪ Building & Pushing Container: ttl.sh/my-java-app-my-java-app:611242
  •  Building image locally  ...
-build -t quay.io/MYUSERNAME/java-odo-example -f /home/user/quickstart-demo/java-demo/Dockerfile /home/user/quickstart-demo/java-demo
+build -t ttl.sh/my-java-app-my-java-app -f /home/user/quickstart-demo/java-demo/Dockerfile /home/user/quickstart-demo/java-demo
  ✓  Building image locally [5ms]
  •  Pushing image to container registry  ...
-push quay.io/MYUSERNAME/java-odo-example
+push ttl.sh/my-java-app-my-java-app
  ✓  Pushing image to container registry
 
 ↪ Deploying Kubernetes Component: my-java-app

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_describe_component_kubernetes_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_describe_component_kubernetes_output.mdx
@@ -23,8 +23,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 Kubernetes Ingresses:
  •  my-java-app: java.example.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_describe_component_openshift_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_describe_component_openshift_output.mdx
@@ -23,8 +23,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 OpenShift Routes:
- •  my-java-app: my-java-app-pvala-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+ •  my-java-app: my-java-app-user-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_final_devfile_kubernetes.mdx
@@ -84,7 +84,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -93,20 +93,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -125,7 +125,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -133,7 +133,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -141,7 +141,7 @@ components:
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         rules:
           - host: "{{DOMAIN_NAME}}"
@@ -151,7 +151,7 @@ components:
                   pathType: Prefix
                   backend:
                     service:
-                      name: {{RESOURCE_NAME}}
+                      name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
 # highlight-end
@@ -176,10 +176,8 @@ starterProjects:
   name: springbootproject
 # highlight-start
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/java-odo-example
-  RESOURCE_NAME: my-java-app
+  APP_NAME: my-java-app
   CONTAINER_PORT: "8080"
   DOMAIN_NAME: java.example.com
 # highlight-end

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_final_devfile_kubernetes.mdx
@@ -175,7 +175,6 @@ starterProjects:
       origin: https://github.com/odo-devfiles/springboot-ex.git
   name: springbootproject
 # highlight-start
-# Add the following variables code anywhere in devfile.yaml
 variables:
   APP_NAME: my-java-app
   CONTAINER_PORT: "8080"

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/java/java_final_devfile_openshift.mdx
@@ -84,7 +84,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -93,20 +93,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -125,7 +125,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -133,7 +133,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -141,12 +141,12 @@ components:
       apiVersion: route.openshift.io/v1
       kind: Route
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         path: /
         to:
           kind: Service
-          name: {{RESOURCE_NAME}}
+          name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
 # highlight-end
@@ -171,10 +171,8 @@ starterProjects:
   name: springbootproject
 # highlight-start
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/java-odo-example
-  RESOURCE_NAME: my-java-app
+  APP_NAME: my-java-app
   CONTAINER_PORT: "8080"
 # highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_Dockerfile.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_Dockerfile.mdx
@@ -1,4 +1,4 @@
-```dockerfile
+```docker
 # Sample copied from https://github.com/nodeshift-starters/devfile-sample/blob/main/Dockerfile
 
 # Install the app dependencies in a full Node docker image

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_deploy_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_deploy_output.mdx
@@ -6,12 +6,12 @@ $ odo deploy
  /  \__/    odo version: v3.13.0
  \__/
 
-↪ Building & Pushing Container: quay.io/MYUSERNAME/nodejs-odo-example
+↪ Building & Pushing Container: ttl.sh/my-nodejs-app-my-nodejs-app:611242
  •  Building image locally  ...
-build -t quay.io/MYUSERNAME/nodejs-odo-example -f /home/user/quickstart-demo/nodejs-demo/Dockerfile /home/user/quickstart-demo/nodejs-demo
+build -t ttl.sh/my-nodejs-app-my-nodejs-app -f /home/user/quickstart-demo/nodejs-demo/Dockerfile /home/user/quickstart-demo/nodejs-demo
  ✓  Building image locally
  •  Pushing image to container registry  ...
-push quay.io/MYUSERNAME/nodejs-odo-example
+push ttl.sh/my-nodejs-app-my-nodejs-app
  ✓  Pushing image to container registry
 
 ↪ Deploying Kubernetes Component: my-nodejs-app

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_describe_component_kubernetes_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_describe_component_kubernetes_output.mdx
@@ -22,8 +22,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 Kubernetes Ingresses:
  •  my-go-app: go.example.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_describe_component_openshift_output.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_describe_component_openshift_output.mdx
@@ -22,8 +22,10 @@ Kubernetes components:
  •  outerloop-service
  •  outerloop-url
 
+# highlight-start
 OpenShift Routes:
- •  my-nodejs-app: my-nodejs-app-pvala-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+ •  my-nodejs-app: my-nodejs-app-user-crt-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/
+# highlight-end
 
 
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_kubernetes.mdx
@@ -82,7 +82,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -91,20 +91,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -123,7 +123,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -131,7 +131,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -139,7 +139,7 @@ components:
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         rules:
           - host: "{{DOMAIN_NAME}}"
@@ -149,7 +149,7 @@ components:
                   pathType: Prefix
                   backend:
                     service:
-                      name: {{RESOURCE_NAME}}
+                      name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
 metadata:
@@ -171,10 +171,8 @@ starterProjects:
       origin: https://github.com/odo-devfiles/nodejs-ex.git
   name: nodejs-starter
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/node-odo-example
-  RESOURCE_NAME: my-node-app
+  APP_NAME: my-node-app
   CONTAINER_PORT: "3000"
   DOMAIN_NAME: node.example.com
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_kubernetes.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_kubernetes.mdx
@@ -32,6 +32,7 @@ commands:
       kind: test
     workingDir: ${PROJECT_SOURCE}
   id: test
+# highlight-start
 # This is the main "composite" command that will run all below commands
 - id: deploy
   composite:
@@ -56,6 +57,7 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 components:
 - container:
     args:
@@ -75,6 +77,7 @@ components:
     memoryLimit: 1024Mi
     mountSources: true
   name: runtime
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -152,6 +155,7 @@ components:
                       name: {{APP_NAME}}
                       port:
                         number: {{CONTAINER_PORT}}
+# highlight-end
 metadata:
   description: Stack with Node.js 16
   displayName: Node.js Runtime
@@ -164,15 +168,17 @@ metadata:
   - Express
   - ubi8
   version: 2.1.1
+# highlight-next-line
 schemaVersion: 2.2.0
 starterProjects:
 - git:
     remotes:
       origin: https://github.com/odo-devfiles/nodejs-ex.git
   name: nodejs-starter
-# Add the following variables code anywhere in devfile.yaml
+# highlight-start
 variables:
   APP_NAME: my-node-app
   CONTAINER_PORT: "3000"
   DOMAIN_NAME: node.example.com
+# highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_openshift.mdx
@@ -82,7 +82,7 @@ components:
       buildContext: ${PROJECT_SOURCE}
       rootRequired: false
       uri: ./Dockerfile
-    imageName: "{{CONTAINER_IMAGE}}"
+    imageName: "{{APP_NAME}}"
 # This will create a Deployment in order to run your container image across
 # the cluster.
 - name: outerloop-deployment
@@ -91,20 +91,20 @@ components:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: {{RESOURCE_NAME}}
+            app: {{APP_NAME}}
         template:
           metadata:
             labels:
-              app: {{RESOURCE_NAME}}
+              app: {{APP_NAME}}
           spec:
             containers:
-              - name: {{RESOURCE_NAME}}
-                image: {{CONTAINER_IMAGE}}
+              - name: {{APP_NAME}}
+                image: {{APP_NAME}}
                 ports:
                   - name: http
                     containerPort: {{CONTAINER_PORT}}
@@ -123,7 +123,7 @@ components:
       apiVersion: v1
       kind: Service
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         ports:
         - name: "{{CONTAINER_PORT}}"
@@ -131,7 +131,7 @@ components:
           protocol: TCP
           targetPort: {{CONTAINER_PORT}}
         selector:
-          app: {{RESOURCE_NAME}}
+          app: {{APP_NAME}}
         type: NodePort
 - name: outerloop-url
   kubernetes:
@@ -139,12 +139,12 @@ components:
       apiVersion: route.openshift.io/v1
       kind: Route
       metadata:
-        name: {{RESOURCE_NAME}}
+        name: {{APP_NAME}}
       spec:
         path: /
         to:
           kind: Service
-          name: {{RESOURCE_NAME}}
+          name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
 metadata:
@@ -166,10 +166,8 @@ starterProjects:
       origin: https://github.com/odo-devfiles/nodejs-ex.git
   name: nodejs-starter
 # Add the following variables code anywhere in devfile.yaml
-# This MUST be a container registry you are able to access
 variables:
-  CONTAINER_IMAGE: quay.io/MYUSERNAME/node-odo-example
-  RESOURCE_NAME: my-node-app
+  APP_NAME: my-node-app
   CONTAINER_PORT: "3000"
   DOMAIN_NAME: node.example.com
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_openshift.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/nodejs/nodejs_final_devfile_openshift.mdx
@@ -32,6 +32,7 @@ commands:
       kind: test
     workingDir: ${PROJECT_SOURCE}
   id: test
+# highlight-start
 # This is the main "composite" command that will run all below commands
 - id: deploy
   composite:
@@ -56,6 +57,7 @@ commands:
 - id: k8s-url
   apply:
     component: outerloop-url
+# highlight-end
 components:
 - container:
     args:
@@ -75,6 +77,7 @@ components:
     memoryLimit: 1024Mi
     mountSources: true
   name: runtime
+# highlight-start
 # This will build the container image before deployment
 - name: outerloop-build
   image:
@@ -147,6 +150,7 @@ components:
           name: {{APP_NAME}}
         port:
           targetPort: {{CONTAINER_PORT}}
+# highlight-end
 metadata:
   description: Stack with Node.js 16
   displayName: Node.js Runtime
@@ -159,15 +163,17 @@ metadata:
   - Express
   - ubi8
   version: 2.1.1
+# highlight-next-line
 schemaVersion: 2.2.0
 starterProjects:
 - git:
     remotes:
       origin: https://github.com/odo-devfiles/nodejs-ex.git
   name: nodejs-starter
-# Add the following variables code anywhere in devfile.yaml
+# highlight-start
 variables:
   APP_NAME: my-node-app
   CONTAINER_PORT: "3000"
   DOMAIN_NAME: node.example.com
+# highlight-end
 ```

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
@@ -3,9 +3,31 @@ import TabItem from '@theme/TabItem';
 
 In order to use `odo deploy`, you must be able to build an image as well as push to a registry.
 
-#### Step 1. Login to your container registry
+#### Step 1. Let `odo` know where to push container images
 
-Login to a container registry that you will be pushing your application to:
+`odo` needs to know where to push non-absolute container images declared in the `devfile.yaml` file.
+
+You can configure `odo` with the `odo preference set` command, like so:
+
+```shell
+odo preference set ImageRegistry $registry
+```
+
+<details>
+<summary>Example Output</summary>
+
+```console
+$ odo preference set ImageRegistry ttl.sh
+ ✓  Value of 'imageregistry' preference was set to 'ttl.sh'
+```
+
+</details>
+
+#### Step 2 (Optional). Login to your container registry
+
+If the container registry you registered requires some form of authentication, you will need to login to it.
+
+Note that the cluster you are deploying to also needs to be able to pull images from this registry in order for the application container to be started properly.
 
 <Tabs
 defaultValue="podman"
@@ -55,27 +77,6 @@ Login Succeeded!
 </TabItem>
 
 </Tabs>
-
-
-#### Step 2. Let `odo` know where to push container images
-
-`odo` needs to know where to push non-absolute container images declared in the `devfile.yaml` file.
-
-You can configure `odo` with the `odo preference set` command, like so:
-
-```shell
-odo preference set ImageRegistry $registry
-```
-
-<details>
-<summary>Example Output</summary>
-
-```console
-$ odo preference set ImageRegistry quay.io/$USER
- ✓  Value of 'imageregistry' preference was set to 'quay.io/user'
-```
-
-</details>
 
 #### Step 3. Set the appropriate container build platform
 

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
@@ -19,8 +19,11 @@ values={[
 <TabItem value="podman">
 
 ```shell
-podman login
+podman login $registry
 ```
+
+<details>
+<summary>Example Output</summary>
 
 ```console
 $ podman login quay.io
@@ -29,13 +32,18 @@ Password:
 Login Succeeded!
 ```
 
+</details>
+
 </TabItem>
 
 <TabItem value="docker">
 
 ```shell
-docker login
+docker login $registry
 ```
+
+<details>
+<summary>Example Output</summary>
 
 ```console
 $ docker login docker.io
@@ -43,6 +51,8 @@ Username:
 Password:
 Login Succeeded!
 ```
+
+</details>
 
 </TabItem>
 

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
@@ -1,9 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-**Prerequisites:**
-
-In order to use `odo deploy` you must be able to build an image as well as push to a registry.
+In order to use `odo deploy`, you must be able to build an image as well as push to a registry.
 
 #### Step 1. Login to your container registry
 
@@ -58,7 +56,28 @@ Login Succeeded!
 
 </Tabs>
 
-#### Step 2. Set the appropriate container build platform
+
+#### Step 2. Let `odo` know where to push container images
+
+`odo` needs to know where to push non-absolute container images declared in the `devfile.yaml` file.
+
+You can configure `odo` with the `odo preference set` command, like so:
+
+```shell
+odo preference set ImageRegistry $registry
+```
+
+<details>
+<summary>Example Output</summary>
+
+```console
+$ odo preference set ImageRegistry quay.io/$USER
+ ✓  Value of 'imageregistry' preference was set to 'quay.io/user'
+```
+
+</details>
+
+#### Step 3. Set the appropriate container build platform
 
 Your container image build must match the same architecture as the cluster you are deploying to.
 

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/prerequisites.mdx
@@ -18,7 +18,7 @@ values={[
 
 <TabItem value="podman">
 
-```console
+```shell
 podman login
 ```
 
@@ -33,7 +33,7 @@ Login Succeeded!
 
 <TabItem value="docker">
 
-```console
+```shell
 docker login
 ```
 
@@ -69,7 +69,7 @@ values={[
 
 <TabItem value="linuxamd64">
 
-```console
+```shell
 export ODO_IMAGE_BUILD_ARGS="--platform=linux/amd64"
 ```
 
@@ -77,7 +77,7 @@ export ODO_IMAGE_BUILD_ARGS="--platform=linux/amd64"
 
 <TabItem value="linuxarm64">
 
-```console
+```shell
 export ODO_IMAGE_BUILD_ARGS="--platform=linux/arm64"
 ```
 
@@ -85,7 +85,7 @@ export ODO_IMAGE_BUILD_ARGS="--platform=linux/arm64"
 
 <TabItem value="windowsamd64">
 
-```console
+```shell
 export ODO_IMAGE_BUILD_ARGS="--platform=windows/amd64"
 ```
 

--- a/docs/website/docs/user-guides/advanced/deploy/docs-mdx/running_deploy_description.mdx
+++ b/docs/website/docs/user-guides/advanced/deploy/docs-mdx/running_deploy_description.mdx
@@ -8,3 +8,9 @@ odo deploy
 <summary>Sample Output</summary>
     {props.deployout}
 </details>
+
+
+:::note
+If you are using the [quay.io](https://quay.io/repository/) registry, you might have to change the permissions of the newly pushed image to Public to continue.
+Otherwise, you might see failures related to pulling the image.
+:::

--- a/docs/website/docs/user-guides/advanced/deploy/dotnet.md
+++ b/docs/website/docs/user-guides/advanced/deploy/dotnet.md
@@ -17,11 +17,12 @@ import PreReq from './docs-mdx/prerequisites.mdx';
 
 ## Step 1. Create the initial development application
 
-Complete the [Developing with .Net](/docs/user-guides/quickstart/dotnet) guide before continuing.
+Complete the [Developing with .NET](/docs/user-guides/quickstart/dotnet) guide before continuing.
 
 ## Step 2. Containerize the application
 
 In order to deploy our application, we must containerize it in order to build and push to a registry. Create the following `Dockerfile` in the same directory:
+
 import Dockerfile from './docs-mdx/dotnet/dotnet_Dockerfile.mdx';
 
 <Dockerfile />

--- a/docs/website/docs/user-guides/advanced/deploy/dotnet.md
+++ b/docs/website/docs/user-guides/advanced/deploy/dotnet.md
@@ -55,7 +55,7 @@ import AccessingApplicationDescription from './docs-mdx/accessing_application.md
 import KubernetesDescribeOutput from './docs-mdx/dotnet/dotnet_describe_component_kubernetes_output.mdx';
 import OpenShiftDescribeOutput from './docs-mdx/dotnet/dotnet_describe_component_openshift_output.mdx';
 
-<AccessingApplicationDescription k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
+<AccessingApplicationDescription name="dotnet" k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
 
 ## Step 6. Delete the resources
 

--- a/docs/website/docs/user-guides/advanced/deploy/go.md
+++ b/docs/website/docs/user-guides/advanced/deploy/go.md
@@ -53,7 +53,7 @@ import AccessingApplicationDescription from './docs-mdx/accessing_application.md
 import KubernetesDescribeOutput from './docs-mdx/go/go_describe_component_kubernetes_output.mdx';
 import OpenShiftDescribeOutput from './docs-mdx/go/go_describe_component_openshift_output.mdx';
 
-<AccessingApplicationDescription k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
+<AccessingApplicationDescription name="go" k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
 
 ## Step 6. Delete the resources
 

--- a/docs/website/docs/user-guides/advanced/deploy/java.md
+++ b/docs/website/docs/user-guides/advanced/deploy/java.md
@@ -55,7 +55,7 @@ import AccessingApplicationDescription from './docs-mdx/accessing_application.md
 import KubernetesDescribeOutput from './docs-mdx/java/java_describe_component_kubernetes_output.mdx';
 import OpenShiftDescribeOutput from './docs-mdx/java/java_describe_component_openshift_output.mdx';
 
-<AccessingApplicationDescription k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
+<AccessingApplicationDescription name="java" k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
 
 ## Step 6. Delete the resources
 

--- a/docs/website/docs/user-guides/advanced/deploy/nodejs.md
+++ b/docs/website/docs/user-guides/advanced/deploy/nodejs.md
@@ -55,7 +55,7 @@ import AccessingApplicationDescription from './docs-mdx/accessing_application.md
 import KubernetesDescribeOutput from './docs-mdx/nodejs/nodejs_describe_component_kubernetes_output.mdx';
 import OpenShiftDescribeOutput from './docs-mdx/nodejs/nodejs_describe_component_openshift_output.mdx';
 
-<AccessingApplicationDescription k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
+<AccessingApplicationDescription name="nodejs" k8sdata=<KubernetesDescribeOutput /> ocdata=<OpenShiftDescribeOutput />/>
 
 ## Step 6. Delete the resources
 

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -117,6 +117,7 @@ module.exports = {
     prism: {
       theme: prismReactRenderer.themes.github,
       darkTheme: prismReactRenderer.themes.oceanicNext,
+      additionalLanguages: ['docker'],
     },
     algolia: {
       appId: '7RBQSTPIA4',

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -29,7 +29,7 @@
     "glob-parent": "^6.0.2",
     "node-forge": "^1.3.1",
     "prism-react-renderer": "^2.0.6",
-    "prismjs": "^1.27.0",
+    "prismjs": "^1.29.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-loadable": "^5.5.0",

--- a/docs/website/yarn.lock
+++ b/docs/website/yarn.lock
@@ -6186,7 +6186,7 @@ prism-react-renderer@^2.0.6:
     "@types/prismjs" "^1.26.0"
     clsx "^1.2.1"
 
-prismjs@^1.27.0, prismjs@^1.28.0:
+prismjs@^1.28.0, prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==


### PR DESCRIPTION
**What type of PR is this:**
/area documentation

**What does this PR do / why we need it:**
This makes use of the image-name-as-selector feature in the "Deploy an application" guides. It also enhances other places in the same docs, like:
- syntax highlighting in Dockerfiles
- highlighting places in the Devfile that need to be modified
- detailing the "Accessing the application" section

**Which issue(s) this PR fixes:**
Fixes #6976 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] [Documentation](https://odo-dev-pr-7013.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/docs/user-guides/advanced/deploy/) 

**How to test changes / Special notes to the reviewer:**
See all the guides under "Advanced Usage > Deploying application": https://odo-dev-pr-7013.odo-test-kubernete-449701-49529fc6e6a4a9fe7ebba9a3db5b55c4-0000.eu-de.containers.appdomain.cloud/docs/user-guides/advanced/deploy/
