### PR TITLE
Remove kubeconfig flag

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -25,6 +25,10 @@ import (
 )
 
 func main() {
+	// We need to reinitialize this global variable in case flags are defined by third-party packages
+	// (for example vendor/sigs.k8s.io/controller-runtime/pkg/client/config/config.go)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	// Create a context ready for receiving telemetry data
 	// and save into it configuration based on environment variables
 	ctx := segment.NewContext(context.Background())

--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -58,8 +58,9 @@ func main() {
 
 	// add the completion flags to the root command, though they won't appear in completions
 	root.Flags().AddGoFlagSet(flag.CommandLine)
+
 	// override usage so that flag.Parse uses root command's usage instead of default one when invoked with -h
-	flag.Usage = func() {
+	flag.CommandLine.Usage = func() {
 		_ = root.Help()
 	}
 

--- a/pkg/odo/cli/list/list.go
+++ b/pkg/odo/cli/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -23,8 +22,6 @@ import (
 	"github.com/redhat-developer/odo/pkg/odo/genericclioptions/clientset"
 	"github.com/redhat-developer/odo/pkg/odo/util"
 	odoutil "github.com/redhat-developer/odo/pkg/odo/util"
-
-	dfutil "github.com/devfile/library/v2/pkg/util"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -62,15 +59,6 @@ func (o *ListOptions) SetClientset(clientset *clientset.Clientset) {
 
 // Complete ...
 func (lo *ListOptions) Complete(ctx context.Context, cmdline cmdline.Cmdline, args []string) (err error) {
-
-	// Check to see if KUBECONFIG exists, and if not, error the user that we would not be able to get cluster information
-	// Do this before anything else, or else we will just error out with the:
-	// invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
-	// instead
-	if !dfutil.CheckKubeConfigExist() {
-		return errors.New("KUBECONFIG not found. Unable to retrieve cluster information. Please set your Kubernetes configuration via KUBECONFIG env variable or ~/.kube/config")
-	}
-
 	// If the namespace flag has been passed, we will search there.
 	// if it hasn't, we will search from the default project / namespace.
 	if lo.namespaceFlag != "" {

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -35,10 +35,13 @@ var _ = Describe("odo generic", func() {
 				BeforeEach(func() {
 					output = helper.Cmd("odo", "--help").ShouldPass().Out()
 				})
-				It("retuns full help contents including usage, examples, commands, utility commands, component shortcuts, and flags sections", func() {
+				It("returns full help contents including usage, examples, commands, utility commands, component shortcuts, and flags sections", func() {
 					helper.MatchAllInOutput(output, []string{"Usage:", "Examples:", "Main Commands:", "OpenShift Commands:", "Utility Commands:", "Flags:"})
+					helper.DontMatchAllInOutput(output, []string{"--kubeconfig"})
 				})
-
+				It("does not support the --kubeconfig flag", func() {
+					helper.DontMatchAllInOutput(output, []string{"--kubeconfig"})
+				})
 			})
 
 			When("running odo without subcommand and flags", func() {


### PR DESCRIPTION
**What type of PR is this:**

/kind bug

**What does this PR do / why we need it:**

- --kubeconfig flag was introduced by mistake by using the library controller-runtime.
- This PR removes the check of the KUBECONFIG value for `odo list`, as this value can be a list of files. The check of the KUBECONFIG value is done by the `clientcmd` library used to get the Kubernetes config

**Which issue(s) this PR fixes:**

Fixes #5732
Fixes #6700 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
