### PR TITLE
Fix potential namespace name collision issue with `odo create/delete/list/set namespace/project` tests

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -362,8 +362,8 @@ func JsonPathContentHasLen(json string, path string, len int) {
 	Expect(intVal).To(Equal(len), fmt.Sprintf("%q should contain exactly %d elements", path, len))
 }
 
-// GetProjectName sets projectNames based on the name of the test file name (without path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
-func GetProjectName() string {
+// GenerateProjectName generates a new projectName based on the name of the test file name (without path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
+func GenerateProjectName() string {
 	//Get current test filename and remove file path, file extension and replace undescores with hyphens
 	currGinkgoTestFileName := strings.Replace(strings.Split(strings.Split(CurrentSpecReport().
 		ContainerHierarchyLocations[0].FileName, "/")[len(strings.Split(CurrentSpecReport().ContainerHierarchyLocations[0].FileName, "/"))-1], ".")[0], "_", "-", -1)

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -298,7 +298,7 @@ func CommonAfterEach(commonVar CommonVar) {
 		}
 	}
 
-	if commonVar.Project != "" {
+	if commonVar.Project != "" && commonVar.CliRunner.HasNamespaceProject(commonVar.Project) {
 		// delete the random project/namespace created in CommonBeforeEach
 		commonVar.CliRunner.DeleteNamespaceProject(commonVar.Project, false)
 	}

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -167,7 +167,7 @@ func (kubectl KubectlRunner) GetServices(namespace string) string {
 
 // CreateAndSetRandNamespaceProject create and set new project
 func (kubectl KubectlRunner) CreateAndSetRandNamespaceProject() string {
-	projectName := GetProjectName()
+	projectName := GenerateProjectName()
 	kubectl.createAndSetRandNamespaceProject(projectName)
 	return projectName
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -173,11 +173,15 @@ func (kubectl KubectlRunner) CreateAndSetRandNamespaceProject() string {
 }
 
 func (kubectl KubectlRunner) createAndSetRandNamespaceProject(projectName string) string {
-	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
-	Cmd("kubectl", "create", "namespace", projectName).ShouldPass()
+	if kubectl.HasNamespaceProject(projectName) {
+		fmt.Fprintf(GinkgoWriter, "Namespace %q already exists\n", projectName)
+	} else {
+		fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
+		Cmd("kubectl", "create", "namespace", projectName).ShouldPass()
+	}
 	Cmd("kubectl", "config", "set-context", "--current", "--namespace", projectName).ShouldPass()
-	session := Cmd("kubectl", "get", "namespaces").ShouldPass().Out()
-	Expect(session).To(ContainSubstring(projectName))
+	// ListNamespaceProject makes sure that project eventually appears in the list of all namespaces/projects.
+	kubectl.ListNamespaceProject(projectName)
 	kubectl.addConfigMapForCleanup(projectName) // add configmap for cleanup
 	return projectName
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -337,9 +337,15 @@ func (oc OcRunner) CreateAndSetRandNamespaceProjectOfLength(i int) string {
 }
 
 func (oc OcRunner) createAndSetRandNamespaceProject(projectName string) string {
-	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
-	session := Cmd(oc.path, "new-project", projectName).ShouldPass().Out()
-	Expect(session).To(ContainSubstring(projectName))
+	if oc.HasNamespaceProject(projectName) {
+		fmt.Fprintf(GinkgoWriter, "Project %q already exists\n", projectName)
+	} else {
+		fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
+		session := Cmd(oc.path, "new-project", projectName).ShouldPass().Out()
+		Expect(session).To(ContainSubstring(projectName))
+	}
+	// ListNamespaceProject makes sure that project eventually appears in the list of all namespaces/projects.
+	oc.ListNamespaceProject(projectName)
 	oc.addConfigMapForCleanup(projectName)
 	return projectName
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -324,7 +324,7 @@ func (oc OcRunner) VerifyResourceToBeDeleted(ri ResourceInfo) {
 
 // CreateAndSetRandNamespaceProject create and set new project
 func (oc OcRunner) CreateAndSetRandNamespaceProject() string {
-	projectName := GetProjectName()
+	projectName := GenerateProjectName()
 	oc.createAndSetRandNamespaceProject(projectName)
 	return projectName
 }

--- a/tests/helper/helper_podman.go
+++ b/tests/helper/helper_podman.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
+
 	"github.com/redhat-developer/odo/pkg/podman"
 )
 
@@ -28,7 +29,7 @@ func GenerateAndSetContainersConf(dir string) {
 	if !useNamespaces {
 		return
 	}
-	ns := GetProjectName()
+	ns := GenerateProjectName()
 	containersConfPath := filepath.Join(dir, "containers.conf")
 	err := CreateFileWithContent(containersConfPath, fmt.Sprintf(`
 [engine]

--- a/tests/helper/odo_utils.go
+++ b/tests/helper/odo_utils.go
@@ -34,7 +34,7 @@ func GetPreferenceValue(key string) string {
 // CreateRandProject create new project with random name (10 letters)
 // without writing to the config file (without switching project)
 func CreateRandProject() string {
-	projectName := GetProjectName()
+	projectName := GenerateProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	session := Cmd("odo", "create", "project", projectName, "-w", "-v4").ShouldPass().Out()
 	Expect(session).To(ContainSubstring("New project created"))

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -81,6 +81,12 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 					Expect(commonVar.CliRunner.HasNamespaceProject(namespace)).To(BeTrue())
 				})
 
+				AfterEach(func() {
+					if commonVar.CliRunner.HasNamespaceProject(namespace) {
+						commonVar.CliRunner.DeleteNamespaceProject(namespace, false)
+					}
+				})
+
 				checkNsDeletionFunc := func(wait bool, nsCheckerFunc func()) {
 					args := []string{"delete", commandName, namespace, "--force"}
 					if wait {

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -30,7 +30,7 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 		// Ref: https://github.com/redhat-developer/odo/issues/6827
 		var namespace string
 		BeforeEach(func() {
-			namespace = helper.GetProjectName()
+			namespace = helper.GenerateProjectName()
 			helper.Cmd("odo", "create", "namespace", namespace, "--wait").ShouldPass()
 		})
 

--- a/tests/integration/cmd_namespace_test.go
+++ b/tests/integration/cmd_namespace_test.go
@@ -33,6 +33,11 @@ var _ = Describe("odo create/delete/list/set namespace/project tests", func() {
 			namespace = helper.GetProjectName()
 			helper.Cmd("odo", "create", "namespace", namespace, "--wait").ShouldPass()
 		})
+
+		AfterEach(func() {
+			commonVar.CliRunner.DeleteNamespaceProject(namespace, false)
+		})
+
 		It("should list the new namespace when listing namespace", func() {
 			out := helper.Cmd("odo", "list", "namespace").ShouldPass().Out()
 			Expect(out).To(ContainSubstring(namespace))


### PR DESCRIPTION
**What type of PR is this:**

/area testing

**What does this PR do / why we need it:**
A random namespace/project was created in the `namespace is created with -w` tests, but never deleted, thus increasing the likelihood of name collisions upon several subsequent runs.
This PR makes sure to delete such namespace/project and also makes other changes to be better resilient to similar issues in the future.

**Which issue(s) this PR fixes:**
Fixes #7044

**PR acceptance criteria:**

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
