### PR TITLE
Instruct Dependabot to maintain dependencies for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,21 @@ updates:
       patterns:
         - "@docusaurus*"
 
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: "github-actions"
+  directory: "/"
+  # Set this to 0 to disable version updates
+  open-pull-requests-limit: 1
+  commit-message:
+    prefix: "GitHub Actions"
+  schedule:
+    interval: "weekly"
+  reviewers:
+  - "redhat-developer/odo-mantainers"
+  labels:
+  - "area/dependency"
+  - "kind/task"
+
 ## Feel free to add other package managers here if needed.
 ## See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
 ## for the full list of supported ecosystems.


### PR DESCRIPTION
**What type of PR is this:**
/kind task
/area dependency

**What does this PR do / why we need it:**
This instructs Dependabot to maintain dependencies for GitHub Actions as well. I noticed that some of the versions there are a bit outdated.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
