### PR TITLE
Make sure to run parallel commands part of a composite command in parallel

### DIFF
--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -230,7 +230,7 @@ func (do *DeleteComponentClient) ExecutePreStopEvents(ctx context.Context, devfi
 	)
 	err = libdevfile.ExecPreStopEvents(ctx, devfileObj, handler)
 	if err != nil {
-		klog.V(4).Infof("Failed to execute %q event commands for component %q, cause: %v", libdevfile.PreStop, componentName, err.Error())
+		log.Warningf("Failed to execute %q event commands for component %q, cause: %v", libdevfile.PreStop, componentName, err.Error())
 	}
 
 	return nil

--- a/pkg/libdevfile/command.go
+++ b/pkg/libdevfile/command.go
@@ -33,8 +33,9 @@ func newCommand(devfileObj parser.DevfileObj, devfileCmd v1alpha2.Command) (comm
 	case v1alpha2.CompositeCommandType:
 		if util.SafeGetBool(devfileCmd.Composite.Parallel) {
 			cmd = newParallelCompositeCommand(devfileObj, devfileCmd)
+		} else {
+			cmd = newCompositeCommand(devfileObj, devfileCmd)
 		}
-		cmd = newCompositeCommand(devfileObj, devfileCmd)
 
 	case v1alpha2.ExecCommandType:
 		cmd = newExecCommand(devfileObj, devfileCmd)

--- a/pkg/libdevfile/command_composite_parallel.go
+++ b/pkg/libdevfile/command_composite_parallel.go
@@ -52,7 +52,7 @@ func (o *parallelCompositeCommand) Execute(ctx context.Context, handler Handler,
 	}
 	commandExecs := util.NewConcurrentTasks(len(o.command.Composite.Commands))
 	for _, devfileCmd := range o.command.Composite.Commands {
-		cmd, err2 := newCommand(o.devfileObj, allCommands[devfileCmd])
+		cmd, err2 := newCommand(o.devfileObj, allCommands[strings.ToLower(devfileCmd)])
 		if err2 != nil {
 			return err2
 		}


### PR DESCRIPTION
**What type of PR is this:**

/kind bug
/area devfile-spec

**What does this PR do / why we need it:**

**Which issue(s) this PR fixes:**
Fixes #6681 

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
See the repro steps in #6681. With the changes in this PR, the output of `odo dev` should reflect that the commands are running in parallel:
```
$ odo init \
  --name my-component-with-parallel-commands \
  --devfile-path https://gist.githubusercontent.com/rm3l/5691e926a4cfe37e369d93695187bdd6/raw/95abc768e83bd83e7acda035a6053f57b20f4939/devfile-with-parallel-commands.yaml

$ odo dev

[...]
 •  Waiting for Kubernetes resources  ...
 ⚠  Pod is Pending
 ✓  Pod is Running
 ✓  Syncing files into the container [57ms]
 ✓  Building your application in container (command: exec-3) [40ms]
 ✓  Building your application in container (command: exec-2) [41ms]
 ✓  Building your application in container (command: exec-1) [5s]
 •  Executing the application (command: run-1)  ...
 •  Executing the application (command: run-3)  ...
 •  Executing the application (command: run-2)  ...
 ✓  Finished executing the application (command: run-3) [145ms]
 ✓  Finished executing the application (command: run-2) [145ms]
 ✓  Finished executing the application (command: run-1) [5s]

p

Pushing files...

 •  Waiting for Kubernetes resources  ...
 ✓  Syncing files into the container 
 ✓  Building your application in container (command: exec-2) [30ms]
 ✓  Building your application in container (command: exec-3) [30ms]
 ✓  Building your application in container (command: exec-1) [5s]
 •  Executing the application (command: run-2)  ...
 •  Executing the application (command: run-3)  ...
 •  Executing the application (command: run-1)  ...
 ✓  Finished executing the application (command: run-3) [2s]
 ✓  Finished executing the application (command: run-2) [2s]
 ✓  Finished executing the application (command: run-1) [7s]
[...]
```