### PR TITLE
Fix API Server port detection issue by making sure the same local address is used for listening and checking if the port is available

### DIFF
--- a/pkg/apiserver-impl/starterserver.go
+++ b/pkg/apiserver-impl/starterserver.go
@@ -96,15 +96,16 @@ func StartServer(
 		router.PathPrefix("/").Handler(staticServer)
 	}
 
+	addr := "127.0.0.1"
 	if port == 0 && !randomPort {
-		port, err = util.NextFreePort(20000, 30001, nil, "")
+		port, err = util.NextFreePort(20000, 30001, nil, addr)
 		if err != nil {
 			klog.V(0).Infof("Unable to start the API server; encountered error: %v", err)
 			cancelFunc()
 		}
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr, port))
 	if err != nil {
 		return ApiServer{}, fmt.Errorf("unable to start API Server listener on port %d: %w", port, err)
 	}


### PR DESCRIPTION
**What type of PR is this:**
/kind bug
/area dev

**What does this PR do / why we need it:**
This ensures the same local address is used for listening and checking if a given port is free.
Otherwise, `net.listen("tcp", ":$port")` would listen on `0.0.0.0:$port` (see output below),
and, on some operating systems like Windows 11, `127.0.0.1:$port` is surprisingly considered free.

```
PS C:\Users\asoro> netstat -aon | grep 2000
  TCP    0.0.0.0:20000          0.0.0.0:0              LISTENING       11044
  TCP    127.0.0.1:20001        0.0.0.0:0              LISTENING       11044
  TCP    [::]:20000             [::]:0                 LISTENING       11044
```

This, as a consequence, made it impossible to run multiple Dev Sessions on Windows.

Using the same local address for listening and checking if the port is free would be safer.
If we decide to support passing a custom address to the API Server, we will use that address instead.

**Which issue(s) this PR fixes:**
Fixes #6721 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
It should be possible to start several Dev Sessions on Windows. See https://github.com/redhat-developer/odo/issues/6721#issuecomment-1693354838