### PR TITLE
Group Dependabot updates to `@docusaurus/*` together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
     # and it does not necessarily make sense to run all the Prow tests here.
     - "area/dependency"
     - "kind/task"
+  groups:
+    # See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
+    docusaurus:
+      patterns:
+        - "@docusaurus*"
 
 ## Feel free to add other package managers here if needed.
 ## See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem


### PR DESCRIPTION
**What type of PR is this:**
/area dependency

**What does this PR do / why we need it:**
This prevents warning messages displayed by Docusaurus when all the `@docusaurus/*` versions are not the same. This avoids having to manually do so (needed in https://github.com/redhat-developer/odo/pull/7112#issuecomment-1761753913), like in https://github.com/redhat-developer/odo/pull/6877#issuecomment-1586793246

Per https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/, Dependabot can create a single PR grouping multiple updates.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
