### PR TITLE
fix: manage podman inspect result as a list also

### DIFF
--- a/pkg/podman/inspect.go
+++ b/pkg/podman/inspect.go
@@ -42,5 +42,8 @@ func (o *PodmanCli) PodInspect(podname string) (PodInspectData, error) {
 		return singleResult, err
 	}
 
-	return result[0], err
+	if len(result) == 0 {
+		return PodInspectData{}, nil
+	}
+	return result[0], nil
 }

--- a/pkg/podman/inspect.go
+++ b/pkg/podman/inspect.go
@@ -35,7 +35,8 @@ func (o *PodmanCli) PodInspect(podname string) (PodInspectData, error) {
 	}
 
 	var result []PodInspectData
-	if err := json.Unmarshal(out, &result); err != nil {
+	err = json.Unmarshal(out, &result)
+	if err != nil {
 		var singleResult PodInspectData
 		err = json.Unmarshal(out, &singleResult)
 		return singleResult, err

--- a/pkg/podman/inspect.go
+++ b/pkg/podman/inspect.go
@@ -34,8 +34,12 @@ func (o *PodmanCli) PodInspect(podname string) (PodInspectData, error) {
 		return PodInspectData{}, err
 	}
 
-	var result PodInspectData
+	var result []PodInspectData
+	if err := json.Unmarshal(out, &result); err != nil {
+		var singleResult PodInspectData
+		err = json.Unmarshal(out, &singleResult)
+		return singleResult, err
+	}
 
-	err = json.Unmarshal(out, &result)
-	return result, err
+	return result[0], err
 }


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Here are some things you need to know before submitting:

1. Please read our developer guideline: https://github.com/redhat-developer/odo/wiki/Dev:-odo-Dev-Guidelines
2. Label this PR accordingly with the '/kind' line
3. Ensure you have written and ran the appropriate tests: https://github.com/redhat-developer/odo/wiki/Dev:-Writing-and-running-tests
4. Read how we approve and LGTM each PR: https://github.com/redhat-developer/odo/wiki/Pull-Requests:-Review-guideline

Documentation:

If you are pushing a change to documentation, please read: https://github.com/redhat-developer/odo/wiki/Documentation:-Contributing
-->

**What type of PR is this:**

/kind bug
/area odo-on-podman
<!--
Add one of the following kinds:
/kind bug
/kind feature

Additionally, add one or more [`area/*` label(s)](https://github.com/redhat-developer/odo/labels?q=area%2F) if applicable. For example:
/area documentation
/area testing
/area refactoring

Feel free to use other [labels](https://github.com/redhat-developer/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.
-->

**What does this PR do / why we need it:**

This PR addresses an issue when using the `odo` commands with Podman, specifically related to the `podman pod inspect` command. Due to a recent change in Podman (see [podman PR #21514](https://github.com/containers/podman/pull/21514)), the output now returns a JSON array instead of a JSON object. This PR modifies `odo` to correctly handle this change, preventing errors in commands like `odo debug` and `odo logs` when running on Podman.

**Which issue(s) this PR fixes:**
<!-- 
Specifying the issue will automatically close it when this PR is merged
-->

Fixes #7252

**PR acceptance criteria:**

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer:**
