### PR TITLE
Use multiarch image for postgresql instance

### DIFF
--- a/tests/examples/manifests/bindablekind-instance.yaml
+++ b/tests/examples/manifests/bindablekind-instance.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-sample
 spec:
+  imageName: quay.io/enterprisedb/postgresql:15.3-multiarch
   logLevel: info
   startDelay: 30
   stopDelay: 30

--- a/tests/examples/source/devfiles/go/cluster.yaml
+++ b/tests/examples/source/devfiles/go/cluster.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-example-initdb
 spec:
+  imageName: quay.io/enterprisedb/postgresql:15.3-multiarch
   bootstrap:
     initdb:
       database: appdb


### PR DESCRIPTION
**What type of PR is this:**

Sets a multiarch image for PostgreSQL Cluster instances, used during tests

/area testing

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #7034

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
