### PR TITLE
Migrate from klog v1 to klog/v2 and honor stderrthreshold

### DIFF
--- a/cmd/odo/common_test.go
+++ b/cmd/odo/common_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/sethvargo/go-envconfig"
 

--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -21,7 +21,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/preference"
 	segment "github.com/redhat-developer/odo/pkg/segment/context"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {
@@ -41,6 +41,8 @@ func main() {
 
 	// create the complete command
 	klog.InitFlags(nil)
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false")
+	_ = flag.Set("stderrthreshold", "INFO")
 
 	root, err := cli.NewCmdOdo(ctx, cli.OdoRecommendedName, cli.OdoRecommendedName, func(err error) {
 		util.LogErrorAndExit(err, "")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/redhat-developer/odo
 
-go 1.19
+go 1.21
+
+toolchain go1.24.6
 
 require (
 	github.com/ActiveState/termtest v0.7.2
@@ -65,8 +67,7 @@ require (
 	k8s.io/apimachinery v0.27.3
 	k8s.io/cli-runtime v0.24.0
 	k8s.io/client-go v0.27.2
-	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.100.1
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubectl v0.24.0
 	k8s.io/pod-security-admission v0.26.10
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
@@ -218,6 +219,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/apiserver v0.27.2 // indirect
 	k8s.io/component-base v0.27.2 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2 h1:x8Brv0YNEe6jY3V/hQglIG2nd8g5E2Zj5ubGKkPQctQ=
 github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2/go.mod h1:XyjUkMA8GN+tOOPXvnbi3XuRxWFvTJntqvTFnjmhzbk=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
+github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Xuanwo/go-locale v1.1.0 h1:51gUxhxl66oXAjI9uPGb2O0qwPECpriKQb2hl35mQkg=
 github.com/Xuanwo/go-locale v1.1.0/go.mod h1:UKrHoZB3FPIk9wIG2/tVSobnHgNnceGSH3Y8DY5cASs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -102,6 +103,7 @@ github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPp
 github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5 h1:P5U+E4x5OkVEKQDklVPmzs71WM56RTTRqV4OrDC//Y4=
 github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
@@ -132,9 +134,13 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
+github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
+github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
+github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
+github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/ccojocar/zxcvbn-go v1.0.1 h1:+sxrANSCj6CdadkcMnvde/GWU1vZiiXRbqYSCalV4/4=
 github.com/ccojocar/zxcvbn-go v1.0.1/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQdw6Qnz/hi60=
@@ -171,9 +177,11 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
+github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.13 h1:wPYKIeGMN8vaggSKuV1X0wZulpMz4CrgEsZdaCyB6Is=
 github.com/containerd/containerd v1.7.13/go.mod h1:zT3up6yTRfEUa6+GsITYIJNgSVL9NQ4x4h1RPzk0Wu4=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=
+github.com/containerd/continuity v0.4.3/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
@@ -244,16 +252,19 @@ github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNk
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
+github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
+github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
+github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emicklei/dot v0.15.0 h1:XDBW0Xco1QNyRb33cqLe10cT04yMWL1XpCZfa98Q6Og=
 github.com/emicklei/dot v0.15.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -310,6 +321,7 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
+github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/go-bindata/go-bindata/v3 v3.1.3/go.mod h1:1/zrpXsLD8YDIbhZRqXzm1Ghc7NhEvIN9+Z6R5/xH4I=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -318,6 +330,7 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmS
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
+github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.11.0 h1:XIZc1p+8YzypNr34itUfSvYJcv+eYdTnTvOZ2vD3cA4=
 github.com/go-git/go-git/v5 v5.11.0/go.mod h1:6GFcX2P3NM7FPBfpePbpLd21XxsgdAt+lKqXmCUiUCY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -427,6 +440,7 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/gomodule/redigo v1.8.2 h1:H5XSIre1MB5NbPYFp+i1NBbb5qN1W8Y8YAQoAYbkm8k=
+github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
@@ -537,6 +551,7 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -603,6 +618,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
@@ -615,6 +631,7 @@ github.com/kubernetes-sigs/go-open-service-broker-client v0.0.0-20200527163240-4
 github.com/kubernetes-sigs/service-catalog v0.3.1 h1:jgE7b16OqBjxG3BScxqQYl5zkx7D+myMjXHIN0EpAqY=
 github.com/kubernetes-sigs/service-catalog v0.3.1/go.mod h1:MUAf+rdT06kiNpLXRAIqtPHC3Kgkw63YziVj1VMu3HM=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
@@ -677,6 +694,7 @@ github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQ
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.7.1 h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g=
+github.com/moby/sys/mountinfo v0.7.1/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
@@ -771,6 +789,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721/go.mod h1:jQyRpOpE/KbvPc0VKXjAqctYglwUO5W6zAcGcFfbvlo=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -835,6 +854,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
@@ -907,6 +927,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -956,8 +977,11 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 h1:+lm10QQTNSBd8DVTNGHx7o/IKu9HYDvLMffDhbyLccI=
+github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMztlGpl/VA+Zm1AcTPHYkHJPbHqE6WJUXE=
+github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=
+github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97yms=
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -982,6 +1006,7 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
+go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUzl5H4LY0Kc=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.25.0/go.mod h1:E5NNboN0UqSAki0Atn9kVwaN7I+l25gGxDqBueo/74E=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0/go.mod h1:h8TWwRAhQpOd0aM5nYsRD8+flnkj+526GEIVlarH7eY=
@@ -1032,6 +1057,7 @@ go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ
 go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
@@ -1583,6 +1609,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -1621,6 +1648,7 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -1666,8 +1694,8 @@ k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.60.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
-k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kms v0.26.1/go.mod h1:ReC1IEGuxgfN+PDCIpR6w8+XMmDE7uJhxcCwMZFdIYc=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=

--- a/pkg/alizer/alizer.go
+++ b/pkg/alizer/alizer.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/devfile/alizer/pkg/apis/recognizer"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/registry"

--- a/pkg/apiserver-gen/go/logger.go
+++ b/pkg/apiserver-gen/go/logger.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func Logger(inner http.Handler, name string) http.Handler {

--- a/pkg/apiserver-impl/api_default_service.go
+++ b/pkg/apiserver-impl/api_default_service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/segment"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/state"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // DefaultApiService is a service that implements the logic for the DefaultApiServicer

--- a/pkg/apiserver-impl/sse/notifications.go
+++ b/pkg/apiserver-impl/sse/notifications.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	openapi "github.com/redhat-developer/odo/pkg/apiserver-gen/go"
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"

--- a/pkg/apiserver-impl/sse/watcher.go
+++ b/pkg/apiserver-impl/sse/watcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/fsnotify/fsnotify"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (n *Notifier) watchDevfileChanges(ctx context.Context, devfileFiles []string) error {

--- a/pkg/apiserver-impl/starterserver.go
+++ b/pkg/apiserver-impl/starterserver.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	openapi "github.com/redhat-developer/odo/pkg/apiserver-gen/go"
 	"github.com/redhat-developer/odo/pkg/apiserver-impl/sse"

--- a/pkg/binding/backend/interactive.go
+++ b/pkg/binding/backend/interactive.go
@@ -7,7 +7,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/binding/asker"
 	"github.com/redhat-developer/odo/pkg/kclient"

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	bindingApis "github.com/redhat-developer/service-binding-operator/apis"
 	bindingApi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"

--- a/pkg/component/apply_kubernetes.go
+++ b/pkg/component/apply_kubernetes.go
@@ -6,7 +6,7 @@ import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	devfilefs "github.com/devfile/library/v2/pkg/testingutil/filesystem"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
 	odolabels "github.com/redhat-developer/odo/pkg/labels"

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/alizer"
 	"github.com/redhat-developer/odo/pkg/api"

--- a/pkg/component/delete/delete.go
+++ b/pkg/component/delete/delete.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/component"
 	"github.com/redhat-developer/odo/pkg/configAutomount"

--- a/pkg/component/describe/describe.go
+++ b/pkg/component/describe/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/generator"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/component"

--- a/pkg/component/execute_new_container.go
+++ b/pkg/component/execute_new_container.go
@@ -21,7 +21,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
 

--- a/pkg/component/execute_run.go
+++ b/pkg/component/execute_run.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/exec"
 	"github.com/redhat-developer/odo/pkg/log"

--- a/pkg/component/execute_terminating.go
+++ b/pkg/component/execute_terminating.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/machineoutput"
 	"github.com/redhat-developer/odo/pkg/platform"
 	"github.com/redhat-developer/odo/pkg/util"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
 

--- a/pkg/component/handler.go
+++ b/pkg/component/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	envcontext "github.com/redhat-developer/odo/pkg/config/context"
 	"github.com/redhat-developer/odo/pkg/configAutomount"

--- a/pkg/dev/kubedev/components.go
+++ b/pkg/dev/kubedev/components.go
@@ -38,7 +38,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
 

--- a/pkg/dev/kubedev/innerloop.go
+++ b/pkg/dev/kubedev/innerloop.go
@@ -20,7 +20,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/sync"
 	"github.com/redhat-developer/odo/pkg/watch"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (o *DevClient) innerloop(ctx context.Context, parameters common.PushParameters, componentStatus *watch.ComponentStatus) error {

--- a/pkg/dev/kubedev/kubedev.go
+++ b/pkg/dev/kubedev/kubedev.go
@@ -21,7 +21,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 	"github.com/redhat-developer/odo/pkg/watch"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type DevClient struct {

--- a/pkg/dev/kubedev/run.go
+++ b/pkg/dev/kubedev/run.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/redhat-developer/odo/pkg/dev/common"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (o *DevClient) Run(

--- a/pkg/dev/kubedev/utils/utils.go
+++ b/pkg/dev/kubedev/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	devfileParser "github.com/devfile/library/v2/pkg/devfile/parser"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"github.com/redhat-developer/odo/pkg/storage"

--- a/pkg/dev/podmandev/pod.go
+++ b/pkg/dev/podmandev/pod.go
@@ -23,7 +23,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // See https://github.com/devfile/developer-images and https://quay.io/repository/devfile/base-developer-image?tab=tags

--- a/pkg/dev/podmandev/podmandev.go
+++ b/pkg/dev/podmandev/podmandev.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/dev"
 	"github.com/redhat-developer/odo/pkg/dev/common"

--- a/pkg/dev/podmandev/reconcile.go
+++ b/pkg/dev/podmandev/reconcile.go
@@ -26,7 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (o *DevClient) reconcile(

--- a/pkg/dev/podmandev/run.go
+++ b/pkg/dev/podmandev/run.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/redhat-developer/odo/pkg/dev/common"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (o *DevClient) Run(

--- a/pkg/devfile/image/docker_compatible.go
+++ b/pkg/devfile/image/docker_compatible.go
@@ -9,7 +9,7 @@ import (
 
 	devfile "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/fatih/color"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	dfutil "github.com/devfile/library/v2/pkg/util"
 

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -7,7 +7,7 @@ import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	v2 "github.com/devfile/library/v2/pkg/devfile/parser/data/v2"
 	parsercommon "github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // ValidateDevfileData validates whether sections of devfile are odo compatible

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/term"
 
 	"github.com/redhat-developer/odo/pkg/log"

--- a/pkg/init/backend/applicationports.go
+++ b/pkg/init/backend/applicationports.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 )

--- a/pkg/init/backend/flags.go
+++ b/pkg/init/backend/flags.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"github.com/redhat-developer/odo/pkg/registry"

--- a/pkg/init/backend/interactive.go
+++ b/pkg/init/backend/interactive.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 	dfutil "github.com/devfile/library/v2/pkg/util"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/alizer"
 	"github.com/redhat-developer/odo/pkg/api"

--- a/pkg/kclient/all.go
+++ b/pkg/kclient/all.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Code into this file is heavily inspired from https://github.com/ahmetb/kubectl-tree

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	odolabels "github.com/redhat-developer/odo/pkg/labels"
 )

--- a/pkg/kclient/dynamic.go
+++ b/pkg/kclient/dynamic.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // PatchDynamicResource patches a dynamic custom resource and returns true

--- a/pkg/kclient/jobs.go
+++ b/pkg/kclient/jobs.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // constants for volumes

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	// api clientsets
 	servicecatalogclienset "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"

--- a/pkg/kclient/namespace.go
+++ b/pkg/kclient/namespace.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/pod-security-admission/api"
 	psaApi "k8s.io/pod-security-admission/api"
 )

--- a/pkg/kclient/oc_server.go
+++ b/pkg/kclient/oc_server.go
@@ -13,7 +13,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // isServerUp returns true if server is up and running

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -16,7 +16,7 @@ import (
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // IsCSVSupported checks if resource of type service binding request present on the cluster

--- a/pkg/kclient/projects.go
+++ b/pkg/kclient/projects.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/kclient/registry.go
+++ b/pkg/kclient/registry.go
@@ -9,7 +9,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (c *Client) GetRegistryList() ([]api.Registry, error) {

--- a/pkg/kclient/secrets.go
+++ b/pkg/kclient/secrets.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/kclient/user.go
+++ b/pkg/kclient/user.go
@@ -8,7 +8,7 @@ import (
 	oauthv1client "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // RunLogout logs out the current user from cluster

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -9,7 +9,7 @@ import (
 	dfutil "github.com/devfile/library/v2/pkg/util"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/version"
 )

--- a/pkg/libdevfile/libdevfile.go
+++ b/pkg/libdevfile/libdevfile.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 	devfilefs "github.com/devfile/library/v2/pkg/testingutil/filesystem"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/util"
 )

--- a/pkg/machineoutput/event_logging.go
+++ b/pkg/machineoutput/event_logging.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/log"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // FormatTime returns time in UTC Unix Epoch Seconds and then the microsecond portion of that time.

--- a/pkg/odo/cli/apiserver/apiserver.go
+++ b/pkg/odo/cli/apiserver/apiserver.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	apiserver_impl "github.com/redhat-developer/odo/pkg/apiserver-impl"
 	"github.com/redhat-developer/odo/pkg/libdevfile"

--- a/pkg/odo/cli/create/namespace/namespace.go
+++ b/pkg/odo/cli/create/namespace/namespace.go
@@ -6,7 +6,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/project"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"os"
 	"time"
 

--- a/pkg/odo/cli/delete/component/component.go
+++ b/pkg/odo/cli/delete/component/component.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/redhat-developer/odo/pkg/api"

--- a/pkg/odo/cli/init/init.go
+++ b/pkg/odo/cli/init/init.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"

--- a/pkg/odo/cli/telemetry/telemetry.go
+++ b/pkg/odo/cli/telemetry/telemetry.go
@@ -14,7 +14,7 @@ import (
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 	"github.com/redhat-developer/odo/pkg/util"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
 

--- a/pkg/odo/cli/ui/common.go
+++ b/pkg/odo/cli/ui/common.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Proceed displays a given message and asks the user if they want to proceed using the optionally specified Stdio instance (useful

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 	odoversion "github.com/redhat-developer/odo/pkg/version"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/redhat-developer/odo/pkg/odo/util"

--- a/pkg/odo/commonflags/main_test.go
+++ b/pkg/odo/commonflags/main_test.go
@@ -10,7 +10,7 @@ import (
 	envcontext "github.com/redhat-developer/odo/pkg/config/context"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/odo/genericclioptions/clientset/clientset.go
+++ b/pkg/odo/genericclioptions/clientset/clientset.go
@@ -15,7 +15,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/configAutomount"
 	"github.com/redhat-developer/odo/pkg/dev/kubedev"

--- a/pkg/odo/genericclioptions/init.go
+++ b/pkg/odo/genericclioptions/init.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/devfile/library/v2/pkg/devfile/parser"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/devfile/location"
 	"github.com/redhat-developer/odo/pkg/log"

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -24,7 +24,7 @@ import (
 
 	"gopkg.in/AlecAivazis/survey.v1"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
 	"github.com/redhat-developer/odo/pkg/odo/cli/feature"

--- a/pkg/podman/component.go
+++ b/pkg/podman/component.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	odolabels "github.com/redhat-developer/odo/pkg/labels"

--- a/pkg/podman/exec.go
+++ b/pkg/podman/exec.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os/exec"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (o *PodmanCli) ExecCMDInContainer(ctx context.Context, containerName, podName string, cmd []string, stdout, stderr io.Writer, stdin io.Reader, tty bool) error {

--- a/pkg/podman/info.go
+++ b/pkg/podman/info.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // podmanInfo originates from https://github.com/containers/podman/blob/main/libpod/define/info.go

--- a/pkg/podman/inspect.go
+++ b/pkg/podman/inspect.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // PodInspectData originates from From https://github.com/containers/podman/blob/main/libpod/define/pod_inspect.go

--- a/pkg/podman/logs.go
+++ b/pkg/podman/logs.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os/exec"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // GetPodLogs returns the logs of the specified pod container.

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -13,7 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
@@ -81,7 +81,7 @@ func (o *PodmanCli) PlayKube(pod *corev1.Pod) error {
 		return err
 	}
 
-	if klog.V(4) {
+	if klog.V(4).Enabled() {
 		var sb strings.Builder
 		_ = serializer.Encode(pod, &sb)
 		klog.Infof("Pod spec to play: \n---\n%s\n---\n", sb.String())

--- a/pkg/podman/pods.go
+++ b/pkg/podman/pods.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/platform"
 )

--- a/pkg/podman/version.go
+++ b/pkg/podman/version.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type Version struct {

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/segmentio/backo-go"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/exec"

--- a/pkg/portForward/kubeportforward/portForward.go
+++ b/pkg/portForward/kubeportforward/portForward.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/kclient"

--- a/pkg/portForward/kubeportforward/writer.go
+++ b/pkg/portForward/kubeportforward/writer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/libdevfile"
 	"github.com/redhat-developer/odo/pkg/log"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type PortWriter struct {

--- a/pkg/portForward/podmanportforward/portForward.go
+++ b/pkg/portForward/podmanportforward/portForward.go
@@ -11,7 +11,7 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/exec"

--- a/pkg/preference/implem.go
+++ b/pkg/preference/implem.go
@@ -19,7 +19,7 @@ import (
 	dfutil "github.com/devfile/library/v2/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	kpointer "k8s.io/utils/pointer"
 )
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -16,7 +16,7 @@ import (
 	dfutil "github.com/devfile/library/v2/pkg/util"
 	indexSchema "github.com/devfile/registry-support/index/generator/schema"
 	"github.com/devfile/registry-support/registry-library/library"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/devfile"

--- a/pkg/remotecmd/kubeexec.go
+++ b/pkg/remotecmd/kubeexec.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/exec"
 	"github.com/redhat-developer/odo/pkg/storage"

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -18,7 +18,7 @@ import (
 
 	dfutil "github.com/devfile/library/v2/pkg/util"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/segment/integrations.go
+++ b/pkg/segment/integrations.go
@@ -10,7 +10,7 @@ import (
 	envcontext "github.com/redhat-developer/odo/pkg/config/context"
 	scontext "github.com/redhat-developer/odo/pkg/segment/context"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // getTelemetryForDevfileRegistry returns a populated TelemetryData object that contains some odo telemetry (with client consent), such as the anonymous ID and

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/term"
 	"gopkg.in/segmentio/analytics-go.v3"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
 	"github.com/redhat-developer/odo/pkg/preference"

--- a/pkg/service/link.go
+++ b/pkg/service/link.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/redhat-developer/odo/pkg/kclient"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -12,7 +12,7 @@ import (
 	devfilefs "github.com/devfile/library/v2/pkg/testingutil/filesystem"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
 	odolabels "github.com/redhat-developer/odo/pkg/labels"

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 
 	"github.com/mitchellh/go-ps"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/api"
 	"github.com/redhat-developer/odo/pkg/odo/cli/feature"

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/kclient"
 	odolabels "github.com/redhat-developer/odo/pkg/labels"

--- a/pkg/sync/copy.go
+++ b/pkg/sync/copy.go
@@ -18,7 +18,7 @@ import (
 	dfutil "github.com/devfile/library/v2/pkg/util"
 	gitignore "github.com/sabhiram/go-gitignore"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // CopyFile copies localPath directory or list of files in copyFiles list to the directory in running Pod.

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -15,7 +15,7 @@ import (
 	"github.com/redhat-developer/odo/pkg/platform"
 	"github.com/redhat-developer/odo/pkg/util"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // SyncClient is a platform-agnostic implementation for sync

--- a/pkg/task/retry.go
+++ b/pkg/task/retry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Retryable represents a task that can be retried.

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -14,7 +14,7 @@ import (
 
 	gitignore "github.com/sabhiram/go-gitignore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const DotOdoDirectory = ".odo"

--- a/pkg/util/httpcache.go
+++ b/pkg/util/httpcache.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/devfile/library/v2/pkg/testingutil/filesystem"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // CleanDefaultHTTPCacheDir cleans the default directory used for HTTP caching

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 var httpCacheDir = filepath.Join(os.TempDir(), "odohttpcache")

--- a/pkg/watch/backo.go
+++ b/pkg/watch/backo.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/segmentio/backo-go"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type ExpBackoff struct {

--- a/pkg/watch/file_watcher.go
+++ b/pkg/watch/file_watcher.go
@@ -8,7 +8,7 @@ import (
 	dfutil "github.com/devfile/library/v2/pkg/util"
 	"github.com/fsnotify/fsnotify"
 	gitignore "github.com/sabhiram/go-gitignore"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/redhat-developer/odo/pkg/testingutil/filesystem"
 	"github.com/redhat-developer/odo/pkg/util"

--- a/pkg/watch/status.go
+++ b/pkg/watch/status.go
@@ -2,7 +2,7 @@ package watch
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type State string

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -28,7 +28,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/vendor/k8s.io/klog/v2/.golangci.yaml
+++ b/vendor/k8s.io/klog/v2/.golangci.yaml
@@ -1,0 +1,6 @@
+linters:
+  disable-all: true
+  enable: # sorted alphabetical
+    - gofmt
+    - misspell
+    - revive

--- a/vendor/k8s.io/klog/v2/OWNERS
+++ b/vendor/k8s.io/klog/v2/OWNERS
@@ -1,14 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
   - harshanarayana
+  - mengjiao-liu
   - pohly
 approvers:
   - dims
+  - pohly
   - thockin
-  - serathius
 emeritus_approvers:
   - brancz
   - justinsb
   - lavalamp
   - piosz
+  - serathius
   - tallclair

--- a/vendor/k8s.io/klog/v2/README.md
+++ b/vendor/k8s.io/klog/v2/README.md
@@ -48,8 +48,6 @@ How to use klog
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 - See our documentation on [pkg.go.dev/k8s.io](https://pkg.go.dev/k8s.io/klog).
 
-**NOTE**: please use the newer go versions that support semantic import versioning in modules, ideally go 1.11.4 or greater.
-
 ### Coexisting with klog/v2
 
 See [this example](examples/coexist_klog_v1_and_v2/) to see how to coexist with both klog/v1 and klog/v2.

--- a/vendor/k8s.io/klog/v2/contextual_slog.go
+++ b/vendor/k8s.io/klog/v2/contextual_slog.go
@@ -1,0 +1,31 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"log/slog"
+
+	"github.com/go-logr/logr"
+)
+
+// SetSlogLogger reconfigures klog to log through the slog logger. The logger must not be nil.
+func SetSlogLogger(logger *slog.Logger) {
+	SetLoggerWithOptions(logr.FromSlogHandler(logger.Handler()), ContextualLogger(true))
+}

--- a/vendor/k8s.io/klog/v2/internal/buffer/buffer.go
+++ b/vendor/k8s.io/klog/v2/internal/buffer/buffer.go
@@ -30,14 +30,16 @@ import (
 var (
 	// Pid is inserted into log headers. Can be overridden for tests.
 	Pid = os.Getpid()
+
+	// Time, if set, will be used instead of the actual current time.
+	Time *time.Time
 )
 
 // Buffer holds a single byte.Buffer for reuse. The zero value is ready for
 // use. It also provides some helper methods for output formatting.
 type Buffer struct {
 	bytes.Buffer
-	Tmp  [64]byte // temporary byte array for creating headers.
-	next *Buffer
+	Tmp [64]byte // temporary byte array for creating headers.
 }
 
 var buffers = sync.Pool{
@@ -122,6 +124,9 @@ func (buf *Buffer) FormatHeader(s severity.Severity, file string, line int, now 
 
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
+	if Time != nil {
+		now = *Time
+	}
 	_, month, day := now.Date()
 	hour, minute, second := now.Clock()
 	// Lmmdd hh:mm:ss.uuuuuu threadid file:line]
@@ -157,6 +162,9 @@ func (buf *Buffer) SprintHeader(s severity.Severity, now time.Time) string {
 
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
+	if Time != nil {
+		now = *Time
+	}
 	_, month, day := now.Date()
 	hour, minute, second := now.Clock()
 	// Lmmdd hh:mm:ss.uuuuuu threadid file:line]

--- a/vendor/k8s.io/klog/v2/internal/clock/clock.go
+++ b/vendor/k8s.io/klog/v2/internal/clock/clock.go
@@ -39,16 +39,6 @@ type Clock interface {
 	// Sleep sleeps for the provided duration d.
 	// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 	Sleep(d time.Duration)
-	// Tick returns the channel of a new Ticker.
-	// This method does not allow to free/GC the backing ticker. Use
-	// NewTicker from WithTicker instead.
-	Tick(d time.Duration) <-chan time.Time
-}
-
-// WithTicker allows for injecting fake or real clocks into code that
-// needs to do arbitrary things based on time.
-type WithTicker interface {
-	Clock
 	// NewTicker returns a new Ticker.
 	NewTicker(time.Duration) Ticker
 }
@@ -66,7 +56,7 @@ type WithDelayedExecution interface {
 // WithTickerAndDelayedExecution allows for injecting fake or real clocks
 // into code that needs Ticker and AfterFunc functionality
 type WithTickerAndDelayedExecution interface {
-	WithTicker
+	Clock
 	// AfterFunc executes f in its own goroutine after waiting
 	// for d duration and returns a Timer whose channel can be
 	// closed by calling Stop() on the Timer.
@@ -79,7 +69,7 @@ type Ticker interface {
 	Stop()
 }
 
-var _ = WithTicker(RealClock{})
+var _ Clock = RealClock{}
 
 // RealClock really calls time.Now()
 type RealClock struct{}
@@ -113,13 +103,6 @@ func (RealClock) AfterFunc(d time.Duration, f func()) Timer {
 	return &realTimer{
 		timer: time.AfterFunc(d, f),
 	}
-}
-
-// Tick is the same as time.Tick(d)
-// This method does not allow to free/GC the backing ticker. Use
-// NewTicker instead.
-func (RealClock) Tick(d time.Duration) <-chan time.Time {
-	return time.Tick(d)
 }
 
 // NewTicker returns a new Ticker.

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 )
@@ -51,206 +53,161 @@ func WithValues(oldKV, newKV []interface{}) []interface{} {
 	return kv
 }
 
-// MergeKVs deduplicates elements provided in two key/value slices.
-//
-// Keys in each slice are expected to be unique, so duplicates can only occur
-// when the first and second slice contain the same key. When that happens, the
-// key/value pair from the second slice is used. The first slice must be well-formed
-// (= even key/value pairs). The second one may have a missing value, in which
-// case the special "missing value" is added to the result.
-func MergeKVs(first, second []interface{}) []interface{} {
-	maxLength := len(first) + (len(second)+1)/2*2
-	if maxLength == 0 {
-		// Nothing to do at all.
-		return nil
-	}
-
-	if len(first) == 0 && len(second)%2 == 0 {
-		// Nothing to be overridden, second slice is well-formed
-		// and can be used directly.
-		return second
-	}
-
-	// Determine which keys are in the second slice so that we can skip
-	// them when iterating over the first one. The code intentionally
-	// favors performance over completeness: we assume that keys are string
-	// constants and thus compare equal when the string values are equal. A
-	// string constant being overridden by, for example, a fmt.Stringer is
-	// not handled.
-	overrides := map[interface{}]bool{}
-	for i := 0; i < len(second); i += 2 {
-		overrides[second[i]] = true
-	}
-	merged := make([]interface{}, 0, maxLength)
-	for i := 0; i+1 < len(first); i += 2 {
-		key := first[i]
-		if overrides[key] {
-			continue
-		}
-		merged = append(merged, key, first[i+1])
-	}
-	merged = append(merged, second...)
-	if len(merged)%2 != 0 {
-		merged = append(merged, missingValue)
-	}
-	return merged
-}
-
 type Formatter struct {
 	AnyToStringHook AnyToStringFunc
 }
 
 type AnyToStringFunc func(v interface{}) string
 
-// MergeKVsInto is a variant of MergeKVs which directly formats the key/value
-// pairs into a buffer.
-func (f Formatter) MergeAndFormatKVs(b *bytes.Buffer, first, second []interface{}) {
-	if len(first) == 0 && len(second) == 0 {
-		// Nothing to do at all.
-		return
-	}
-
-	if len(first) == 0 && len(second)%2 == 0 {
-		// Nothing to be overridden, second slice is well-formed
-		// and can be used directly.
-		for i := 0; i < len(second); i += 2 {
-			f.KVFormat(b, second[i], second[i+1])
-		}
-		return
-	}
-
-	// Determine which keys are in the second slice so that we can skip
-	// them when iterating over the first one. The code intentionally
-	// favors performance over completeness: we assume that keys are string
-	// constants and thus compare equal when the string values are equal. A
-	// string constant being overridden by, for example, a fmt.Stringer is
-	// not handled.
-	overrides := map[interface{}]bool{}
-	for i := 0; i < len(second); i += 2 {
-		overrides[second[i]] = true
-	}
-	for i := 0; i < len(first); i += 2 {
-		key := first[i]
-		if overrides[key] {
-			continue
-		}
-		f.KVFormat(b, key, first[i+1])
-	}
-	// Round down.
-	l := len(second)
-	l = l / 2 * 2
-	for i := 1; i < l; i += 2 {
-		f.KVFormat(b, second[i-1], second[i])
-	}
-	if len(second)%2 == 1 {
-		f.KVFormat(b, second[len(second)-1], missingValue)
-	}
-}
-
-func MergeAndFormatKVs(b *bytes.Buffer, first, second []interface{}) {
-	Formatter{}.MergeAndFormatKVs(b, first, second)
-}
-
 const missingValue = "(MISSING)"
 
-// KVListFormat serializes all key/value pairs into the provided buffer.
-// A space gets inserted before the first pair and between each pair.
-func (f Formatter) KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
-	for i := 0; i < len(keysAndValues); i += 2 {
-		var v interface{}
-		k := keysAndValues[i]
-		if i+1 < len(keysAndValues) {
-			v = keysAndValues[i+1]
-		} else {
-			v = missingValue
+func FormatKVs(b *bytes.Buffer, kvs ...[]interface{}) {
+	Formatter{}.FormatKVs(b, kvs...)
+}
+
+// FormatKVs formats all key/value pairs such that the output contains no
+// duplicates ("last one wins").
+func (f Formatter) FormatKVs(b *bytes.Buffer, kvs ...[]interface{}) {
+	// De-duplication is done by optimistically formatting all key value
+	// pairs and then cutting out the output of those key/value pairs which
+	// got overwritten later.
+	//
+	// In the common case of no duplicates, the only overhead is tracking
+	// previous keys. This uses a slice with a simple linear search because
+	// the number of entries is typically so low that allocating a map or
+	// keeping a sorted slice with binary search aren't justified.
+	//
+	// Using a fixed size here makes the Go compiler use the stack as
+	// initial backing store for the slice, which is crucial for
+	// performance.
+	existing := make([]obsoleteKV, 0, 32)
+	obsolete := make([]interval, 0, 32) // Sorted by start index.
+	for _, keysAndValues := range kvs {
+		for i := 0; i < len(keysAndValues); i += 2 {
+			var v interface{}
+			k := keysAndValues[i]
+			if i+1 < len(keysAndValues) {
+				v = keysAndValues[i+1]
+			} else {
+				v = missingValue
+			}
+			var e obsoleteKV
+			e.start = b.Len()
+			e.key = f.KVFormat(b, k, v)
+			e.end = b.Len()
+			i := findObsoleteEntry(existing, e.key)
+			if i >= 0 {
+				data := b.Bytes()
+				if bytes.Compare(data[existing[i].start:existing[i].end], data[e.start:e.end]) == 0 {
+					// The new entry gets obsoleted because it's identical.
+					// This has the advantage that key/value pairs from
+					// a WithValues call always come first, even if the same
+					// pair gets added again later. This makes different log
+					// entries more consistent.
+					//
+					// The new entry has a higher start index and thus can be appended.
+					obsolete = append(obsolete, e.interval)
+				} else {
+					// The old entry gets obsoleted because it's value is different.
+					//
+					// Sort order is not guaranteed, we have to insert at the right place.
+					index, _ := slices.BinarySearchFunc(obsolete, existing[i].interval, func(a, b interval) int { return a.start - b.start })
+					obsolete = slices.Insert(obsolete, index, existing[i].interval)
+					existing[i].interval = e.interval
+				}
+			} else {
+				// Instead of appending at the end and doing a
+				// linear search in findEntry, we could keep
+				// the slice sorted by key and do a binary search.
+				//
+				// Above:
+				//    i, ok := slices.BinarySearchFunc(existing, e, func(a, b entry) int { return strings.Compare(a.key, b.key) })
+				// Here:
+				//    existing = slices.Insert(existing, i, e)
+				//
+				// But that adds a dependency on the slices package
+				// and made performance slightly worse, presumably
+				// because the cost of shifting entries around
+				// did not pay of with faster lookups.
+				existing = append(existing, e)
+			}
 		}
-		f.KVFormat(b, k, v)
-	}
-}
-
-func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
-	Formatter{}.KVListFormat(b, keysAndValues...)
-}
-
-// KVFormat serializes one key/value pair into the provided buffer.
-// A space gets inserted before the pair.
-func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
-	b.WriteByte(' ')
-	// Keys are assumed to be well-formed according to
-	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
-	// for the sake of performance. Keys with spaces,
-	// special characters, etc. will break parsing.
-	if sK, ok := k.(string); ok {
-		// Avoid one allocation when the key is a string, which
-		// normally it should be.
-		b.WriteString(sK)
-	} else {
-		b.WriteString(fmt.Sprintf("%s", k))
 	}
 
-	// The type checks are sorted so that more frequently used ones
-	// come first because that is then faster in the common
-	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
-	// than plain strings
-	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
-	switch v := v.(type) {
-	case textWriter:
-		writeTextWriterValue(b, v)
-	case fmt.Stringer:
-		writeStringValue(b, StringerToString(v))
-	case string:
-		writeStringValue(b, v)
-	case error:
-		writeStringValue(b, ErrorToString(v))
-	case logr.Marshaler:
-		value := MarshalerToValue(v)
-		// A marshaler that returns a string is useful for
-		// delayed formatting of complex values. We treat this
-		// case like a normal string. This is useful for
-		// multi-line support.
-		//
-		// We could do this by recursively formatting a value,
-		// but that comes with the risk of infinite recursion
-		// if a marshaler returns itself. Instead we call it
-		// only once and rely on it returning the intended
-		// value directly.
-		switch value := value.(type) {
-		case string:
-			writeStringValue(b, value)
-		default:
-			f.formatAny(b, value)
+	// If we need to remove some obsolete key/value pairs then move the memory.
+	if len(obsolete) > 0 {
+		// Potentially the next remaining output (might itself be obsolete).
+		from := obsolete[0].end
+		// Next obsolete entry.
+		nextObsolete := 1
+		// This is the source buffer, before truncation.
+		all := b.Bytes()
+		b.Truncate(obsolete[0].start)
+
+		for nextObsolete < len(obsolete) {
+			if from == obsolete[nextObsolete].start {
+				// Skip also the next obsolete key/value.
+				from = obsolete[nextObsolete].end
+				nextObsolete++
+				continue
+			}
+
+			// Preserve some output. Write uses copy, which
+			// explicitly allows source and destination to overlap.
+			// That could happen here.
+			valid := all[from:obsolete[nextObsolete].start]
+			b.Write(valid)
+			from = obsolete[nextObsolete].end
+			nextObsolete++
 		}
-	case []byte:
-		// In https://github.com/kubernetes/klog/pull/237 it was decided
-		// to format byte slices with "%+q". The advantages of that are:
-		// - readable output if the bytes happen to be printable
-		// - non-printable bytes get represented as unicode escape
-		//   sequences (\uxxxx)
-		//
-		// The downsides are that we cannot use the faster
-		// strconv.Quote here and that multi-line output is not
-		// supported. If developers know that a byte array is
-		// printable and they want multi-line output, they can
-		// convert the value to string before logging it.
-		b.WriteByte('=')
-		b.WriteString(fmt.Sprintf("%+q", v))
-	default:
-		f.formatAny(b, v)
+		// Copy end of buffer.
+		valid := all[from:]
+		b.Write(valid)
 	}
 }
 
-func KVFormat(b *bytes.Buffer, k, v interface{}) {
-	Formatter{}.KVFormat(b, k, v)
+type obsoleteKV struct {
+	key string
+	interval
+}
+
+// interval includes the start and excludes the end.
+type interval struct {
+	start int
+	end   int
+}
+
+func findObsoleteEntry(entries []obsoleteKV, key string) int {
+	for i, entry := range entries {
+		if entry.key == key {
+			return i
+		}
+	}
+	return -1
 }
 
 // formatAny is the fallback formatter for a value. It supports a hook (for
 // example, for YAML encoding) and itself uses JSON encoding.
 func (f Formatter) formatAny(b *bytes.Buffer, v interface{}) {
-	b.WriteRune('=')
 	if f.AnyToStringHook != nil {
-		b.WriteString(f.AnyToStringHook(v))
+		str := f.AnyToStringHook(v)
+		if strings.Contains(str, "\n") {
+			// If it's multi-line, then pass it through writeStringValue to get start/end delimiters,
+			// which separates it better from any following key/value pair.
+			writeStringValue(b, str)
+			return
+		}
+		// Otherwise put it directly after the separator, on the same lime,
+		// The assumption is that the hook returns something where start/end are obvious.
+		b.WriteRune('=')
+		b.WriteString(str)
 		return
 	}
+	b.WriteRune('=')
+	formatAsJSON(b, v)
+}
+
+func formatAsJSON(b *bytes.Buffer, v interface{}) {
 	encoder := json.NewEncoder(b)
 	l := b.Len()
 	if err := encoder.Encode(v); err != nil {

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_no_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_no_slog.go
@@ -1,0 +1,101 @@
+//go:build !go1.21
+// +build !go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serialize
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// KVFormat serializes one key/value pair into the provided buffer.
+// A space gets inserted before the pair.
+func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) string {
+	// This is the version without slog support. Must be kept in sync with
+	// the version in keyvalues_slog.go.
+
+	b.WriteByte(' ')
+	// Keys are assumed to be well-formed according to
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
+	// for the sake of performance. Keys with spaces,
+	// special characters, etc. will break parsing.
+	var key string
+	if sK, ok := k.(string); ok {
+		// Avoid one allocation when the key is a string, which
+		// normally it should be.
+		key = sK
+	} else {
+		key = fmt.Sprintf("%s", k)
+	}
+	b.WriteString(key)
+
+	// The type checks are sorted so that more frequently used ones
+	// come first because that is then faster in the common
+	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
+	// than plain strings
+	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
+	switch v := v.(type) {
+	case textWriter:
+		writeTextWriterValue(b, v)
+	case fmt.Stringer:
+		writeStringValue(b, StringerToString(v))
+	case string:
+		writeStringValue(b, v)
+	case error:
+		writeStringValue(b, ErrorToString(v))
+	case logr.Marshaler:
+		value := MarshalerToValue(v)
+		// A marshaler that returns a string is useful for
+		// delayed formatting of complex values. We treat this
+		// case like a normal string. This is useful for
+		// multi-line support.
+		//
+		// We could do this by recursively formatting a value,
+		// but that comes with the risk of infinite recursion
+		// if a marshaler returns itself. Instead we call it
+		// only once and rely on it returning the intended
+		// value directly.
+		switch value := value.(type) {
+		case string:
+			writeStringValue(b, value)
+		default:
+			f.formatAny(b, value)
+		}
+	case []byte:
+		// In https://github.com/kubernetes/klog/pull/237 it was decided
+		// to format byte slices with "%+q". The advantages of that are:
+		// - readable output if the bytes happen to be printable
+		// - non-printable bytes get represented as unicode escape
+		//   sequences (\uxxxx)
+		//
+		// The downsides are that we cannot use the faster
+		// strconv.Quote here and that multi-line output is not
+		// supported. If developers know that a byte array is
+		// printable and they want multi-line output, they can
+		// convert the value to string before logging it.
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%+q", v))
+	default:
+		f.formatAny(b, v)
+	}
+
+	return key
+}

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_slog.go
@@ -1,0 +1,159 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serialize
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/go-logr/logr"
+)
+
+// KVFormat serializes one key/value pair into the provided buffer.
+// A space gets inserted before the pair. It returns the key.
+func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) string {
+	// This is the version without slog support. Must be kept in sync with
+	// the version in keyvalues_slog.go.
+
+	b.WriteByte(' ')
+	// Keys are assumed to be well-formed according to
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
+	// for the sake of performance. Keys with spaces,
+	// special characters, etc. will break parsing.
+	var key string
+	if sK, ok := k.(string); ok {
+		// Avoid one allocation when the key is a string, which
+		// normally it should be.
+		key = sK
+	} else {
+		key = fmt.Sprintf("%s", k)
+	}
+	b.WriteString(key)
+
+	// The type checks are sorted so that more frequently used ones
+	// come first because that is then faster in the common
+	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
+	// than plain strings
+	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
+	//
+	// slog.LogValuer does not need to be handled here because the handler will
+	// already have resolved such special values to the final value for logging.
+	switch v := v.(type) {
+	case textWriter:
+		writeTextWriterValue(b, v)
+	case slog.Value:
+		// This must come before fmt.Stringer because slog.Value implements
+		// fmt.Stringer, but does not produce the output that we want.
+		b.WriteByte('=')
+		generateJSON(b, v)
+	case fmt.Stringer:
+		writeStringValue(b, StringerToString(v))
+	case string:
+		writeStringValue(b, v)
+	case error:
+		writeStringValue(b, ErrorToString(v))
+	case logr.Marshaler:
+		value := MarshalerToValue(v)
+		// A marshaler that returns a string is useful for
+		// delayed formatting of complex values. We treat this
+		// case like a normal string. This is useful for
+		// multi-line support.
+		//
+		// We could do this by recursively formatting a value,
+		// but that comes with the risk of infinite recursion
+		// if a marshaler returns itself. Instead we call it
+		// only once and rely on it returning the intended
+		// value directly.
+		switch value := value.(type) {
+		case string:
+			writeStringValue(b, value)
+		default:
+			f.formatAny(b, value)
+		}
+	case slog.LogValuer:
+		value := slog.AnyValue(v).Resolve()
+		if value.Kind() == slog.KindString {
+			writeStringValue(b, value.String())
+		} else {
+			b.WriteByte('=')
+			generateJSON(b, value)
+		}
+	case []byte:
+		// In https://github.com/kubernetes/klog/pull/237 it was decided
+		// to format byte slices with "%+q". The advantages of that are:
+		// - readable output if the bytes happen to be printable
+		// - non-printable bytes get represented as unicode escape
+		//   sequences (\uxxxx)
+		//
+		// The downsides are that we cannot use the faster
+		// strconv.Quote here and that multi-line output is not
+		// supported. If developers know that a byte array is
+		// printable and they want multi-line output, they can
+		// convert the value to string before logging it.
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%+q", v))
+	default:
+		f.formatAny(b, v)
+	}
+
+	return key
+}
+
+// generateJSON has the same preference for plain strings as KVFormat.
+// In contrast to KVFormat it always produces valid JSON with no line breaks.
+func generateJSON(b *bytes.Buffer, v interface{}) {
+	switch v := v.(type) {
+	case slog.Value:
+		switch v.Kind() {
+		case slog.KindGroup:
+			// Format as a JSON group. We must not involve f.AnyToStringHook (if there is any),
+			// because there is no guarantee that it produces valid JSON.
+			b.WriteByte('{')
+			for i, attr := range v.Group() {
+				if i > 0 {
+					b.WriteByte(',')
+				}
+				b.WriteString(strconv.Quote(attr.Key))
+				b.WriteByte(':')
+				generateJSON(b, attr.Value)
+			}
+			b.WriteByte('}')
+		case slog.KindLogValuer:
+			generateJSON(b, v.Resolve())
+		default:
+			// Peel off the slog.Value wrapper and format the actual value.
+			generateJSON(b, v.Any())
+		}
+	case fmt.Stringer:
+		b.WriteString(strconv.Quote(StringerToString(v)))
+	case logr.Marshaler:
+		generateJSON(b, MarshalerToValue(v))
+	case slog.LogValuer:
+		generateJSON(b, slog.AnyValue(v).Resolve().Any())
+	case string:
+		b.WriteString(strconv.Quote(v))
+	case error:
+		b.WriteString(strconv.Quote(v.Error()))
+	default:
+		formatAsJSON(b, v)
+	}
+}

--- a/vendor/k8s.io/klog/v2/internal/sloghandler/sloghandler_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/sloghandler/sloghandler_slog.go
@@ -1,0 +1,96 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sloghandler
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2/internal/severity"
+)
+
+func Handle(_ context.Context, record slog.Record, groups string, printWithInfos func(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{})) error {
+	now := record.Time
+	if now.IsZero() {
+		// This format doesn't support printing entries without a time.
+		now = time.Now()
+	}
+
+	// slog has numeric severity levels, with 0 as default "info", negative for debugging, and
+	// positive with some pre-defined levels for more important. Those ranges get mapped to
+	// the corresponding klog levels where possible, with "info" the default that is used
+	// also for negative debug levels.
+	level := record.Level
+	s := severity.InfoLog
+	switch {
+	case level >= slog.LevelError:
+		s = severity.ErrorLog
+	case level >= slog.LevelWarn:
+		s = severity.WarningLog
+	}
+
+	var file string
+	var line int
+	if record.PC != 0 {
+		// Same as https://cs.opensource.google/go/x/exp/+/642cacee:slog/record.go;drc=642cacee5cc05231f45555a333d07f1005ffc287;l=70
+		fs := runtime.CallersFrames([]uintptr{record.PC})
+		f, _ := fs.Next()
+		if f.File != "" {
+			file = f.File
+			if slash := strings.LastIndex(file, "/"); slash >= 0 {
+				file = file[slash+1:]
+			}
+			line = f.Line
+		}
+	} else {
+		file = "???"
+		line = 1
+	}
+
+	kvList := make([]interface{}, 0, 2*record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		kvList = appendAttr(groups, kvList, attr)
+		return true
+	})
+
+	printWithInfos(file, line, now, nil, s, record.Message, kvList)
+	return nil
+}
+
+func Attrs2KVList(groups string, attrs []slog.Attr) []interface{} {
+	kvList := make([]interface{}, 0, 2*len(attrs))
+	for _, attr := range attrs {
+		kvList = appendAttr(groups, kvList, attr)
+	}
+	return kvList
+}
+
+func appendAttr(groups string, kvList []interface{}, attr slog.Attr) []interface{} {
+	var key string
+	if groups != "" {
+		key = groups + "." + attr.Key
+	} else {
+		key = attr.Key
+	}
+	return append(kvList, key, attr.Value)
+}

--- a/vendor/k8s.io/klog/v2/k8s_references_slog.go
+++ b/vendor/k8s.io/klog/v2/k8s_references_slog.go
@@ -1,0 +1,39 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"log/slog"
+)
+
+func (ref ObjectRef) LogValue() slog.Value {
+	if ref.Namespace != "" {
+		return slog.GroupValue(slog.String("name", ref.Name), slog.String("namespace", ref.Namespace))
+	}
+	return slog.GroupValue(slog.String("name", ref.Name))
+}
+
+var _ slog.LogValuer = ObjectRef{}
+
+func (ks kobjSlice) LogValue() slog.Value {
+	return slog.AnyValue(ks.MarshalLog())
+}
+
+var _ slog.LogValuer = kobjSlice{}

--- a/vendor/k8s.io/klog/v2/klog.go
+++ b/vendor/k8s.io/klog/v2/klog.go
@@ -14,9 +14,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package klog implements logging analogous to the Google-internal C++ INFO/ERROR/V setup.
-// It provides functions Info, Warning, Error, Fatal, plus formatting variants such as
-// Infof. It also provides V-style logging controlled by the -v and -vmodule=file=2 flags.
+// Package klog contains the following functionality:
+//
+//   - output routing as defined via command line flags ([InitFlags])
+//   - log formatting as text, either with a single, unstructured string ([Info], [Infof], etc.)
+//     or as a structured log entry with message and key/value pairs ([InfoS], etc.)
+//   - management of a go-logr [Logger] ([SetLogger], [Background], [TODO])
+//   - helper functions for logging values ([Format]) and managing the state of klog ([CaptureState], [State.Restore])
+//   - wrappers for [logr] APIs for contextual logging where the wrappers can
+//     be turned into no-ops ([EnableContextualLogging], [NewContext], [FromContext],
+//     [LoggerWithValues], [LoggerWithName]); if the ability to turn off
+//     contextual logging is not needed, then go-logr can also be used directly
+//   - type aliases for go-logr types to simplify imports in code which uses both (e.g. [Logger])
+//   - [k8s.io/klog/v2/textlogger]: a logger which uses the same formatting as klog log with
+//     simpler output routing; beware that it comes with its own command line flags
+//     and does not use the ones from klog
+//   - [k8s.io/klog/v2/ktesting]: per-test output in Go unit tests
+//   - [k8s.io/klog/v2/klogr]: a deprecated, standalone [logr.Logger] on top of the main klog package;
+//     use [Background] instead if klog output routing is needed, [k8s.io/klog/v2/textlogger] if not
+//   - [k8s.io/klog/v2/examples]: demos of this functionality
+//   - [k8s.io/klog/v2/test]: reusable tests for [logr.Logger] implementations
 //
 // Basic examples:
 //
@@ -41,15 +58,30 @@
 //
 //		-logtostderr=true
 //			Logs are written to standard error instead of to files.
-//	             This shortcuts most of the usual output routing:
-//	             -alsologtostderr, -stderrthreshold and -log_dir have no
-//	             effect and output redirection at runtime with SetOutput is
-//	             ignored.
+//	             By default, all logs are written regardless of severity
+//	             (legacy behavior). To filter logs by severity when
+//	             -logtostderr=true, set -legacy_stderr_threshold_behavior=false
+//	             and use -stderrthreshold.
+//              With -legacy_stderr_threshold_behavior=true,
+//              -stderrthreshold has no effect.
+//
+//	             The following flags always have no effect:
+//	             -alsologtostderr, -alsologtostderrthreshold, and -log_dir.
+//	             Output redirection at runtime with SetOutput is also ignored.
 //		-alsologtostderr=false
 //			Logs are written to standard error as well as to files.
+//		-alsologtostderrthreshold=INFO
+//			Log events at or above this severity are logged to standard
+//			error when -alsologtostderr=true (no effect when -logtostderr=true).
+//			Default is INFO to maintain backward compatibility.
 //		-stderrthreshold=ERROR
 //			Log events at or above this severity are logged to standard
-//			error as well as to files.
+//			error as well as to files. When -logtostderr=true, this flag
+//			has no effect unless -legacy_stderr_threshold_behavior=false.
+//		-legacy_stderr_threshold_behavior=true
+//			If true, -stderrthreshold is ignored when -logtostderr=true
+//			(legacy behavior). If false, -stderrthreshold is honored even
+//			when -logtostderr=true, allowing severity-based filtering.
 //		-log_dir=""
 //			Log files will be written to this directory instead of the
 //			default temporary directory.
@@ -139,7 +171,7 @@ func (s *severityValue) Set(value string) error {
 		}
 		threshold = severity.Severity(v)
 	}
-	logging.stderrThreshold.set(threshold)
+	s.set(threshold)
 	return nil
 }
 
@@ -387,18 +419,20 @@ func (t *traceLocation) Set(value string) error {
 	return nil
 }
 
-// flushSyncWriter is the interface satisfied by logging destinations.
-type flushSyncWriter interface {
-	Flush() error
-	Sync() error
-	io.Writer
-}
-
 var logging loggingT
 var commandLine flag.FlagSet
 
 // init sets up the defaults and creates command line flags.
 func init() {
+	// Initialize severity thresholds
+	logging.stderrThreshold = severityValue{
+		Severity: severity.ErrorLog, // Default stderrThreshold is ERROR.
+	}
+	logging.alsologtostderrthreshold = severityValue{
+		Severity: severity.InfoLog, // Default alsologtostderrthreshold is INFO (to maintain backward compatibility).
+	}
+	logging.setVState(0, nil, false)
+
 	commandLine.StringVar(&logging.logDir, "log_dir", "", "If non-empty, write log files in this directory (no effect when -logtostderr=true)")
 	commandLine.StringVar(&logging.logFile, "log_file", "", "If non-empty, use this log file (no effect when -logtostderr=true)")
 	commandLine.Uint64Var(&logging.logFileMaxSizeMB, "log_file_max_size", 1800,
@@ -406,16 +440,14 @@ func init() {
 			"If the value is 0, the maximum file size is unlimited.")
 	commandLine.BoolVar(&logging.toStderr, "logtostderr", true, "log to standard error instead of files")
 	commandLine.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files (no effect when -logtostderr=true)")
-	logging.setVState(0, nil, false)
+	commandLine.BoolVar(&logging.legacyStderrThresholdBehavior, "legacy_stderr_threshold_behavior", true, "If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true")
 	commandLine.Var(&logging.verbosity, "v", "number for the log level verbosity")
 	commandLine.BoolVar(&logging.addDirHeader, "add_dir_header", false, "If true, adds the file directory to the header of the log messages")
 	commandLine.BoolVar(&logging.skipHeaders, "skip_headers", false, "If true, avoid header prefixes in the log messages")
 	commandLine.BoolVar(&logging.oneOutput, "one_output", false, "If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)")
 	commandLine.BoolVar(&logging.skipLogHeaders, "skip_log_headers", false, "If true, avoid headers when opening log files (no effect when -logtostderr=true)")
-	logging.stderrThreshold = severityValue{
-		Severity: severity.ErrorLog, // Default stderrThreshold is ERROR.
-	}
-	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false)")
+	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false)")
+	commandLine.Var(&logging.alsologtostderrthreshold, "alsologtostderrthreshold", "logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)")
 	commandLine.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	commandLine.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 
@@ -460,16 +492,18 @@ type settings struct {
 	// Boolean flags. Not handled atomically because the flag.Value interface
 	// does not let us avoid the =true, and that shorthand is necessary for
 	// compatibility. TODO: does this matter enough to fix? Seems unlikely.
-	toStderr     bool // The -logtostderr flag.
-	alsoToStderr bool // The -alsologtostderr flag.
+	toStderr                      bool // The -logtostderr flag.
+	alsoToStderr                  bool // The -alsologtostderr flag.
+	legacyStderrThresholdBehavior bool // The -legacy_stderr_threshold_behavior flag.
 
 	// Level flag. Handled atomically.
-	stderrThreshold severityValue // The -stderrthreshold flag.
+	stderrThreshold          severityValue // The -stderrthreshold flag.
+	alsologtostderrthreshold severityValue // The -alsologtostderrthreshold flag.
 
 	// Access to all of the following fields must be protected via a mutex.
 
 	// file holds writer for each of the log types.
-	file [severity.NumSeverity]flushSyncWriter
+	file [severity.NumSeverity]io.Writer
 	// flushInterval is the interval for periodic flushing. If zero,
 	// the global default will be used.
 	flushInterval time.Duration
@@ -518,9 +552,7 @@ type settings struct {
 func (s settings) deepCopy() settings {
 	// vmodule is a slice and would be shared, so we have copy it.
 	filter := make([]modulePat, len(s.vmodule.filter))
-	for i := range s.vmodule.filter {
-		filter[i] = s.vmodule.filter[i]
-	}
+	copy(filter, s.vmodule.filter)
 	s.vmodule.filter = filter
 
 	if s.logger != nil {
@@ -657,16 +689,15 @@ func (l *loggingT) header(s severity.Severity, depth int) (*buffer.Buffer, strin
 			}
 		}
 	}
-	return l.formatHeader(s, file, line), file, line
+	return l.formatHeader(s, file, line, timeNow()), file, line
 }
 
 // formatHeader formats a log header using the provided file name and line number.
-func (l *loggingT) formatHeader(s severity.Severity, file string, line int) *buffer.Buffer {
+func (l *loggingT) formatHeader(s severity.Severity, file string, line int, now time.Time) *buffer.Buffer {
 	buf := buffer.GetBuffer()
 	if l.skipHeaders {
 		return buf
 	}
-	now := timeNow()
 	buf.FormatHeader(s, file, line, now)
 	return buf
 }
@@ -676,6 +707,10 @@ func (l *loggingT) println(s severity.Severity, logger *logWriter, filter LogFil
 }
 
 func (l *loggingT) printlnDepth(s severity.Severity, logger *logWriter, filter LogFilter, depth int, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintln(args...) // cause vet to treat this function like fmt.Println
+	}
+
 	buf, file, line := l.header(s, depth)
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
@@ -696,7 +731,15 @@ func (l *loggingT) print(s severity.Severity, logger *logWriter, filter LogFilte
 }
 
 func (l *loggingT) printDepth(s severity.Severity, logger *logWriter, filter LogFilter, depth int, args ...interface{}) {
+	if false {
+		_ = fmt.Sprint(args...) //  // cause vet to treat this function like fmt.Print
+	}
+
 	buf, file, line := l.header(s, depth)
+	l.printWithInfos(buf, file, line, s, logger, filter, depth+1, args...)
+}
+
+func (l *loggingT) printWithInfos(buf *buffer.Buffer, file string, line int, s severity.Severity, logger *logWriter, filter LogFilter, depth int, args ...interface{}) {
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
 	// logger implementation to print headers.
@@ -719,6 +762,10 @@ func (l *loggingT) printf(s severity.Severity, logger *logWriter, filter LogFilt
 }
 
 func (l *loggingT) printfDepth(s severity.Severity, logger *logWriter, filter LogFilter, depth int, format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // cause vet to treat this function like fmt.Printf
+	}
+
 	buf, file, line := l.header(s, depth)
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
@@ -741,7 +788,7 @@ func (l *loggingT) printfDepth(s severity.Severity, logger *logWriter, filter Lo
 // alsoLogToStderr is true, the log message always appears on standard error; it
 // will also appear in the log file unless --logtostderr is set.
 func (l *loggingT) printWithFileLine(s severity.Severity, logger *logWriter, filter LogFilter, file string, line int, alsoToStderr bool, args ...interface{}) {
-	buf := l.formatHeader(s, file, line)
+	buf := l.formatHeader(s, file, line, timeNow())
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
 	// logger implementation to print headers.
@@ -759,7 +806,7 @@ func (l *loggingT) printWithFileLine(s severity.Severity, logger *logWriter, fil
 	l.output(s, logger, buf, 2 /* depth */, file, line, alsoToStderr)
 }
 
-// if loggr is specified, will call loggr.Error, otherwise output with logging module.
+// if logger is specified, will call logger.Error, otherwise output with logging module.
 func (l *loggingT) errorS(err error, logger *logWriter, filter LogFilter, depth int, msg string, keysAndValues ...interface{}) {
 	if filter != nil {
 		msg, keysAndValues = filter.FilterS(msg, keysAndValues)
@@ -771,7 +818,7 @@ func (l *loggingT) errorS(err error, logger *logWriter, filter LogFilter, depth 
 	l.printS(err, severity.ErrorLog, depth+1, msg, keysAndValues...)
 }
 
-// if loggr is specified, will call loggr.Info, otherwise output with logging module.
+// if logger is specified, will call logger.Info, otherwise output with logging module.
 func (l *loggingT) infoS(logger *logWriter, filter LogFilter, depth int, msg string, keysAndValues ...interface{}) {
 	if filter != nil {
 		msg, keysAndValues = filter.FilterS(msg, keysAndValues)
@@ -783,39 +830,27 @@ func (l *loggingT) infoS(logger *logWriter, filter LogFilter, depth int, msg str
 	l.printS(nil, severity.InfoLog, depth+1, msg, keysAndValues...)
 }
 
-// printS is called from infoS and errorS if loggr is not specified.
+// printS is called from infoS and errorS if logger is not specified.
 // set log severity by s
 func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string, keysAndValues ...interface{}) {
-	// Only create a new buffer if we don't have one cached.
-	b := buffer.GetBuffer()
 	// The message is always quoted, even if it contains line breaks.
 	// If developers want multi-line output, they should use a small, fixed
 	// message and put the multi-line output into a value.
-	b.WriteString(strconv.Quote(msg))
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
+	// Only create a new buffer if we don't have one cached.
+	b := buffer.GetBuffer()
+	b.Write(qMsg)
+
+	var errKV []interface{}
 	if err != nil {
-		serialize.KVListFormat(&b.Buffer, "err", err)
+		errKV = []interface{}{"err", err}
 	}
-	serialize.KVListFormat(&b.Buffer, keysAndValues...)
-	l.printDepth(s, logging.logger, nil, depth+1, &b.Buffer)
+	serialize.FormatKVs(&b.Buffer, errKV, keysAndValues)
+	l.printDepth(s, nil, nil, depth+1, &b.Buffer)
 	// Make the buffer available for reuse.
 	buffer.PutBuffer(b)
-}
-
-// redirectBuffer is used to set an alternate destination for the logs
-type redirectBuffer struct {
-	w io.Writer
-}
-
-func (rb *redirectBuffer) Sync() error {
-	return nil
-}
-
-func (rb *redirectBuffer) Flush() error {
-	return nil
-}
-
-func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
-	return rb.w.Write(bytes)
 }
 
 // SetOutput sets the output destination for all severities
@@ -823,10 +858,7 @@ func SetOutput(w io.Writer) {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 	for s := severity.FatalLog; s >= severity.InfoLog; s-- {
-		rb := &redirectBuffer{
-			w: w,
-		}
-		logging.file[s] = rb
+		logging.file[s] = w
 	}
 }
 
@@ -838,10 +870,7 @@ func SetOutputBySeverity(name string, w io.Writer) {
 	if !ok {
 		panic(fmt.Sprintf("SetOutputBySeverity(%q): unrecognized severity name", name))
 	}
-	rb := &redirectBuffer{
-		w: w,
-	}
-	logging.file[sev] = rb
+	logging.file[sev] = w
 }
 
 // LogToStderr sets whether to log exclusively to stderr, bypassing outputs
@@ -873,6 +902,9 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 		if logger.writeKlogBuffer != nil {
 			logger.writeKlogBuffer(data)
 		} else {
+			if len(data) > 0 && data[len(data)-1] == '\n' {
+				data = data[:len(data)-1]
+			}
 			// TODO: set 'severity' and caller information as structured log info
 			// keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 			if s == severity.ErrorLog {
@@ -882,9 +914,25 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 			}
 		}
 	} else if l.toStderr {
-		os.Stderr.Write(data)
+		// When logging to stderr only, check if we should filter by severity.
+		// This is controlled by the legacy_stderr_threshold_behavior flag.
+		if l.legacyStderrThresholdBehavior {
+			// Legacy behavior: always write to stderr, ignore stderrthreshold
+			os.Stderr.Write(data)
+		} else {
+			// New behavior: honor stderrthreshold even when logtostderr=true
+			if s >= l.stderrThreshold.get() {
+				os.Stderr.Write(data)
+			}
+		}
 	} else {
-		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {
+		// Write to stderr if any of these conditions are met:
+		// - alsoToStderr is set (legacy behavior)
+		// - alsologtostderr is set and severity meets alsologtostderrthreshold
+		// - alsologtostderr is not set and severity meets stderrThreshold
+		if alsoToStderr ||
+			(l.alsoToStderr && s >= l.alsologtostderrthreshold.get()) ||
+			(!l.alsoToStderr && s >= l.stderrThreshold.get()) {
 			os.Stderr.Write(data)
 		}
 
@@ -897,7 +945,7 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 					l.exit(err)
 				}
 			}
-			l.file[severity.InfoLog].Write(data)
+			_, _ = l.file[severity.InfoLog].Write(data)
 		} else {
 			if l.file[s] == nil {
 				if err := l.createFiles(s); err != nil {
@@ -907,20 +955,20 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 			}
 
 			if l.oneOutput {
-				l.file[s].Write(data)
+				_, _ = l.file[s].Write(data)
 			} else {
 				switch s {
 				case severity.FatalLog:
-					l.file[severity.FatalLog].Write(data)
+					_, _ = l.file[severity.FatalLog].Write(data)
 					fallthrough
 				case severity.ErrorLog:
-					l.file[severity.ErrorLog].Write(data)
+					_, _ = l.file[severity.ErrorLog].Write(data)
 					fallthrough
 				case severity.WarningLog:
-					l.file[severity.WarningLog].Write(data)
+					_, _ = l.file[severity.WarningLog].Write(data)
 					fallthrough
 				case severity.InfoLog:
-					l.file[severity.InfoLog].Write(data)
+					_, _ = l.file[severity.InfoLog].Write(data)
 				}
 			}
 		}
@@ -946,7 +994,7 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 		logExitFunc = func(error) {} // If we get a write error, we'll still exit below.
 		for log := severity.FatalLog; log >= severity.InfoLog; log-- {
 			if f := l.file[log]; f != nil { // Can be nil if -logtostderr is set.
-				f.Write(trace)
+				_, _ = f.Write(trace)
 			}
 		}
 		l.mu.Unlock()
@@ -978,7 +1026,8 @@ func (l *loggingT) exit(err error) {
 		logExitFunc(err)
 		return
 	}
-	l.flushAll()
+	needToSync := l.flushAll()
+	l.syncAll(needToSync)
 	OsExit(2)
 }
 
@@ -993,10 +1042,6 @@ type syncBuffer struct {
 	sev      severity.Severity
 	nbytes   uint64 // The number of bytes written to this file
 	maxbytes uint64 // The max number of bytes this syncBuffer.file can hold before cleaning up.
-}
-
-func (sb *syncBuffer) Sync() error {
-	return sb.file.Sync()
 }
 
 // CalculateMaxSize returns the real max size in bytes after considering the default max size and the flag options.
@@ -1102,7 +1147,7 @@ const flushInterval = 5 * time.Second
 // flushDaemon periodically flushes the log file buffers.
 type flushDaemon struct {
 	mu       sync.Mutex
-	clock    clock.WithTicker
+	clock    clock.Clock
 	flush    func()
 	stopC    chan struct{}
 	stopDone chan struct{}
@@ -1110,7 +1155,7 @@ type flushDaemon struct {
 
 // newFlushDaemon returns a new flushDaemon. If the passed clock is nil, a
 // clock.RealClock is used.
-func newFlushDaemon(flush func(), tickClock clock.WithTicker) *flushDaemon {
+func newFlushDaemon(flush func(), tickClock clock.Clock) *flushDaemon {
 	if tickClock == nil {
 		tickClock = clock.RealClock{}
 	}
@@ -1190,23 +1235,44 @@ func StartFlushDaemon(interval time.Duration) {
 // lockAndFlushAll is like flushAll but locks l.mu first.
 func (l *loggingT) lockAndFlushAll() {
 	l.mu.Lock()
-	l.flushAll()
+	needToSync := l.flushAll()
 	l.mu.Unlock()
+	// Some environments are slow when syncing and holding the lock might cause contention.
+	l.syncAll(needToSync)
 }
 
-// flushAll flushes all the logs and attempts to "sync" their data to disk.
+// flushAll flushes all the logs
 // l.mu is held.
-func (l *loggingT) flushAll() {
+//
+// The result is the number of files which need to be synced and the pointers to them.
+func (l *loggingT) flushAll() fileArray {
+	var needToSync fileArray
+
 	// Flush from fatal down, in case there's trouble flushing.
 	for s := severity.FatalLog; s >= severity.InfoLog; s-- {
 		file := l.file[s]
-		if file != nil {
-			file.Flush() // ignore error
-			file.Sync()  // ignore error
+		if sb, ok := file.(*syncBuffer); ok && sb.file != nil {
+			_ = sb.Flush() // ignore error
+			needToSync.files[needToSync.num] = sb.file
+			needToSync.num++
 		}
 	}
 	if logging.loggerOptions.flush != nil {
 		logging.loggerOptions.flush()
+	}
+	return needToSync
+}
+
+type fileArray struct {
+	num   int
+	files [severity.NumSeverity]*os.File
+}
+
+// syncAll attempts to "sync" their data to disk.
+func (l *loggingT) syncAll(needToSync fileArray) {
+	// Flush from fatal down, in case there's trouble flushing.
+	for i := 0; i < needToSync.num; i++ {
+		_ = needToSync.files[i].Sync() // ignore error
 	}
 }
 
@@ -1281,9 +1347,7 @@ func (l *loggingT) setV(pc uintptr) Level {
 	fn := runtime.FuncForPC(pc)
 	file, _ := fn.FileLine(pc)
 	// The file is something like /a/b/c/d.go. We want just the d.
-	if strings.HasSuffix(file, ".go") {
-		file = file[:len(file)-3]
-	}
+	file = strings.TrimSuffix(file, ".go")
 	if slash := strings.LastIndex(file, "/"); slash >= 0 {
 		file = file[slash+1:]
 	}

--- a/vendor/k8s.io/klog/v2/klog_file.go
+++ b/vendor/k8s.io/klog/v2/klog_file.go
@@ -109,8 +109,8 @@ func create(tag string, t time.Time, startup bool) (f *os.File, filename string,
 		f, err := openOrCreate(fname, startup)
 		if err == nil {
 			symlink := filepath.Join(dir, link)
-			os.Remove(symlink)        // ignore err
-			os.Symlink(name, symlink) // ignore err
+			_ = os.Remove(symlink)        // ignore err
+			_ = os.Symlink(name, symlink) // ignore err
 			return f, fname, nil
 		}
 		lastErr = err

--- a/vendor/k8s.io/klog/v2/klogr.go
+++ b/vendor/k8s.io/klog/v2/klogr.go
@@ -22,6 +22,11 @@ import (
 	"k8s.io/klog/v2/internal/serialize"
 )
 
+const (
+	// nameKey is used to log the `WithName` values as an additional attribute.
+	nameKey = "logger"
+)
+
 // NewKlogr returns a logger that is functionally identical to
 // klogr.NewWithOptions(klogr.FormatKlog), i.e. it passes through to klog. The
 // difference is that it uses a simpler implementation.
@@ -32,10 +37,15 @@ func NewKlogr() Logger {
 // klogger is a subset of klogr/klogr.go. It had to be copied to break an
 // import cycle (klogr wants to use klog, and klog wants to use klogr).
 type klogger struct {
-	level     int
 	callDepth int
-	prefix    string
-	values    []interface{}
+
+	// hasPrefix is true if the first entry in values is the special
+	// nameKey key/value. Such an entry gets added and later updated in
+	// WithName.
+	hasPrefix bool
+
+	values []interface{}
+	groups string
 }
 
 func (l *klogger) Init(info logr.RuntimeInfo) {
@@ -43,35 +53,41 @@ func (l *klogger) Init(info logr.RuntimeInfo) {
 }
 
 func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
-	merged := serialize.MergeKVs(l.values, kvList)
-	if l.prefix != "" {
-		msg = l.prefix + ": " + msg
-	}
+	merged := serialize.WithValues(l.values, kvList)
 	// Skip this function.
 	VDepth(l.callDepth+1, Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 }
 
 func (l *klogger) Enabled(level int) bool {
-	// Skip this function and logr.Logger.Info where Enabled is called.
-	return VDepth(l.callDepth+2, Level(level)).Enabled()
+	return VDepth(l.callDepth+1, Level(level)).Enabled()
 }
 
 func (l *klogger) Error(err error, msg string, kvList ...interface{}) {
-	merged := serialize.MergeKVs(l.values, kvList)
-	if l.prefix != "" {
-		msg = l.prefix + ": " + msg
-	}
+	merged := serialize.WithValues(l.values, kvList)
 	ErrorSDepth(l.callDepth+1, err, msg, merged...)
 }
 
 // WithName returns a new logr.Logger with the specified name appended.  klogr
-// uses '/' characters to separate name elements.  Callers should not pass '/'
+// uses '.' characters to separate name elements.  Callers should not pass '.'
 // in the provided name string, but this library does not actually enforce that.
 func (l klogger) WithName(name string) logr.LogSink {
-	if len(l.prefix) > 0 {
-		l.prefix = l.prefix + "/"
+	if l.hasPrefix {
+		// Copy slice and modify value. No length checks and type
+		// assertions are needed because hasPrefix is only true if the
+		// first two elements exist and are key/value strings.
+		v := make([]interface{}, 0, len(l.values))
+		v = append(v, l.values...)
+		prefix, _ := v[1].(string)
+		v[1] = prefix + "." + name
+		l.values = v
+	} else {
+		// Preprend new key/value pair.
+		v := make([]interface{}, 0, 2+len(l.values))
+		v = append(v, nameKey, name)
+		v = append(v, l.values...)
+		l.values = v
+		l.hasPrefix = true
 	}
-	l.prefix += name
 	return &l
 }
 

--- a/vendor/k8s.io/klog/v2/klogr_slog.go
+++ b/vendor/k8s.io/klog/v2/klogr_slog.go
@@ -1,0 +1,101 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/buffer"
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/severity"
+	"k8s.io/klog/v2/internal/sloghandler"
+)
+
+func (l *klogger) Handle(ctx context.Context, record slog.Record) error {
+	if logging.logger != nil {
+		if slogSink, ok := logging.logger.GetSink().(logr.SlogSink); ok {
+			// Let that logger do the work.
+			return slogSink.Handle(ctx, record)
+		}
+	}
+
+	return sloghandler.Handle(ctx, record, l.groups, slogOutput)
+}
+
+// slogOutput corresponds to several different functions in klog.go.
+// It goes through some of the same checks and formatting steps before
+// it ultimately converges by calling logging.printWithInfos.
+func slogOutput(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{}) {
+	// See infoS.
+	if logging.logger != nil {
+		// Taking this path happens when klog has a logger installed
+		// as backend which doesn't support slog. Not good, we have to
+		// guess about the call depth and drop the actual location.
+		logger := logging.logger.WithCallDepth(2)
+		if s > severity.ErrorLog {
+			logger.Error(err, msg, kvList...)
+		} else {
+			logger.Info(msg, kvList...)
+		}
+		return
+	}
+
+	// See printS.
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
+	b := buffer.GetBuffer()
+	b.Write(qMsg)
+
+	var errKV []interface{}
+	if err != nil {
+		errKV = []interface{}{"err", err}
+	}
+	serialize.FormatKVs(&b.Buffer, errKV, kvList)
+
+	// See print + header.
+	buf := logging.formatHeader(s, file, line, now)
+	logging.printWithInfos(buf, file, line, s, nil, nil, 0, &b.Buffer)
+
+	buffer.PutBuffer(b)
+}
+
+func (l *klogger) WithAttrs(attrs []slog.Attr) logr.SlogSink {
+	clone := *l
+	clone.values = serialize.WithValues(l.values, sloghandler.Attrs2KVList(l.groups, attrs))
+	return &clone
+}
+
+func (l *klogger) WithGroup(name string) logr.SlogSink {
+	clone := *l
+	if clone.groups != "" {
+		clone.groups += "." + name
+	} else {
+		clone.groups = name
+	}
+	return &clone
+}
+
+var _ logr.SlogSink = &klogger{}

--- a/vendor/k8s.io/klog/v2/safeptr.go
+++ b/vendor/k8s.io/klog/v2/safeptr.go
@@ -1,0 +1,34 @@
+//go:build go1.18
+// +build go1.18
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+// SafePtr is a function that takes a pointer of any type (T) as an argument.
+// If the provided pointer is not nil, it returns the same pointer. If it is nil, it returns nil instead.
+//
+// This function is particularly useful to prevent nil pointer dereferencing when:
+//
+//   - The type implements interfaces that are called by the logger, such as `fmt.Stringer`.
+//   - And these interface implementations do not perform nil checks themselves.
+func SafePtr[T any](p *T) any {
+	if p == nil {
+		return nil
+	}
+	return p
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1463,14 +1463,15 @@ k8s.io/component-base/version
 # k8s.io/klog v1.0.0
 ## explicit; go 1.12
 k8s.io/klog
-# k8s.io/klog/v2 v2.100.1
-## explicit; go 1.13
+# k8s.io/klog/v2 v2.140.0
+## explicit; go 1.21
 k8s.io/klog/v2
 k8s.io/klog/v2/internal/buffer
 k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/dbg
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
+k8s.io/klog/v2/internal/sloghandler
 # k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f
 ## explicit; go 1.19
 k8s.io/kube-openapi/pkg/builder3/util


### PR DESCRIPTION
## Summary

- Replace the deprecated `k8s.io/klog` (v1) import with `k8s.io/klog/v2` across all 91 non-vendor Go source files
- Fix klog v1→v2 API incompatibility: `klog.V(level)` returns `klog.Verbose` instead of `bool` in v2, updated to use `.Enabled()` in `pkg/podman/podman.go`
- Upgrade `k8s.io/klog/v2` from v2.100.1 to v2.140.0
- Configure `legacy_stderr_threshold_behavior=false` and `stderrthreshold=INFO` flags after `klog.InitFlags()` in `cmd/odo/odo.go` so that klog properly honors the stderr threshold setting
- Regenerate `vendor/` directory

## Motivation

`k8s.io/klog` v1 is deprecated and unmaintained. The v2 module is the actively maintained replacement.

Additionally, klog v2 introduced a behavioral change where `stderrthreshold` defaults to `ERROR` but the legacy behavior silently overrides it. Setting `legacy_stderr_threshold_behavior=false` ensures the `stderrthreshold` flag is actually respected.

**Ref:** kubernetes/klog#212, kubernetes/klog#432

## Test plan

- [x] `go build ./...` passes (all packages)
- [x] `go mod tidy` produces clean dependency graph
- [x] `go mod vendor` regenerated successfully
- [ ] Existing CI/CD pipeline should validate no regressions

/cc @feloy @rm3l @kadel