### PR TITLE
Show last update date on documentation pages

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -134,6 +134,8 @@ module.exports = {
           breadcrumbs: true,
           sidebarCollapsible: true,
           lastVersion: 'current',
+          showLastUpdateTime: true,
+          showLastUpdateAuthor: false,
           exclude: [
               '**/docs-mdx/**',
               '**/_*.{js,jsx,ts,tsx,md,mdx}',


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**
/area documentation

**What does this PR do / why we need it:**
This shows information about the last update on all documentation pages.
This can be useful to quickly determine if some page is still up-to-date or not.

**Which issue(s) this PR fixes:**
&mdash;

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer:**

**Preview**:

![image](https://github.com/redhat-developer/odo/assets/593208/e74d045f-ece0-429f-8924-9f5117323aaf)
