### PR TITLE
Fix issue with OpenShift CI Interop tests failing due to error with glibc when executing any `oc` command

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.15
 
 RUN yum -y install make wget gcc git httpd-tools

--- a/openshift-ci/build-root/README.md
+++ b/openshift-ci/build-root/README.md
@@ -1,5 +1,4 @@
 # Base Image for running tests on OpenShift CI
 
-This image is meant to be used as build root for tests on [OpenShift CI](https://github.com/openshift/release/blob/master/ci-operator/config/redhat-developer/odo/redhat-developer-odo-master.yaml)
-You can find out more in the [
-](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md)
+This image is meant to be used as build root for tests on [OpenShift CI](https://github.com/openshift/release/blob/master/ci-operator/config/redhat-developer/odo/)
+You can find out more in the [CI Operator docs](https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image) ([archived link](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#build_root)).


### PR DESCRIPTION
Use build root tag compatible with oc 4.16 (and below).

Fixes #7242 